### PR TITLE
fix: honest status-specific messages for web scraping failures

### DIFF
--- a/apps/api/src/capabilities/danish-company-data.ts
+++ b/apps/api/src/capabilities/danish-company-data.ts
@@ -69,8 +69,14 @@ async function fetchCompany(
   if (response.status === 429) {
     throw new Error("The Danish business registry (cvrapi.dk) is temporarily rate-limiting requests. Please try again in a few minutes.");
   }
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(`The Danish business registry (cvrapi.dk) denied the request (HTTP ${response.status}). This is an authentication or access-control issue, not a transient error.`);
+  }
+  if (response.status >= 500) {
+    throw new Error(`The Danish business registry (cvrapi.dk) returned a server error (HTTP ${response.status}). This is usually transient — please try again in a few minutes.`);
+  }
   if (!response.ok) {
-    throw new Error(`The Danish business registry returned an error (HTTP ${response.status}). Please try again later.`);
+    throw new Error(`The Danish business registry (cvrapi.dk) returned an unexpected response (HTTP ${response.status}).`);
   }
 
   const data = await response.json() as any;

--- a/apps/api/src/capabilities/lib/web-provider.ts
+++ b/apps/api/src/capabilities/lib/web-provider.ts
@@ -73,6 +73,36 @@ function isTransient(status: number): boolean {
   return status === 429 || status >= 500;
 }
 
+/** Map a non-OK Browserless response status into an honest, actionable message. */
+function humanizeBrowserlessStatus(status: number, targetUrl: string): string {
+  let hostname = "";
+  try { hostname = new URL(targetUrl).hostname; } catch { /* ignore */ }
+  const domain = hostname ? ` (${hostname})` : "";
+
+  if (status === 408) {
+    return `The web page${domain} took too long to load. The target site is slow or heavy; try again, or try a simpler page on the same site.`;
+  }
+  if (status === 429) {
+    return `The web scraping service is temporarily rate-limited. Please try again in a few minutes.`;
+  }
+  if (status === 404) {
+    return `This page does not exist (HTTP 404)${domain}. The server is reachable, but this specific URL returned 'not found'. This often happens when a site migrates and old URLs redirect to pages that have been removed. Check the path, or try the site's homepage.`;
+  }
+  if (status === 410) {
+    return `This page has been permanently removed (HTTP 410)${domain}. The URL is gone and will not return.`;
+  }
+  if (status === 401 || status === 407) {
+    return `This page requires authentication (HTTP ${status})${domain}. Only publicly available pages can be scraped.`;
+  }
+  if (status === 403) {
+    return `The site${domain} blocks automated access (HTTP 403 Forbidden). This is bot protection on the target site, not a Strale issue.`;
+  }
+  if (status >= 500) {
+    return `The target site${domain} returned a server error (HTTP ${status}). This is usually transient — try again in a few minutes.`;
+  }
+  return `The web page${domain} could not be loaded (HTTP ${status}).`;
+}
+
 function backoffMs(attempt: number): number {
   const base = Math.min(1000 * 2 ** attempt, 8000);
   const jitter = Math.random() * 500;
@@ -171,20 +201,24 @@ export async function fetchPage(
         }
         // HTTP response received but not usable HTML — fall through to Browserless
       } else if (plainResp.status >= 400 && plainResp.status < 500) {
-        // 4xx errors (404, 403, etc.) are permanent — don't retry via Browserless
-        throw new Error(`URL returned HTTP ${plainResp.status}. Check the URL is correct.`);
+        // 4xx errors (404, 403, etc.) are permanent — don't retry via Browserless.
+        // Prefix with "URL returned HTTP" so the catch block below recognizes it as fatal.
+        throw new Error(`URL returned HTTP ${plainResp.status}. ${humanizeBrowserlessStatus(plainResp.status, targetUrl)}`);
       }
       // 5xx errors: fall through to Browserless (server might render differently)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      // Helpful 4xx message already constructed upstream — propagate as-is.
+      if (msg.includes("URL returned HTTP 4")) {
+        throw err;
+      }
       // DNS failures, connection refused, and SSL errors are fatal — no point
       // sending to Browserless, the domain simply doesn't resolve.
       if (
         msg.includes("ENOTFOUND") ||
         msg.includes("ECONNREFUSED") ||
         msg.includes("ERR_TLS") ||
-        msg.includes("getaddrinfo") ||
-        msg.includes("URL returned HTTP 4")
+        msg.includes("getaddrinfo")
       ) {
         const hostname = new URL(targetUrl).hostname;
         throw new Error(
@@ -266,11 +300,7 @@ export async function fetchPage(
             );
             continue;
           }
-          const humanMsg = response.status === 408
-            ? "The web page took too long to load. This capability uses web scraping which can be slow for some sites. Please try again."
-            : response.status === 429
-            ? "The web scraping service is temporarily rate-limited. Please try again in a few minutes."
-            : `The web page could not be loaded (HTTP ${response.status}). Please try again later.`;
+          const humanMsg = humanizeBrowserlessStatus(response.status, targetUrl);
           throw new Error(humanMsg);
         }
 

--- a/apps/api/src/capabilities/uk-filing-events.ts
+++ b/apps/api/src/capabilities/uk-filing-events.ts
@@ -81,8 +81,17 @@ registerCapability("uk-filing-events", async (input: CapabilityInput) => {
   if (filingsResp.status === 404) {
     throw new Error(`UK company ${resolvedNumber} not found in Companies House.`);
   }
+  if (filingsResp.status === 401 || filingsResp.status === 403) {
+    throw new Error(`Companies House API denied the request (HTTP ${filingsResp.status}). The COMPANIES_HOUSE_API_KEY may be invalid or rate-limited.`);
+  }
+  if (filingsResp.status === 429) {
+    throw new Error(`Companies House API is rate-limiting requests (HTTP 429). Please try again in a few minutes.`);
+  }
+  if (filingsResp.status >= 500) {
+    throw new Error(`Companies House API returned a server error (HTTP ${filingsResp.status}). This is usually transient — please try again in a few minutes.`);
+  }
   if (!filingsResp.ok) {
-    throw new Error(`Companies House API returned HTTP ${filingsResp.status}. Please try again later.`);
+    throw new Error(`Companies House API returned an unexpected response (HTTP ${filingsResp.status}).`);
   }
 
   const filingsData = await filingsResp.json() as any;

--- a/apps/api/src/capabilities/url-to-markdown.ts
+++ b/apps/api/src/capabilities/url-to-markdown.ts
@@ -4,6 +4,14 @@ import { htmlToCleanMarkdown } from "./lib/readability-convert.js";
 import { fetchViaJina } from "./lib/jina-reader.js";
 import { validateUrl } from "../lib/url-validator.js";
 
+/** Thrown when the target responded definitively — no point trying Jina/Browserless. */
+class DefinitiveFetchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DefinitiveFetchError";
+  }
+}
+
 /** Sites known to block server-side fetches with specific guidance. */
 const BLOCKED_SITE_HINTS: Record<string, string> = {
   "npmjs.com": "npmjs.com blocks automated access. Use the 'npm-package-info' capability instead to get package metadata.",
@@ -54,10 +62,10 @@ async function tryPlainFetch(url: string): Promise<string | null> {
       if (resp.status >= 400 && resp.status < 500) {
         const hint = getBlockedSiteHint(url);
         if (hint) {
-          throw new Error(hint);
+          throw new DefinitiveFetchError(hint);
         }
         if (resp.status === 403) {
-          throw new Error(
+          throw new DefinitiveFetchError(
             "This site blocks automated access (HTTP 403 Forbidden). " +
             "This is bot protection on the target site, not a Strale issue. " +
             "Alternatives: try 'dns-lookup' or 'domain-reputation' for structured data about this domain, " +
@@ -66,25 +74,30 @@ async function tryPlainFetch(url: string): Promise<string | null> {
         }
         if (resp.status === 404) {
           let hostname = "";
-          try { hostname = new URL(url).hostname; } catch { /* ignore */ }
-          throw new Error(
+          try { hostname = new URL(resp.url || url).hostname; } catch { /* ignore */ }
+          const originalHost = (() => { try { return new URL(url).hostname; } catch { return ""; } })();
+          const redirectNote = hostname && originalHost && hostname !== originalHost
+            ? ` The original URL redirected to ${resp.url}, which returned 404.`
+            : "";
+          throw new DefinitiveFetchError(
             `This page does not exist (HTTP 404). The server at ${hostname || "this domain"} is reachable, ` +
-            "but this specific URL returned 'not found'. Check for typos in the path, or try the site's homepage instead.",
+            "but this specific URL returned 'not found'." + redirectNote + " " +
+            "Check for typos in the path, or try the site's homepage instead.",
           );
         }
         if (resp.status === 401 || resp.status === 407) {
-          throw new Error(
+          throw new DefinitiveFetchError(
             `This page requires authentication (HTTP ${resp.status}). ` +
             "url-to-markdown can only access publicly available pages.",
           );
         }
         if (resp.status === 429) {
-          throw new Error(
+          throw new DefinitiveFetchError(
             "This site is rate-limiting requests (HTTP 429). " +
             "The target site has throttled access. Try again in a few minutes.",
           );
         }
-        throw new Error(
+        throw new DefinitiveFetchError(
           `URL returned HTTP ${resp.status}. The server is reachable but returned an error. ` +
           "Check the URL is correct and publicly accessible.",
         );
@@ -96,13 +109,13 @@ async function tryPlainFetch(url: string): Promise<string | null> {
 
     if (!contentType.includes("text/html") && !contentType.includes("xhtml")) {
       if (contentType.includes("application/pdf")) {
-        throw new Error("This URL points to a PDF file, not a web page. Use the 'pdf-extract' capability instead.");
+        throw new DefinitiveFetchError("This URL points to a PDF file, not a web page. Use the 'pdf-extract' capability instead.");
       }
       if (contentType.includes("image/")) {
-        throw new Error("This URL points to an image, not a web page.");
+        throw new DefinitiveFetchError("This URL points to an image, not a web page.");
       }
       if (contentType.includes("application/json")) {
-        throw new Error("This URL returns JSON data, not a web page. The content is already structured.");
+        throw new DefinitiveFetchError("This URL returns JSON data, not a web page. The content is already structured.");
       }
       return null;
     }
@@ -122,18 +135,9 @@ async function tryPlainFetch(url: string): Promise<string | null> {
 
     return null;
   } catch (err) {
-    if (err instanceof Error && !err.message.includes("abort") && !err.message.includes("timeout") && !err.message.includes("ECONNREFUSED")) {
-      if (
-        err.message.includes("URL returned HTTP") ||
-        err.message.includes("PDF file") ||
-        err.message.includes("image") ||
-        err.message.includes("JSON data") ||
-        err.message.includes("SSRF") ||
-        err.message.includes("private") ||
-        err.message.includes("blocked")
-      ) {
-        throw err;
-      }
+    if (err instanceof DefinitiveFetchError) throw err;
+    if (err instanceof Error && (err.message.includes("SSRF") || err.message.includes("private"))) {
+      throw err;
     }
     return null;
   }
@@ -144,6 +148,23 @@ function mapBrowserlessError(msg: string, url?: string): Error {
   try { if (url) hostname = new URL(url).hostname; } catch { /* ignore */ }
   const domainNote = hostname ? ` (${hostname})` : "";
 
+  if (msg.includes("HTTP 404") || msg.includes("(404)")) {
+    return new Error(
+      `This page does not exist (HTTP 404)${domainNote}. The server is reachable, but this specific URL returned 'not found'. ` +
+      "This often happens when a site migrates and old URLs redirect to pages that have been removed. " +
+      "Check the path, or try the site's homepage.",
+    );
+  }
+  if (msg.includes("HTTP 401") || msg.includes("HTTP 407")) {
+    return new Error(
+      `This page requires authentication${domainNote}. url-to-markdown can only access publicly available pages.`,
+    );
+  }
+  if (msg.includes("HTTP 410")) {
+    return new Error(
+      `This page has been permanently removed (HTTP 410)${domainNote}. The URL is gone and will not return.`,
+    );
+  }
   if (msg.includes("408") || msg.includes("timed out") || msg.includes("timeout")) {
     return new Error(
       `This page${domainNote} took too long to render (>30s). ` +


### PR DESCRIPTION
## Summary
- Surfaced while investigating a real failed call today: `url-to-markdown` on `https://www.synthesia.cz/en/` returned *"HTTP 500, please try again later"* — but the actual problem was a 302 redirect to a 404 page on `synthesia.eu`. The error was factually wrong and wasted the caller's retry budget.
- Root cause is shared: [`web-provider.ts:269-274`](apps/api/src/capabilities/lib/web-provider.ts) produced the same misleading message for every 4xx from Browserless, affecting **all 47+ capabilities** that use `fetchRenderedHtml`.
- Plus two sibling bugs in [`danish-company-data.ts`](apps/api/src/capabilities/danish-company-data.ts) and [`uk-filing-events.ts`](apps/api/src/capabilities/uk-filing-events.ts) where auth/rate-limit/server-error were all lumped as "try again later".
- Also fixes a substring-matching anti-pattern in `url-to-markdown` that was swallowing helpful 404/403/401/429 messages because the re-throw list didn't match the actual strings.

## What changed

**`web-provider.ts`** (affects all 47+ scraping capabilities)
- New `humanizeBrowserlessStatus()` helper — status-specific honest messages: 404 = permanent, 410 = gone, 401/407 = auth, 403 = bot-blocked, 429/5xx = transient.
- Applied to both plain-fetch and Browserless error paths.
- Fixed the downstream catch that was discarding helpful 4xx messages and mis-wrapping them as "could not reach domain" (the domain *is* reachable — it returned 4xx).

**`url-to-markdown.ts`**
- `DefinitiveFetchError` class replaces brittle substring-based re-throw decisions.
- `mapBrowserlessError` extended with 404/410/401 branches.
- 404 message now names the redirect target when one was followed.

**`danish-company-data.ts`, `uk-filing-events.ts`**
- Differentiated 401/403 (auth), 429 (rate-limit on UK), and 5xx (transient) from generic HTTP errors.

## Scope decisions
- Did a global scan for the same anti-patterns. `adverse-media-check.ts` and `beneficial-ownership-lookup.ts` use `err.message.includes()` for fallback-chain signaling (intentional, not error-swallowing) — left alone.
- `vat-validate.ts` also has "try again later" messages — correct use (VIES upstream `MS_UNAVAILABLE` is genuinely transient) — left alone.

## Test plan
- [x] `tsc --noEmit` clean on all touched files
- [x] Verified against the original failing input (`https://www.synthesia.cz/en/`): error now *"This page does not exist (HTTP 404) (www.synthesia.cz). The server is reachable, but this specific URL returned 'not found'. This often happens when a site migrates and old URLs redirect to pages that have been removed. Check the path, or try the site's homepage."*
- [ ] Smoke-check one other scraping capability (e.g. `danish-company-data`) in staging to confirm no regression on happy path
- [ ] Watch next 24h of transactions for any new error shapes from scraping capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)