### PR TITLE
fix(x402): verify → execute → settle across all x402 paths (no charge on failure)

### DIFF
--- a/apps/api/src/lib/x402-gateway.ts
+++ b/apps/api/src/lib/x402-gateway.ts
@@ -131,8 +131,22 @@ export interface X402VerificationResult {
   error?: string;
 }
 
+export interface X402PaymentRequirement {
+  resource?: string;
+  description?: string;
+  outputSchema?: Record<string, unknown>;
+}
+
 /**
- * Verify an x402 payment header using the facilitator.
+ * Verify AND settle an x402 payment header using the facilitator.
+ *
+ * This is the legacy one-shot flow — the on-chain transaction is broadcast
+ * before the capability runs, so a validation/execution failure still charges
+ * the caller. Kept for the /v1/do x402 path which hasn't yet been refactored.
+ *
+ * For new code (e.g. /x402/:slug), prefer `verifyX402PaymentOnly` +
+ * `settleX402Payment` so the USDC is only moved after the capability produces
+ * output (DEC-14: don't charge before execution succeeds).
  *
  * @param paymentHeader - Base64-encoded X-PAYMENT header from the request
  * @param priceCentsEur - EUR price of the capability (for fallback conversion)
@@ -142,24 +156,68 @@ export interface X402VerificationResult {
  *   verification amount exactly matches what was in the 402 response's
  *   maxAmountRequired field.
  */
-export interface X402PaymentRequirement {
-  resource?: string;
-  description?: string;
-  outputSchema?: Record<string, unknown>;
-}
-
 export async function verifyX402Payment(
   paymentHeader: string,
   priceCentsEur: number,
   priceUsdOverride?: number,
   requirementOverrides?: X402PaymentRequirement,
 ): Promise<X402VerificationResult> {
+  const verifyOnly = await verifyX402PaymentOnly(
+    paymentHeader, priceCentsEur, priceUsdOverride, requirementOverrides,
+  );
+  if (!verifyOnly.valid || !verifyOnly.verified) {
+    return { valid: false, error: verifyOnly.error };
+  }
+  const settle = await settleX402Payment(verifyOnly.verified);
+  return { valid: settle.valid, settlementId: settle.settlementId, error: settle.error };
+}
+
+/**
+ * Opaque handle returned by a successful verify. Pass it to
+ * `settleX402Payment` once execution has succeeded to move the USDC on-chain.
+ * Not serializable across process boundaries — discard if unused (the
+ * on-chain authorization expires via `maxTimeoutSeconds`).
+ */
+export interface X402VerifiedPayment {
+  payload: unknown;
+  requirements: unknown;
+}
+
+export interface X402VerifyOnlyResult {
+  valid: boolean;
+  /** Only present when `valid === true`. Hand to `settleX402Payment` to finalize. */
+  verified?: X402VerifiedPayment;
+  error?: string;
+}
+
+export interface X402SettlementResult {
+  valid: boolean;
+  settlementId?: string;
+  error?: string;
+}
+
+/**
+ * Verify an x402 payment header without broadcasting the transaction.
+ *
+ * Non-destructive — checks the signed authorization is valid and covers the
+ * quoted price, but does NOT settle on-chain. Hand the returned `verified`
+ * handle to `settleX402Payment` after execution succeeds.
+ *
+ * Rationale: matches DEC-14 ("don't charge before execution succeeds"). Input
+ * validation errors and capability failures no longer charge the caller —
+ * their signed authorization simply expires unused.
+ */
+export async function verifyX402PaymentOnly(
+  paymentHeader: string,
+  priceCentsEur: number,
+  priceUsdOverride?: number,
+  requirementOverrides?: X402PaymentRequirement,
+): Promise<X402VerifyOnlyResult> {
   if (!isX402Configured()) {
     return { valid: false, error: "x402 not configured (no wallet address)" };
   }
 
   try {
-    // Decode the base64-encoded X-PAYMENT header into a PaymentPayload
     const decoded = Buffer.from(paymentHeader, "base64").toString("utf-8");
     const parsed = parsePaymentPayload(JSON.parse(decoded));
     if (!parsed.success) {
@@ -167,17 +225,10 @@ export async function verifyX402Payment(
     }
     const payload = parsed.data;
 
-    // Use USD override if provided (matches what the 402 response quoted to the client).
-    // Otherwise fall back to EUR→USD conversion. The two must match exactly or the
-    // facilitator returns "authorization value mismatch".
     const priceAtomic =
       priceUsdOverride !== undefined
         ? Math.ceil(priceUsdOverride * 1_000_000).toString()
         : eurCentsToUsdcAtomic(priceCentsEur);
-    // Requirements passed to the facilitator must carry the discovery outputSchema
-    // (v1 path) so the Bazaar indexer catalogs the resource at settle time.
-    // `resource` and `description` must match what the 402 response quoted so the
-    // indexed URL is canonical.
     const requirements: Record<string, unknown> = {
       scheme: "exact",
       network: NETWORK,
@@ -195,27 +246,46 @@ export async function verifyX402Payment(
     }
 
     const facilitator = getFacilitator();
-
-    // Verify first (non-destructive check), then settle (broadcasts the tx)
     const verifyResult = await facilitator.verify(payload as any, requirements as any);
     if (!verifyResult.isValid) {
       return { valid: false, error: verifyResult.invalidReason ?? "Payment invalid" };
     }
 
-    const settleResult = await facilitator.settle(payload as any, requirements as any);
-    if (!settleResult.success) {
-      return { valid: false, error: settleResult.errorReason ?? "Settlement failed" };
-    }
-
-    return {
-      valid: true,
-      settlementId: settleResult.transaction ?? "settled",
-    };
+    return { valid: true, verified: { payload, requirements } };
   } catch (err) {
     console.error("[x402] Payment verification failed:", err instanceof Error ? err.message : err);
     return {
       valid: false,
       error: err instanceof Error ? err.message : "Payment verification failed",
+    };
+  }
+}
+
+/**
+ * Broadcast the settlement for a previously verified payment.
+ *
+ * Call only after the capability has successfully produced output. Errors here
+ * are rare (verify already passed) but the facilitator can still reject if the
+ * authorization has meanwhile been used or expired.
+ */
+export async function settleX402Payment(
+  verified: X402VerifiedPayment,
+): Promise<X402SettlementResult> {
+  try {
+    const facilitator = getFacilitator();
+    const settleResult = await facilitator.settle(
+      verified.payload as any,
+      verified.requirements as any,
+    );
+    if (!settleResult.success) {
+      return { valid: false, error: settleResult.errorReason ?? "Settlement failed" };
+    }
+    return { valid: true, settlementId: settleResult.transaction ?? "settled" };
+  } catch (err) {
+    console.error("[x402] Settlement failed:", err instanceof Error ? err.message : err);
+    return {
+      valid: false,
+      error: err instanceof Error ? err.message : "Settlement failed",
     };
   }
 }

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -39,8 +39,10 @@ import { computeIntegrityHash, getPreviousHash } from "../lib/integrity-hash.js"
 import {
   isX402Configured,
   build402Response,
-  verifyX402Payment,
+  verifyX402PaymentOnly,
+  settleX402Payment,
   extractPaymentHeader,
+  type X402VerifiedPayment,
 } from "../lib/x402-gateway.js";
 import { recordUnlock, isUnlocked, getUnlockedSlugs } from "../lib/progressive-unlock.js";
 import type { AppEnv } from "../types.js";
@@ -513,16 +515,17 @@ doRoute.post(
       const paymentHeader = extractPaymentHeader(c.req.raw.headers);
 
       if (paymentHeader && isX402Configured()) {
-        // Verify x402 payment → if valid, proceed with execution
-        const verification = await verifyX402Payment(paymentHeader, lookedUp.priceCents);
-        if (!verification.valid) {
+        // Verify x402 payment WITHOUT broadcasting settlement — the settle
+        // step runs only after the capability has produced output (DEC-14).
+        const verification = await verifyX402PaymentOnly(paymentHeader, lookedUp.priceCents);
+        if (!verification.valid || !verification.verified) {
           return c.json({
             error_code: "payment_failed",
             message: verification.error ?? "x402 payment verification failed",
           }, 402);
         }
-        // Payment verified — store settlement ID in request context for audit trail
-        c.set("x402_settlement" as any, verification.settlementId);
+        // Stash the verified handle for executeFreeTier to settle post-success.
+        c.set("x402_verified" as any, verification.verified);
         c.set("x402_paid" as any, true);
         // Fall through to normal execution — the capability will execute
         // and the transaction will be logged with payment_method: "x402"
@@ -1072,6 +1075,35 @@ async function executeFreeTier(
       requestContext: c.get("requestContext" as any),
     });
 
+    // If this call was x402-paid, settle NOW (after success). If settle
+    // fails — rare, since verify already passed — mark the transaction
+    // failed and surface a 402 so the caller knows the payment didn't land.
+    const x402Verified = c.get("x402_verified" as any) as X402VerifiedPayment | undefined;
+    let x402SettlementId: string | null = null;
+    if (x402Verified) {
+      const settled = await settleX402Payment(x402Verified);
+      if (!settled.valid) {
+        await db
+          .update(transactions)
+          .set({
+            status: "failed",
+            error: `Payment settlement failed: ${settled.error ?? "unknown"}`,
+            latencyMs,
+            completedAt: new Date(),
+          })
+          .where(eq(transactions.id, txnRecord.id));
+        return c.json(
+          {
+            error_code: "payment_failed",
+            message: "x402 settlement failed after successful execution.",
+            detail: settled.error,
+          },
+          402,
+        );
+      }
+      x402SettlementId = settled.settlementId ?? null;
+    }
+
     await db
       .update(transactions)
       .set({
@@ -1081,6 +1113,9 @@ async function executeFreeTier(
         auditTrail: audit,
         latencyMs,
         completedAt: new Date(),
+        ...(x402SettlementId
+          ? { paymentMethod: "x402", x402SettlementId, isFreeTier: false }
+          : {}),
       })
       .where(eq(transactions.id, txnRecord.id));
 

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -17,11 +17,13 @@ import { capabilities, solutions, transactions } from "../db/schema.js";
 import { getExecutor } from "../capabilities/index.js";
 import {
   isX402Configured,
-  verifyX402Payment,
+  verifyX402PaymentOnly,
+  settleX402Payment,
   extractPaymentHeader,
   eurCentsToUsdcAtomic,
   eurCentsToUsdString,
   encodePaymentResponseHeader,
+  type X402VerifiedPayment,
 } from "../lib/x402-gateway.js";
 import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
@@ -545,7 +547,11 @@ x402GatewayV2.on(["GET", "POST"], "/solutions/:slug", async (c) => {
 
   // Payment check FIRST — so Bazaar's empty-body discovery crawl gets a 402
   // (not a 400 from failed JSON parse). See capability handler for detail.
-  let solSettlementId: string | undefined;
+  //
+  // Verify only; defer settlement until the solution has produced at least one
+  // successful step (DEC-14). If the solution produces no output the caller is
+  // not charged.
+  let verified: X402VerifiedPayment | undefined;
   if (sol.x402PriceUsd > 0) {
     const paymentHeader = extractPaymentHeader(c.req.raw.headers);
 
@@ -566,14 +572,12 @@ x402GatewayV2.on(["GET", "POST"], "/solutions/:slug", async (c) => {
       return c.json({ error: "x402 payments not configured." }, 503);
     }
 
-    // Build the requirement again (cheap) so verify+settle carry the same
-    // resource URL + discovery outputSchema the client signed against.
     const solRebuild = build402(
       sol.name, sol.description, sol.x402PriceUsd,
       `${BASE_URL}/x402/solutions/${slug}`,
       null, sol.inputSchema, "POST", sol.outputSchema,
     );
-    const verification = await verifyX402Payment(
+    const verification = await verifyX402PaymentOnly(
       paymentHeader,
       sol.priceCents,
       sol.x402PriceUsd,
@@ -583,17 +587,13 @@ x402GatewayV2.on(["GET", "POST"], "/solutions/:slug", async (c) => {
         outputSchema: solRebuild.paymentRequirement.outputSchema as Record<string, unknown>,
       },
     );
-    if (!verification.valid) {
+    if (!verification.valid || !verification.verified) {
       return c.json({ error: "Payment verification failed", detail: verification.error }, 402);
     }
-    solSettlementId = verification.settlementId;
+    verified = verification.verified;
   }
 
-  if (solSettlementId) {
-    c.header("X-Payment-Response", encodePaymentResponseHeader(solSettlementId));
-  }
-
-  // Extract inputs (after payment clears)
+  // Extract inputs (after verify, before settle — bad input returns 4xx without charging)
   let inputs: Record<string, unknown>;
   try {
     inputs = await extractInputs(c, sol.inputSchema);
@@ -608,6 +608,43 @@ x402GatewayV2.on(["GET", "POST"], "/solutions/:slug", async (c) => {
     return c.json({ error: "Solution has no steps configured." }, 503);
   }
 
+  // Settle only if at least one step produced output. All-steps-failed returns
+  // a 4xx-shaped response and the caller keeps their USDC authorization.
+  // `result.steps` is a Record<slug, output | {error} | {skipped}>. A step
+  // counts as successful when its value is an object with neither `error` nor
+  // `skipped` set.
+  const anyStepSucceeded = Object.values(result.steps).some((v) => {
+    if (!v || typeof v !== "object") return false;
+    const obj = v as Record<string, unknown>;
+    return !("error" in obj) && !("skipped" in obj);
+  });
+  if (!anyStepSucceeded) {
+    return c.json(
+      {
+        error: "Solution failed — no steps produced output. No payment was taken.",
+        solution: sol.slug,
+        steps: result.steps,
+        errors: result.errors,
+      },
+      502,
+    );
+  }
+
+  let settlementId: string | undefined;
+  if (verified) {
+    const settled = await settleX402Payment(verified);
+    if (!settled.valid) {
+      return c.json(
+        { error: "Payment settlement failed", detail: settled.error },
+        402,
+      );
+    }
+    settlementId = settled.settlementId;
+    if (settlementId) {
+      c.header("X-Payment-Response", encodePaymentResponseHeader(settlementId));
+    }
+  }
+
   return c.json({
     solution: sol.slug,
     steps: result.steps,
@@ -616,7 +653,9 @@ x402GatewayV2.on(["GET", "POST"], "/solutions/:slug", async (c) => {
       solution: sol.slug,
       step_count: result.step_count,
       latency_ms: result.latency_ms,
-      payment: { method: "x402", price_usd: sol.x402PriceUsd },
+      payment: settlementId
+        ? { method: "x402", settlement_id: settlementId, price_usd: sol.x402PriceUsd }
+        : { method: "x402", price_usd: sol.x402PriceUsd },
     },
   });
 });
@@ -640,7 +679,7 @@ x402GatewayV2.on(["GET", "POST"], "/:slug", async (c) => {
 
   // Free capabilities ($0.00) skip payment
   const isFree = cap.x402PriceUsd === 0;
-  let settlementId: string | undefined;
+  let verified: X402VerifiedPayment | undefined;
 
   // Payment check FIRST — before any input validation. CDP's Bazaar crawler
   // sends an empty request to discover endpoints and requires HTTP 402 back.
@@ -648,6 +687,11 @@ x402GatewayV2.on(["GET", "POST"], "/:slug", async (c) => {
   // https://docs.cdp.coinbase.com/x402/quickstart-for-sellers — "If your
   // server returns any other status code (e.g. 400 Bad Request), the resource
   // will not be indexed."
+  //
+  // We VERIFY the signed authorization here but defer SETTLE until after the
+  // capability has successfully produced output (DEC-14). Input validation and
+  // capability failures no longer charge the caller; the signed authorization
+  // simply expires via maxTimeoutSeconds.
   if (!isFree) {
     const paymentHeader = extractPaymentHeader(c.req.raw.headers);
 
@@ -668,14 +712,15 @@ x402GatewayV2.on(["GET", "POST"], "/:slug", async (c) => {
       return c.json({ error: "x402 payments not configured." }, 503);
     }
 
-    // Rebuild the same requirement so verify+settle carry the discovery
+    // Rebuild the same requirement so verify carries the discovery
     // outputSchema (v1 Bazaar indexing path) and the canonical resource URL.
+    // The same handle is reused at settle time below.
     const capRebuild = build402(
       cap.name, cap.description, cap.x402PriceUsd,
       `${BASE_URL}/x402/${slug}`, cap.matrixSqs,
       cap.inputSchema, cap.x402Method, cap.outputSchema,
     );
-    const verification = await verifyX402Payment(
+    const verification = await verifyX402PaymentOnly(
       paymentHeader,
       cap.priceCents,
       cap.x402PriceUsd,
@@ -685,23 +730,16 @@ x402GatewayV2.on(["GET", "POST"], "/:slug", async (c) => {
         outputSchema: capRebuild.paymentRequirement.outputSchema as Record<string, unknown>,
       },
     );
-    if (!verification.valid) {
+    if (!verification.valid || !verification.verified) {
       return c.json(
         { error: "Payment verification failed", detail: verification.error },
         402,
       );
     }
-    settlementId = verification.settlementId;
+    verified = verification.verified;
   }
 
-  // From this point on, payment may already be settled. Surface the tx hash
-  // via X-PAYMENT-RESPONSE on every response — including 4xx — so clients can
-  // reconcile failed executions against on-chain settlements.
-  if (settlementId) {
-    c.header("X-Payment-Response", encodePaymentResponseHeader(settlementId));
-  }
-
-  // Method check (after payment — crawler hits with any method)
+  // Method check (after verify — crawler hits with any method)
   if (c.req.method === "GET" && !isSimpleSchema(cap.inputSchema)) {
     return c.json(
       { error: "This capability requires POST with JSON body.", input_schema: cap.inputSchema },
@@ -709,7 +747,7 @@ x402GatewayV2.on(["GET", "POST"], "/:slug", async (c) => {
     );
   }
 
-  // Extract inputs (after payment clears)
+  // Extract inputs (after verify, before settle — bad input returns 4xx without charging)
   let inputs: Record<string, unknown>;
   try {
     inputs = await extractInputs(c, cap.inputSchema);
@@ -737,43 +775,53 @@ x402GatewayV2.on(["GET", "POST"], "/:slug", async (c) => {
   }
 
   const startMs = Date.now();
+  let result: Awaited<ReturnType<typeof executor>>;
   try {
-    const result = await executor(inputs);
-    const latencyMs = Date.now() - startMs;
-
-    // Record transaction (fire-and-forget)
-    const txnId = recordX402Transaction(
-      cap.id, cap.slug, inputs, result.output, latencyMs,
-      cap.priceCents, cap.x402PriceUsd,
-      cap.transparencyTag, cap.dataJurisdiction,
-      settlementId,
-    );
-
-    return c.json({
-      ...result.output,
-      _meta: {
-        capability: cap.slug,
-        latency_ms: latencyMs,
-        provenance: result.provenance,
-        payment: settlementId
-          ? { method: "x402", settlement_id: settlementId, price_usd: cap.x402PriceUsd }
-          : { method: "free" },
-      },
-    });
+    result = await executor(inputs);
   } catch (err) {
-    const latencyMs = Date.now() - startMs;
+    // Execution failed — do NOT settle. The signed authorization expires unused.
     const message = err instanceof Error ? err.message : String(err);
-
-    // Record failed transaction for audit trail
-    recordX402Transaction(
-      cap.id, cap.slug, inputs, null, latencyMs,
-      cap.priceCents, cap.x402PriceUsd,
-      cap.transparencyTag, cap.dataJurisdiction,
-      settlementId, message,
-    );
-
     return c.json({ error: sanitizeFailureReason(message) }, 400);
   }
+
+  const latencyMs = Date.now() - startMs;
+
+  // Settle now that we have a real result. If settlement fails (rare — verify
+  // already passed) surface a clear error; the client can retry the paid call.
+  let settlementId: string | undefined;
+  if (verified) {
+    const settled = await settleX402Payment(verified);
+    if (!settled.valid) {
+      return c.json(
+        { error: "Payment settlement failed", detail: settled.error },
+        402,
+      );
+    }
+    settlementId = settled.settlementId;
+    if (settlementId) {
+      c.header("X-Payment-Response", encodePaymentResponseHeader(settlementId));
+    }
+  }
+
+  // Record transaction (fire-and-forget)
+  recordX402Transaction(
+    cap.id, cap.slug, inputs, result.output, latencyMs,
+    cap.priceCents, cap.x402PriceUsd,
+    cap.transparencyTag, cap.dataJurisdiction,
+    settlementId,
+  );
+
+  return c.json({
+    ...result.output,
+    _meta: {
+      capability: cap.slug,
+      latency_ms: latencyMs,
+      provenance: result.provenance,
+      payment: settlementId
+        ? { method: "x402", settlement_id: settlementId, price_usd: cap.x402PriceUsd }
+        : { method: "free" },
+    },
+  });
 });
 
 // ─── Exported for .well-known/x402.json ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Before this change, the x402 gateways verified **and settled** the USDC payment *before* input validation or capability execution. Any failure — missing required field, empty body, capability error — still consumed the caller's USDC. This contradicts [DEC-14](CLAUDE.md) ("don't charge before execution succeeds") which was already policy for the wallet model.

## What surfaced this

A real probe burst on 2026-04-15 (see /activity investigation): 20 capabilities hit with `{}` input in 90 seconds. Every call settled on-chain, every call then returned a validation error, and the caller paid for 20 failed calls. Looks like someone smoke-testing x402 coverage across the catalog — real USDC consumed.

## Changes

**`apps/api/src/lib/x402-gateway.ts`** — split the verify+settle one-shot into two steps:
- `verifyX402PaymentOnly(...)` → non-destructive verify, returns an opaque `X402VerifiedPayment` handle.
- `settleX402Payment(handle)` → broadcasts the settlement.
- `verifyX402Payment(...)` is kept with its original signature as a legacy combined helper for any caller that still needs it.

**`apps/api/src/routes/x402-gateway-v2.ts`**:
- **Capability handler (`/x402/:slug`)**: verify → method check → input validate → execute → **settle on success**. Validation errors and executor throws return 4xx with no `X-Payment-Response` header and no transaction record. The signed authorization expires unused (`maxTimeoutSeconds`).
- **Solution handler (`/x402/solutions/:slug`)**: verify → input validate → `executeSolution` → **settle only if at least one step produced output**. All-steps-failed returns 502 and the caller keeps their authorization.

**`apps/api/src/routes/do.ts`** (second commit):
- `/v1/do` x402 path: verify upfront, stash the handle in request context, settle inside `executeFreeTier` after the capability has produced output.
- Fixes a latent bug on the success path too — x402-paid transactions were being miscategorized as `is_free_tier=true` with no `payment_method` or `x402_settlement_id` recorded. Now they correctly carry `payment_method='x402'` + settlement ID.
- Settle-after-success failures (rare — verify already passed) mark the transaction failed and return a 402 instead of a success response with no payment.

## What this does NOT change

- The 402-response-on-missing-payment behavior (still required for Bazaar indexing).
- Transaction recording semantics for successful wallet-model calls.
- Free-tier / authenticated paths.

## Test plan
- [x] `tsc --noEmit` clean on touched files
- [ ] Replay the empty-input probe against staging: expect 4xx with **no** `X-Payment-Response` header and **no** on-chain USDC movement
- [ ] Replay a valid call (e.g. `vat-validate` with `SE556703748501`) via both `/x402/:slug` and `/v1/do` with `X-Payment`: expect 200 and a single settlement
- [ ] Solution happy path on a KYB-essentials variant
- [ ] Solution all-fail path (force every step to error): expect 502 and no settlement
- [ ] Check a few /v1/do x402 transactions post-deploy: `payment_method` and `x402_settlement_id` should now be populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)