### PR TITLE
chore(ci): seed minimal GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+# Minimal seed workflow. Its only job is to get a working Actions pipeline
+# into main's history so future PRs trigger CI reliably. The Phase B+C PR
+# (which ships F-0-001..F-0-020) adds the real check steps — typecheck,
+# vitest, the lint:no-bare-catch guard, and the SSRF inventory guard —
+# once those scripts exist on main.
+#
+# Until then this workflow runs only `npm ci` + `npm run build --workspace=apps/api`
+# which is what main currently has the infrastructure to do.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm --workspace=packages/mcp-server run build
+      - run: npm --workspace=apps/api run build


### PR DESCRIPTION
Seeds a workflow file into main so that \`pull_request\` triggers on future PRs fire reliably. Enables the Phase B+C PR (#8) to run CI.

## Why this exists as a separate small PR

Today there is no workflow file on main. When #8 was opened, GitHub didn't auto-trigger its workflow because introducing a workflow in a PR against a base that has never had one leaves the trigger in an ambiguous state. Seeding this tiny workflow first, then rebasing/merging #8 on top, gets #8's richer CI running.

## What this workflow does

Just \`npm ci\` + \`npm run build\` (mcp-server then apps/api) — the only steps main's current package.json has scripts for.

## What this PR does NOT include

- The \`typecheck\`, \`test\`, \`lint:no-bare-catch\`, \`lint:ssrf-inventory\` scripts — those arrive with #8. Adding their steps now would fail because the scripts don't exist on main.
- Any source code changes. Workflow file only.

After this merges, #8 will be updated to merge main back in (resolves conflicts), and its fuller ci.yml will land when #8 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)