### PR TITLE
hotfix(jobs): xact-scoped advisory locks (unstick integrity-hash retry worker)

### DIFF
--- a/apps/api/src/jobs/activation-drip.ts
+++ b/apps/api/src/jobs/activation-drip.ts
@@ -2,7 +2,9 @@
  * Activation Drip — sends timed nudge emails to users who haven't made their first API call.
  *
  * Schedule: every 6 hours + once 90s after startup.
- * Uses pg_try_advisory_lock to prevent duplicate sends in multi-instance deployments.
+ * Uses pg_try_advisory_xact_lock inside a db.transaction to prevent duplicate
+ * sends in multi-instance deployments (xact-scoped so the lock sits on the
+ * same connection as the work and auto-releases on commit/rollback).
  *
  * Stages:
  *   0 → 1: Day-2 nudge (48h after signup)
@@ -14,7 +16,7 @@ import { sql, eq, and, lt, isNull } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { users } from "../db/schema.js";
 import { sendDay2NudgeEmail, sendDay5ReminderEmail } from "../lib/activation-emails.js";
-import { logError } from "../lib/log.js";
+import { logWarn } from "../lib/log.js";
 
 const DRIP_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 const STARTUP_DELAY_MS = 90_000; // 90 seconds
@@ -25,20 +27,26 @@ let _running = false;
 async function runActivationDrip(): Promise<void> {
   const db = getDb();
 
-  // Advisory lock: prevent duplicate runs across instances
-  const [lock] = await db.execute(sql`SELECT pg_try_advisory_lock(${ADVISORY_LOCK_ID}) AS acquired`);
-  if (!(lock as any)?.acquired) {
-    console.log("[activation-drip] Another instance holds the lock — skipping");
-    return;
-  }
+  // Advisory lock + all work runs inside a single transaction so the
+  // xact-scoped lock sits on the same connection as every statement
+  // and auto-releases at commit/rollback. The session-scoped
+  // pg_try_advisory_lock variant broke on pool reuse (see Phase C
+  // deploy notes in PHASE_C_DEPLOY_OBSERVATIONS.md).
+  await db.transaction(async (tx) => {
+    const [lock] = await tx.execute(
+      sql`SELECT pg_try_advisory_xact_lock(${ADVISORY_LOCK_ID}) AS acquired`,
+    );
+    if (!(lock as { acquired?: boolean })?.acquired) {
+      logWarn("activation-drip-lock-busy", "another holder; skipping tick");
+      return;
+    }
 
-  try {
     const now = new Date();
     const twoDaysAgo = new Date(now.getTime() - 48 * 60 * 60 * 1000);
     const fiveDaysAgo = new Date(now.getTime() - 120 * 60 * 60 * 1000);
 
     // Find users needing day-2 nudge: signed up 48h+ ago, stage 0, not activated
-    const day2Users = await db
+    const day2Users = await tx
       .select({ id: users.id, email: users.email })
       .from(users)
       .where(
@@ -52,7 +60,7 @@ async function runActivationDrip(): Promise<void> {
     for (const user of day2Users) {
       try {
         await sendDay2NudgeEmail(user.email);
-        await db.update(users).set({ activationEmailStage: 1, updatedAt: now }).where(eq(users.id, user.id));
+        await tx.update(users).set({ activationEmailStage: 1, updatedAt: now }).where(eq(users.id, user.id));
         console.log(`[activation-drip] Day-2 nudge sent to ${user.email}`);
       } catch (err) {
         console.warn(`[activation-drip] Day-2 failed for ${user.email}:`, err instanceof Error ? err.message : err);
@@ -60,7 +68,7 @@ async function runActivationDrip(): Promise<void> {
     }
 
     // Find users needing day-5 reminder: signed up 120h+ ago, stage 1, not activated
-    const day5Users = await db
+    const day5Users = await tx
       .select({ id: users.id, email: users.email })
       .from(users)
       .where(
@@ -74,7 +82,7 @@ async function runActivationDrip(): Promise<void> {
     for (const user of day5Users) {
       try {
         await sendDay5ReminderEmail(user.email);
-        await db.update(users).set({ activationEmailStage: 2, updatedAt: now }).where(eq(users.id, user.id));
+        await tx.update(users).set({ activationEmailStage: 2, updatedAt: now }).where(eq(users.id, user.id));
         console.log(`[activation-drip] Day-5 reminder sent to ${user.email}`);
       } catch (err) {
         console.warn(`[activation-drip] Day-5 failed for ${user.email}:`, err instanceof Error ? err.message : err);
@@ -85,12 +93,7 @@ async function runActivationDrip(): Promise<void> {
     if (total > 0) {
       console.log(`[activation-drip] Sent ${day2Users.length} day-2 + ${day5Users.length} day-5 emails`);
     }
-  } finally {
-    // Release advisory lock
-    await db
-      .execute(sql`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`)
-      .catch((err) => logError("advisory-unlock-failed", err, { job: "activation-drip" }));
-  }
+  });
 }
 
 export function startActivationDrip(): void {

--- a/apps/api/src/jobs/db-retention.ts
+++ b/apps/api/src/jobs/db-retention.ts
@@ -2,7 +2,9 @@
  * DB Retention — daily job that prunes old rows from high-volume internal tables.
  *
  * Schedule: every 24 hours, with a 5-minute delay after startup.
- * Uses pg_try_advisory_lock to prevent duplicate runs across instances.
+ * Uses pg_try_advisory_xact_lock inside a db.transaction to prevent duplicate
+ * runs across instances (xact-scoped so the lock sits on the same connection
+ * as the work and auto-releases on commit/rollback).
  *
  * Retention windows:
  *   test_results              > 30 days   (SQS uses rolling 10-run window; 30d is ample history)
@@ -17,7 +19,7 @@
 
 import { sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
-import { logError } from "../lib/log.js";
+import { logWarn } from "../lib/log.js";
 
 const RETENTION_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const STARTUP_DELAY_MS = 5 * 60 * 1000;
@@ -38,20 +40,26 @@ let _running = false;
 async function runRetention(): Promise<void> {
   const db = getDb();
 
-  const [lock] = await db.execute(sql`SELECT pg_try_advisory_lock(${ADVISORY_LOCK_ID}) AS acquired`);
-  if (!(lock as { acquired?: boolean })?.acquired) {
-    console.log("[db-retention] Another instance holds the lock — skipping");
-    return;
-  }
+  // Advisory lock + all work runs inside a single transaction so the
+  // xact-scoped lock sits on the same connection as every statement.
+  // Auto-releases at commit/rollback. Session-scoped variant broke on
+  // pool reuse (see Phase C deploy notes).
+  await db.transaction(async (tx) => {
+    const [lock] = await tx.execute(
+      sql`SELECT pg_try_advisory_xact_lock(${ADVISORY_LOCK_ID}) AS acquired`,
+    );
+    if (!(lock as { acquired?: boolean })?.acquired) {
+      logWarn("db-retention-lock-busy", "another holder; skipping tick");
+      return;
+    }
 
-  try {
     const started = Date.now();
     const results: Array<{ table: string; deleted: number }> = [];
 
     for (const rule of RULES) {
       const cutoff = new Date(Date.now() - rule.days * 86_400_000);
       try {
-        const res = await db.execute(
+        const res = await tx.execute(
           sql`DELETE FROM ${sql.raw(rule.table)} WHERE ${sql.raw(rule.column)} < ${cutoff}`,
         );
         const deleted = (res as { count?: number }).count ?? 0;
@@ -66,11 +74,7 @@ async function runRetention(): Promise<void> {
     console.log(
       `[db-retention] Pruned ${total} rows in ${elapsed}s: ${results.map((r) => `${r.table}=${r.deleted}`).join(", ")}`,
     );
-  } finally {
-    await db
-      .execute(sql`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`)
-      .catch((err) => logError("advisory-unlock-failed", err, { job: "db-retention" }));
-  }
+  });
 }
 
 export function startDbRetention(): void {

--- a/apps/api/src/jobs/integrity-hash-retry.ts
+++ b/apps/api/src/jobs/integrity-hash-retry.ts
@@ -22,8 +22,12 @@
  * workflow on prod that tags 'customer' / 'test' for analytics.
  * See PHASE_C_COLUMN_INVESTIGATION.md.
  *
- * Uses pg_try_advisory_lock to cooperate with multi-instance deploys
- * (even though today is 1 replica per Phase A Q2).
+ * Uses pg_try_advisory_xact_lock inside a db.transaction to cooperate
+ * with multi-instance deploys (even though today is 1 replica per
+ * Phase A Q2). Xact-scoped locks auto-release at transaction end and
+ * are guaranteed to sit on the same connection as the work — avoiding
+ * the stuck-lock pool-reuse bug that crippled this worker on the first
+ * Phase C deploy.
  */
 
 import { sql, eq, and, lt } from "drizzle-orm";
@@ -45,107 +49,113 @@ let _running = false;
 async function runOnce(): Promise<void> {
   const db = getDb();
 
-  const [lock] = await db.execute(
-    sql`SELECT pg_try_advisory_lock(${ADVISORY_LOCK_ID}) AS acquired`,
-  );
-  if (!(lock as { acquired?: boolean })?.acquired) {
-    // Another instance has it. Not an error.
-    return;
-  }
-
+  // Advisory-lock + all work runs inside a single transaction so the
+  // xact-scoped lock sits on the same connection as every subsequent
+  // statement. Lock auto-releases at commit/rollback — no explicit
+  // pg_advisory_unlock needed (which is what broke the session-scoped
+  // pattern on a pooled connection).
   try {
-    const pendingCutoff = new Date(Date.now() - GRACE_MS);
-    const pending = await db
-      .select()
-      .from(transactions)
-      .where(
-        and(
-          eq(transactions.complianceHashState, "pending"),
-          lt(transactions.createdAt, pendingCutoff),
-        ),
-      )
-      .limit(BATCH_SIZE);
-
-    if (pending.length === 0) return;
-
-    let staleCount = 0;
-    let completed = 0;
-    let failed = 0;
-    const staleCutoff = Date.now() - STALE_WARN_MS;
-
-    for (const txn of pending) {
-      if (txn.createdAt.getTime() < staleCutoff) {
-        staleCount++;
+    await db.transaction(async (tx) => {
+      const [lock] = await tx.execute(
+        sql`SELECT pg_try_advisory_xact_lock(${ADVISORY_LOCK_ID}) AS acquired`,
+      );
+      if (!(lock as { acquired?: boolean })?.acquired) {
+        logWarn(
+          "integrity-hash-retry-lock-busy",
+          "another holder; skipping tick",
+        );
+        return;
       }
 
-      try {
-        const previousHash = await getPreviousHash();
-        const hash = computeIntegrityHash(
-          {
-            id: txn.id,
-            userId: txn.userId,
-            status: txn.status,
-            input: txn.input,
-            output: txn.output,
-            error: txn.error,
-            priceCents: txn.priceCents,
-            latencyMs: txn.latencyMs,
-            provenance: txn.provenance,
-            auditTrail: txn.auditTrail,
-            transparencyMarker: txn.transparencyMarker,
-            dataJurisdiction: txn.dataJurisdiction,
-            createdAt: txn.createdAt,
-            completedAt: txn.completedAt,
-          },
-          previousHash,
-        );
+      const pendingCutoff = new Date(Date.now() - GRACE_MS);
+      const pending = await tx
+        .select()
+        .from(transactions)
+        .where(
+          and(
+            eq(transactions.complianceHashState, "pending"),
+            lt(transactions.createdAt, pendingCutoff),
+          ),
+        )
+        .limit(BATCH_SIZE);
 
-        await db
-          .update(transactions)
-          .set({
-            integrityHash: hash,
+      if (pending.length === 0) return;
+
+      let staleCount = 0;
+      let completed = 0;
+      let failed = 0;
+      const staleCutoff = Date.now() - STALE_WARN_MS;
+
+      for (const txn of pending) {
+        if (txn.createdAt.getTime() < staleCutoff) {
+          staleCount++;
+        }
+
+        try {
+          const previousHash = await getPreviousHash();
+          const hash = computeIntegrityHash(
+            {
+              id: txn.id,
+              userId: txn.userId,
+              status: txn.status,
+              input: txn.input,
+              output: txn.output,
+              error: txn.error,
+              priceCents: txn.priceCents,
+              latencyMs: txn.latencyMs,
+              provenance: txn.provenance,
+              auditTrail: txn.auditTrail,
+              transparencyMarker: txn.transparencyMarker,
+              dataJurisdiction: txn.dataJurisdiction,
+              createdAt: txn.createdAt,
+              completedAt: txn.completedAt,
+            },
             previousHash,
-            complianceHashState: "complete",
-          })
-          .where(eq(transactions.id, txn.id));
-        completed++;
-      } catch (err) {
-        // One row failing shouldn't take down the whole batch. Log and move on.
-        logError("integrity-hash-retry-row-failed", err, { transactionId: txn.id });
-        failed++;
+          );
 
-        // If this row has been pending for well past STALE_WARN_MS, flip to
-        // 'failed' so it stops clogging the queue and operators get a ping.
-        if (Date.now() - txn.createdAt.getTime() > STALE_WARN_MS * MAX_HASH_ATTEMPTS) {
-          await db
+          await tx
             .update(transactions)
-            .set({ complianceHashState: "failed" })
-            .where(eq(transactions.id, txn.id))
-            .catch((err2) =>
-              logError("integrity-hash-mark-failed-failed", err2, { transactionId: txn.id }),
-            );
+            .set({
+              integrityHash: hash,
+              previousHash,
+              complianceHashState: "complete",
+            })
+            .where(eq(transactions.id, txn.id));
+          completed++;
+        } catch (err) {
+          // One row failing shouldn't take down the whole batch. Log and move on.
+          logError("integrity-hash-retry-row-failed", err, { transactionId: txn.id });
+          failed++;
+
+          // If this row has been pending for well past STALE_WARN_MS, flip to
+          // 'failed' so it stops clogging the queue and operators get a ping.
+          if (Date.now() - txn.createdAt.getTime() > STALE_WARN_MS * MAX_HASH_ATTEMPTS) {
+            await tx
+              .update(transactions)
+              .set({ complianceHashState: "failed" })
+              .where(eq(transactions.id, txn.id))
+              .catch((err2) =>
+                logError("integrity-hash-mark-failed-failed", err2, { transactionId: txn.id }),
+              );
+          }
         }
       }
-    }
 
-    if (staleCount > 0) {
-      logWarn(
-        "integrity-hash-stale-rows",
-        `${staleCount} transactions pending > 5 min; compliance chain falling behind`,
-        { staleCount, batchSize: pending.length },
+      if (staleCount > 0) {
+        logWarn(
+          "integrity-hash-stale-rows",
+          `${staleCount} transactions pending > 5 min; compliance chain falling behind`,
+          { staleCount, batchSize: pending.length },
+        );
+      }
+
+      log.info(
+        { completed, failed, stale: staleCount, batch_size: pending.length },
+        "integrity-hash-batch-done",
       );
-    }
-
-    log.info(
-      { completed, failed, stale: staleCount, batch_size: pending.length },
-      "integrity-hash-batch-done",
-    );
+    });
   } catch (err) {
     logError("integrity-hash-retry-batch-failed", err);
-  } finally {
-    await db
-      .execute(sql`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`)
-      .catch((err) => logError("advisory-unlock-failed", err, { job: "integrity-hash-retry" }));
   }
 }
 

--- a/apps/api/src/jobs/test-scheduler.ts
+++ b/apps/api/src/jobs/test-scheduler.ts
@@ -153,11 +153,17 @@ async function withAdvisoryLock<T>(
       return { acquired: true, value: await fn() };
     } finally {
       // Best-effort release on the same dedicated connection that took the
-      // lock — pool reuse cannot steal this unlock.
-      await client`SELECT pg_advisory_unlock(${id})`.catch(() => {});
+      // lock — pool reuse cannot steal this unlock. A failure here is
+      // harmless (the session ends below and PG releases the lock
+      // implicitly) but we log it so operators see if it ever happens.
+      await client`SELECT pg_advisory_unlock(${id})`.catch((err) =>
+        logError("test-scheduler-lock-release-failed", err, { lockId: id }),
+      );
     }
   } finally {
-    await client.end({ timeout: 5 }).catch(() => {});
+    await client.end({ timeout: 5 }).catch((err) =>
+      logError("test-scheduler-lock-client-end-failed", err, { lockId: id }),
+    );
   }
 }
 

--- a/apps/api/src/jobs/test-scheduler.ts
+++ b/apps/api/src/jobs/test-scheduler.ts
@@ -16,6 +16,7 @@
  */
 
 import { sql, eq, and, inArray, asc, desc } from "drizzle-orm";
+import postgres from "postgres";
 import { getDb } from "../db/index.js";
 import { capabilities, solutions, solutionSteps, testSuites, testResults } from "../db/schema.js";
 import { runTests, persistDualProfileScores } from "../lib/test-runner.js";
@@ -23,7 +24,7 @@ import { logHealthEvent } from "../lib/health-monitor.js";
 import { isCacheExpired, refreshUpstreamMapping } from "../lib/upstream-health-gate.js";
 import { probeChromiumHealth } from "../lib/chromium-health.js";
 import { fireAndForget } from "../lib/fire-and-forget.js";
-import { logError } from "../lib/log.js";
+import { logError, logWarn } from "../lib/log.js";
 
 // ─── Solution quality gate (auto-activate when all steps are scored) ────────
 
@@ -98,27 +99,65 @@ function shouldRun(taskName: string, intervalMs: number): boolean {
   return false;
 }
 
-// ─── Advisory lock helpers ──────────────────────────────────────────────────
+// ─── Advisory lock helper ───────────────────────────────────────────────────
+//
+// Why a dedicated connection instead of the sibling jobs' xact-scoped pattern:
+// a poll cycle iterates up to BATCH_SIZE (20) capabilities with ~2s delay
+// between each and each capability makes live HTTP calls (Browserless, paid
+// APIs, registries) — a single cycle runs 5–10 minutes. Wrapping the whole
+// thing in `db.transaction(async (tx) => {...})` would (a) hold one pooled
+// connection for the entire cycle, starving the live API, and (b) rollback
+// every test_result write on any single failure, poisoning the SQS window.
+//
+// Instead we carve out a single dedicated `postgres` client (max: 1) whose
+// sole job is to hold the session-scoped lock. All test work runs through
+// the regular pool and commits independently. The lock lives on a connection
+// we own — `pg_advisory_unlock` is guaranteed to hit the same session, so
+// the pool-reuse bug that bit the Phase C deploy (session-scoped lock on a
+// shared pool connection) cannot happen here.
 
 const LOCK_ID = 314159; // arbitrary unique lock ID for test scheduler
 
-async function tryAcquireLock(): Promise<boolean> {
-  try {
-    const db = getDb();
-    const result = await db.execute(sql`SELECT pg_try_advisory_lock(${LOCK_ID}) AS acquired`);
-    const rows = Array.isArray(result) ? result : (result as any)?.rows ?? [];
-    return rows[0]?.acquired === true;
-  } catch {
-    return true; // If lock query fails, proceed anyway (single-instance fallback)
+async function withAdvisoryLock<T>(
+  id: number,
+  fn: () => Promise<T>,
+): Promise<{ acquired: true; value: T } | { acquired: false }> {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    // No DB configured (local dev without env) — fall through without locking.
+    return { acquired: true, value: await fn() };
   }
-}
 
-async function releaseLock(): Promise<void> {
+  const client = postgres(dbUrl, { max: 1 });
   try {
-    const db = getDb();
-    await db.execute(sql`SELECT pg_advisory_unlock(${LOCK_ID})`);
-  } catch {
-    // Best-effort release
+    let acquired = false;
+    try {
+      const rows = await client<{ acquired: boolean }[]>`
+        SELECT pg_try_advisory_lock(${id}) AS acquired
+      `;
+      acquired = rows[0]?.acquired === true;
+    } catch (err) {
+      // If the lock query itself fails, log and proceed unlocked (single-
+      // instance fallback). Better to run unlocked than to silently skip.
+      logWarn("test-scheduler-lock-query-failed", "proceeding without lock", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return { acquired: true, value: await fn() };
+    }
+
+    if (!acquired) {
+      return { acquired: false };
+    }
+
+    try {
+      return { acquired: true, value: await fn() };
+    } finally {
+      // Best-effort release on the same dedicated connection that took the
+      // lock — pool reuse cannot steal this unlock.
+      await client`SELECT pg_advisory_unlock(${id})`.catch(() => {});
+    }
+  } finally {
+    await client.end({ timeout: 5 }).catch(() => {});
   }
 }
 
@@ -267,151 +306,149 @@ async function pollCycle(): Promise<void> {
   }
 
   _isRunning = true;
-  let lockAcquired = false;
 
   try {
-    // Advisory lock — prevents duplicate runs if Railway scales to 2 instances
-    lockAcquired = await tryAcquireLock();
-    if (!lockAcquired) {
-      console.log("[test-scheduler] Another instance holds the lock, skipping");
-      return;
-    }
+    // Advisory lock on a dedicated connection. Prevents duplicate runs when
+    // Railway scales to 2+ instances; the helper's own connection guarantees
+    // the lock and the unlock hit the same session (no pool-reuse gap).
+    const outcome = await withAdvisoryLock(LOCK_ID, async () => {
+      // Refresh upstream health mapping if stale
+      if (isCacheExpired()) {
+        await refreshUpstreamMapping().catch((err) =>
+          logError("upstream-mapping-refresh-failed", err, { job: "test-scheduler" }),
+        );
+      }
 
-    // Refresh upstream health mapping if stale
-    if (isCacheExpired()) {
-      await refreshUpstreamMapping().catch((err) =>
-        logError("upstream-mapping-refresh-failed", err, { job: "test-scheduler" }),
-      );
-    }
+      // Run auxiliary tasks (health checks, probes, etc.)
+      await runAuxiliaryTasks();
 
-    // Run auxiliary tasks (health checks, probes, etc.)
-    await runAuxiliaryTasks();
+      // Find overdue capabilities
+      const overdue = await findOverdueCapabilities();
 
-    // Find overdue capabilities
-    const overdue = await findOverdueCapabilities();
+      if (overdue.length === 0) {
+        console.log("[test-scheduler] Poll: all capabilities fresh, nothing to test");
+        return;
+      }
 
-    if (overdue.length === 0) {
-      console.log("[test-scheduler] Poll: all capabilities fresh, nothing to test");
-      return;
-    }
-
-    // Check provider health — skip capabilities whose provider is unhealthy
-    // to prevent SQS score pollution during outages
-    let runnableCaps = overdue;
-    try {
-      const { runDependencyHealthChecks } = await import("../lib/dependency-health.js");
-      const { getActiveProviders } = await import("../lib/dependency-manifest.js");
-      const providerHealth = await runDependencyHealthChecks();
-      const unhealthySlugs = new Set<string>();
-      for (const provider of getActiveProviders()) {
-        const health = providerHealth[provider.name];
-        if (health && !health.healthy) {
-          for (const cap of provider.capabilities) {
-            unhealthySlugs.add(cap);
+      // Check provider health — skip capabilities whose provider is unhealthy
+      // to prevent SQS score pollution during outages
+      let runnableCaps = overdue;
+      try {
+        const { runDependencyHealthChecks } = await import("../lib/dependency-health.js");
+        const { getActiveProviders } = await import("../lib/dependency-manifest.js");
+        const providerHealth = await runDependencyHealthChecks();
+        const unhealthySlugs = new Set<string>();
+        for (const provider of getActiveProviders()) {
+          const health = providerHealth[provider.name];
+          if (health && !health.healthy) {
+            for (const cap of provider.capabilities) {
+              unhealthySlugs.add(cap);
+            }
           }
         }
-      }
-      if (unhealthySlugs.size > 0) {
-        const before = runnableCaps.length;
-        runnableCaps = overdue.filter((cap) => !unhealthySlugs.has(cap.slug));
-        const skipped = before - runnableCaps.length;
-        if (skipped > 0) {
-          console.log(
-            `[test-scheduler] Skipping ${skipped} capabilities with unhealthy providers`,
-          );
-        }
-      }
-    } catch {
-      // If health check fails, run all tests (graceful degradation)
-    }
-
-    if (runnableCaps.length === 0) {
-      console.log("[test-scheduler] Poll: all overdue capabilities have unhealthy providers, skipping");
-      return;
-    }
-
-    // Summarize by tier
-    const tierCounts: Record<string, number> = {};
-    for (const cap of runnableCaps) {
-      tierCounts[cap.scheduleTier] = (tierCounts[cap.scheduleTier] ?? 0) + 1;
-    }
-    const tierSummary = Object.entries(tierCounts)
-      .map(([tier, count]) => `${count} tier-${tier}`)
-      .join(", ");
-    console.log(`[test-scheduler] Poll: ${runnableCaps.length} overdue capabilities (${tierSummary})`);
-
-    let totalPassed = 0;
-    let totalFailed = 0;
-
-    for (const cap of runnableCaps) {
-      const agoMs = cap.lastTestedAt ? Date.now() - cap.lastTestedAt.getTime() : null;
-      const agoLabel = agoMs != null ? `${Math.round(agoMs / 3600_000)}h ago` : "never tested";
-
-      try {
-        console.log(`[test-scheduler] Testing ${cap.slug} (tier ${cap.scheduleTier}, last tested ${agoLabel})...`);
-
-        const summary = await runTests({ capabilitySlug: cap.slug });
-        totalPassed += summary.passed;
-        totalFailed += summary.failed;
-
-        // runTests() already calls persistDualProfileScores() internally (line 294),
-        // so DB columns are updated immediately after each capability's tests.
-
-        console.log(
-          `[test-scheduler] ${cap.slug}: ${summary.passed}/${summary.total} passed`,
-        );
-
-        // Auto-activate gated solutions when all steps become qualified
-        try {
-          await checkSolutionGates(cap.slug);
-        } catch (gateErr) {
-          // Non-critical — don't block the scheduler
-        }
-
-        // Log individual failures for Railway log monitoring
-        for (const r of summary.results) {
-          if (!r.passed) {
-            const tag = r.remediation
-              ? `[${r.remediation.outcome}]`
-              : "[escalate]";
-            console.warn(
-              `[test-scheduler] FAIL ${tag} [${r.capabilitySlug}] ${r.testName} — ${r.failureReason}`,
+        if (unhealthySlugs.size > 0) {
+          const before = runnableCaps.length;
+          runnableCaps = overdue.filter((cap) => !unhealthySlugs.has(cap.slug));
+          const skipped = before - runnableCaps.length;
+          if (skipped > 0) {
+            console.log(
+              `[test-scheduler] Skipping ${skipped} capabilities with unhealthy providers`,
             );
           }
         }
-      } catch (err) {
-        console.error(`[test-scheduler] ${cap.slug} threw:`, err instanceof Error ? err.message : err);
+      } catch {
+        // If health check fails, run all tests (graceful degradation)
       }
 
-      await delay(DELAY_BETWEEN_CAPABILITIES_MS);
+      if (runnableCaps.length === 0) {
+        console.log("[test-scheduler] Poll: all overdue capabilities have unhealthy providers, skipping");
+        return;
+      }
+
+      // Summarize by tier
+      const tierCounts: Record<string, number> = {};
+      for (const cap of runnableCaps) {
+        tierCounts[cap.scheduleTier] = (tierCounts[cap.scheduleTier] ?? 0) + 1;
+      }
+      const tierSummary = Object.entries(tierCounts)
+        .map(([tier, count]) => `${count} tier-${tier}`)
+        .join(", ");
+      console.log(`[test-scheduler] Poll: ${runnableCaps.length} overdue capabilities (${tierSummary})`);
+
+      let totalPassed = 0;
+      let totalFailed = 0;
+
+      for (const cap of runnableCaps) {
+        const agoMs = cap.lastTestedAt ? Date.now() - cap.lastTestedAt.getTime() : null;
+        const agoLabel = agoMs != null ? `${Math.round(agoMs / 3600_000)}h ago` : "never tested";
+
+        try {
+          console.log(`[test-scheduler] Testing ${cap.slug} (tier ${cap.scheduleTier}, last tested ${agoLabel})...`);
+
+          const summary = await runTests({ capabilitySlug: cap.slug });
+          totalPassed += summary.passed;
+          totalFailed += summary.failed;
+
+          // runTests() already calls persistDualProfileScores() internally (line 294),
+          // so DB columns are updated immediately after each capability's tests.
+
+          console.log(
+            `[test-scheduler] ${cap.slug}: ${summary.passed}/${summary.total} passed`,
+          );
+
+          // Auto-activate gated solutions when all steps become qualified
+          try {
+            await checkSolutionGates(cap.slug);
+          } catch (gateErr) {
+            // Non-critical — don't block the scheduler
+          }
+
+          // Log individual failures for Railway log monitoring
+          for (const r of summary.results) {
+            if (!r.passed) {
+              const tag = r.remediation
+                ? `[${r.remediation.outcome}]`
+                : "[escalate]";
+              console.warn(
+                `[test-scheduler] FAIL ${tag} [${r.capabilitySlug}] ${r.testName} — ${r.failureReason}`,
+              );
+            }
+          }
+        } catch (err) {
+          console.error(`[test-scheduler] ${cap.slug} threw:`, err instanceof Error ? err.message : err);
+        }
+
+        await delay(DELAY_BETWEEN_CAPABILITIES_MS);
+      }
+
+      console.log(
+        `[test-scheduler] Poll complete: ${runnableCaps.length} capabilities tested, ${totalPassed} passed, ${totalFailed} failed`,
+      );
+
+      // Write scheduler heartbeat for watchdog monitoring
+      fireAndForget(
+        () =>
+          logHealthEvent({
+            eventType: "scheduler_heartbeat",
+            tier: 1,
+            actionTaken: `DB-driven poll: ${runnableCaps.length} capabilities tested`,
+            details: {
+              tested: runnableCaps.length,
+              passed: totalPassed,
+              failed: totalFailed,
+              tierCounts,
+            },
+          }),
+        { label: "health-event-log", context: { event: "scheduler_heartbeat" } },
+      );
+    });
+
+    if (!outcome.acquired) {
+      logWarn("test-scheduler-lock-busy", "another holder; skipping tick");
     }
-
-    console.log(
-      `[test-scheduler] Poll complete: ${runnableCaps.length} capabilities tested, ${totalPassed} passed, ${totalFailed} failed`,
-    );
-
-    // Write scheduler heartbeat for watchdog monitoring
-    fireAndForget(
-      () =>
-        logHealthEvent({
-          eventType: "scheduler_heartbeat",
-          tier: 1,
-          actionTaken: `DB-driven poll: ${runnableCaps.length} capabilities tested`,
-          details: {
-            tested: runnableCaps.length,
-            passed: totalPassed,
-            failed: totalFailed,
-            tierCounts,
-          },
-        }),
-      { label: "health-event-log", context: { event: "scheduler_heartbeat" } },
-    );
   } catch (err) {
     console.error("[test-scheduler] Poll cycle error:", err);
   } finally {
-    if (lockAcquired) {
-      await releaseLock();
-    }
     _isRunning = false;
   }
 }


### PR DESCRIPTION
## Summary

Production hotfix for the stuck-advisory-lock bug that crippled the Phase C
integrity-hash retry worker post-deploy (zero batches in 15 min, `/v1/audit/:id`
stuck at 202). The same latent bug was present in three sibling jobs.

- **3 jobs → xact-scoped lock inside `db.transaction(async (tx) => ...)`:**
  `integrity-hash-retry.ts`, `activation-drip.ts`, `db-retention.ts`.
  Lock pins to the callback's connection, auto-releases at commit/rollback.
- **`test-scheduler.ts` → dedicated `postgres` client (max: 1) holding the
  session lock.** A 5–10 min poll cycle can't sit inside one transaction
  (would rollback all `test_result` writes on any failure, starve the pool).
  The dedicated client is not shared, so the pool-reuse gap cannot happen.
- All four jobs now emit `<job>-lock-busy` `logWarn` on skip (structured,
  Better Stack visible) instead of plain `console.log`.

Root cause: `pg_try_advisory_lock` (session-scoped) on a pooled connection.
Drizzle's `getDb()` borrows connections per statement; the lock sat on
connection A while subsequent queries borrowed B; `pg_advisory_unlock`
silently no-op'd on the wrong connection. Lock stayed held forever.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 192 passed, 4 skipped (audit-token local-env
      failure is pre-existing; CI sets `AUDIT_HMAC_SECRET` at workflow level)
- [x] `grep pg_advisory_unlock / pg_try_advisory_lock` — only remaining
      call sites are `test-scheduler`'s deliberate dedicated-connection
      pattern + existing mocks in `integrity-hash-retry.test.ts`
- [ ] CI green
- [ ] Post-deploy: `integrity-hash-batch-done` log line within 40s of Railway
      restart
- [ ] Post-deploy: `pg_locks` shows no stuck advisory lock on 20260417,
      20260402, 20260415, 314159
- [ ] Post-deploy: `compliance_hash_state = 'pending'` count drains on the
      30s cadence
- [ ] Spot-check A: new `/v1/do` txn → `/v1/audit/:id` 202 → wait → 200 with
      hash populated
- [ ] Spot-check B: SSRF refusal (F-0-007)

Deferred: deep lock-busy unit tests across all four jobs require the Phase D
Testcontainers harness (real Postgres). Mocking `pg_try_advisory_xact_lock`
inside a drizzle transaction is a fragile proxy for the real bug this PR
fixes. Follow-up filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)