### PR TITLE
fix(ecb-interest-rates): swap data source from ECB SDW to FRED mirror

### DIFF
--- a/apps/api/src/capabilities/ecb-interest-rates.ts
+++ b/apps/api/src/capabilities/ecb-interest-rates.ts
@@ -1,25 +1,27 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 
-function parseEcbCsv(csv: string): { date: string; value: number } | null {
+function parseFredCsv(csv: string): { date: string; value: number } | null {
   const lines = csv.trim().split("\n");
   if (lines.length < 2) return null;
-  const headers = lines[0].split(",");
-  const dateIdx = headers.findIndex(h => h.trim() === "TIME_PERIOD");
-  const valIdx = headers.findIndex(h => h.trim() === "OBS_VALUE");
-  if (dateIdx < 0 || valIdx < 0) return null;
-  const lastLine = lines[lines.length - 1];
-  const cols = lastLine.split(",");
-  return { date: cols[dateIdx]?.trim() ?? "", value: parseFloat(cols[valIdx]?.trim() ?? "0") };
+  for (let i = lines.length - 1; i >= 1; i--) {
+    const cols = lines[i].split(",");
+    if (cols.length < 2) continue;
+    const date = cols[0]?.trim() ?? "";
+    const raw = cols[1]?.trim() ?? "";
+    if (!raw || raw === ".") continue;
+    const value = parseFloat(raw);
+    if (Number.isFinite(value)) return { date, value };
+  }
+  return null;
 }
 
-registerCapability("ecb-interest-rates", async (input: CapabilityInput) => {
-  const base = "https://data-api.ecb.europa.eu/service/data/FM";
-  const suffix = "?format=csvdata&lastNObservations=1";
+registerCapability("ecb-interest-rates", async (_input: CapabilityInput) => {
+  const base = "https://fred.stlouisfed.org/graph/fredgraph.csv";
 
   const rateKeys = {
-    main_refinancing_rate: "/B.U2.EUR.4F.KR.MRR_FR.LEV",
-    deposit_facility_rate: "/B.U2.EUR.4F.KR.DFR.LEV",
-    marginal_lending_rate: "/B.U2.EUR.4F.KR.MLFR.LEV",
+    main_refinancing_rate: "ECBMRRFR",
+    deposit_facility_rate: "ECBDFR",
+    marginal_lending_rate: "ECBMLFR",
   };
 
   const results: Record<string, number | null> = {};
@@ -27,14 +29,14 @@ registerCapability("ecb-interest-rates", async (input: CapabilityInput) => {
 
   const entries = Object.entries(rateKeys);
   const responses = await Promise.allSettled(
-    entries.map(async ([key, path]) => {
-      const resp = await fetch(`${base}${path}${suffix}`, {
+    entries.map(async ([key, seriesId]) => {
+      const resp = await fetch(`${base}?id=${seriesId}`, {
         headers: { Accept: "text/csv" },
         signal: AbortSignal.timeout(10000),
       });
-      if (!resp.ok) throw new Error(`ECB API returned ${resp.status}`);
+      if (!resp.ok) throw new Error(`FRED API returned ${resp.status}`);
       const csv = await resp.text();
-      const parsed = parseEcbCsv(csv);
+      const parsed = parseFredCsv(csv);
       return { key, parsed };
     })
   );
@@ -49,7 +51,7 @@ registerCapability("ecb-interest-rates", async (input: CapabilityInput) => {
   }
 
   if (!results.main_refinancing_rate && !results.deposit_facility_rate && !results.marginal_lending_rate) {
-    throw new Error("Could not retrieve any ECB interest rates. The ECB API may be temporarily unavailable.");
+    throw new Error("Could not retrieve any ECB interest rates. The FRED API may be temporarily unavailable.");
   }
 
   return {
@@ -59,8 +61,8 @@ registerCapability("ecb-interest-rates", async (input: CapabilityInput) => {
       marginal_lending_rate: results.marginal_lending_rate,
       effective_date: effectiveDate,
       currency: "EUR",
-      source_url: "https://data-api.ecb.europa.eu",
+      source_url: "https://fred.stlouisfed.org",
     },
-    provenance: { source: "ecb.europa.eu", fetched_at: new Date().toISOString() },
+    provenance: { source: "fred.stlouisfed.org (mirrors ECB)", fetched_at: new Date().toISOString() },
   };
 });

--- a/manifests/ecb-interest-rates.yaml
+++ b/manifests/ecb-interest-rates.yaml
@@ -1,8 +1,8 @@
 slug: ecb-interest-rates
 name: ECB Interest Rates
 description: >-
-  Fetch current ECB key interest rates (main refinancing, deposit facility, marginal lending) from the European Central
-  Bank Statistical Data Warehouse.
+  Fetch current ECB key interest rates (main refinancing, deposit facility, marginal lending). Sourced from FRED
+  (Federal Reserve Economic Data), which mirrors the ECB Statistical Data Warehouse.
 category: finance
 price_cents: 2
 is_free_tier: false
@@ -28,7 +28,7 @@ output_schema:
       type: string
     source_url:
       type: string
-data_source: European Central Bank Statistical Data Warehouse (ECB SDW)
+data_source: FRED (fred.stlouisfed.org), mirroring ECB Statistical Data Warehouse
 data_source_type: api
 transparency_tag: algorithmic
 freshness_category: live-fetch
@@ -46,9 +46,8 @@ test_fixtures:
         operator: not_null
         reliability: guaranteed
       - field: effective_date
-        operator: equals
+        operator: not_null
         reliability: guaranteed
-        value: "2025-06-11"
       - field: currency
         operator: equals
         reliability: guaranteed
@@ -56,7 +55,7 @@ test_fixtures:
       - field: source_url
         operator: equals
         reliability: guaranteed
-        value: https://data-api.ecb.europa.eu
+        value: https://fred.stlouisfed.org
   health_check_input: {}
 output_field_reliability:
   main_refinancing_rate: guaranteed
@@ -66,15 +65,15 @@ output_field_reliability:
   currency: guaranteed
   source_url: guaranteed
 limitations:
-  - title: Geo-restricted API
+  - title: Data routed through FRED mirror
     text: >-
-      The ECB SDW API may be unreachable from non-EU server locations. Railway US East deployment may experience
-      intermittent failures.
+      Values come from FRED, which mirrors ECB publications. FRED's update cadence (typically same-day) introduces
+      a small lag versus fetching directly from ECB. Authoritative source remains the European Central Bank.
     category: dependency
-    severity: warning
+    severity: info
   - title: Data freshness tied to ECB publication schedule
     text: >-
       Rates update only when the ECB Governing Council changes them, typically every 6 weeks. The effective_date
-      reflects the last change.
+      reflects the most recent observation date, which advances daily even when rates are unchanged.
     category: freshness
     severity: info


### PR DESCRIPTION
## Summary
- Swaps `ecb-interest-rates` from the geo-restricted ECB Statistical Data Warehouse API (unreachable from Railway US East) to FRED's public `fredgraph.csv` endpoint, which mirrors the same three series (ECBMRRFR, ECBDFR, ECBMLFR), is US-hosted, and requires no API key.
- Prevents scheduled auto-suspension (18 Apr 23:08 CET) — capability has been degraded at SQS 0 for 6 days due to structural unreachability, not intermittent failure.
- Manifest updated: `data_source` now names FRED, geo-restriction limitation removed, and `effective_date` fixture changed from `equals 2025-06-11` to `not_null` (FRED advances observation_date daily).

## Trade-off
FRED is a mirror, not the primary publisher. Authoritative source remains the ECB; `provenance.source` now reads `"fred.stlouisfed.org (mirrors ECB)"` to stay honest about the routing. Values are identical.

## Test plan
- [x] Local smoke test: live execution succeeded in 8.6s, returned all 6 fields with current values (MRR 2.15, DFR 2.00, MLFR 2.40 — matches ECB).
- [x] Structural validation passed.
- [x] Negative test (empty input) passed.
- [ ] After merge: confirm next scheduled test run in prod passes and SQS recovers.
- [ ] After merge: confirm capability lifecycle transitions out of degraded within 3 consecutive passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)