### PR TITLE
feat(health): add /health/deep endpoint probing DB write-path

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -37,6 +37,8 @@ import { aiCatalogRoute } from "./routes/ai-catalog.js";
 import { llmsTxtRoute } from "./routes/llms-txt.js";
 import { openApiSpec } from "./openapi.js";
 import { welcomeRoute } from "./routes/welcome.js";
+import { getDb } from "./db/index.js";
+import { sql } from "drizzle-orm";
 
 // Capability executors + DataProvider chains are registered by
 // autoRegisterCapabilities() in index.ts before the server starts.
@@ -191,8 +193,32 @@ app.use("*", async (c, next) => {
   );
 });
 
-// Health check
+// Health check — shallow (app is running)
 app.get("/health", (c) => c.json({ status: "ok" }));
+
+// Health check — deep (DB write path works, including indexes on transactions table)
+// Use this for Railway health checks to catch index corruption, disk full, connection pool exhaustion, etc.
+app.get("/health/deep", async (c) => {
+  const start = Date.now();
+  try {
+    const db = getDb();
+    // Test the write path on the transactions table (touches all indexes).
+    // CTE inserts a probe row and immediately deletes it — atomic, no data left behind.
+    // Uses solution_slug (not capability_id) to satisfy the XOR check constraint.
+    await db.execute(sql`
+      WITH probe AS (
+        INSERT INTO transactions (solution_slug, status, input, price_cents, transparency_marker, data_jurisdiction, is_free_tier)
+        VALUES ('_health_probe', 'health_probe', '{}', 0, 'algorithmic', 'EU', true)
+        RETURNING id
+      )
+      DELETE FROM transactions WHERE id IN (SELECT id FROM probe)
+    `);
+    return c.json({ status: "ok", write_path: "ok", latency_ms: Date.now() - start });
+  } catch (err) {
+    console.error("[health/deep] Write-path probe failed:", err instanceof Error ? err.message : err);
+    return c.json({ status: "degraded", write_path: "failed", error: err instanceof Error ? err.message : "unknown", latency_ms: Date.now() - start }, 503);
+  }
+});
 
 // OpenAPI specification (with content negotiation)
 let _openApiMd: string | null = null;

--- a/apps/api/src/routes/health-deep.test.ts
+++ b/apps/api/src/routes/health-deep.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for GET /health/deep — the DB write-path probe added after the
+ * 2026-04-16 outage. /health (shallow) only confirms the process is
+ * alive; /health/deep inserts and immediately deletes a probe row inside
+ * a single CTE, exercising every index on the transactions table.
+ *
+ * The endpoint must:
+ *   1. Return 200 { status: "ok", write_path: "ok", latency_ms } on a
+ *      healthy DB (mocked execute resolves without throwing).
+ *   2. Return 503 { status: "degraded", write_path: "failed", error }
+ *      on a broken DB (mocked execute rejects).
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+
+// execute() is the single method /health/deep calls. Toggle its behaviour
+// per test via `executeImpl`.
+let executeImpl: () => Promise<unknown> = () => Promise.resolve([]);
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({
+    execute: (..._args: unknown[]) => executeImpl(),
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+        innerJoin: () => ({ where: () => ({ orderBy: () => Promise.resolve([]) }) }),
+      }),
+    }),
+  }),
+}));
+
+// Same MCP route stub as internal-auth.test.ts — app.ts imports it at
+// module-load and vitest's resolver can't find the workspace package
+// without a prior build.
+vi.mock("./mcp.js", () => {
+  const { Hono } = require("hono");
+  return { mcpRoute: new Hono() };
+});
+
+beforeAll(() => {
+  process.env.ADMIN_SECRET =
+    "unit-test-admin-secret-plenty-of-entropy-0123456789";
+  process.env.AUDIT_HMAC_SECRET =
+    "unit-test-audit-secret-plenty-of-entropy-0123456789";
+});
+
+async function loadApp() {
+  const { app } = await import("./../app.js");
+  return app;
+}
+
+describe("GET /health/deep", () => {
+  it("returns 200 with write_path=ok when the DB probe succeeds", async () => {
+    executeImpl = () => Promise.resolve([]);
+    const app = await loadApp();
+    const res = await app.request("/health/deep");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.write_path).toBe("ok");
+    expect(typeof body.latency_ms).toBe("number");
+  });
+
+  it("returns 503 with write_path=failed when the DB probe throws", async () => {
+    executeImpl = () =>
+      Promise.reject(new Error("connection refused on probe insert"));
+    const app = await loadApp();
+    const res = await app.request("/health/deep");
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.status).toBe("degraded");
+    expect(body.write_path).toBe("failed");
+    // The error message surfaces the underlying cause so Railway log
+    // viewers can see WHY the deep check failed — don't swallow it.
+    expect(body.error).toContain("connection refused");
+    expect(typeof body.latency_ms).toBe("number");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `GET /health/deep`, a DB write-path probe that inserts and deletes a
`transactions` row inside a single CTE — exercising every index on the
schema's highest-write table without leaving data behind. Closes the gap
that the 2026-04-16 outage surfaced: `/health` (shallow) was returning
200 while the write path was broken.

- **200** `{ status: "ok", write_path: "ok", latency_ms }` on a healthy DB.
- **503** `{ status: "degraded", write_path: "failed", error, latency_ms }` on a broken DB.

Resumed from `stash@{0}` — Petter's draft from 2026-04-16 that got
stashed when Phase C close-out took priority. REINDEX portion of that
stash ships separately as a monthly cron.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 16 files, **194 pass** / 4 skip (baseline was 192)
- [x] `check-no-bare-catch` green
- [x] `check-ssrf-inventory` green
- [x] New unit tests in `apps/api/src/routes/health-deep.test.ts` cover both 200 and 503 paths
- [ ] CI green
- [ ] Post-deploy: `curl -o- https://strale-production.up.railway.app/health/deep` returns 200
- [ ] Ops follow-up (out of scope for this PR): point Railway healthcheckPath at `/health/deep`

🤖 Generated with [Claude Code](https://claude.com/claude-code)