### PR TITLE
feat(digest): external API calls section + document strale-digest-cron Railway service

### DIFF
--- a/apps/api/railway-config.md
+++ b/apps/api/railway-config.md
@@ -65,6 +65,52 @@ Key vars:
 
 ---
 
+## strale-digest-cron (daily digest email)
+
+Runs the daily digest job once per day and exits. Uses the same Docker image
+as the `strale` service — only the start command and schedule differ.
+
+### Service setup (one-time, in Railway UI)
+
+1. In the same Railway project as `strale`, click **+ New → GitHub Repo** and
+   select the same `strale` repo. This creates a second service from the same
+   image build.
+2. In the new service → **Settings**:
+   - **Service name**: `strale-digest-cron`
+   - **Build**: Dockerfile (same root `Dockerfile`, no changes needed — both
+     `apps/api/dist/index.js` and `apps/api/dist/jobs/daily-digest.js` are
+     produced by `npm run build --workspace=apps/api`).
+   - **Custom start command**: `node apps/api/dist/jobs/daily-digest.js`
+   - **Cron Schedule**: `30 5 * * *` (UTC, = 07:30 CEST summer / 06:30 CET
+     winter — GitHub-style cron, Railway UI field under Settings → Deploy)
+   - **Restart policy**: `Never` (it's a one-shot; exiting is success)
+3. **Variables** tab → link to the shared project variables so it inherits:
+   - `DATABASE_URL`
+   - `RESEND_API_KEY`
+   - `ANTHROPIC_API_KEY` (used by `analyzeDigest`)
+   - `NOTION_TOKEN` (for ship-log / Notion activity)
+   - `GITHUB_TOKEN` (for shiplog commit fetching, if configured)
+   Any missing variable causes that section to fall back to its default;
+   the email still sends.
+
+### Notes
+
+- No `ADMIN_SECRET` is needed — this service runs the digest directly, it
+  does not call `POST /v1/admin/digest`.
+- DST drift: the email arrives at 07:30 CEST in summer and 06:30 CET in
+  winter. Railway cron is UTC-only; a ±1h shift twice a year is acceptable
+  for an informational email.
+- To trigger manually, either redeploy the service or click **Deploy** in
+  the Railway UI — it will run the job once and exit.
+- Logs: each run's stdout/stderr appears in the Railway logs tab for this
+  service.
+- Excludes from "External API calls" metric: `@strale.io`, `@strale.dev`,
+  `@strale.internal`, `@example.com`, `petterlindstrom@hotmail.com`, the
+  `system@strale.internal` user, and all `transparency_marker = 'algorithmic'`
+  transactions (pure-computation capabilities).
+
+---
+
 ## postgres (PostgreSQL)
 
 ### Notes

--- a/apps/api/src/lib/daily-digest/fetch-platform.ts
+++ b/apps/api/src/lib/daily-digest/fetch-platform.ts
@@ -8,7 +8,9 @@ function toRows(result: unknown): any[] {
   return (result as any)?.rows ?? [];
 }
 
-const INTERNAL_EMAIL_SUFFIXES = ["@strale.io", "@strale.internal", "@example.com"];
+const INTERNAL_EMAIL_SUFFIXES = ["@strale.io", "@strale.dev", "@strale.internal", "@example.com"];
+// Extra per-address exclusions for the "external API calls" metric (personal accounts etc.)
+const EXTRA_EXCLUDED_EMAILS = ["petterlindstrom@hotmail.com"];
 
 export async function getPlatformActivity(
   yesterday: Partial<Scoreboard> | null,
@@ -20,6 +22,24 @@ export async function getPlatformActivity(
     SELECT id FROM users WHERE email = 'system@strale.internal' LIMIT 1
   `);
   const systemUserId = toRows(sysRows)[0]?.id ?? "00000000-0000-0000-0000-000000000000";
+
+  // Build the "internal users" exclusion set for the external-API-calls metric:
+  // all @strale.* / @example.com accounts + EXTRA_EXCLUDED_EMAILS.
+  const internalLikeClauses = INTERNAL_EMAIL_SUFFIXES
+    .map((s) => `email LIKE '%${s.replace(/'/g, "''")}'`)
+    .join(" OR ");
+  const extraClause = EXTRA_EXCLUDED_EMAILS.length
+    ? `OR email IN (${EXTRA_EXCLUDED_EMAILS.map((e) => `'${e.replace(/'/g, "''")}'`).join(",")})`
+    : "";
+  const internalUsersRows = await db.execute(
+    sql.raw(`SELECT id FROM users WHERE ${internalLikeClauses} ${extraClause}`),
+  );
+  const internalUserIds: string[] = toRows(internalUsersRows).map((r: any) => r.id);
+  // Drizzle-safe: materialise as a SQL array literal for NOT IN filters.
+  const internalUserIdList =
+    internalUserIds.length > 0
+      ? sql.raw(`ARRAY[${internalUserIds.map((id) => `'${id}'::uuid`).join(",")}]::uuid[]`)
+      : sql.raw(`ARRAY[]::uuid[]`);
 
   const [signupsRaw, txnRaw, revenueRaw, uniqueRaw, topCapsRaw] = await Promise.all([
     db.execute(sql`
@@ -94,6 +114,58 @@ export async function getPlatformActivity(
   const externalEmails = allNewEmails.filter((e) => !INTERNAL_EMAIL_SUFFIXES.some((s) => e.endsWith(s)));
   const internalEmails = allNewEmails.filter((e) => INTERNAL_EMAIL_SUFFIXES.some((s) => e.endsWith(s)));
 
+  // ─── External API calls (last 24h) ─────────────────────────────────────────
+  // Counts only transactions that actually hit an upstream service
+  // (transparency_marker != 'algorithmic'), excluding all internal users and
+  // EXTRA_EXCLUDED_EMAILS. Free-tier (user_id IS NULL) calls ARE included —
+  // those come from anonymous external traffic, which is real usage.
+  const [extAuthRaw, extFreeRaw, extFailedRaw, extByCapRaw] = await Promise.all([
+    db.execute(sql`
+      SELECT COUNT(*)::int AS cnt
+      FROM transactions
+      WHERE status = 'completed'
+        AND created_at >= NOW() - INTERVAL '24 hours'
+        AND transparency_marker != 'algorithmic'
+        AND user_id IS NOT NULL
+        AND user_id != ${systemUserId}
+        AND NOT (user_id = ANY(${internalUserIdList}))
+    `),
+    db.execute(sql`
+      SELECT COUNT(*)::int AS cnt
+      FROM transactions
+      WHERE status = 'completed'
+        AND created_at >= NOW() - INTERVAL '24 hours'
+        AND transparency_marker != 'algorithmic'
+        AND user_id IS NULL
+    `),
+    db.execute(sql`
+      SELECT COUNT(*)::int AS cnt
+      FROM transactions
+      WHERE status = 'failed'
+        AND created_at >= NOW() - INTERVAL '24 hours'
+        AND transparency_marker != 'algorithmic'
+        AND (user_id IS NULL
+             OR (user_id != ${systemUserId}
+                 AND NOT (user_id = ANY(${internalUserIdList}))))
+    `),
+    db.execute(sql`
+      SELECT c.slug, COUNT(*)::int AS cnt
+      FROM transactions t
+      JOIN capabilities c ON c.id = t.capability_id
+      WHERE t.status = 'completed'
+        AND t.created_at >= NOW() - INTERVAL '24 hours'
+        AND t.transparency_marker != 'algorithmic'
+        AND (t.user_id IS NULL
+             OR (t.user_id != ${systemUserId}
+                 AND NOT (t.user_id = ANY(${internalUserIdList}))))
+      GROUP BY c.slug ORDER BY cnt DESC LIMIT 10
+    `),
+  ]);
+  const extAuth = toRows(extAuthRaw)[0]?.cnt ?? 0;
+  const extFree = toRows(extFreeRaw)[0]?.cnt ?? 0;
+  const extFailed = toRows(extFailedRaw)[0]?.cnt ?? 0;
+  const extByCap = toRows(extByCapRaw).map((r: any) => ({ slug: r.slug as string, count: r.cnt as number }));
+
   const ySignups = yesterday?.totalUsers ?? signups.total;
 
   return {
@@ -103,6 +175,13 @@ export async function getPlatformActivity(
     transactions: { count: txnCount, delta: 0 },
     revenue: { cents: revCents, delta: 0 },
     solutionExecutions,
+    externalApiCalls: {
+      total: extAuth + extFree,
+      authenticated: extAuth,
+      freeTier: extFree,
+      failed: extFailed,
+      byCapability: extByCap,
+    },
     zeroActivity: signups.last_24h === 0 && txnCount === 0,
   };
 }

--- a/apps/api/src/lib/daily-digest/index.ts
+++ b/apps/api/src/lib/daily-digest/index.ts
@@ -28,6 +28,7 @@ const defaultPlatformActivity: PlatformActivity = {
   transactions: { count: 0, delta: 0 },
   revenue: { cents: 0, delta: 0 },
   solutionExecutions: [],
+  externalApiCalls: { total: 0, authenticated: 0, freeTier: 0, failed: 0, byCapability: [] },
   zeroActivity: true,
 };
 

--- a/apps/api/src/lib/daily-digest/render-email.ts
+++ b/apps/api/src/lib/daily-digest/render-email.ts
@@ -147,6 +147,26 @@ export function renderDigestEmail(data: DigestData, analysis: DigestAnalysis): s
     ${pa.signups.emails.length > 0 ? `<tr><td style="padding: 6px 0 0 0; font-size: 12px; color: ${MUTED};">New: ${pa.signups.emails.map(escHtml).join(", ")}</td></tr>` : ""}
     ${pa.signups.internalEmails.length > 0 ? `<tr><td style="padding: 2px 0 0 0; font-size: 11px; color: ${NEUTRAL};">Internal: ${pa.signups.internalEmails.map(escHtml).join(", ")}</td></tr>` : ""}`;
 
+  // External API calls — real outside traffic only
+  const ext = pa.externalApiCalls;
+  const extTopCaps = ext.byCapability.slice(0, 5)
+    .map((c) => `<span style="font-family: monospace; font-size: 12px; background: #f3f4f6; padding: 2px 6px; border-radius: 3px;">${escHtml(c.slug)}</span> (${fmt(c.count)})`)
+    .join(", ");
+  const externalHtml = `
+    ${sectionHeader("🌍", "External API calls (last 24h)")}
+    <tr><td style="padding: 0 0 6px 0; font-size: 12px; color: ${MUTED};">
+      Excludes @strale.io/@strale.dev, petterlindstrom@hotmail.com, system test user, and algorithmic-only capabilities.
+    </td></tr>
+    <tr><td style="padding: 4px 0;">
+      <table width="100%" cellpadding="0" cellspacing="0" style="font-size: 14px;">
+        ${metricRow("Total external calls", ext.total, 0)}
+        ${metricRow("&nbsp;&nbsp;Authenticated", ext.authenticated, 0)}
+        ${metricRow("&nbsp;&nbsp;Free-tier (anon)", ext.freeTier, 0)}
+        ${metricRow("Failed", ext.failed, 0)}
+      </table>
+    </td></tr>
+    ${extTopCaps ? `<tr><td style="padding: 8px 0 0 0; font-size: 13px; color: ${MUTED};">Top: ${extTopCaps}</td></tr>` : ""}`;
+
   // Platform health
   const breakerHtml = ph.circuitBreakers.length > 0
     ? ph.circuitBreakers.map((b) => `<span style="color:${RED};">${escHtml(b.slug)} (${b.state}, ${b.consecutiveFailures} failures)</span>`).join("<br>")
@@ -314,6 +334,7 @@ export function renderDigestEmail(data: DigestData, analysis: DigestAnalysis): s
       ${strategicHtml}
       ${shipLogHtml}
       ${activityHtml}
+      ${externalHtml}
       ${healthHtml}
       ${beaconHtml}
       ${trafficHtml}

--- a/apps/api/src/lib/daily-digest/types.ts
+++ b/apps/api/src/lib/daily-digest/types.ts
@@ -12,6 +12,16 @@ export interface PlatformActivity {
   transactions: { count: number; delta: number };
   revenue: { cents: number; delta: number };
   solutionExecutions: SolutionExecution[];
+  // External API calls (last 24h) — excludes internal users (@strale.*, petterlindstrom@hotmail.com,
+  // system user) and excludes purely-algorithmic capabilities (transparency_marker = 'algorithmic').
+  // This is the "real outside-world usage" metric.
+  externalApiCalls: {
+    total: number;
+    authenticated: number;
+    freeTier: number;
+    failed: number;
+    byCapability: Array<{ slug: string; count: number }>;
+  };
   zeroActivity: boolean;
 }
 


### PR DESCRIPTION
## Summary

Cherry-picked from `claude/practical-maxwell@9a0de14` (2026-04-14). Adds a focused "External API calls (last 24h)" section to the daily digest that counts only traffic that actually hit an upstream service (`transparency_marker != 'algorithmic'`) and excludes internal users (`@strale.io`, `@strale.dev`, `@strale.internal`, `@example.com`, `petterlindstrom@hotmail.com`, the system test user).

Breakdown: authenticated vs free-tier anonymous, failed count, top 5 capabilities by volume. Rendered into the email template with a "Excludes @strale.io/@strale.dev..." caveat line so you can tell at a glance what is and isn't counted.

Also documents a new `strale-digest-cron` Railway service in `railway-config.md`: a one-shot cron that runs the digest job directly (no HTTP, no ADMIN_SECRET duplication), scheduled at `30 5 * * *` UTC (= 07:30 CEST summer / 06:30 CET winter) using the same Docker image as the main API.

## Scope deliberately excluded

The `source` column migration that lived alongside this feature in the worktree — **NOT in this PR**. See `PRE_RESOLUTION_INVESTIGATION.md` §1: migration file number collides with main's 0045, and the `customer` / `test` values overlap conceptually with the existing `integrity_hash_status` column that's co-owned by an untracked workflow. Needs a design decision before shipping. Preserved on `claude/practical-maxwell` for a future Session 5 conversation.

## Deploy follow-up (out of scope for this PR)

Once merged, Petter needs to create the `strale-digest-cron` Railway service using the recipe in `railway-config.md`:
- Same GitHub repo
- Start command: `node apps/api/dist/jobs/daily-digest.js`
- Cron schedule: `30 5 * * *`
- Restart policy: Never

No code change or env var beyond what the `strale` service already has.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 17 files, 196 pass / 4 skip (baseline)
- [x] `check-no-bare-catch` green
- [x] `check-ssrf-inventory` green
- [ ] CI green
- [ ] Next digest email includes the new "External API calls" section (next scheduled send after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)