### PR TITLE
chore(scripts): delete 6 one-off diagnostics, promote 5 operational tools

### DIFF
--- a/apps/api/scripts/window-users.ts
+++ b/apps/api/scripts/window-users.ts
@@ -1,0 +1,29 @@
+// Operational: list authenticated (non-internal) user activity in a time window.
+// For each transaction, prints the calling user's email, wallet balance,
+// capability slug, input, status, payment method, and timestamp. Filters
+// out the health probe rows and the fixed internal-email allowlist.
+// Usage: tsx apps/api/scripts/window-users.ts <from-iso> <to-iso>
+
+const from = process.argv[2];
+const to = process.argv[3];
+if (!from || !to) {
+  console.error("usage: tsx window-users.ts <from-iso> <to-iso>");
+  process.exit(1);
+}
+const postgres = (await import("postgres")).default;
+const sql = postgres(process.env.DATABASE_URL!, { max: 1, ssl: "require" });
+const rows = await sql`
+  SELECT u.email, u.created_at AS signed_up_at, COALESCE(w.balance_cents, 0) AS balance_cents,
+         c.slug AS capability, t.payment_method, t.status, t.input, t.created_at AS called_at
+  FROM transactions t
+  LEFT JOIN users u ON u.id = t.user_id
+  LEFT JOIN wallets w ON w.user_id = t.user_id
+  LEFT JOIN capabilities c ON c.id = t.capability_id
+  WHERE t.created_at >= ${from} AND t.created_at <= ${to}
+    AND t.status <> 'health_probe'
+    AND t.user_id IS NOT NULL
+    AND u.email <> ALL(ARRAY['petter@strale.io','test@strale.io','test2@strale.io','system@strale.internal','test@example.com'])
+  ORDER BY t.created_at
+`;
+for (const r of rows) console.log(JSON.stringify(r));
+await sql.end();

--- a/apps/api/scripts/window-x402.ts
+++ b/apps/api/scripts/window-x402.ts
@@ -1,0 +1,46 @@
+// Operational: list all x402-paid transactions in a time window.
+// For each row prints id, capability slug, status, input, price, settlement
+// ID, timestamps, latency, and audit trail. Useful when reconstructing a
+// window of x402 traffic (e.g. during an incident or for a revenue check).
+// Usage: tsx apps/api/scripts/window-x402.ts <from-iso> <to-iso>
+
+const from = process.argv[2];
+const to = process.argv[3];
+if (!from || !to) {
+  console.error("usage: tsx window-x402.ts <from-iso> <to-iso>");
+  process.exit(1);
+}
+const postgres = (await import("postgres")).default;
+const sql = postgres(process.env.DATABASE_URL!, { max: 1, ssl: "require" });
+
+const rows = await sql`
+  SELECT t.id, c.slug AS capability, t.status, t.input, t.price_cents, t.price_usd,
+         t.x402_settlement_id, t.created_at, t.completed_at, t.latency_ms,
+         t.audit_trail
+  FROM transactions t
+  LEFT JOIN capabilities c ON c.id = t.capability_id
+  WHERE t.created_at >= ${from} AND t.created_at <= ${to}
+    AND t.payment_method = 'x402'
+  ORDER BY t.created_at
+`;
+
+for (const r of rows) {
+  console.log("id:            ", r.id);
+  console.log("capability:    ", r.capability);
+  console.log("status:        ", r.status);
+  console.log("input:         ", JSON.stringify(r.input));
+  console.log("price_cents:   ", r.price_cents);
+  console.log("price_usd:     ", r.price_usd);
+  console.log("settlement_id: ", r.x402_settlement_id);
+  console.log("created_at:    ", r.created_at);
+  console.log("completed_at:  ", r.completed_at);
+  console.log("latency_ms:    ", r.latency_ms);
+  if (r.audit_trail) {
+    const at = r.audit_trail as Record<string, unknown>;
+    console.log("audit_trail.keys:", Object.keys(at).join(", "));
+    if (at.x402) console.log("audit_trail.x402:", JSON.stringify(at.x402));
+    if (at.request_context) console.log("audit_trail.request_context:", JSON.stringify(at.request_context));
+  }
+  console.log("---");
+}
+await sql.end();

--- a/apps/api/scripts/x402-audit-inspect.ts
+++ b/apps/api/scripts/x402-audit-inspect.ts
@@ -1,0 +1,23 @@
+// Operational: print the audit trail for the 5 most-recent completed x402
+// transactions. Dumps `audit_trail` as pretty-printed JSON so you can
+// verify what ended up in the compliance record after a payment flow.
+// Usage: tsx apps/api/scripts/x402-audit-inspect.ts
+
+const postgres = (await import("postgres")).default;
+const sql = postgres(process.env.DATABASE_URL!, { max: 1, ssl: "require" });
+const rows = await sql`
+  SELECT t.id, c.slug AS capability, t.status, t.x402_settlement_id,
+         t.price_usd, t.created_at, t.audit_trail
+  FROM transactions t
+  LEFT JOIN capabilities c ON c.id = t.capability_id
+  WHERE t.payment_method = 'x402'
+    AND t.status = 'completed'
+  ORDER BY t.created_at DESC
+  LIMIT 5
+`;
+for (const r of rows as any[]) {
+  console.log("---", r.created_at.toISOString(), r.capability, "$" + r.price_usd, "---");
+  console.log("settle:", r.x402_settlement_id);
+  console.log("audit_trail:", JSON.stringify(r.audit_trail, null, 2));
+}
+await sql.end();

--- a/apps/api/scripts/x402-detail.ts
+++ b/apps/api/scripts/x402-detail.ts
@@ -1,0 +1,25 @@
+// Operational: one-line-per-row summary of x402 transactions since the
+// hardcoded 2026-04-14 start date (bump the date in the query for a new
+// window). Shows timestamp, capability, status, price, truncated
+// settlement ID, input, and error if any — useful for spotting failure
+// patterns across a batch of x402 traffic.
+// Usage: tsx apps/api/scripts/x402-detail.ts
+
+const postgres = (await import("postgres")).default;
+const sql = postgres(process.env.DATABASE_URL!, { max: 1, ssl: "require" });
+const rows = await sql`
+  SELECT t.id, c.slug AS capability, t.status, t.input, t.error,
+         t.price_cents, t.price_usd, t.x402_settlement_id, t.created_at
+  FROM transactions t
+  LEFT JOIN capabilities c ON c.id = t.capability_id
+  WHERE t.payment_method = 'x402'
+    AND t.created_at >= '2026-04-14T00:00:00Z'
+  ORDER BY t.created_at
+`;
+for (const r of rows as any[]) {
+  const err = r.error ? ` ERR=${String(r.error).slice(0, 80)}` : "";
+  console.log(
+    `${r.created_at.toISOString()}  ${r.capability}  [${r.status}]  $${r.price_usd}  settle=${r.x402_settlement_id?.slice(0, 18) ?? "none"}...  input=${JSON.stringify(r.input)}${err}`,
+  );
+}
+await sql.end();

--- a/apps/api/scripts/x402-payer-history.ts
+++ b/apps/api/scripts/x402-payer-history.ts
@@ -1,0 +1,60 @@
+// Operational: find all x402 transactions from a specific payer wallet.
+// Scans the most recent 500 x402 rows and matches the argument fragment
+// against both audit_trail JSON and the settlement ID (case-insensitive).
+// Useful for KYC / abuse investigation when you have a partial address.
+// Usage: tsx apps/api/scripts/x402-payer-history.ts <payer-address-fragment>
+
+const payerFragment = process.argv[2];
+if (!payerFragment) {
+  console.error("usage: tsx x402-payer-history.ts <payer-address-fragment>");
+  process.exit(1);
+}
+
+const postgres = (await import("postgres")).default;
+const sql = postgres(process.env.DATABASE_URL!, { max: 1, ssl: "require" });
+
+// All x402 transactions, pull audit_trail for matches
+const rows = await sql`
+  SELECT t.id, c.slug AS capability, t.status, t.input,
+         t.price_cents, t.price_usd, t.x402_settlement_id,
+         t.created_at, t.audit_trail
+  FROM transactions t
+  LEFT JOIN capabilities c ON c.id = t.capability_id
+  WHERE t.payment_method = 'x402'
+  ORDER BY t.created_at DESC
+  LIMIT 500
+`;
+
+const needle = payerFragment.toLowerCase();
+let matches = 0;
+for (const r of rows as any[]) {
+  const atStr = JSON.stringify(r.audit_trail ?? {}).toLowerCase();
+  const settleStr = (r.x402_settlement_id ?? "").toLowerCase();
+  if (atStr.includes(needle) || settleStr.includes(needle)) {
+    matches++;
+    console.log(
+      `${r.created_at}  ${r.capability}  ${r.status}  $${r.price_usd}  settle=${r.x402_settlement_id}`,
+    );
+    console.log("  input:", JSON.stringify(r.input));
+    console.log("  audit_trail keys:", Object.keys(r.audit_trail ?? {}).join(", "));
+  }
+}
+
+console.log(`\nScanned ${rows.length} recent x402 txns. Matches for '${payerFragment}': ${matches}`);
+
+// Also show x402 activity summary by day
+const byDay = await sql`
+  SELECT DATE(t.created_at AT TIME ZONE 'UTC') AS day,
+         COUNT(*)::int AS calls,
+         COUNT(*) FILTER (WHERE t.status = 'completed')::int AS completed,
+         SUM(t.price_usd)::text AS revenue_usd
+  FROM transactions t
+  WHERE t.payment_method = 'x402'
+    AND t.created_at >= NOW() - INTERVAL '14 days'
+  GROUP BY DATE(t.created_at AT TIME ZONE 'UTC')
+  ORDER BY day DESC
+`;
+console.log("\n=== x402 last 14 days ===");
+for (const r of byDay) console.log(`  ${r.day}  calls=${r.calls}  completed=${r.completed}  revenue=$${r.revenue_usd}`);
+
+await sql.end();


### PR DESCRIPTION
## Summary

Step 8c follow-up from `RESOLUTION_REPORT.md`. 11 diagnostic scripts were sitting untracked in `apps/api/scripts/`; triaged into:

**Deleted (6)**: `check-suggest-log`, `check-uk-all`, `check-uk-suites`, `check-uk-suspend`, `count-x402`, `diag-cz-state` — single-use diagnostics for rollouts that are done.

**Promoted to tracked (5)**: `window-users`, `window-x402`, `x402-audit-inspect`, `x402-detail`, `x402-payer-history` — reusable ops tools (x402 incident response, KYC investigation, user-activity windowing). Each gets a header comment; contents otherwise preserved.

Narrow slice of F-0-012 (dead-code Session 0 finding) — just the scripts that appeared during the Phase B/C/D sprint.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `check-no-bare-catch` green
- [x] `check-ssrf-inventory` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)