### PR TITLE
feat(gr): greek-company-data capability + GR KYB solutions + SE retirement artifacts

### DIFF
--- a/apps/api/scripts/drop-se-deactivated-caps.ts
+++ b/apps/api/scripts/drop-se-deactivated-caps.ts
@@ -1,0 +1,78 @@
+/**
+ * One-off retirement script: soft-deactivate the 2 SE capabilities deactivated
+ * in DEC-20260421-SE-B (annual-report-extract) and DEC-20260421-SE-C
+ * (business-license-check-se).
+ *
+ * Both capabilities were already removed from the DEACTIVATED-skip auto-register
+ * map (commits fc74b1b, 07055ab) so their executors no longer load. This
+ * script flips the DB rows to is_active=false so /v1/do calls fail with a
+ * clean "capability is deactivated" error rather than "no executor registered".
+ *
+ * Rollback:
+ *   UPDATE capabilities SET is_active = true
+ *    WHERE slug IN ('annual-report-extract', 'business-license-check-se');
+ *   AND remove the DEACTIVATED-map entries in apps/api/src/capabilities/auto-register.ts.
+ *
+ * This script is idempotent — re-running after the UPDATE is a no-op.
+ * Kept in the repo as a retirement-pattern artifact (per DEC-20260421-J).
+ */
+import { config } from "dotenv";
+import { resolve } from "node:path";
+config({ path: resolve(import.meta.dirname, "../../../.env") });
+
+import { inArray } from "drizzle-orm";
+import { getDb } from "../src/db/index.js";
+import { capabilities } from "../src/db/schema.js";
+
+const SE_SLUGS = ["annual-report-extract", "business-license-check-se"];
+
+async function main() {
+  const db = getDb();
+
+  const before = await db
+    .select({ slug: capabilities.slug, isActive: capabilities.isActive })
+    .from(capabilities)
+    .where(inArray(capabilities.slug, SE_SLUGS));
+
+  console.log("PRE-STATE:");
+  for (const row of before) {
+    console.log(`  ${row.slug}: is_active=${row.isActive}`);
+  }
+
+  if (before.length !== 2) {
+    throw new Error(
+      `Expected 2 SE-deactivated capabilities, found ${before.length}. Halting. Found: ${before.map((r) => r.slug).join(", ")}`,
+    );
+  }
+  if (before.every((r) => !r.isActive)) {
+    console.log("\nBoth already inactive. No-op. Exiting.");
+    process.exit(0);
+  }
+
+  await db
+    .update(capabilities)
+    .set({ isActive: false, updatedAt: new Date() })
+    .where(inArray(capabilities.slug, SE_SLUGS));
+
+  const after = await db
+    .select({ slug: capabilities.slug, isActive: capabilities.isActive })
+    .from(capabilities)
+    .where(inArray(capabilities.slug, SE_SLUGS));
+
+  console.log("\nPOST-STATE:");
+  for (const row of after) {
+    console.log(`  ${row.slug}: is_active=${row.isActive}`);
+  }
+
+  if (after.some((r) => r.isActive)) {
+    throw new Error("Update failed: at least one capability still active. Halting.");
+  }
+  console.log("\nBoth SE capabilities soft-deactivated.");
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("FATAL", err);
+  process.exit(1);
+});

--- a/apps/api/scripts/seed-kyb-solutions.ts
+++ b/apps/api/scripts/seed-kyb-solutions.ts
@@ -60,6 +60,7 @@ const COUNTRIES: Country[] = [
   { code: "pl", name: "Poland", companyDataSlug: "polish-company-data", isEU: true, geography: "eu", inputField: "krs_number", inputLabel: "Polish KRS number", exampleId: "0000019193" },
   { code: "pt", name: "Portugal", companyDataSlug: "portuguese-company-data", isEU: true, geography: "eu", inputField: "company_name", inputLabel: "Portuguese company name or NIPC", exampleId: "EDP" },
   { code: "hr", name: "Croatia", companyDataSlug: "croatian-company-data", isEU: true, geography: "eu", inputField: "oib", inputLabel: "Croatian OIB (11 digits), MBS, or company name", exampleId: "81793146560" },
+  { code: "gr", name: "Greece", companyDataSlug: "greek-company-data", isEU: true, geography: "eu", inputField: "gemi_number", inputLabel: "Greek GEMI registry number", exampleId: "000237954001" },
   { code: "us", name: "United States", companyDataSlug: "us-company-data", isEU: false, geography: "us", inputField: "company_name", inputLabel: "US company name or EIN", exampleId: "Apple Inc" },
   { code: "ca", name: "Canada", companyDataSlug: "canadian-company-data", isEU: false, geography: "us", inputField: "company_name", inputLabel: "Canadian company name or corporation number", exampleId: "Shopify Inc" },
   { code: "au", name: "Australia", companyDataSlug: "au-company-data", isEU: false, geography: "us-global", inputField: "abn", inputLabel: "Australian Business Number (11 digits)", exampleId: "51824753556" },

--- a/apps/api/src/capabilities/greek-company-data.ts
+++ b/apps/api/src/capabilities/greek-company-data.ts
@@ -1,0 +1,242 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+// GEMI Open Data API — Γενικό Εμπορικό Μητρώο (Greek Business Registry)
+// Operated by GEMI/UHC under the Greek Ministry of Development.
+// Licence: ODC-BY-1.0 (commercial use permitted with attribution).
+// Rate limit: 8 req/min (raise via support@uhc.gr if needed).
+const GEMI_BASE_URL = "https://opendata-api.businessportal.gr/api/opendata/v1";
+
+const GEMI_NUMBER_RE = /^\d{6,14}$/;
+const AFM_RE = /^\d{9}$/;
+
+interface GemiActivity {
+  activity?: { id?: number | string; descr?: string };
+  type?: string;
+  dtFrom?: string;
+  dtTo?: string | null;
+}
+
+interface GemiPerson {
+  personName?: string;
+  businessName?: string;
+  role?: string;
+  dtFrom?: string;
+  dtTo?: string | null;
+}
+
+interface GemiEnum {
+  id?: number | string;
+  descr?: string;
+}
+
+interface GemiCompany {
+  arGemi?: string;
+  afm?: string;
+  coNameEl?: string;
+  coNamesEn?: string[];
+  coTitlesEl?: string[];
+  coTitlesEn?: string[];
+  legalType?: GemiEnum;
+  status?: GemiEnum;
+  gemiOffice?: GemiEnum;
+  municipality?: GemiEnum;
+  incorporationDate?: string;
+  lastStatusChange?: string;
+  city?: string;
+  zipCode?: string;
+  street?: string;
+  streetNumber?: string;
+  phone?: string;
+  url?: string;
+  email?: string;
+  objective?: string;
+  isBranch?: boolean;
+  activities?: GemiActivity[];
+  persons?: GemiPerson[];
+}
+
+function normaliseGemiNumber(input: string): string | null {
+  const cleaned = input.replace(/[\s.-]/g, "");
+  return GEMI_NUMBER_RE.test(cleaned) ? cleaned : null;
+}
+
+function normaliseAfm(input: string): string | null {
+  const cleaned = input.replace(/[\s.-]/g, "");
+  return AFM_RE.test(cleaned) ? cleaned : null;
+}
+
+async function gemiFetch(path: string): Promise<unknown> {
+  const apiKey = process.env.GEMI_API_KEY;
+  if (!apiKey) {
+    throw new Error("GEMI_API_KEY environment variable is required for greek-company-data.");
+  }
+  const url = `${GEMI_BASE_URL}${path}`;
+  const response = await fetch(url, {
+    headers: { api_key: apiKey, Accept: "application/json" },
+    signal: AbortSignal.timeout(15000),
+  });
+  if (response.status === 401) {
+    throw new Error("GEMI API returned 401 Unauthorized — check GEMI_API_KEY value.");
+  }
+  if (response.status === 429) {
+    throw new Error("GEMI API rate limit exceeded (8 req/min). Retry after a short wait.");
+  }
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`GEMI API returned HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+async function fetchByGemiNumber(arGemi: string): Promise<GemiCompany | null> {
+  const data = await gemiFetch(`/companies/${encodeURIComponent(arGemi)}`);
+  if (!data || typeof data !== "object") return null;
+  return data as GemiCompany;
+}
+
+async function searchByAfm(afm: string): Promise<GemiCompany | null> {
+  const data = await gemiFetch(`/companies?afm=${encodeURIComponent(afm)}&resultsSize=1`);
+  if (!data || typeof data !== "object") return null;
+  const results = (data as { searchResults?: GemiCompany[] }).searchResults;
+  if (!Array.isArray(results) || results.length === 0) return null;
+  return results[0];
+}
+
+function pickCompanyName(company: GemiCompany): string {
+  if (company.coNameEl) return company.coNameEl;
+  const enName = company.coNamesEn?.[0];
+  if (enName) return enName;
+  const titleEl = company.coTitlesEl?.[0];
+  if (titleEl) return titleEl;
+  const titleEn = company.coTitlesEn?.[0];
+  if (titleEn) return titleEn;
+  return "";
+}
+
+function buildAddress(company: GemiCompany): string {
+  const parts: string[] = [];
+  const streetLine = [company.street, company.streetNumber].filter(Boolean).join(" ").trim();
+  if (streetLine) parts.push(streetLine);
+  const cityLine = [company.zipCode, company.city].filter(Boolean).join(" ").trim();
+  if (cityLine) parts.push(cityLine);
+  if (company.municipality?.descr && company.municipality.descr !== company.city) {
+    parts.push(company.municipality.descr);
+  }
+  return parts.join(", ");
+}
+
+function pickPrimaryActivity(activities: GemiActivity[] | undefined): {
+  id: string | null;
+  description: string | null;
+} {
+  if (!activities || activities.length === 0) return { id: null, description: null };
+  const primary = activities.find((a) => a.type === "Κύρια") ?? activities[0];
+  const id = primary.activity?.id;
+  return {
+    id: id !== undefined && id !== null ? String(id) : null,
+    description: primary.activity?.descr ?? null,
+  };
+}
+
+function summariseDirectors(persons: GemiPerson[] | undefined): string[] {
+  if (!persons || persons.length === 0) return [];
+  // Filter out terminated roles (dtTo set to a real date)
+  const active = persons.filter((p) => !p.dtTo);
+  const source = active.length > 0 ? active : persons;
+  return source
+    .map((p) => {
+      const name = p.personName ?? p.businessName ?? "";
+      if (!name) return null;
+      return p.role ? `${name} (${p.role})` : name;
+    })
+    .filter((s): s is string => Boolean(s));
+}
+
+function deriveStatus(company: GemiCompany): string {
+  const descr = company.status?.descr?.toLowerCase() ?? "";
+  if (!descr) return "unknown";
+  if (descr.includes("ενεργ")) return "active"; // Ενεργή
+  if (descr.includes("διαγραφ") || descr.includes("λυσ")) return "dissolved"; // Διαγραφή / Λύση
+  if (descr.includes("πτωχ")) return "bankrupt"; // Πτώχευση
+  if (descr.includes("εκκαθ")) return "liquidation"; // Εκκαθάριση
+  return company.status?.descr ?? "unknown";
+}
+
+function mapToOutput(company: GemiCompany): Record<string, unknown> {
+  const activity = pickPrimaryActivity(company.activities);
+  return {
+    company_name: pickCompanyName(company),
+    org_number: company.arGemi ?? "",
+    vat_number: company.afm ? `EL${company.afm}` : null,
+    afm: company.afm ?? null,
+    business_type: company.legalType?.descr ?? null,
+    address: buildAddress(company),
+    registration_date: company.incorporationDate ?? null,
+    industry_code: activity.id,
+    industry_description: activity.description,
+    status: deriveStatus(company),
+    directors: summariseDirectors(company.persons),
+    is_branch: company.isBranch ?? false,
+  };
+}
+
+registerCapability("greek-company-data", async (input: CapabilityInput) => {
+  const gemiInput =
+    (input.gemi_number as string) ??
+    (input.org_number as string) ??
+    (input.ar_gemi as string) ??
+    "";
+  const afmInput = (input.afm as string) ?? (input.tax_id as string) ?? "";
+
+  if (
+    (typeof gemiInput !== "string" || !gemiInput.trim()) &&
+    (typeof afmInput !== "string" || !afmInput.trim())
+  ) {
+    throw new Error(
+      "Provide either 'gemi_number' (Greek GEMI registry number) or 'afm' (Greek tax ID, 9 digits).",
+    );
+  }
+
+  let company: GemiCompany | null = null;
+  let resolvedFrom: "gemi_number" | "afm" = "gemi_number";
+
+  if (typeof gemiInput === "string" && gemiInput.trim()) {
+    const arGemi = normaliseGemiNumber(gemiInput);
+    if (!arGemi) {
+      throw new Error(
+        `'gemi_number' must be 6-14 digits. Received: "${gemiInput}".`,
+      );
+    }
+    company = await fetchByGemiNumber(arGemi);
+    if (!company) {
+      throw new Error(`No Greek company found with GEMI number ${arGemi}.`);
+    }
+  } else if (typeof afmInput === "string" && afmInput.trim()) {
+    const afm = normaliseAfm(afmInput);
+    if (!afm) {
+      throw new Error(`'afm' must be exactly 9 digits. Received: "${afmInput}".`);
+    }
+    company = await searchByAfm(afm);
+    if (!company) {
+      throw new Error(`No Greek company found with AFM ${afm}.`);
+    }
+    resolvedFrom = "afm";
+  }
+
+  if (!company) {
+    throw new Error("Failed to resolve Greek company.");
+  }
+
+  const output = mapToOutput(company);
+
+  return {
+    output,
+    provenance: {
+      source: "opendata-api.businessportal.gr",
+      fetched_at: new Date().toISOString(),
+      resolved_from: resolvedFrom,
+    },
+  };
+});

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -236,6 +236,39 @@ const seedCapabilities = [
     outputSchema: { type: "object", properties: { company_name: { type: "string" }, company_number: { type: "string" }, company_status: { type: "string" }, filings: { type: "array" }, events_returned: { type: "number" } } },
     priceCents: 5,
   },
+  {
+    name: "Greek Company Data",
+    slug: "greek-company-data",
+    description:
+      "Look up Greek company data from the GEMI Open Data API (Γενικό Εμπορικό Μητρώο). Accepts a GEMI registry number or Greek tax ID (AFM, 9 digits).",
+    category: "data-extraction",
+    inputSchema: {
+      type: "object",
+      properties: {
+        gemi_number: { type: "string", description: "Greek GEMI registry number (6-14 digits)" },
+        afm: { type: "string", description: "Greek tax ID (AFM, 9 digits)" },
+      },
+      required: [],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        company_name: { type: "string" },
+        org_number: { type: "string" },
+        vat_number: { type: "string" },
+        afm: { type: "string" },
+        business_type: { type: "string" },
+        address: { type: "string" },
+        registration_date: { type: "string" },
+        industry_code: { type: "string" },
+        industry_description: { type: "string" },
+        status: { type: "string" },
+        directors: { type: "array" },
+        is_branch: { type: "boolean" },
+      },
+    },
+    priceCents: 5,
+  },
   // ─── New capabilities (DEC-20260226-P-s3t4) ─────────────────────────────
   {
     name: "Norwegian Company Data",

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -236,39 +236,6 @@ const seedCapabilities = [
     outputSchema: { type: "object", properties: { company_name: { type: "string" }, company_number: { type: "string" }, company_status: { type: "string" }, filings: { type: "array" }, events_returned: { type: "number" } } },
     priceCents: 5,
   },
-  {
-    name: "Greek Company Data",
-    slug: "greek-company-data",
-    description:
-      "Look up Greek company data from the GEMI Open Data API (Γενικό Εμπορικό Μητρώο). Accepts a GEMI registry number or Greek tax ID (AFM, 9 digits).",
-    category: "data-extraction",
-    inputSchema: {
-      type: "object",
-      properties: {
-        gemi_number: { type: "string", description: "Greek GEMI registry number (6-14 digits)" },
-        afm: { type: "string", description: "Greek tax ID (AFM, 9 digits)" },
-      },
-      required: [],
-    },
-    outputSchema: {
-      type: "object",
-      properties: {
-        company_name: { type: "string" },
-        org_number: { type: "string" },
-        vat_number: { type: "string" },
-        afm: { type: "string" },
-        business_type: { type: "string" },
-        address: { type: "string" },
-        registration_date: { type: "string" },
-        industry_code: { type: "string" },
-        industry_description: { type: "string" },
-        status: { type: "string" },
-        directors: { type: "array" },
-        is_branch: { type: "boolean" },
-      },
-    },
-    priceCents: 5,
-  },
   // ─── New capabilities (DEC-20260226-P-s3t4) ─────────────────────────────
   {
     name: "Norwegian Company Data",

--- a/apps/api/src/lib/dependency-manifest.ts
+++ b/apps/api/src/lib/dependency-manifest.ts
@@ -287,6 +287,24 @@ export const PROVIDERS: DependencyProvider[] = [
     capabilities: ["croatian-company-data"],
     tier: "free",
   },
+  {
+    name: "gemi",
+    displayName: "GEMI Open Data (Greece)",
+    description: "Greek Business Registry (Γενικό Εμπορικό Μητρώο) Open Data API — api_key header.",
+    baseUrl: "https://opendata-api.businessportal.gr/api/opendata/v1",
+    authType: "api-key-header",
+    envVar: "GEMI_API_KEY",
+    healthProbe: {
+      // Unauthenticated GET returns 401 without consuming the 8 req/min quota.
+      path: "/companies/000237954001",
+      method: "GET",
+      healthyStatuses: [200, 401],
+      timeoutMs: 5000,
+      skipAuth: true,
+    },
+    capabilities: ["greek-company-data"],
+    tier: "free",
+  },
 
   // ─── Web3 providers (free, no key) ────────────────────────────────────────
   {

--- a/manifests/greek-company-data.yaml
+++ b/manifests/greek-company-data.yaml
@@ -2,8 +2,8 @@ slug: greek-company-data
 name: Greek Company Data
 description: >-
   Look up Greek company data from the GEMI Open Data API (Γενικό Εμπορικό Μητρώο). Accepts a GEMI registry number or
-  Greek tax ID (AFM, 9 digits). Returns name, legal form, address, status, primary activity, directors, and the
-  derived VAT number (EL + AFM).
+  Greek tax ID (AFM, 9 digits). Returns name, legal form, address, status, primary activity, directors, and the derived
+  VAT number (EL + AFM).
 category: data-extraction
 price_cents: 5
 is_free_tier: false
@@ -68,8 +68,39 @@ test_fixtures:
         operator: not_null
         reliability: guaranteed
       - field: org_number
+        operator: equals
+        reliability: guaranteed
+        value: "237954001"
+      - field: vat_number
+        operator: equals
+        reliability: guaranteed
+        value: EL094014201
+      - field: afm
+        operator: equals
+        reliability: guaranteed
+        value: "094014201"
+      - field: business_type
+        operator: equals
+        reliability: guaranteed
+        value: ΑΕ
+      - field: address
         operator: not_null
         reliability: guaranteed
+      - field: registration_date
+        operator: equals
+        reliability: guaranteed
+        value: "1941-01-01"
+      - field: status
+        operator: equals
+        reliability: guaranteed
+        value: active
+      - field: directors
+        operator: not_null
+        reliability: guaranteed
+      - field: is_branch
+        operator: equals
+        reliability: guaranteed
+        value: true
   health_check_input:
     gemi_number: "000237954001"
 output_field_reliability:
@@ -87,17 +118,23 @@ output_field_reliability:
   is_branch: guaranteed
 limitations:
   - title: GEMI rate limit is 8 requests per minute
-    text: The GEMI Open Data API enforces a maximum of 8 requests per minute per API key. Requests exceeding this limit return HTTP 429.
+    text: >-
+      The GEMI Open Data API enforces a maximum of 8 requests per minute per API key. Requests exceeding this limit
+      return HTTP 429.
     category: rate-limit
     severity: info
     workaround: Request a higher rate limit from support@uhc.gr describing the use case and expected volume.
   - title: AFM (tax ID) field is occasionally absent for older or special-status entities
-    text: When AFM is missing the derived vat_number is null; vat-validate downstream steps will soft-fail for those entities.
+    text: >-
+      When AFM is missing the derived vat_number is null; vat-validate downstream steps will soft-fail for those
+      entities.
     category: coverage
     severity: info
     workaround: Provide the AFM as input directly when known, or use a separate VAT validation source.
   - title: Branches and main entities are both returned by GEMI
-    text: GEMI includes branch records (is_branch=true) alongside main-entity records. Some KYB use cases want the parent only.
+    text: >-
+      GEMI includes branch records (is_branch=true) alongside main-entity records. Some KYB use cases want the parent
+      only.
     category: coverage
     severity: info
     workaround: Check the is_branch field before using the record as the principal counterparty.

--- a/manifests/greek-company-data.yaml
+++ b/manifests/greek-company-data.yaml
@@ -1,0 +1,103 @@
+slug: greek-company-data
+name: Greek Company Data
+description: >-
+  Look up Greek company data from the GEMI Open Data API (Γενικό Εμπορικό Μητρώο). Accepts a GEMI registry number or
+  Greek tax ID (AFM, 9 digits). Returns name, legal form, address, status, primary activity, directors, and the
+  derived VAT number (EL + AFM).
+category: data-extraction
+price_cents: 5
+is_free_tier: false
+input_schema:
+  type: object
+  properties:
+    gemi_number:
+      type: string
+      description: Greek GEMI registry number (6-14 digits)
+    afm:
+      type: string
+      description: Greek tax ID (AFM, 9 digits) — used as fallback when GEMI number is not known
+output_schema:
+  type: object
+  properties:
+    company_name:
+      type: string
+    org_number:
+      type: string
+      description: GEMI registry number
+    vat_number:
+      type: string
+      description: VIES VAT number, format EL{AFM}
+    afm:
+      type: string
+      description: Greek tax ID
+    business_type:
+      type: string
+    address:
+      type: string
+    registration_date:
+      type: string
+    industry_code:
+      type: string
+    industry_description:
+      type: string
+    status:
+      type: string
+    directors:
+      type: array
+      items:
+        type: string
+    is_branch:
+      type: boolean
+data_source: GEMI Open Data API — Γενικό Εμπορικό Μητρώο (Greek Business Registry)
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+processes_personal_data: true
+personal_data_categories:
+  - name
+  - address
+  - professional
+geography: eu
+test_fixtures:
+  known_answer:
+    input:
+      gemi_number: "000237954001"
+    expected_fields:
+      - field: company_name
+        operator: not_null
+        reliability: guaranteed
+      - field: org_number
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    gemi_number: "000237954001"
+output_field_reliability:
+  company_name: guaranteed
+  org_number: guaranteed
+  vat_number: common
+  afm: common
+  business_type: guaranteed
+  address: common
+  registration_date: common
+  industry_code: common
+  industry_description: common
+  status: guaranteed
+  directors: common
+  is_branch: guaranteed
+limitations:
+  - title: GEMI rate limit is 8 requests per minute
+    text: The GEMI Open Data API enforces a maximum of 8 requests per minute per API key. Requests exceeding this limit return HTTP 429.
+    category: rate-limit
+    severity: info
+    workaround: Request a higher rate limit from support@uhc.gr describing the use case and expected volume.
+  - title: AFM (tax ID) field is occasionally absent for older or special-status entities
+    text: When AFM is missing the derived vat_number is null; vat-validate downstream steps will soft-fail for those entities.
+    category: coverage
+    severity: info
+    workaround: Provide the AFM as input directly when known, or use a separate VAT validation source.
+  - title: Branches and main entities are both returned by GEMI
+    text: GEMI includes branch records (is_branch=true) alongside main-entity records. Some KYB use cases want the parent only.
+    category: coverage
+    severity: info
+    workaround: Check the is_branch field before using the record as the principal counterparty.


### PR DESCRIPTION
## Summary

- Add `greek-company-data` capability against the GEMI Open Data API (Γενικό Εμπορικό Μητρώο) — Greek Business Registry. Free under ODC-BY-1.0; commercial redistribution permitted with attribution. Auth: api_key header. 8 req/min rate limit.
- Generate 3 GR KYB solutions: `kyb-essentials-gr`, `kyb-complete-gr`, `invoice-verify-gr` (auto-generated by adding GR to `seed-kyb-solutions.ts` COUNTRIES).
- Wire GEMI provider into `dependency-manifest.ts` with a zero-cost 401 health probe (skipAuth: true) so credential monitoring doesn't consume the 8 req/min quota.
- Add SE soft-deactivate retirement-pattern artifact `apps/api/scripts/drop-se-deactivated-caps.ts` covering `business-license-check-se` (DEC-20260421-SE-C) and `annual-report-extract` (DEC-20260421-SE-B).

## Prod DB state (already mutated)

The onboarding pipeline was run against prod DB during this session:

- `greek-company-data` capability row inserted, lifecycle=`probation`, visible=false (will transition to active after SQS proves stable per DEC-20260320-B)
- 5 test suites created (known_answer + schema_check + negative + edge_case + dependency_health), all live-verified against National Bank of Greece (GEMI 237954001)
- 12 output fields with reliability annotations (5 guaranteed)
- 3 GR solutions inserted via `seed-kyb-solutions.ts`
- `kyb-complete-se` updated to drop the `annual-report-extract` step (capability is deactivated; this aligns the solution to the deactivation)
- SE retirement script: rows already `is_active=false` from a prior session

This PR brings prod **code** in line with prod **DB**. Until merged + deployed, the GR capability rows exist but the executor isn't deployed → any non-gated call would 500. Visible=false gates external discovery, so impact is bounded but the drift should close ASAP.

## Wave 1 EU direct-API workstream context

Per `docs/audits/2026-04-21-company-registry-direct-api-audit.md`:
- ✅ HR shipped earlier (commit d56d8af, 2026-04-22)
- ✅ GR shipped here
- ⏳ NL deferred to Wave 2 — KVK HVDS scope is too narrow (no company name, no address, no officers); needs paid KVK Search subscription or licensed aggregator. Plan-invalidating finding documented in session.

## Test plan

- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] Live smoke test against National Bank of Greece (GEMI 237954001): all 10 known_answer assertions pass
- [x] Onboarding pipeline `--discover --apply`: 19/19 readiness checks pass
- [x] `smoke-test.ts --slug greek-company-data`: 11/11 steps pass
- [x] All 4 SE deactivation entries (DEACTIVATED map + extendsWith refs in 4 Nordic KYC + non-SE KYB Complete extendsWith) verified intact
- [ ] Post-deploy: verify `/v1/quality/greek-company-data` returns
- [ ] Post-deploy: confirm test scheduler picks up GR's known_answer test on next cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)