### PR TITLE
feat(capability): gleif-l2-ubo-lookup — UBO supplement via GLEIF Level 2

### DIFF
--- a/apps/api/src/capabilities/gleif-l2-ubo-lookup.ts
+++ b/apps/api/src/capabilities/gleif-l2-ubo-lookup.ts
@@ -1,0 +1,160 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * GLEIF Level 2 (Who Owns Whom) UBO supplement.
+ *
+ * For any LEI-bearing entity, returns direct + ultimate parent relationships
+ * if reported, or the structured reporting exception (NATURAL_PERSONS,
+ * NON_CONSOLIDATING, NO_KNOWN_PERSON, etc.) if the entity declares a
+ * reason for not reporting a parent.
+ *
+ * Free, no auth, CC0-equivalent license. Coverage is limited to entities
+ * that have an LEI (~2.6M globally, mostly large/regulated). Acts as a UBO
+ * supplement, not a replacement — pairs with country registries for SMEs.
+ */
+
+const GLEIF_API = "https://api.gleif.org/api/v1";
+const LEI_RE = /^[A-Z0-9]{20}$/;
+
+type ParentInfo = {
+  lei: string;
+  legal_name: string;
+  jurisdiction: string | null;
+  country: string | null;
+};
+
+type ReportingException = {
+  category: string | null;
+  reason: string | null;
+  reference: string | null;
+};
+
+async function gleifFetch(path: string): Promise<Response> {
+  return fetch(`${GLEIF_API}${path}`, {
+    headers: { Accept: "application/vnd.api+json" },
+    signal: AbortSignal.timeout(10000),
+  });
+}
+
+async function lookupByLei(lei: string): Promise<{ lei: string; legal_name: string; jurisdiction: string | null }> {
+  const res = await gleifFetch(`/lei-records/${lei}`);
+  if (res.status === 404) throw new Error(`LEI ${lei} not found in GLEIF database.`);
+  if (!res.ok) throw new Error(`GLEIF API returned HTTP ${res.status}`);
+  const data = (await res.json()) as any;
+  const entity = data?.data?.attributes?.entity ?? {};
+  return {
+    lei: data?.data?.attributes?.lei || lei,
+    legal_name: entity.legalName?.name || "",
+    jurisdiction: entity.jurisdiction || null,
+  };
+}
+
+async function searchByName(name: string, jurisdiction?: string): Promise<string> {
+  let url = `/lei-records?filter[entity.legalName]=${encodeURIComponent(name)}&page[size]=5`;
+  if (jurisdiction) url += `&filter[entity.legalAddress.country]=${encodeURIComponent(jurisdiction)}`;
+  const res = await gleifFetch(url);
+  if (!res.ok) throw new Error(`GLEIF search returned HTTP ${res.status}`);
+  const data = (await res.json()) as any;
+  const records: any[] = data?.data ?? [];
+  if (records.length === 0) throw new Error(`No LEI found matching "${name}".`);
+  // Prefer ACTIVE status; otherwise first result
+  const active = records.find((r) => r?.attributes?.entity?.status === "ACTIVE");
+  return (active ?? records[0])?.attributes?.lei;
+}
+
+function parseParent(payload: any): ParentInfo | null {
+  const record = payload?.data;
+  if (!record || record.type !== "lei-records") return null;
+  const entity = record.attributes?.entity ?? {};
+  return {
+    lei: record.attributes?.lei || record.id || "",
+    legal_name: entity.legalName?.name || "",
+    jurisdiction: entity.jurisdiction || null,
+    country: entity.legalAddress?.country || null,
+  };
+}
+
+function parseException(payload: any): ReportingException | null {
+  const record = payload?.data;
+  if (!record || record.type !== "reporting-exceptions") return null;
+  return {
+    category: record.attributes?.category ?? null,
+    reason: record.attributes?.reason ?? null,
+    reference: record.attributes?.reference ?? null,
+  };
+}
+
+async function fetchParentOrException(
+  lei: string,
+  level: "direct" | "ultimate",
+): Promise<{ parent: ParentInfo | null; exception: ReportingException | null }> {
+  const parentRes = await gleifFetch(`/lei-records/${lei}/${level}-parent`);
+
+  if (parentRes.ok) {
+    const parsed = parseParent(await parentRes.json());
+    return { parent: parsed, exception: null };
+  }
+
+  // 404 on the parent endpoint means either (a) a reporting exception is filed,
+  // or (b) the entity simply has no parent record at all. Check the exception
+  // endpoint to disambiguate.
+  if (parentRes.status === 404) {
+    const excRes = await gleifFetch(`/lei-records/${lei}/${level}-parent-reporting-exception`);
+    if (excRes.ok) {
+      return { parent: null, exception: parseException(await excRes.json()) };
+    }
+    if (excRes.status === 404) {
+      return { parent: null, exception: null };
+    }
+    throw new Error(`GLEIF L2 exception endpoint returned HTTP ${excRes.status}`);
+  }
+
+  throw new Error(`GLEIF L2 parent endpoint returned HTTP ${parentRes.status}`);
+}
+
+registerCapability("gleif-l2-ubo-lookup", async (input: CapabilityInput) => {
+  const leiInput = (input.lei as string)?.trim().toUpperCase() ?? "";
+  const companyName = (input.company_name as string)?.trim() ?? "";
+  const jurisdiction = (input.jurisdiction as string)?.trim().toUpperCase() ?? undefined;
+
+  if (!leiInput && !companyName) {
+    throw new Error("'lei' or 'company_name' is required. Provide a 20-character LEI or a company name to search.");
+  }
+
+  const lei = LEI_RE.test(leiInput) ? leiInput : await searchByName(companyName, jurisdiction);
+
+  // Fetch entity record + both parents in parallel
+  const [entity, direct, ultimate] = await Promise.all([
+    lookupByLei(lei),
+    fetchParentOrException(lei, "direct"),
+    fetchParentOrException(lei, "ultimate"),
+  ]);
+
+  const isTopOfTree =
+    !direct.parent &&
+    !ultimate.parent &&
+    (direct.exception !== null || ultimate.exception !== null);
+
+  const ownershipChainComplete = direct.parent !== null && ultimate.parent !== null;
+
+  return {
+    output: {
+      input_lei: entity.lei,
+      legal_name: entity.legal_name,
+      jurisdiction: entity.jurisdiction,
+      direct_parent: direct.parent,
+      direct_parent_exception: direct.exception,
+      ultimate_parent: ultimate.parent,
+      ultimate_parent_exception: ultimate.exception,
+      has_direct_parent: direct.parent !== null,
+      has_ultimate_parent: ultimate.parent !== null,
+      is_top_of_tree: isTopOfTree,
+      ownership_chain_complete: ownershipChainComplete,
+      data_source: "GLEIF Level 2 (Who Owns Whom)",
+    },
+    provenance: {
+      source: "gleif.org",
+      fetched_at: new Date().toISOString(),
+    },
+  };
+});

--- a/manifests/gleif-l2-ubo-lookup.yaml
+++ b/manifests/gleif-l2-ubo-lookup.yaml
@@ -1,0 +1,172 @@
+slug: gleif-l2-ubo-lookup
+name: GLEIF L2 UBO Lookup
+description: >-
+  Beneficial ownership supplement via GLEIF Level 2 (Who Owns Whom). Returns direct and ultimate parent relationships
+  for any LEI-bearing entity globally, plus structured reporting exceptions when a parent is not reported. Free,
+  CC0-equivalent license. Pairs with country registries to fill UBO gaps.
+category: compliance
+price_cents: 5
+is_free_tier: false
+avg_latency_ms: 1000
+input_schema:
+  type: object
+  required: []
+  properties:
+    lei:
+      type: string
+      description: 20-character LEI of the entity to look up parents for. Canonical input.
+    company_name:
+      type: string
+      description: >-
+        Optional fallback input — company name to search GLEIF for if no LEI is known. Resolves to an LEI internally
+        before fetching parent data.
+    jurisdiction:
+      type: string
+      description: Optional ISO country code (e.g. "SE") to disambiguate name search.
+output_schema:
+  type: object
+  example:
+    input_lei: 5493004INDUJX1TDHI57
+    legal_name: Spotify AB
+    jurisdiction: SE
+    direct_parent:
+      lei: 549300B4X0JHWV0DTD60
+      legal_name: SPOTIFY TECHNOLOGY S.A.
+      jurisdiction: LU
+      country: LU
+    direct_parent_exception: null
+    ultimate_parent:
+      lei: 549300B4X0JHWV0DTD60
+      legal_name: SPOTIFY TECHNOLOGY S.A.
+      jurisdiction: LU
+      country: LU
+    ultimate_parent_exception: null
+    has_direct_parent: true
+    has_ultimate_parent: true
+    is_top_of_tree: false
+    ownership_chain_complete: true
+    data_source: GLEIF Level 2 (Who Owns Whom)
+  properties:
+    input_lei:
+      type: string
+    legal_name:
+      type: string
+    jurisdiction:
+      type:
+        - string
+        - "null"
+    direct_parent:
+      type:
+        - object
+        - "null"
+    direct_parent_exception:
+      type:
+        - object
+        - "null"
+    ultimate_parent:
+      type:
+        - object
+        - "null"
+    ultimate_parent_exception:
+      type:
+        - object
+        - "null"
+    has_direct_parent:
+      type: boolean
+    has_ultimate_parent:
+      type: boolean
+    is_top_of_tree:
+      type: boolean
+    ownership_chain_complete:
+      type: boolean
+    data_source:
+      type: string
+data_source: GLEIF Level 2 (Who Owns Whom)
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: global
+test_fixtures:
+  known_answer:
+    input:
+      lei: 5493004INDUJX1TDHI57
+    expected_fields:
+      - field: input_lei
+        operator: equals
+        reliability: guaranteed
+        value: 5493004INDUJX1TDHI57
+      - field: legal_name
+        operator: not_null
+        reliability: guaranteed
+      - field: jurisdiction
+        operator: equals
+        reliability: guaranteed
+        value: SE
+      - field: direct_parent
+        operator: not_null
+        reliability: guaranteed
+      - field: ultimate_parent
+        operator: not_null
+        reliability: guaranteed
+      - field: has_direct_parent
+        operator: equals
+        reliability: guaranteed
+        value: true
+      - field: has_ultimate_parent
+        operator: equals
+        reliability: guaranteed
+        value: true
+      - field: is_top_of_tree
+        operator: equals
+        reliability: guaranteed
+        value: false
+      - field: ownership_chain_complete
+        operator: equals
+        reliability: guaranteed
+        value: true
+      - field: data_source
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    lei: 5493004INDUJX1TDHI57
+output_field_reliability:
+  input_lei: guaranteed
+  legal_name: guaranteed
+  jurisdiction: guaranteed
+  has_direct_parent: guaranteed
+  has_ultimate_parent: guaranteed
+  is_top_of_tree: guaranteed
+  ownership_chain_complete: guaranteed
+  data_source: guaranteed
+  direct_parent: common
+  direct_parent_exception: common
+  ultimate_parent: common
+  ultimate_parent_exception: common
+limitations:
+  - title: Coverage is limited to entities that have an LEI
+    text: >-
+      GLEIF L2 only contains relationship data for entities registered in the GLEIF system. Approximately 2.6M entities
+      globally have LEIs, primarily large or regulated entities. SMEs without LEIs return no L2 data — pair with
+      country-registry beneficial ownership lookups for full SME coverage.
+    category: coverage
+    severity: info
+    workaround: >-
+      For SMEs without an LEI, use country-specific UBO sources (e.g. Companies House PSC for UK, OpenOwnership BODS for
+      UK/DK/SK).
+  - title: Reporting exceptions are common
+    text: >-
+      Many entities report a structured "reporting exception" instead of naming a parent (NATURAL_PERSONS,
+      NON_CONSOLIDATING, NO_KNOWN_PERSON, LEGAL_OBSTACLES, DISCLOSURE_DETRIMENTAL, BINDING_LEGAL_COMMITMENTS). The
+      exception is structured data and is surfaced verbatim in direct_parent_exception / ultimate_parent_exception, but
+      it does not name an ultimate beneficiary.
+    category: coverage
+    severity: warning
+  - title: Parent relationships are self-reported and refreshed annually
+    text: >-
+      Entities self-report parent relationships in their annual LEI renewal. Stale data is possible for restructurings
+      between renewal cycles. The lastUpdateDate on the underlying LEI record indicates currency.
+    category: freshness
+    severity: info


### PR DESCRIPTION
## Summary

- Adds **`gleif-l2-ubo-lookup`** — UBO supplement that returns direct + ultimate parent relationships (or structured reporting exceptions) for any LEI-bearing entity globally.
- Free GLEIF Level 2 "Who Owns Whom" API. CC0-equivalent license. No auth.
- Pairs with country-registry UBO sources (UK PSC, OpenOwnership BODS for UK/DK/SK) to fill Payee Assurance UBO gaps.

## Why now

First Phase-0 capability under DEC-20260430-A vendor-stack canonicalization: free, no signup, no contract, no spend. Highest leverage per dev hour — adds UBO coverage to every Payee Assurance call that has an LEI.

## Implementation

- New executor `apps/api/src/capabilities/gleif-l2-ubo-lookup.ts` — accepts `lei` (canonical) or `company_name` (optional fallback that resolves to LEI via GLEIF search). Fetches `/lei-records/{lei}/{direct,ultimate}-parent` in parallel; on 404, falls back to `/{...}-parent-reporting-exception` to surface structured reasons (NATURAL_PERSONS, NON_CONSOLIDATING, NO_KNOWN_PERSON, etc.).
- New manifest `manifests/gleif-l2-ubo-lookup.yaml` with field reliability, 3 limitations, complete output schema.

## Verification

- Manifest pipeline: all 5 onboarding gates pass.
- Known-answer test: **all 10 assertions verified live** against Spotify AB (LEI `5493004INDUJX1TDHI57`) → SPOTIFY TECHNOLOGY S.A. (LU, LEI `549300B4X0JHWV0DTD60`).
- Smoke test: **11/12 pass**. Only "SQS pending" fails — expected for a fresh capability; score populates after the test scheduler accumulates runs.
- Negative test: throws structured error on empty input.
- Live execution: 12 fields returned in 306ms (3 GLEIF calls in parallel).

## Test plan

- [x] Onboarding pipeline `--discover` runs clean
- [x] Known-answer assertions verified live
- [x] Negative test (empty input) returns structured error
- [x] Capability is `is_active=true, visible=true, lifecycle_state=active`
- [x] Manifest validation passes
- [ ] First scheduled test run computes SQS (will happen automatically post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)