### PR TITLE
feat(capability): fr-bodacc-lookup — French commercial-registry + insolvency

### DIFF
--- a/apps/api/src/capabilities/fr-bodacc-lookup.ts
+++ b/apps/api/src/capabilities/fr-bodacc-lookup.ts
@@ -1,0 +1,166 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * BODACC (Bulletin Officiel des Annonces Civiles et Commerciales) lookup.
+ *
+ * BODACC is the French government's official journal of all commercial-
+ * registry events: insolvency proceedings, sales, registry modifications,
+ * incorporations, strikeoffs, annual-accounts deposits.
+ *
+ * For Payee Assurance the primary value is the insolvency signal —
+ * Procédures collectives (familleavis = "collective"). The executor
+ * returns all announcement types for full history but elevates insolvency
+ * count + most-recent-insolvency to top-level fields.
+ *
+ * Source: data.gouv.fr / Direction de l'information légale et
+ * administrative. Free, no auth, CC-BY-2.0.
+ */
+
+const BODACC_API =
+  "https://bodacc-datadila.opendatasoft.com/api/explore/v2.1/catalog/datasets/annonces-commerciales/records";
+
+const SIREN_RE = /^\d{9}$/;
+
+type Announcement = {
+  id: string;
+  date: string;
+  family: string;
+  family_label: string;
+  court: string | null;
+  entity_name: string | null;
+  city: string | null;
+  postal_code: string | null;
+  judgment: Record<string, unknown> | null;
+  url: string | null;
+};
+
+function normalizeSiren(input: string): string {
+  return input.replace(/\s+/g, "").trim();
+}
+
+function safeParseJson(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "string") return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+async function bodaccQuery(params: Record<string, string>): Promise<{ total_count: number; results: any[] }> {
+  const qs = new URLSearchParams(params).toString();
+  const res = await fetch(`${BODACC_API}?${qs}`, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(15000),
+  });
+  if (!res.ok) {
+    throw new Error(`BODACC API returned HTTP ${res.status}`);
+  }
+  const data = (await res.json()) as { total_count?: number; results?: any[] };
+  return { total_count: data.total_count ?? 0, results: data.results ?? [] };
+}
+
+async function searchSirenByName(companyName: string): Promise<string> {
+  // BODACC search-by-name uses the `commercant` field
+  const { results } = await bodaccQuery({
+    limit: "5",
+    where: `commercant like "${companyName.replace(/"/g, '\\"')}"`,
+    order_by: "dateparution desc",
+  });
+  if (results.length === 0) {
+    throw new Error(`No BODACC announcement found for company name "${companyName}".`);
+  }
+  // Return first SIREN from `registre` array
+  for (const r of results) {
+    const reg = r?.registre;
+    if (Array.isArray(reg)) {
+      const unformatted = reg.find((s: string) => /^\d{9}$/.test(s));
+      if (unformatted) return unformatted;
+    }
+  }
+  throw new Error(`Found BODACC announcements for "${companyName}" but no SIREN extractable.`);
+}
+
+function mapResult(r: any): Announcement {
+  const reg = Array.isArray(r?.registre) ? r.registre : [];
+  return {
+    id: r?.id ?? "",
+    date: r?.dateparution ?? "",
+    family: r?.familleavis ?? "",
+    family_label: r?.familleavis_lib ?? "",
+    court: r?.tribunal ?? null,
+    entity_name: r?.commercant ?? null,
+    city: r?.ville ?? null,
+    postal_code: r?.cp ?? null,
+    judgment: safeParseJson(r?.jugement),
+    url: r?.url_complete ?? null,
+  };
+}
+
+registerCapability("fr-bodacc-lookup", async (input: CapabilityInput) => {
+  const sirenInput = ((input.siren as string) ?? "").trim();
+  const companyName = ((input.company_name as string) ?? "").trim();
+  const sinceDate = ((input.since_date as string) ?? "").trim();
+  const limit = Math.min(Math.max(Number(input.limit) || 50, 1), 200);
+
+  if (!sirenInput && !companyName) {
+    throw new Error("'siren' or 'company_name' is required. Provide a 9-digit SIREN (with or without spaces) or a company name.");
+  }
+
+  let siren: string;
+  if (sirenInput) {
+    siren = normalizeSiren(sirenInput);
+    if (!SIREN_RE.test(siren)) {
+      throw new Error(`Invalid SIREN: "${sirenInput}". SIREN must be exactly 9 digits.`);
+    }
+  } else {
+    siren = await searchSirenByName(companyName);
+  }
+
+  // Build where clause
+  const whereParts: string[] = [`registre like "${siren}"`];
+  if (sinceDate) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(sinceDate)) {
+      throw new Error(`Invalid since_date: "${sinceDate}". Must be ISO date YYYY-MM-DD.`);
+    }
+    whereParts.push(`dateparution >= "${sinceDate}"`);
+  }
+
+  const { total_count, results } = await bodaccQuery({
+    limit: String(limit),
+    where: whereParts.join(" AND "),
+    order_by: "dateparution desc",
+  });
+
+  const announcements = results.map(mapResult);
+  const insolvencyAnnouncements = announcements.filter((a) => a.family === "collective");
+  const mostRecentInsolvency = insolvencyAnnouncements[0] ?? null;
+  const mostRecentAny = announcements[0] ?? null;
+
+  return {
+    output: {
+      siren,
+      total_announcements: total_count,
+      insolvency_count: insolvencyAnnouncements.length,
+      has_insolvency_filing: insolvencyAnnouncements.length > 0,
+      most_recent_announcement_date: mostRecentAny?.date ?? null,
+      most_recent_insolvency: mostRecentInsolvency
+        ? {
+            date: mostRecentInsolvency.date,
+            court: mostRecentInsolvency.court,
+            judgment_type: (mostRecentInsolvency.judgment?.type as string) ?? null,
+            judgment_nature: (mostRecentInsolvency.judgment?.nature as string) ?? null,
+            judgment_date: (mostRecentInsolvency.judgment?.date as string) ?? null,
+            summary: (mostRecentInsolvency.judgment?.complementJugement as string) ?? null,
+            url: mostRecentInsolvency.url,
+          }
+        : null,
+      announcements,
+      data_source: "BODACC (Bulletin Officiel des Annonces Civiles et Commerciales)",
+    },
+    provenance: {
+      source: "bodacc-datadila.opendatasoft.com",
+      fetched_at: new Date().toISOString(),
+    },
+  };
+});

--- a/manifests/fr-bodacc-lookup.yaml
+++ b/manifests/fr-bodacc-lookup.yaml
@@ -1,0 +1,135 @@
+slug: fr-bodacc-lookup
+name: BODACC Lookup (FR)
+description: >-
+  Lookup of French commercial-registry announcements (BODACC) by SIREN. Returns insolvency proceedings (procédures
+  collectives), modifications, sales, strikeoffs, and incorporations from the official Bulletin Officiel des Annonces
+  Civiles et Commerciales. Elevates insolvency signal for risk decisions.
+category: compliance
+price_cents: 5
+is_free_tier: false
+avg_latency_ms: 800
+input_schema:
+  type: object
+  required: []
+  properties:
+    siren:
+      type: string
+      description: 9-digit French SIREN (with or without spaces). Canonical input.
+    company_name:
+      type: string
+      description: Optional fallback input — company name to search BODACC if no SIREN is known. Resolves to SIREN internally.
+    since_date:
+      type: string
+      description: Optional ISO date (YYYY-MM-DD) to filter announcements published on or after this date.
+    limit:
+      type: integer
+      description: Optional max number of announcements to return (default 50, max 200).
+output_schema:
+  type: object
+  example:
+    siren: "552049447"
+    total_announcements: 72
+    insolvency_count: 0
+    has_insolvency_filing: false
+    most_recent_announcement_date: "2021-08-27"
+    most_recent_insolvency: null
+    announcements:
+      - id: B202101671375
+        date: "2021-08-27"
+        family: modification
+        family_label: Modifications diverses
+        court: GREFFE DU TRIBUNAL DE COMMERCE DE BOBIGNY
+        entity_name: Société nationale SNCF
+        city: Saint-Denis
+        postal_code: "93200"
+        judgment: null
+        url: https://www.bodacc.fr/pages/annonces-commerciales-detail/?q.id=id:B202101671375
+    data_source: BODACC (Bulletin Officiel des Annonces Civiles et Commerciales)
+  properties:
+    siren:
+      type: string
+    total_announcements:
+      type: integer
+    insolvency_count:
+      type: integer
+    has_insolvency_filing:
+      type: boolean
+    most_recent_announcement_date:
+      type:
+        - string
+        - "null"
+    most_recent_insolvency:
+      type:
+        - object
+        - "null"
+    announcements:
+      type: array
+    data_source:
+      type: string
+data_source: BODACC (Bulletin Officiel des Annonces Civiles et Commerciales)
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: fr
+test_fixtures:
+  known_answer:
+    input:
+      siren: "552049447"
+    expected_fields:
+      - field: siren
+        operator: equals
+        reliability: guaranteed
+        value: "552049447"
+      - field: total_announcements
+        operator: not_null
+        reliability: guaranteed
+      - field: insolvency_count
+        operator: not_null
+        reliability: guaranteed
+      - field: has_insolvency_filing
+        operator: equals
+        reliability: guaranteed
+        value: false
+      - field: announcements
+        operator: not_null
+        reliability: guaranteed
+      - field: data_source
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    siren: "552049447"
+output_field_reliability:
+  siren: guaranteed
+  total_announcements: guaranteed
+  insolvency_count: guaranteed
+  has_insolvency_filing: guaranteed
+  announcements: guaranteed
+  data_source: guaranteed
+  most_recent_announcement_date: common
+  most_recent_insolvency: common
+limitations:
+  - title: Coverage limited to French registered entities
+    text: >-
+      BODACC only contains announcements for entities registered in the French commercial register (RCS). Foreign
+      entities operating in France without RCS registration are not covered. SIREN is the unique identifier — entities
+      without a SIREN cannot be looked up.
+    category: coverage
+    severity: info
+  - title: Annual-accounts deposits ("dpc") dominate the corpus
+    text: >-
+      The most common announcement type is "Dépôts des comptes" (annual accounts deposit) — these are routine compliance
+      filings, not risk signals. Use has_insolvency_filing or insolvency_count to isolate the litigation/bankruptcy
+      signal.
+    category: accuracy
+    severity: info
+  - title: Recovery from insolvency is not auto-detected
+    text: >-
+      has_insolvency_filing is true if any procédure collective announcement exists in history. It does not distinguish
+      active proceedings from closed/recovered ones. Inspect most_recent_insolvency.judgment_nature to read the latest
+      court action (e.g. "Jugement de clôture" indicates closure).
+    category: accuracy
+    severity: warning
+    workaround: Read most_recent_insolvency.judgment_nature and judgment_date to determine current status.


### PR DESCRIPTION
## Summary

- Adds **`fr-bodacc-lookup`** — returns all BODACC announcements for a French SIREN: insolvency proceedings, modifications, sales, strikeoffs, incorporations.
- Elevates insolvency signal as top-level fields: `insolvency_count`, `has_insolvency_filing`, `most_recent_insolvency` (with court, judgment date, judgment nature, summary).
- Free `bodacc-datadila.opendatasoft.com` API. CC-BY-2.0 license. No auth.

## Why now

Phase 0 step #2 from DEC-20260430-A — biggest single litigation/bankruptcy source in EU for the largest direct-API country (FR). No commercial commitment required.

## Verification

- Manifest pipeline: all 5 onboarding gates pass.
- Known-answer test: **all 6 assertions verified live** against SNCF (SIREN `552049447`): `has_insolvency_filing=false`, `total_announcements>0`, etc.
- Smoke test: **11/12 pass**. Only "SQS pending" fails (expected for fresh cap).
- Negative test: throws structured error on empty input.
- Live execution: 8 fields returned in 476ms.

## Note

The auto-discover step initially turned `most_recent_announcement_date` into an `equals` assertion against the live value — which would have been flaky since SNCF files new announcements over time. Removed before backfill; 6 stable assertions remain.

## Test plan

- [x] Onboarding pipeline `--discover` runs clean
- [x] Known-answer assertions verified live
- [x] Negative test (empty input) returns structured error
- [x] Capability is `is_active=true, visible=true, lifecycle_state=active`
- [x] Manifest validation passes
- [ ] First scheduled test run computes SQS (will happen automatically post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)