### PR TITLE
feat(capability): no-bankruptcy-check — Norwegian bankruptcy/dissolution

### DIFF
--- a/apps/api/src/capabilities/no-bankruptcy-check.ts
+++ b/apps/api/src/capabilities/no-bankruptcy-check.ts
@@ -1,0 +1,108 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * Norwegian bankruptcy / dissolution status check via Brønnøysundregistrene
+ * Enhetsregisteret. Surfaces the structured bankruptcy fields that the
+ * registry exposes per entity:
+ *
+ *   konkurs                                  → has_bankruptcy_filing
+ *   konkursdato                              → bankruptcy_date
+ *   underAvvikling                           → is_under_dissolution
+ *   underTvangsavviklingEllerTvangsopplosning → is_under_compulsory_dissolution
+ *   paategninger                             → registry_annotations
+ *
+ * The companion `norwegian-company-data` capability returns the broader
+ * registry record but exposes bankruptcy as a coarse `status` enum only.
+ * This capability is the dedicated litigation/bankruptcy leg for Payee
+ * Assurance — the boolean signals plus the bankruptcy filing date are
+ * what risk-decisioning code needs.
+ *
+ * Source: data.brreg.no, NLOD 2.0, free, no auth.
+ */
+
+const BRREG_API = "https://data.brreg.no/enhetsregisteret/api";
+const ORG_NUMBER_RE = /^\d{9}$/;
+
+function normalizeOrgNumber(input: string): string {
+  return input.replace(/[\s.-]/g, "").trim();
+}
+
+async function searchByName(name: string): Promise<string> {
+  const res = await fetch(
+    `${BRREG_API}/enheter?navn=${encodeURIComponent(name)}&size=1`,
+    {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10000),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Brønnøysundregistrene search returned HTTP ${res.status}`);
+  }
+  const data = (await res.json()) as any;
+  const entities = data?._embedded?.enheter;
+  if (!entities || entities.length === 0) {
+    throw new Error(`No Norwegian company found matching "${name}".`);
+  }
+  return String(entities[0].organisasjonsnummer);
+}
+
+registerCapability("no-bankruptcy-check", async (input: CapabilityInput) => {
+  const orgInput = ((input.org_number as string) ?? "").trim();
+  const companyName = ((input.company_name as string) ?? "").trim();
+
+  if (!orgInput && !companyName) {
+    throw new Error("'org_number' or 'company_name' is required. Provide a 9-digit Norwegian org number or a company name.");
+  }
+
+  let orgNumber: string;
+  if (orgInput) {
+    orgNumber = normalizeOrgNumber(orgInput);
+    if (!ORG_NUMBER_RE.test(orgNumber)) {
+      throw new Error(`Invalid org_number: "${orgInput}". Norwegian org numbers must be exactly 9 digits.`);
+    }
+  } else {
+    orgNumber = await searchByName(companyName);
+  }
+
+  const res = await fetch(`${BRREG_API}/enheter/${orgNumber}`, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (res.status === 404) {
+    throw new Error(`Norwegian company with org number ${orgNumber} not found.`);
+  }
+  if (!res.ok) {
+    throw new Error(`Brønnøysundregistrene returned HTTP ${res.status}`);
+  }
+  const data = (await res.json()) as any;
+
+  const hasBankruptcy = Boolean(data.konkurs);
+  const isUnderDissolution = Boolean(data.underAvvikling);
+  const isUnderCompulsoryDissolution = Boolean(data.underTvangsavviklingEllerTvangsopplosning);
+  const annotations = Array.isArray(data.paategninger) ? data.paategninger : [];
+
+  return {
+    output: {
+      org_number: orgNumber,
+      company_name: data.navn ?? null,
+      has_bankruptcy_filing: hasBankruptcy,
+      bankruptcy_date: data.konkursdato ?? null,
+      is_under_dissolution: isUnderDissolution,
+      is_under_compulsory_dissolution: isUnderCompulsoryDissolution,
+      has_any_distress_signal:
+        hasBankruptcy || isUnderDissolution || isUnderCompulsoryDissolution,
+      registry_annotations: annotations,
+      data_source: "Brønnøysundregistrene Enhetsregisteret",
+    },
+    provenance: {
+      source: "data.brreg.no",
+      source_url: `${BRREG_API}/enheter/${orgNumber}`,
+      fetched_at: new Date().toISOString(),
+      acquisition_method: "direct_api" as const,
+      primary_source_reference: `${BRREG_API}/enheter/${orgNumber}`,
+      license: "NLOD 2.0",
+      license_url: "https://data.norge.no/nlod/no/2.0",
+      attribution: "Kilde: Brønnøysundregistrene",
+    },
+  };
+});

--- a/manifests/no-bankruptcy-check.yaml
+++ b/manifests/no-bankruptcy-check.yaml
@@ -1,0 +1,130 @@
+slug: no-bankruptcy-check
+name: Norwegian Bankruptcy Check
+description: >-
+  Check Norwegian entity bankruptcy and dissolution status via Brønnøysundregistrene Enhetsregisteret. Returns
+  structured signals: has_bankruptcy_filing, bankruptcy_date, is_under_dissolution, is_under_compulsory_dissolution,
+  plus official registry annotations. NLOD 2.0 license.
+category: compliance
+price_cents: 5
+is_free_tier: false
+avg_latency_ms: 400
+input_schema:
+  type: object
+  required: []
+  properties:
+    org_number:
+      type: string
+      description: 9-digit Norwegian organization number (with or without spaces). Canonical input.
+    company_name:
+      type: string
+      description: Optional fallback input — Norwegian company name to search Brønnøysundregistrene if no org number is known.
+output_schema:
+  type: object
+  example:
+    org_number: "923609016"
+    company_name: EQUINOR ASA
+    has_bankruptcy_filing: false
+    bankruptcy_date: null
+    is_under_dissolution: false
+    is_under_compulsory_dissolution: false
+    has_any_distress_signal: false
+    registry_annotations: []
+    data_source: Brønnøysundregistrene Enhetsregisteret
+  properties:
+    org_number:
+      type: string
+    company_name:
+      type:
+        - string
+        - "null"
+    has_bankruptcy_filing:
+      type: boolean
+    bankruptcy_date:
+      type:
+        - string
+        - "null"
+    is_under_dissolution:
+      type: boolean
+    is_under_compulsory_dissolution:
+      type: boolean
+    has_any_distress_signal:
+      type: boolean
+    registry_annotations:
+      type: array
+    data_source:
+      type: string
+data_source: Brønnøysundregistrene Enhetsregisteret
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: "no"
+test_fixtures:
+  known_answer:
+    input:
+      org_number: "923609016"
+    expected_fields:
+      - field: org_number
+        operator: equals
+        reliability: guaranteed
+        value: "923609016"
+      - field: company_name
+        operator: not_null
+        reliability: guaranteed
+      - field: has_bankruptcy_filing
+        operator: equals
+        reliability: guaranteed
+        value: false
+      - field: is_under_dissolution
+        operator: equals
+        reliability: guaranteed
+        value: false
+      - field: is_under_compulsory_dissolution
+        operator: equals
+        reliability: guaranteed
+        value: false
+      - field: has_any_distress_signal
+        operator: equals
+        reliability: guaranteed
+        value: false
+      - field: registry_annotations
+        operator: not_null
+        reliability: guaranteed
+      - field: data_source
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    org_number: "923609016"
+output_field_reliability:
+  org_number: guaranteed
+  has_bankruptcy_filing: guaranteed
+  is_under_dissolution: guaranteed
+  is_under_compulsory_dissolution: guaranteed
+  has_any_distress_signal: guaranteed
+  registry_annotations: guaranteed
+  data_source: guaranteed
+  company_name: common
+  bankruptcy_date: rare
+limitations:
+  - title: Coverage limited to entities in Brønnøysundregistrene Enhetsregisteret
+    text: >-
+      Only Norwegian entities registered in Enhetsregisteret are covered. Foreign entities and informal businesses
+      without an org number cannot be looked up.
+    category: coverage
+    severity: info
+  - title: Recovery from bankruptcy or dissolution is not surfaced separately
+    text: >-
+      has_bankruptcy_filing reflects current registry state. If a previously bankrupt entity has been restored or
+      completed liquidation, the registry may no longer show konkurs=true. Inspect registry_annotations (paategninger)
+      for the historical timeline of registry events.
+    category: accuracy
+    severity: info
+  - title: Bankruptcy proceedings detail (court, trustee, creditor list) not exposed
+    text: >-
+      Brønnøysundregistrene's free open-data API exposes only the structured booleans and bankruptcy_date. Full
+      case-by-case detail (handling court, appointed trustee, creditor schedule) is held in Konkursregisteret and Norsk
+      Lysingsblad and is not free machine-readable.
+    category: coverage
+    severity: warning


### PR DESCRIPTION
## Summary

- Adds **`no-bankruptcy-check`** — Norwegian entity bankruptcy and dissolution status via Brønnøysundregistrene Enhetsregisteret.
- Returns structured signals: `has_bankruptcy_filing`, `bankruptcy_date`, `is_under_dissolution`, `is_under_compulsory_dissolution`, `has_any_distress_signal`, plus official registry annotations (`paategninger`).
- Free, NLOD 2.0 license, no auth.

## Why now

Phase 0 step #3 from DEC-20260430-A — closes the NO bankruptcy/litigation leg for Payee Assurance.

## Why a separate capability vs extending norwegian-company-data

`norwegian-company-data` already returns a coarse `status` enum (active/dissolving/bankrupt) but doesn't surface the structured underlying fields (`konkursdato`, `underTvangsavvikling*`, `paategninger`). The Payee Assurance bundle architecture needs litigation/bankruptcy as a distinct leg — same shape as BODACC for FR. A shared `lib/brreg-fetch.ts` can deduplicate the upstream call later if volume warrants.

## Verification

- All 5 onboarding gates pass.
- **All 8 known-answer assertions verified live** against Equinor ASA (`923609016`) — large stable entity, returns all distress signals false.
- Smoke test: **11/12 pass** (SQS pending, expected for fresh cap).
- Negative test: throws structured error on empty input.
- Live execution: 9 fields in 308ms.

## Test plan

- [x] Onboarding pipeline `--discover` runs clean
- [x] Known-answer assertions verified live
- [x] Negative test returns structured error
- [x] Capability is `is_active=true, visible=true, lifecycle_state=active`
- [ ] First scheduled test run computes SQS

🤖 Generated with [Claude Code](https://claude.com/claude-code)