### PR TITLE
feat(capability): gleif-l2-children-lookup — subsidiaries via GLEIF L2

### DIFF
--- a/apps/api/src/capabilities/gleif-l2-children-lookup.ts
+++ b/apps/api/src/capabilities/gleif-l2-children-lookup.ts
@@ -1,0 +1,122 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * GLEIF Level 2 (Who Owns Whom) — children lookup.
+ *
+ * Returns direct or ultimate child LEI records for a given entity. Useful
+ * for due-diligence questions like "is this a holding company?" or "what
+ * subsidiaries does this entity own?". Pairs with `gleif-l2-ubo-lookup`
+ * which goes the other direction (parents).
+ *
+ * Free, no auth, CC0-equivalent license. Coverage limited to entities
+ * that have an LEI (~2.6M globally, mostly large/regulated). Children
+ * are entities that themselves have LEIs and report this entity as
+ * direct or ultimate parent.
+ */
+
+const GLEIF_API = "https://api.gleif.org/api/v1";
+const LEI_RE = /^[A-Z0-9]{20}$/;
+
+type ChildInfo = {
+  lei: string;
+  legal_name: string;
+  jurisdiction: string | null;
+  country: string | null;
+};
+
+async function gleifFetch(path: string): Promise<Response> {
+  return fetch(`${GLEIF_API}${path}`, {
+    headers: { Accept: "application/vnd.api+json" },
+    signal: AbortSignal.timeout(10000),
+  });
+}
+
+async function lookupByLei(lei: string): Promise<{ lei: string; legal_name: string; jurisdiction: string | null }> {
+  const res = await gleifFetch(`/lei-records/${lei}`);
+  if (res.status === 404) throw new Error(`LEI ${lei} not found in GLEIF database.`);
+  if (!res.ok) throw new Error(`GLEIF API returned HTTP ${res.status}`);
+  const data = (await res.json()) as any;
+  const entity = data?.data?.attributes?.entity ?? {};
+  return {
+    lei: data?.data?.attributes?.lei || lei,
+    legal_name: entity.legalName?.name || "",
+    jurisdiction: entity.jurisdiction || null,
+  };
+}
+
+async function searchByName(name: string, jurisdiction?: string): Promise<string> {
+  let url = `/lei-records?filter[entity.legalName]=${encodeURIComponent(name)}&page[size]=5`;
+  if (jurisdiction) url += `&filter[entity.legalAddress.country]=${encodeURIComponent(jurisdiction)}`;
+  const res = await gleifFetch(url);
+  if (!res.ok) throw new Error(`GLEIF search returned HTTP ${res.status}`);
+  const data = (await res.json()) as any;
+  const records: any[] = data?.data ?? [];
+  if (records.length === 0) throw new Error(`No LEI found matching "${name}".`);
+  const active = records.find((r) => r?.attributes?.entity?.status === "ACTIVE");
+  return (active ?? records[0])?.attributes?.lei;
+}
+
+function mapChild(record: any): ChildInfo {
+  const entity = record?.attributes?.entity ?? {};
+  return {
+    lei: record?.attributes?.lei || record?.id || "",
+    legal_name: entity.legalName?.name || "",
+    jurisdiction: entity.jurisdiction || null,
+    country: entity.legalAddress?.country || null,
+  };
+}
+
+registerCapability("gleif-l2-children-lookup", async (input: CapabilityInput) => {
+  const leiInput = (input.lei as string)?.trim().toUpperCase() ?? "";
+  const companyName = (input.company_name as string)?.trim() ?? "";
+  const jurisdiction = (input.jurisdiction as string)?.trim().toUpperCase() ?? undefined;
+  const level = ((input.level as string) ?? "direct").trim().toLowerCase();
+  const limit = Math.min(Math.max(Number(input.limit) || 20, 1), 200);
+
+  if (!leiInput && !companyName) {
+    throw new Error("'lei' or 'company_name' is required. Provide a 20-character LEI or a company name to search.");
+  }
+
+  if (level !== "direct" && level !== "ultimate") {
+    throw new Error(`Invalid level: "${level}". Must be "direct" or "ultimate".`);
+  }
+
+  const lei = LEI_RE.test(leiInput) ? leiInput : await searchByName(companyName, jurisdiction);
+
+  // Fetch entity record + first page of children
+  const [entity, childrenRes] = await Promise.all([
+    lookupByLei(lei),
+    gleifFetch(`/lei-records/${lei}/${level}-children?page[size]=${limit}`),
+  ]);
+
+  let totalChildren = 0;
+  let children: ChildInfo[] = [];
+
+  if (childrenRes.ok) {
+    const data = (await childrenRes.json()) as any;
+    totalChildren = data?.meta?.pagination?.total ?? (data?.data?.length ?? 0);
+    children = (data?.data ?? []).map(mapChild);
+  } else if (childrenRes.status !== 404) {
+    throw new Error(`GLEIF L2 children endpoint returned HTTP ${childrenRes.status}`);
+  }
+  // 404 → no children, return totals=0
+
+  return {
+    output: {
+      input_lei: entity.lei,
+      legal_name: entity.legal_name,
+      jurisdiction: entity.jurisdiction,
+      level,
+      total_children: totalChildren,
+      has_children: totalChildren > 0,
+      is_holding_entity: totalChildren > 0,
+      children,
+      paginated: totalChildren > children.length,
+      data_source: "GLEIF Level 2 (Who Owns Whom)",
+    },
+    provenance: {
+      source: "gleif.org",
+      fetched_at: new Date().toISOString(),
+    },
+  };
+});

--- a/manifests/gleif-l2-children-lookup.yaml
+++ b/manifests/gleif-l2-children-lookup.yaml
@@ -1,0 +1,154 @@
+slug: gleif-l2-children-lookup
+name: GLEIF L2 Children Lookup
+description: >-
+  Direct or ultimate child LEI records for a given entity, via GLEIF Level 2 (Who Owns Whom). Useful for "is this a
+  holding entity?" and "what subsidiaries does this entity own?". Pairs with gleif-l2-ubo-lookup (which goes the other
+  direction). Free, CC0-equivalent license.
+category: compliance
+price_cents: 5
+is_free_tier: false
+avg_latency_ms: 800
+input_schema:
+  type: object
+  required: []
+  properties:
+    lei:
+      type: string
+      description: 20-character LEI of the entity to look up children for. Canonical input.
+    company_name:
+      type: string
+      description: Optional fallback input — company name to search GLEIF for if no LEI is known. Resolves to an LEI internally.
+    jurisdiction:
+      type: string
+      description: Optional ISO country code (e.g. "LU") to disambiguate name search.
+    level:
+      type: string
+      description: Optional. Either "direct" (immediate children) or "ultimate" (full descendant tree). Default direct.
+    limit:
+      type: integer
+      description: Optional max number of children to return per page (default 20, max 200).
+output_schema:
+  type: object
+  example:
+    input_lei: 549300B4X0JHWV0DTD60
+    legal_name: SPOTIFY TECHNOLOGY S.A.
+    jurisdiction: LU
+    level: direct
+    total_children: 2
+    has_children: true
+    is_holding_entity: true
+    children:
+      - lei: 335800LYVN89V3RVI889
+        legal_name: SPOTIFY INDIA LLP
+        jurisdiction: IN
+        country: IN
+    paginated: false
+    data_source: GLEIF Level 2 (Who Owns Whom)
+  properties:
+    input_lei:
+      type: string
+    legal_name:
+      type: string
+    jurisdiction:
+      type:
+        - string
+        - "null"
+    level:
+      type: string
+    total_children:
+      type: integer
+    has_children:
+      type: boolean
+    is_holding_entity:
+      type: boolean
+    children:
+      type: array
+    paginated:
+      type: boolean
+    data_source:
+      type: string
+data_source: GLEIF Level 2 (Who Owns Whom)
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: global
+test_fixtures:
+  known_answer:
+    input:
+      lei: 549300B4X0JHWV0DTD60
+    expected_fields:
+      - field: input_lei
+        operator: equals
+        reliability: guaranteed
+        value: 549300B4X0JHWV0DTD60
+      - field: legal_name
+        operator: not_null
+        reliability: guaranteed
+      - field: jurisdiction
+        operator: equals
+        reliability: guaranteed
+        value: LU
+      - field: level
+        operator: equals
+        reliability: guaranteed
+        value: direct
+      - field: total_children
+        operator: not_null
+        reliability: guaranteed
+      - field: has_children
+        operator: equals
+        reliability: guaranteed
+        value: true
+      - field: is_holding_entity
+        operator: equals
+        reliability: guaranteed
+        value: true
+      - field: children
+        operator: not_null
+        reliability: guaranteed
+      - field: paginated
+        operator: equals
+        reliability: guaranteed
+        value: false
+      - field: data_source
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    lei: 549300B4X0JHWV0DTD60
+output_field_reliability:
+  input_lei: guaranteed
+  legal_name: guaranteed
+  jurisdiction: guaranteed
+  level: guaranteed
+  total_children: guaranteed
+  has_children: guaranteed
+  is_holding_entity: guaranteed
+  children: guaranteed
+  paginated: guaranteed
+  data_source: guaranteed
+limitations:
+  - title: Coverage is limited to entities that have an LEI
+    text: >-
+      GLEIF L2 only lists children whose LEIs themselves are registered in the GLEIF system. A subsidiary that has not
+      registered for an LEI will not appear in the children list, even if its parent relationship is real and reported
+      elsewhere. Pair with country-registry subsidiary lookups for SMEs.
+    category: coverage
+    severity: info
+  - title: Direct vs ultimate is the explicit knob
+    text: >-
+      Default is `level=direct` — only immediate children are returned. Pass `level=ultimate` to return the full
+      descendant tree (entities reporting this LEI as their ultimate parent transitively). Ultimate-children pages can
+      be very large for top-of-tree multinationals; use `limit` to bound.
+    category: accuracy
+    severity: info
+  - title: Pagination not yet exposed in output
+    text: >-
+      First page of children is returned with total_children indicating the full count. When total_children >
+      children.length, the `paginated: true` flag signals more results available upstream but the executor returns only
+      the first page. To retrieve subsequent pages a new capability call would be needed (next-page support is a future
+      enhancement).
+    category: coverage
+    severity: warning


### PR DESCRIPTION
## Summary

- Adds **`gleif-l2-children-lookup`** — returns direct or ultimate child LEI records for any entity. Companion to [`gleif-l2-ubo-lookup`](https://github.com/strale-io/strale/pull/23) (parents).
- Same GLEIF L2 API, same auth-free / CC0 / global coverage. Surfaces `is_holding_entity`, `total_children`, structured children list.
- Useful for due-diligence: "is this a holding entity?" / "what subsidiaries does this entity own?".

## Why now

Quick win using a proven pattern — same API as `gleif-l2-ubo-lookup` shipped earlier today. ~30 min of work. No signup, no contract, no spend. Adds material value to KYB Complete bundles.

## Verification

- All 5 onboarding gates pass.
- **All 10 known-answer assertions verified live** against Spotify Technology S.A. (LEI `549300B4X0JHWV0DTD60`) — 2 direct children, including SPOTIFY INDIA LLP.
- Smoke test: **11/12 pass** (SQS pending, expected for fresh cap).
- Negative test: throws structured error on empty input.
- Live execution: 10 fields in 369ms.

## Note

Pagination is partially exposed: first page is returned with `total_children` indicating full count, and a `paginated: true` flag signals more available. Multi-page retrieval is a future enhancement. Acceptable for v1 — most entities don't have hundreds of direct subsidiaries; ultimate-tree calls are bounded by the `limit` param (max 200).

## Test plan

- [x] Onboarding pipeline `--discover` runs clean
- [x] Known-answer assertions verified live
- [x] Negative test returns structured error
- [x] Capability is `is_active=true, visible=true, lifecycle_state=active`
- [ ] First scheduled test run computes SQS

🤖 Generated with [Claude Code](https://claude.com/claude-code)