### PR TITLE
chore(ops): suspend 4 pre-deploy capabilities + reactivation script

### DIFF
--- a/apps/api/scripts/reactivate-pre-deploy-caps.ts
+++ b/apps/api/scripts/reactivate-pre-deploy-caps.ts
@@ -1,0 +1,67 @@
+/**
+ * Re-activate the 4 capabilities suspended by suspend-pre-deploy-caps.ts.
+ * Run this AFTER the corresponding PRs (#23, #24, #25, #28) merge and
+ * Railway has deployed.
+ *
+ * Sets: isActive=true, visible=true, lifecycleState=active.
+ *
+ * The scheduler picks them up on the next tick. After 3 consecutive
+ * passes, recovery is automatic per the SQS recovery rule.
+ *
+ * Verification: after running this, watch the test_results table for
+ * passing test runs — should see PASS results within ~10-15 minutes.
+ * If failures continue, the executor still isn't deployed.
+ */
+
+import { config } from "dotenv";
+import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+
+config({ path: resolve(import.meta.dirname, "../../../.env") });
+if (!process.env.DATABASE_URL) {
+  const buf = readFileSync(resolve(import.meta.dirname, "../../../.env"));
+  const text = buf.toString("utf16le");
+  const clean = text.charCodeAt(0) === 0xFEFF ? text.slice(1) : text;
+  for (const line of clean.split(/\r?\n/)) {
+    if (line.startsWith("DATABASE_URL=")) {
+      process.env.DATABASE_URL = line.substring("DATABASE_URL=".length);
+      break;
+    }
+  }
+}
+
+import { getDb } from "../src/db/index.js";
+import { capabilities } from "../src/db/schema.js";
+import { inArray } from "drizzle-orm";
+
+const SLUGS = [
+  "gleif-l2-ubo-lookup",
+  "fr-bodacc-lookup",
+  "no-bankruptcy-check",
+  "gleif-l2-children-lookup",
+];
+
+const db = getDb();
+const result = await db
+  .update(capabilities)
+  .set({
+    isActive: true,
+    visible: true,
+    lifecycleState: "active",
+    updatedAt: new Date(),
+  })
+  .where(inArray(capabilities.slug, SLUGS))
+  .returning({
+    slug: capabilities.slug,
+    isActive: capabilities.isActive,
+    visible: capabilities.visible,
+    lifecycleState: capabilities.lifecycleState,
+  });
+
+console.log("Re-activated:");
+for (const r of result) {
+  console.log(`  ${r.slug.padEnd(28)} active=${r.isActive} visible=${r.visible} lifecycle=${r.lifecycleState}`);
+}
+console.log(`\n${result.length} of ${SLUGS.length} rows updated.`);
+console.log(`\nNext: watch test_results for PASS results within ~10-15 min. If failures persist, executor isn't deployed.`);
+process.exit(0);

--- a/apps/api/scripts/suspend-pre-deploy-caps.ts
+++ b/apps/api/scripts/suspend-pre-deploy-caps.ts
@@ -1,0 +1,75 @@
+/**
+ * Suspend the 4 capabilities onboarded today (2026-04-30) until their
+ * PRs merge and Railway redeploys with the executor files.
+ *
+ * Why: the onboarding pipeline writes to the production DB even when the
+ * executor file only exists on a feature branch. Production's auto-register
+ * can't find the file at startup, every test run fails with "No executor
+ * registered", and the cap auto-degrades. Customers may see the cap in
+ * /v1/capabilities and call it, getting an error response.
+ *
+ * This script suspends them: isActive=false + visible=false +
+ * lifecycleState=validating. Re-activate via reactivate-pre-deploy-caps.ts
+ * once the PRs merge and the new code is deployed.
+ *
+ * Slugs:
+ *   gleif-l2-ubo-lookup        (PR #23)
+ *   fr-bodacc-lookup           (PR #24)
+ *   no-bankruptcy-check        (PR #25)
+ *   gleif-l2-children-lookup   (PR #28)
+ *
+ * Long-term fix (out of scope here): pipeline should detect missing
+ * executor on the deploy target and refuse to set lifecycle=active.
+ */
+
+import { config } from "dotenv";
+import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+
+config({ path: resolve(import.meta.dirname, "../../../.env") });
+if (!process.env.DATABASE_URL) {
+  const buf = readFileSync(resolve(import.meta.dirname, "../../../.env"));
+  const text = buf.toString("utf16le");
+  const clean = text.charCodeAt(0) === 0xFEFF ? text.slice(1) : text;
+  for (const line of clean.split(/\r?\n/)) {
+    if (line.startsWith("DATABASE_URL=")) {
+      process.env.DATABASE_URL = line.substring("DATABASE_URL=".length);
+      break;
+    }
+  }
+}
+
+import { getDb } from "../src/db/index.js";
+import { capabilities } from "../src/db/schema.js";
+import { inArray } from "drizzle-orm";
+
+const SLUGS = [
+  "gleif-l2-ubo-lookup",
+  "fr-bodacc-lookup",
+  "no-bankruptcy-check",
+  "gleif-l2-children-lookup",
+];
+
+const db = getDb();
+const result = await db
+  .update(capabilities)
+  .set({
+    isActive: false,
+    visible: false,
+    lifecycleState: "validating",
+    updatedAt: new Date(),
+  })
+  .where(inArray(capabilities.slug, SLUGS))
+  .returning({
+    slug: capabilities.slug,
+    isActive: capabilities.isActive,
+    visible: capabilities.visible,
+    lifecycleState: capabilities.lifecycleState,
+  });
+
+console.log("Suspended:");
+for (const r of result) {
+  console.log(`  ${r.slug.padEnd(28)} active=${r.isActive} visible=${r.visible} lifecycle=${r.lifecycleState}`);
+}
+console.log(`\n${result.length} of ${SLUGS.length} rows updated.`);
+process.exit(0);


### PR DESCRIPTION
## Summary

Closes a deploy-lag issue: the 4 capabilities onboarded today (PRs #23, #24, #25, #28) had their DB rows created against production but the executor files only exist on unmerged feature branches. Production's auto-register can't find the files, every test scheduler tick fails, the caps auto-degrade.

Diagnostic against `test_results` confirmed all 4 affected caps had identical "No executor registered" failures across every test type.

## What's in this PR

- **`suspend-pre-deploy-caps.ts`** — sets `isActive=false`, `visible=false`, `lifecycleState=validating` on the 4 caps. Hides them from `/v1/capabilities` and stops the test scheduler. **Already executed against production today** (output: 4 of 4 rows updated).
- **`reactivate-pre-deploy-caps.ts`** — inverse. Run AFTER PRs #23, #24, #25, #28 merge and Railway redeploys. Sets `isActive=true`, `visible=true`, `lifecycleState=active`. Recovery to non-degraded state is automatic after 3 consecutive passing test runs per the SQS recovery rule.

## Long-term fix (separate work)

The onboarding pipeline should detect that the executor isn't on the deploy target before flipping `lifecycle=active`. Currently it activates immediately — only safe if the deploy lands within minutes, not realistic for PR-driven deploys.

## Deploy sequence (in order)

1. Merge PR #23 (gleif-l2-ubo-lookup)
2. Merge PR #24 (fr-bodacc-lookup)
3. Merge PR #25 (no-bankruptcy-check)
4. Merge PR #28 (gleif-l2-children-lookup)
5. Wait for Railway to redeploy (~3 min)
6. Run `npx tsx apps/api/scripts/reactivate-pre-deploy-caps.ts`
7. Watch `test_results` for PASS results within 10-15 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)