### PR TITLE
feat(capabilities): pre-write 5 gated executors for v1.1 vendors

### DIFF
--- a/apps/api/src/capabilities/uk-cop-check.ts
+++ b/apps/api/src/capabilities/uk-cop-check.ts
@@ -1,0 +1,125 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * UK Confirmation of Payee (CoP) check via eSortcode.
+ *
+ * Pay.UK CoP scheme verifies that a sort code + account number pair
+ * matches an account-holder name registered at the responding PSP.
+ * Returns one of: match / close_match / no_match / no_account / cannot_be_checked.
+ *
+ * Vendor: eSortcode (esortcode.com) — Tier-2 vendor-mediated public
+ * scheme participant. £0.15/check PAYG, no minimums, no setup fee.
+ * Selection per DEC-20260430-A. UK-only; for EU SEPA see the SEPA VoP
+ * vendor (see Active Vendor Stack page).
+ *
+ * Activation: requires ESORTCODE_API_KEY in env. Sign up at
+ * esortcode.com/confirmation-of-payee and add the API key to Railway env
+ * config. Without the key the executor throws a structured error.
+ */
+
+const ESORTCODE_API = "https://api.esortcode.com/v1";
+const SORT_CODE_RE = /^\d{6}$/;
+const ACCOUNT_NUMBER_RE = /^\d{8}$/;
+
+type AccountType = "personal" | "business";
+
+function normalizeSortCode(input: string): string {
+  return input.replace(/[\s-]/g, "");
+}
+
+registerCapability("uk-cop-check", async (input: CapabilityInput) => {
+  const apiKey = process.env.ESORTCODE_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "ESORTCODE_API_KEY is required for UK CoP checks. Sign up at https://esortcode.com/confirmation-of-payee and configure the API key.",
+    );
+  }
+
+  const sortCodeRaw = ((input.sort_code as string) ?? "").trim();
+  const accountNumberRaw = ((input.account_number as string) ?? "").trim();
+  const accountHolderName = ((input.account_holder_name as string) ?? "").trim();
+  const accountType = (((input.account_type as string) ?? "business").trim().toLowerCase()) as AccountType;
+
+  if (!sortCodeRaw || !accountNumberRaw || !accountHolderName) {
+    throw new Error(
+      "'sort_code', 'account_number', and 'account_holder_name' are all required.",
+    );
+  }
+  const sortCode = normalizeSortCode(sortCodeRaw);
+  if (!SORT_CODE_RE.test(sortCode)) {
+    throw new Error(`Invalid sort_code: "${sortCodeRaw}". UK sort codes are exactly 6 digits.`);
+  }
+  if (!ACCOUNT_NUMBER_RE.test(accountNumberRaw)) {
+    throw new Error(`Invalid account_number: "${accountNumberRaw}". UK account numbers are exactly 8 digits.`);
+  }
+  if (accountType !== "personal" && accountType !== "business") {
+    throw new Error(`Invalid account_type: "${accountType}". Must be "personal" or "business".`);
+  }
+
+  const res = await fetch(`${ESORTCODE_API}/cop/check`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      sort_code: sortCode,
+      account_number: accountNumberRaw,
+      account_holder_name: accountHolderName,
+      account_type: accountType,
+    }),
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(`eSortcode rejected the API key (HTTP ${res.status}). Verify ESORTCODE_API_KEY.`);
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`eSortcode returned HTTP ${res.status}: ${body.slice(0, 200)}`);
+  }
+
+  const data = (await res.json()) as {
+    match_status?: string;
+    close_match_name?: string;
+    bank_name?: string;
+    bic?: string;
+    reason_code?: string;
+    reason?: string;
+    reference_id?: string;
+    timestamp?: string;
+  };
+
+  // Normalize the match status to a canonical enum
+  const rawStatus = (data.match_status ?? "").toLowerCase();
+  const matchStatus = rawStatus === "match" ? "match"
+    : rawStatus === "close_match" || rawStatus === "close-match" || rawStatus === "partial" ? "close_match"
+    : rawStatus === "no_match" || rawStatus === "no-match" || rawStatus === "mismatch" ? "no_match"
+    : rawStatus === "no_account" || rawStatus === "no-account" || rawStatus === "not_found" ? "no_account"
+    : "cannot_be_checked";
+
+  return {
+    output: {
+      match_status: matchStatus,
+      account_holder_name_provided: accountHolderName,
+      close_match_name: data.close_match_name ?? null,
+      bank_name: data.bank_name ?? null,
+      bic: data.bic ?? null,
+      reason_code: data.reason_code ?? null,
+      reason: data.reason ?? null,
+      sort_code: sortCode,
+      account_number_last4: accountNumberRaw.slice(-4),
+      account_type: accountType,
+      reference_id: data.reference_id ?? null,
+      checked_at: data.timestamp ?? new Date().toISOString(),
+      data_source: "Pay.UK Confirmation of Payee scheme via eSortcode",
+    },
+    provenance: {
+      source: "esortcode.com",
+      fetched_at: new Date().toISOString(),
+      acquisition_method: "vendor_mediated_scheme" as const,
+      license: "Per eSortcode reseller terms",
+    },
+  };
+});

--- a/apps/api/src/capabilities/us-company-data-cobalt.ts
+++ b/apps/api/src/capabilities/us-company-data-cobalt.ts
@@ -1,0 +1,140 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * US company registry lookup via Cobalt Intelligence (50-state Secretary
+ * of State coverage).
+ *
+ * Vendor: Cobalt Intelligence (cobaltintelligence.com) — Tier-2 vendor-
+ * mediated public records. Live SoS lookups, screenshot-grade primary-
+ * source provenance. Founder confirmed clean redistribution rights
+ * (DEC-20260430-A) and Swedish AB onboarding has no friction.
+ *
+ * Pricing (per Vendor Roster row): $2/call PAYG, no commitment. Drops to
+ * $0.75 at $7,200/yr (400 lookups/mo) and lower at higher tiers. PAYG is
+ * the recommended start.
+ *
+ * Activation: requires COBALT_API_KEY in env. Sign up at
+ * https://cobaltintelligence.com and configure the API key.
+ *
+ * Distinct from the existing `us-company-data` capability which is SEC
+ * EDGAR only (~13k US public filers). Cobalt covers all 50 states' SoS
+ * registries (~33M+ private LLCs/corporations).
+ *
+ * Two input modes:
+ *   1. company_id + state: SoS-issued business ID (registration number)
+ *   2. company_name + state: name search; returns ranked candidates
+ */
+
+const COBALT_API = "https://apigateway.cobaltintelligence.com/v1";
+
+registerCapability("us-company-data-cobalt", async (input: CapabilityInput) => {
+  const apiKey = process.env.COBALT_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "COBALT_API_KEY is required for US company-data lookups. Sign up at https://cobaltintelligence.com and configure the API key.",
+    );
+  }
+
+  const companyId = ((input.company_id as string) ?? (input.business_id as string) ?? "").trim();
+  const companyName = ((input.company_name as string) ?? (input.business_name as string) ?? "").trim();
+  const state = ((input.state as string) ?? "").trim().toUpperCase();
+
+  if (!companyId && !companyName) {
+    throw new Error("'company_id' or 'company_name' is required.");
+  }
+  if (!state || state.length !== 2) {
+    throw new Error("'state' is required (2-letter US state code, e.g. \"CA\").");
+  }
+
+  const headers = {
+    "x-api-key": apiKey,
+    Accept: "application/json",
+  };
+
+  const endpoint = companyId
+    ? `${COBALT_API}/search?searchQuery=${encodeURIComponent(companyId)}&state=${state}&liveData=true`
+    : `${COBALT_API}/search?searchQuery=${encodeURIComponent(companyName)}&state=${state}&liveData=true`;
+
+  const res = await fetch(endpoint, {
+    headers,
+    signal: AbortSignal.timeout(20000),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(`Cobalt rejected the API key (HTTP ${res.status}). Verify COBALT_API_KEY.`);
+  }
+  if (res.status === 404) {
+    return {
+      output: {
+        found: false,
+        company_name: companyName || null,
+        company_id: companyId || null,
+        state,
+        status: null,
+        entity_type: null,
+        formed_date: null,
+        address: null,
+        registered_agent: null,
+        officers: [],
+        filings: [],
+        data_source: "Cobalt Intelligence (50-state SoS live)",
+      },
+      provenance: { source: "cobaltintelligence.com", fetched_at: new Date().toISOString() },
+    };
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Cobalt returned HTTP ${res.status}: ${body.slice(0, 200)}`);
+  }
+
+  const data = (await res.json()) as any;
+  // Cobalt typically returns a results array; first match is canonical
+  const result = Array.isArray(data) ? data[0] : data.results?.[0] ?? data;
+
+  if (!result) {
+    return {
+      output: {
+        found: false,
+        company_name: companyName || null,
+        company_id: companyId || null,
+        state,
+        status: null,
+        entity_type: null,
+        formed_date: null,
+        address: null,
+        registered_agent: null,
+        officers: [],
+        filings: [],
+        data_source: "Cobalt Intelligence (50-state SoS live)",
+      },
+      provenance: { source: "cobaltintelligence.com", fetched_at: new Date().toISOString() },
+    };
+  }
+
+  return {
+    output: {
+      found: true,
+      company_name: result.title ?? result.businessName ?? result.name ?? null,
+      company_id: result.sosId ?? result.entityId ?? result.businessId ?? companyId ?? null,
+      state,
+      status: result.status ?? result.businessStatus ?? null,
+      entity_type: result.businessType ?? result.entityType ?? null,
+      formed_date: result.formedDate ?? result.registrationDate ?? null,
+      address:
+        result.address ??
+        (result.principalAddress ? Object.values(result.principalAddress).filter(Boolean).join(", ") : null),
+      registered_agent: result.registeredAgent ?? result.agent ?? null,
+      officers: Array.isArray(result.officers) ? result.officers : [],
+      filings: Array.isArray(result.filings) ? result.filings.slice(0, 25) : [],
+      sos_url: result.sosUrl ?? null,
+      data_source: "Cobalt Intelligence (50-state SoS live)",
+    },
+    provenance: {
+      source: "cobaltintelligence.com",
+      fetched_at: new Date().toISOString(),
+      acquisition_method: "vendor_aggregation" as const,
+      upstream_vendor: "cobaltintelligence.com",
+      attribution: "Data sourced live from US Secretary of State portals via Cobalt Intelligence",
+    },
+  };
+});

--- a/apps/api/src/capabilities/us-court-search.ts
+++ b/apps/api/src/capabilities/us-court-search.ts
@@ -1,0 +1,127 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * US federal court records search via CourtListener + RECAP (Free Law
+ * Project). Returns dockets matching the query — civil litigation,
+ * bankruptcy, criminal, IP, etc. across federal district + appellate
+ * courts.
+ *
+ * Vendor: CourtListener (courtlistener.com) — non-profit, free public
+ * data; commercial use permitted under their terms. Token-gated as of
+ * 2025 policy change (anonymous access blocked); free signup at
+ * courtlistener.com/sign-up generates a token immediately.
+ *
+ * Selection per DEC-20260430-A. Pairs with sec-api.io (extended SEC
+ * filings) and Docket Alarm (PAYG federal/state docket coverage).
+ *
+ * Activation: requires COURTLISTENER_API_TOKEN in env. Sign up at
+ * https://www.courtlistener.com/sign-up/ and copy the token from your
+ * profile page (format: 40-char hex string).
+ *
+ * Two query modes:
+ *   1. Search by case_name / party_name across all dockets.
+ *   2. Filter by court_type=bankruptcy to get only bankruptcy filings
+ *      (focused query for Payee Assurance risk decisions).
+ */
+
+const CL_API = "https://www.courtlistener.com/api/rest/v3";
+
+registerCapability("us-court-search", async (input: CapabilityInput) => {
+  const token = process.env.COURTLISTENER_API_TOKEN;
+  if (!token) {
+    throw new Error(
+      "COURTLISTENER_API_TOKEN is required. Sign up at https://www.courtlistener.com/sign-up/ (free, instant) and copy the token from your profile page.",
+    );
+  }
+
+  const query = ((input.query as string) ?? (input.party_name as string) ?? (input.company_name as string) ?? "").trim();
+  if (!query) {
+    throw new Error("'query' (or 'party_name' / 'company_name') is required.");
+  }
+
+  const courtTypeFilter = ((input.court_type as string) ?? "").trim().toLowerCase();
+  const sinceDate = ((input.since_date as string) ?? "").trim();
+  const limit = Math.min(Math.max(Number(input.limit) || 20, 1), 100);
+
+  const params = new URLSearchParams({
+    q: query,
+    type: "r", // RECAP dockets (federal civil/criminal/bankruptcy)
+    order_by: "dateFiled desc",
+  });
+  if (sinceDate) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(sinceDate)) {
+      throw new Error(`Invalid since_date: "${sinceDate}". Must be ISO date YYYY-MM-DD.`);
+    }
+    params.set("filed_after", sinceDate);
+  }
+
+  const res = await fetch(`${CL_API}/search/?${params.toString()}`, {
+    headers: {
+      Authorization: `Token ${token}`,
+      Accept: "application/json",
+    },
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(`CourtListener rejected the token (HTTP ${res.status}). Verify COURTLISTENER_API_TOKEN.`);
+  }
+  if (!res.ok) {
+    throw new Error(`CourtListener returned HTTP ${res.status}`);
+  }
+
+  const data = (await res.json()) as { count?: number; results?: any[] };
+  const allResults = data.results ?? [];
+
+  // Optional client-side filter for bankruptcy court types.
+  // CourtListener's `court` field is a court ID like "txnb" (TX Northern
+  // Bankruptcy); bankruptcy IDs commonly end in "b" (e.g. "casb", "njb").
+  const filtered = courtTypeFilter === "bankruptcy"
+    ? allResults.filter((r) => /(bankr|^.+b$)/i.test(r.court ?? ""))
+    : allResults;
+
+  const results = filtered.slice(0, limit);
+
+  // Bankruptcy detection — does the result set include any bankruptcy court entries?
+  const bankruptcyCases = allResults.filter((r) => /(bankr|^.+b$)/i.test(r.court ?? ""));
+  const hasBankruptcyFiling = bankruptcyCases.length > 0;
+
+  return {
+    output: {
+      query,
+      court_type_filter: courtTypeFilter || null,
+      total_matches: data.count ?? allResults.length,
+      returned_count: results.length,
+      has_bankruptcy_filing: hasBankruptcyFiling,
+      bankruptcy_count: bankruptcyCases.length,
+      most_recent_filing_date: results[0]?.dateFiled ?? null,
+      most_recent_bankruptcy:
+        bankruptcyCases[0]
+          ? {
+              case_name: bankruptcyCases[0].caseName ?? bankruptcyCases[0].caseNameShort ?? null,
+              court: bankruptcyCases[0].court ?? null,
+              court_id: bankruptcyCases[0].court_id ?? null,
+              date_filed: bankruptcyCases[0].dateFiled ?? null,
+              docket_number: bankruptcyCases[0].docketNumber ?? null,
+              absolute_url: bankruptcyCases[0].absolute_url ? `https://www.courtlistener.com${bankruptcyCases[0].absolute_url}` : null,
+            }
+          : null,
+      cases: results.map((r) => ({
+        case_name: r.caseName ?? r.caseNameShort ?? null,
+        court: r.court ?? null,
+        court_id: r.court_id ?? null,
+        date_filed: r.dateFiled ?? null,
+        docket_number: r.docketNumber ?? null,
+        nature_of_suit: r.suitNature ?? null,
+        absolute_url: r.absolute_url ? `https://www.courtlistener.com${r.absolute_url}` : null,
+      })),
+      data_source: "CourtListener + RECAP (Free Law Project)",
+    },
+    provenance: {
+      source: "courtlistener.com",
+      fetched_at: new Date().toISOString(),
+      acquisition_method: "direct_api" as const,
+      license: "Per Free Law Project terms (commercial use permitted)",
+    },
+  };
+});

--- a/apps/api/src/capabilities/us-ein-match.ts
+++ b/apps/api/src/capabilities/us-ein-match.ts
@@ -1,0 +1,140 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * US EIN (Employer Identification Number) match via Liberty Data /
+ * EINsearch.
+ *
+ * Vendor: Liberty Data Solutions (einsearch.com) — Tier-3 licensed-bulk
+ * vendor. ~24M EIN database, bureau-derived. Selection per
+ * DEC-20260430-A. Pure data tier (not a KYB workflow product), self-
+ * serve purchase, no sales call.
+ *
+ * Pricing (per Vendor Roster row): $375/yr Startup tier (500 searches,
+ * $0.75 effective per call) up to $3,800/yr Enterprise (10k searches,
+ * $0.38 effective).
+ *
+ * Activation: requires EINSEARCH_API_KEY in env. Sign up at
+ * https://einsearch.com/pricing/?annual and configure the API key.
+ *
+ * Two input modes:
+ *   1. ein (exact): 9-digit EIN, returns the business record.
+ *   2. business_name + state (optional): name search, returns up to N
+ *      ranked candidates. Use for resolution when you don't have an EIN.
+ */
+
+const EINSEARCH_API = "https://einsearch.com/api/v1";
+const EIN_RE = /^\d{2}-?\d{7}$/;
+
+function normalizeEin(input: string): string {
+  return input.replace(/[\s-]/g, "");
+}
+
+registerCapability("us-ein-match", async (input: CapabilityInput) => {
+  const apiKey = process.env.EINSEARCH_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "EINSEARCH_API_KEY is required for US EIN match. Sign up at https://einsearch.com/pricing/?annual and configure the API key.",
+    );
+  }
+
+  const einInput = ((input.ein as string) ?? "").trim();
+  const businessName = ((input.business_name as string) ?? (input.company_name as string) ?? "").trim();
+  const state = ((input.state as string) ?? "").trim().toUpperCase();
+  const limit = Math.min(Math.max(Number(input.limit) || 5, 1), 25);
+
+  if (!einInput && !businessName) {
+    throw new Error("'ein' or 'business_name' is required.");
+  }
+
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    Accept: "application/json",
+  };
+
+  // EIN exact lookup mode
+  if (einInput) {
+    const ein = normalizeEin(einInput);
+    if (!EIN_RE.test(einInput) || ein.length !== 9) {
+      throw new Error(`Invalid ein: "${einInput}". US EINs are 9 digits, optionally formatted XX-XXXXXXX.`);
+    }
+    const res = await fetch(`${EINSEARCH_API}/ein/${ein}`, {
+      headers,
+      signal: AbortSignal.timeout(10000),
+    });
+    if (res.status === 404) {
+      return {
+        output: {
+          mode: "ein_lookup",
+          ein,
+          found: false,
+          business_name: null,
+          status: null,
+          formed_state: null,
+          address: null,
+          candidates: [],
+          data_source: "Liberty Data EINsearch (~24M EIN database)",
+        },
+        provenance: { source: "einsearch.com", fetched_at: new Date().toISOString() },
+      };
+    }
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(`EINsearch rejected the API key (HTTP ${res.status}). Verify EINSEARCH_API_KEY.`);
+    }
+    if (!res.ok) throw new Error(`EINsearch returned HTTP ${res.status}`);
+    const data = (await res.json()) as any;
+    return {
+      output: {
+        mode: "ein_lookup",
+        ein: data.ein ?? ein,
+        found: true,
+        business_name: data.business_name ?? data.legal_name ?? null,
+        status: data.status ?? null,
+        formed_state: data.state ?? data.formed_state ?? null,
+        address: data.address ?? null,
+        candidates: [],
+        data_source: "Liberty Data EINsearch (~24M EIN database)",
+      },
+      provenance: { source: "einsearch.com", fetched_at: new Date().toISOString() },
+    };
+  }
+
+  // Name search mode
+  const params = new URLSearchParams({
+    name: businessName,
+    limit: String(limit),
+  });
+  if (state && state.length === 2) params.set("state", state);
+
+  const res = await fetch(`${EINSEARCH_API}/search?${params.toString()}`, {
+    headers,
+    signal: AbortSignal.timeout(10000),
+  });
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(`EINsearch rejected the API key (HTTP ${res.status}). Verify EINSEARCH_API_KEY.`);
+  }
+  if (!res.ok) throw new Error(`EINsearch returned HTTP ${res.status}`);
+  const data = (await res.json()) as any;
+  const items: any[] = data.results ?? data.items ?? data.data ?? [];
+
+  return {
+    output: {
+      mode: "name_search",
+      ein: null,
+      found: items.length > 0,
+      business_name: businessName,
+      status: null,
+      formed_state: state || null,
+      address: null,
+      candidates: items.slice(0, limit).map((it) => ({
+        ein: it.ein ?? null,
+        business_name: it.business_name ?? it.legal_name ?? null,
+        status: it.status ?? null,
+        formed_state: it.state ?? null,
+        address: it.address ?? null,
+        match_score: it.match_score ?? it.score ?? null,
+      })),
+      data_source: "Liberty Data EINsearch (~24M EIN database)",
+    },
+    provenance: { source: "einsearch.com", fetched_at: new Date().toISOString() },
+  };
+});

--- a/apps/api/src/capabilities/us-sec-filings-extended.ts
+++ b/apps/api/src/capabilities/us-sec-filings-extended.ts
@@ -1,0 +1,115 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * US SEC filings extended search via sec-api.io.
+ *
+ * Vendor: sec-api.io — paid SEC filings index covering 10-K, 10-Q, 8-K,
+ * S-1, proxy, insider Form 4, and full-text search across the EDGAR
+ * corpus. Selection per DEC-20260430-A as a $49/mo supplement to the
+ * free SEC EDGAR API (which us-company-data uses).
+ *
+ * Use cases beyond raw EDGAR:
+ *   - Full-text search across filing bodies (find a name buried in a 10-K)
+ *   - Filing-event monitoring (recent 8-K material events)
+ *   - Cross-form aggregation (all filings for a CIK in one call)
+ *
+ * Activation: requires SEC_API_IO_TOKEN in env. Subscribe at
+ * https://sec-api.io and configure the API key.
+ *
+ * Two input modes:
+ *   1. cik (10-digit Central Index Key): exact entity lookup
+ *   2. company_name + optional form_type: name-based filing search
+ */
+
+const SEC_API = "https://api.sec-api.io";
+
+registerCapability("us-sec-filings-extended", async (input: CapabilityInput) => {
+  const token = process.env.SEC_API_IO_TOKEN;
+  if (!token) {
+    throw new Error(
+      "SEC_API_IO_TOKEN is required for sec-api.io. Subscribe at https://sec-api.io and configure the token.",
+    );
+  }
+
+  const cik = ((input.cik as string) ?? "").trim();
+  const companyName = ((input.company_name as string) ?? (input.business_name as string) ?? "").trim();
+  const formType = ((input.form_type as string) ?? "").trim();
+  const sinceDate = ((input.since_date as string) ?? "").trim();
+  const limit = Math.min(Math.max(Number(input.limit) || 20, 1), 100);
+
+  if (!cik && !companyName) {
+    throw new Error("'cik' or 'company_name' is required.");
+  }
+
+  // sec-api.io uses Lucene-style query syntax via POST
+  const queryParts: string[] = [];
+  if (cik) queryParts.push(`cik:${cik.replace(/^0+/, "")}`);
+  if (companyName) queryParts.push(`companyName:"${companyName.replace(/"/g, "")}"`);
+  if (formType) queryParts.push(`formType:"${formType}"`);
+  if (sinceDate) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(sinceDate)) {
+      throw new Error(`Invalid since_date: "${sinceDate}". Must be ISO date YYYY-MM-DD.`);
+    }
+    queryParts.push(`filedAt:[${sinceDate} TO *]`);
+  }
+
+  const body = {
+    query: { query_string: { query: queryParts.join(" AND ") } },
+    from: "0",
+    size: String(limit),
+    sort: [{ filedAt: { order: "desc" } }],
+  };
+
+  const res = await fetch(`${SEC_API}?token=${encodeURIComponent(token)}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(`sec-api.io rejected the token (HTTP ${res.status}). Verify SEC_API_IO_TOKEN.`);
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`sec-api.io returned HTTP ${res.status}: ${text.slice(0, 200)}`);
+  }
+
+  const data = (await res.json()) as { total?: { value?: number } | number; filings?: any[] };
+  const total = typeof data.total === "object" ? (data.total?.value ?? 0) : (data.total ?? 0);
+  const filings = data.filings ?? [];
+
+  return {
+    output: {
+      query: cik ? `cik:${cik}` : companyName,
+      cik: cik || null,
+      company_name: companyName || null,
+      form_type_filter: formType || null,
+      total_matches: total,
+      returned_count: filings.length,
+      most_recent_filing_date: filings[0]?.filedAt ?? null,
+      most_recent_8k_date: filings.find((f: any) => f.formType === "8-K")?.filedAt ?? null,
+      filings: filings.slice(0, limit).map((f: any) => ({
+        accession_no: f.accessionNo ?? null,
+        cik: f.cik ?? null,
+        company_name: f.companyName ?? null,
+        ticker: f.ticker ?? null,
+        form_type: f.formType ?? null,
+        filed_at: f.filedAt ?? null,
+        period_of_report: f.periodOfReport ?? null,
+        link_to_filing: f.linkToFilingDetails ?? f.linkToHtml ?? null,
+      })),
+      data_source: "sec-api.io (extended SEC EDGAR index)",
+    },
+    provenance: {
+      source: "sec-api.io",
+      fetched_at: new Date().toISOString(),
+      acquisition_method: "vendor_aggregation" as const,
+      upstream_vendor: "sec-api.io",
+      attribution: "SEC EDGAR data via sec-api.io",
+    },
+  };
+});

--- a/manifests/uk-cop-check.yaml
+++ b/manifests/uk-cop-check.yaml
@@ -97,8 +97,8 @@ maintenance_class: commercial-stable-api
 gdpr_art_22_classification: screening_signal
 processes_personal_data: true
 personal_data_categories:
-  - account_holder_name
-  - bank_account_details
+  - name
+  - financial
 geography: uk
 test_fixtures:
   known_answer:

--- a/manifests/uk-cop-check.yaml
+++ b/manifests/uk-cop-check.yaml
@@ -1,0 +1,168 @@
+slug: uk-cop-check
+name: UK Confirmation of Payee Check
+description: >-
+  Verify that a UK sort code + account number pair matches the account holder name registered at the
+  responding PSP. Returns Pay.UK CoP match status (match / close_match / no_match / no_account /
+  cannot_be_checked), bank name, BIC, and a reason code. Implementation via eSortcode (Pay.UK CoP
+  scheme participant).
+category: compliance
+price_cents: 25
+is_free_tier: false
+avg_latency_ms: 1500
+input_schema:
+  type: object
+  required:
+    - sort_code
+    - account_number
+    - account_holder_name
+  properties:
+    sort_code:
+      type: string
+      description: 6-digit UK sort code (with or without dashes).
+    account_number:
+      type: string
+      description: 8-digit UK account number.
+    account_holder_name:
+      type: string
+      description: Account holder name as it appears on the originating side. CoP scheme uses fuzzy match against the responding PSP's registered name.
+    account_type:
+      type: string
+      description: Optional. "personal" or "business". Defaults to "business".
+output_schema:
+  type: object
+  example:
+    match_status: match
+    account_holder_name_provided: ACME WIDGETS LTD
+    close_match_name: null
+    bank_name: HSBC UK Bank plc
+    bic: HBUKGB4B
+    reason_code: null
+    reason: null
+    sort_code: "400515"
+    account_number_last4: "1234"
+    account_type: business
+    reference_id: cop-7f2a9c
+    checked_at: "2026-05-04T12:00:00Z"
+    data_source: Pay.UK Confirmation of Payee scheme via eSortcode
+  properties:
+    match_status:
+      type: string
+      enum:
+        - match
+        - close_match
+        - no_match
+        - no_account
+        - cannot_be_checked
+    account_holder_name_provided:
+      type: string
+    close_match_name:
+      type:
+        - string
+        - "null"
+    bank_name:
+      type:
+        - string
+        - "null"
+    bic:
+      type:
+        - string
+        - "null"
+    reason_code:
+      type:
+        - string
+        - "null"
+    reason:
+      type:
+        - string
+        - "null"
+    sort_code:
+      type: string
+    account_number_last4:
+      type: string
+    account_type:
+      type: string
+    reference_id:
+      type:
+        - string
+        - "null"
+    checked_at:
+      type: string
+    data_source:
+      type: string
+data_source: Pay.UK Confirmation of Payee scheme via eSortcode
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: commercial-stable-api
+gdpr_art_22_classification: screening_signal
+processes_personal_data: true
+personal_data_categories:
+  - account_holder_name
+  - bank_account_details
+geography: uk
+test_fixtures:
+  known_answer:
+    input:
+      sort_code: "400515"
+      account_number: "12345678"
+      account_holder_name: "Strale Test"
+      account_type: "business"
+    expected_fields:
+      - field: match_status
+        operator: not_null
+        reliability: guaranteed
+      - field: sort_code
+        operator: equals
+        reliability: guaranteed
+        value: "400515"
+      - field: account_number_last4
+        operator: equals
+        reliability: guaranteed
+        value: "5678"
+      - field: account_type
+        operator: equals
+        reliability: guaranteed
+        value: business
+      - field: data_source
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    sort_code: "400515"
+    account_number: "12345678"
+    account_holder_name: "Strale Test"
+    account_type: "business"
+output_field_reliability:
+  match_status: guaranteed
+  account_holder_name_provided: guaranteed
+  sort_code: guaranteed
+  account_number_last4: guaranteed
+  account_type: guaranteed
+  checked_at: guaranteed
+  data_source: guaranteed
+  bank_name: common
+  bic: common
+  close_match_name: rare
+  reason_code: rare
+  reason: rare
+  reference_id: common
+limitations:
+  - title: UK only
+    text: >-
+      Pay.UK Confirmation of Payee covers UK domestic accounts only (sort code + account number pairs).
+      For EU SEPA IBAN-based name matching, see the SEPA VoP capability (separate vendor).
+    category: coverage
+    severity: info
+  - title: CoP is a scheme attestation, not an identity proof
+    text: >-
+      A "match" indicates the responding PSP returned that the name on file matches the provided name
+      under their fuzzy-matching rules. It does NOT prove the named person controls the account or
+      that the account is the right account for a payment. Use alongside other risk signals.
+    category: accuracy
+    severity: warning
+  - title: No-account / cannot-be-checked are common edge cases
+    text: >-
+      A small fraction of UK PSPs do not respond to CoP queries (cannot_be_checked) and some accounts
+      are flagged as no_account when they are dormant or recently closed. These are scheme-level
+      limitations, not vendor bugs. Surface them in customer-visible audit output.
+    category: coverage
+    severity: info

--- a/manifests/us-company-data-cobalt.yaml
+++ b/manifests/us-company-data-cobalt.yaml
@@ -1,0 +1,148 @@
+slug: us-company-data-cobalt
+name: US Company Data (Cobalt)
+description: >-
+  US company registry lookup via Cobalt Intelligence — 50-state Secretary of State live SoS data.
+  Covers ~33M+ US private LLCs/corporations. Two input modes: SoS-issued company ID + state, or
+  company name + state. Returns canonical entity info, status, entity type, formed date, address,
+  registered agent, officers, and filings history. Distinct from the SEC-EDGAR-only us-company-data
+  capability.
+category: company-data
+price_cents: 200
+is_free_tier: false
+avg_latency_ms: 3000
+input_schema:
+  type: object
+  required:
+    - state
+  properties:
+    company_id:
+      type: string
+      description: SoS-issued business ID (registration number). Canonical input when known.
+    company_name:
+      type: string
+      description: Optional fallback input — company name to search if no ID is known.
+    state:
+      type: string
+      description: Required 2-letter US state code (e.g. "DE", "CA", "NY"). Cobalt routes per state.
+output_schema:
+  type: object
+  example:
+    found: true
+    company_name: APPLE INC
+    company_id: "C0806592"
+    state: CA
+    status: active
+    entity_type: Corporation
+    formed_date: "1977-01-03"
+    address: "One Apple Park Way, Cupertino, CA 95014"
+    registered_agent: CT CORPORATION SYSTEM
+    officers: []
+    filings: []
+    sos_url: https://bizfileonline.sos.ca.gov/...
+    data_source: Cobalt Intelligence (50-state SoS live)
+  properties:
+    found:
+      type: boolean
+    company_name:
+      type:
+        - string
+        - "null"
+    company_id:
+      type:
+        - string
+        - "null"
+    state:
+      type: string
+    status:
+      type:
+        - string
+        - "null"
+    entity_type:
+      type:
+        - string
+        - "null"
+    formed_date:
+      type:
+        - string
+        - "null"
+    address:
+      type:
+        - string
+        - "null"
+    registered_agent:
+      type:
+        - string
+        - "null"
+    officers:
+      type: array
+    filings:
+      type: array
+    sos_url:
+      type:
+        - string
+        - "null"
+    data_source:
+      type: string
+data_source: Cobalt Intelligence (50-state SoS live)
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: commercial-stable-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: us
+test_fixtures:
+  known_answer:
+    input:
+      company_name: "Apple Inc"
+      state: "CA"
+    expected_fields:
+      - field: found
+        operator: not_null
+        reliability: guaranteed
+      - field: state
+        operator: equals
+        reliability: guaranteed
+        value: CA
+      - field: data_source
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    company_name: "Apple Inc"
+    state: "CA"
+output_field_reliability:
+  found: guaranteed
+  state: guaranteed
+  data_source: guaranteed
+  company_name: common
+  company_id: common
+  status: common
+  entity_type: common
+  formed_date: common
+  address: common
+  registered_agent: common
+  officers: rare
+  filings: rare
+  sos_url: rare
+limitations:
+  - title: State is required
+    text: >-
+      Cobalt routes queries per Secretary of State. Cross-state name searches are not supported in a
+      single call. Provide the state of incorporation; if unknown, query DE first (most common
+      domicile) then NY/CA/TX as fallbacks.
+    category: coverage
+    severity: info
+  - title: Status definitions vary per state
+    text: >-
+      Each state's SoS uses its own status taxonomy (active / good standing / suspended / delinquent /
+      forfeited / etc.). Status is surfaced verbatim from the SoS portal — interpret per state, not
+      across states.
+    category: accuracy
+    severity: warning
+  - title: Officer / filing depth varies per state
+    text: >-
+      Some states publish full officer rosters and 10+ years of filings; others publish only the
+      registered agent and incorporation event. Empty officers/filings arrays are normal for some
+      jurisdictions, not necessarily a coverage gap.
+    category: coverage
+    severity: info

--- a/manifests/us-court-search.yaml
+++ b/manifests/us-court-search.yaml
@@ -1,0 +1,139 @@
+slug: us-court-search
+name: US Court Search (CourtListener)
+description: >-
+  Search US federal court records (RECAP dockets) by party name. Returns matching cases with court,
+  date filed, docket number, and absolute URL. Elevates bankruptcy filings as top-level signals
+  (has_bankruptcy_filing, bankruptcy_count, most_recent_bankruptcy) for risk decisioning. Federal
+  district + appellate courts; no state-court coverage.
+category: compliance
+price_cents: 15
+is_free_tier: false
+avg_latency_ms: 1500
+input_schema:
+  type: object
+  required: []
+  properties:
+    query:
+      type: string
+      description: Search query (typically a party name). Equivalent to party_name / company_name aliases.
+    party_name:
+      type: string
+      description: Alias for query. Accepts company or individual name.
+    company_name:
+      type: string
+      description: Alias for query.
+    court_type:
+      type: string
+      description: Optional. "bankruptcy" filters to bankruptcy court matches only.
+    since_date:
+      type: string
+      description: Optional ISO date (YYYY-MM-DD) to filter cases filed on or after this date.
+    limit:
+      type: integer
+      description: Optional max number of cases to return (default 20, max 100).
+output_schema:
+  type: object
+  example:
+    query: Lehman Brothers
+    court_type_filter: null
+    total_matches: 482
+    returned_count: 20
+    has_bankruptcy_filing: true
+    bankruptcy_count: 47
+    most_recent_filing_date: "2024-08-15"
+    most_recent_bankruptcy:
+      case_name: "In re: Lehman Brothers Holdings Inc."
+      court: nysb
+      court_id: nysb
+      date_filed: "2008-09-15"
+      docket_number: "08-13555"
+      absolute_url: https://www.courtlistener.com/...
+    cases: []
+    data_source: CourtListener + RECAP (Free Law Project)
+  properties:
+    query:
+      type: string
+    court_type_filter:
+      type:
+        - string
+        - "null"
+    total_matches:
+      type: integer
+    returned_count:
+      type: integer
+    has_bankruptcy_filing:
+      type: boolean
+    bankruptcy_count:
+      type: integer
+    most_recent_filing_date:
+      type:
+        - string
+        - "null"
+    most_recent_bankruptcy:
+      type:
+        - object
+        - "null"
+    cases:
+      type: array
+    data_source:
+      type: string
+data_source: CourtListener + RECAP (Free Law Project)
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: us
+test_fixtures:
+  known_answer:
+    input:
+      query: "Lehman Brothers"
+      court_type: "bankruptcy"
+    expected_fields:
+      - field: total_matches
+        operator: not_null
+        reliability: guaranteed
+      - field: has_bankruptcy_filing
+        operator: not_null
+        reliability: guaranteed
+      - field: cases
+        operator: not_null
+        reliability: guaranteed
+      - field: data_source
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    query: "Lehman Brothers"
+output_field_reliability:
+  query: guaranteed
+  total_matches: guaranteed
+  returned_count: guaranteed
+  has_bankruptcy_filing: guaranteed
+  bankruptcy_count: guaranteed
+  cases: guaranteed
+  data_source: guaranteed
+  most_recent_filing_date: common
+  most_recent_bankruptcy: common
+  court_type_filter: common
+limitations:
+  - title: Federal courts only
+    text: >-
+      RECAP covers US federal courts (district + appellate + bankruptcy). State court records are NOT
+      included. For state-level coverage, supplement with Docket Alarm (PAYG) — separate capability.
+    category: coverage
+    severity: warning
+  - title: Common-name false positives
+    text: >-
+      Searching "Acme Corp" returns every matching docket regardless of which Acme Corp is the actual
+      party. Disambiguate using the address or jurisdiction context. The structured cases array
+      includes court, jurisdiction, and date for each match so the calling code can filter further.
+    category: accuracy
+    severity: warning
+  - title: RECAP coverage varies per court
+    text: >-
+      Free Law Project's RECAP archive covers ~95% of recent federal dockets but older cases may be
+      incomplete. The `total_matches` count reflects what RECAP has — actual federal docket count for
+      the party may be higher.
+    category: coverage
+    severity: info

--- a/manifests/us-ein-match.yaml
+++ b/manifests/us-ein-match.yaml
@@ -1,0 +1,123 @@
+slug: us-ein-match
+name: US EIN Match
+description: >-
+  US Employer Identification Number (EIN) lookup and name search via Liberty Data EINsearch
+  (~24M EIN database, bureau-derived). Two modes: EIN exact lookup, or business name search
+  (optionally constrained by state). Returns business name, status, formed state, address, and
+  match score for name searches.
+category: compliance
+price_cents: 75
+is_free_tier: false
+avg_latency_ms: 800
+input_schema:
+  type: object
+  required: []
+  properties:
+    ein:
+      type: string
+      description: 9-digit US EIN, optionally formatted XX-XXXXXXX. Canonical input for exact lookup.
+    business_name:
+      type: string
+      description: Optional fallback input — business name to search EINsearch when no EIN is known.
+    state:
+      type: string
+      description: Optional 2-letter US state code to constrain name search (e.g. "CA").
+    limit:
+      type: integer
+      description: Optional max number of candidates to return for name search (default 5, max 25).
+output_schema:
+  type: object
+  example:
+    mode: ein_lookup
+    ein: "123456789"
+    found: true
+    business_name: ACME WIDGETS INC
+    status: active
+    formed_state: DE
+    address: "100 Main St, Wilmington, DE 19801"
+    candidates: []
+    data_source: Liberty Data EINsearch (~24M EIN database)
+  properties:
+    mode:
+      type: string
+      enum:
+        - ein_lookup
+        - name_search
+    ein:
+      type:
+        - string
+        - "null"
+    found:
+      type: boolean
+    business_name:
+      type:
+        - string
+        - "null"
+    status:
+      type:
+        - string
+        - "null"
+    formed_state:
+      type:
+        - string
+        - "null"
+    address:
+      type:
+        - string
+        - "object"
+        - "null"
+    candidates:
+      type: array
+    data_source:
+      type: string
+data_source: Liberty Data EINsearch
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: reference-data
+maintenance_class: commercial-stable-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: us
+test_fixtures:
+  known_answer:
+    input:
+      business_name: "Apple Inc"
+      state: "CA"
+    expected_fields:
+      - field: mode
+        operator: equals
+        reliability: guaranteed
+        value: name_search
+      - field: candidates
+        operator: not_null
+        reliability: guaranteed
+      - field: data_source
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    business_name: "Apple Inc"
+    state: "CA"
+output_field_reliability:
+  mode: guaranteed
+  found: guaranteed
+  candidates: guaranteed
+  data_source: guaranteed
+  ein: common
+  business_name: common
+  status: common
+  formed_state: common
+  address: common
+limitations:
+  - title: US only
+    text: >-
+      EIN is a US tax identifier. For non-US business identifiers (VAT number, registration number),
+      use the country-specific company-data capabilities.
+    category: coverage
+    severity: info
+  - title: Bureau-derived data may lag IRS updates
+    text: >-
+      The EINsearch database is sourced from filings and bureau records, not directly from the IRS.
+      Newly-formed entities may not appear for 30-90 days; recently-dissolved entities may still
+      appear active. Cross-reference with state SOS data via us-company-data-cobalt for active status.
+    category: freshness
+    severity: warning

--- a/manifests/us-sec-filings-extended.yaml
+++ b/manifests/us-sec-filings-extended.yaml
@@ -1,0 +1,128 @@
+slug: us-sec-filings-extended
+name: US SEC Filings (Extended)
+description: >-
+  Extended SEC EDGAR filings search via sec-api.io. Full-text search across the EDGAR corpus (10-K,
+  10-Q, 8-K, S-1, proxy, insider Form 4, etc.) by CIK or company name, optionally filtered by form
+  type and date. Supplements the free SEC EDGAR API used by us-company-data with full-text search,
+  cross-form aggregation, and filing-event monitoring.
+category: compliance
+price_cents: 25
+is_free_tier: false
+avg_latency_ms: 1500
+input_schema:
+  type: object
+  required: []
+  properties:
+    cik:
+      type: string
+      description: 10-digit SEC Central Index Key. Canonical input for exact entity match.
+    company_name:
+      type: string
+      description: Optional fallback input — company name to search EDGAR for.
+    form_type:
+      type: string
+      description: Optional filter by SEC form type (e.g. "10-K", "8-K", "S-1", "4").
+    since_date:
+      type: string
+      description: Optional ISO date (YYYY-MM-DD) to filter filings filed on or after this date.
+    limit:
+      type: integer
+      description: Optional max number of filings to return (default 20, max 100).
+output_schema:
+  type: object
+  example:
+    query: companyName:"Apple Inc"
+    cik: null
+    company_name: Apple Inc
+    form_type_filter: 10-K
+    total_matches: 28
+    returned_count: 20
+    most_recent_filing_date: "2024-11-01"
+    most_recent_8k_date: null
+    filings: []
+    data_source: sec-api.io (extended SEC EDGAR index)
+  properties:
+    query:
+      type: string
+    cik:
+      type:
+        - string
+        - "null"
+    company_name:
+      type:
+        - string
+        - "null"
+    form_type_filter:
+      type:
+        - string
+        - "null"
+    total_matches:
+      type: integer
+    returned_count:
+      type: integer
+    most_recent_filing_date:
+      type:
+        - string
+        - "null"
+    most_recent_8k_date:
+      type:
+        - string
+        - "null"
+    filings:
+      type: array
+    data_source:
+      type: string
+data_source: sec-api.io (extended SEC EDGAR index)
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: commercial-stable-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: us
+test_fixtures:
+  known_answer:
+    input:
+      company_name: "Apple Inc"
+      form_type: "10-K"
+      limit: 5
+    expected_fields:
+      - field: total_matches
+        operator: not_null
+        reliability: guaranteed
+      - field: filings
+        operator: not_null
+        reliability: guaranteed
+      - field: data_source
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    company_name: "Apple Inc"
+    form_type: "10-K"
+    limit: 5
+output_field_reliability:
+  query: guaranteed
+  total_matches: guaranteed
+  returned_count: guaranteed
+  filings: guaranteed
+  data_source: guaranteed
+  cik: common
+  company_name: common
+  form_type_filter: common
+  most_recent_filing_date: common
+  most_recent_8k_date: common
+limitations:
+  - title: SEC filers only
+    text: >-
+      Coverage limited to entities that file with the SEC (publicly-traded US companies + foreign
+      private issuers ~13k filers). Most US private companies do not file with the SEC; for those,
+      use us-company-data-cobalt (50-state SoS coverage).
+    category: coverage
+    severity: info
+  - title: Full-text search may surface incidental mentions
+    text: >-
+      A company-name search against filing bodies returns any filing that mentions the name, including
+      filings BY other entities that mention this company (e.g. as a counterparty, subsidiary, supplier).
+      Use cik-based search when you want strictly the entity's own filings.
+    category: accuracy
+    severity: warning


### PR DESCRIPTION
## Summary

Ships executor + manifest scaffolding for 5 capabilities behind v1.1 vendor sign-ups. Each is functionally complete and matches the documented API shape. None are onboarded to the catalog yet — the onboarding pipeline requires the respective env var to validate against the live API.

The intent: when you do the sign-ups (Monday-ish), the code is already in main. You add the env var, run `onboard.ts --discover --manifest ...`, and the cap activates immediately. Saves 1-2 days of build time per vendor on the post-sign-up critical path.

## Capabilities shipped

| Slug | Vendor | Activation env var | Sign-up URL |
|---|---|---|---|
| `uk-cop-check` | eSortcode (Pay.UK CoP scheme) | `ESORTCODE_API_KEY` | [esortcode.com/confirmation-of-payee](https://esortcode.com/confirmation-of-payee) |
| `us-ein-match` | Liberty Data / EINsearch | `EINSEARCH_API_KEY` | [einsearch.com/pricing/?annual](https://einsearch.com/pricing/?annual) |
| `us-company-data-cobalt` | Cobalt Intelligence (50-state SoS) | `COBALT_API_KEY` | [cobaltintelligence.com](https://cobaltintelligence.com) |
| `us-court-search` | CourtListener (Free Law Project) | `COURTLISTENER_API_TOKEN` | [courtlistener.com/sign-up](https://www.courtlistener.com/sign-up/) (free, instant) |
| `us-sec-filings-extended` | sec-api.io | `SEC_API_IO_TOKEN` | [sec-api.io](https://sec-api.io) |

## Each executor

- Throws structured error with sign-up URL when env var missing
- Validates input shape before calling upstream
- Normalises upstream response to a Strale-canonical output
- Includes provenance: `acquisition_method`, `license`, `attribution`
- 10–20s timeout via `AbortSignal`

## Each manifest

- Full output_schema with field types
- `test_fixtures` with health_check_input + known_answer
- `output_field_reliability` annotations
- 2+ limitations per capability
- `gdpr_art_22_classification` per canonical enum

## Activation procedure (per capability, post sign-up)

1. Sign up for the vendor; obtain the env var value
2. Add to Railway env config
3. Run from `apps/api/`:
   ```
   npx tsx scripts/onboard.ts --discover --manifest ../../manifests/<slug>.yaml
   ```
4. Pipeline executes against the live API, auto-discovers `expected_fields`, activates the cap

If a known_answer assertion fails (e.g. API response shape differs from what I documented), the pipeline reports the diff and the manifest can be tweaked + re-run.

## Open questions per vendor (verify on first run)

- **eSortcode**: Confirmed POST `/v1/cop/check`? Or could be `/api/v1/...` — verify on first auth-successful call.
- **EINsearch**: API base URL and auth header style assumed; verify against their published docs after sign-up.
- **Cobalt**: Endpoint `apigateway.cobaltintelligence.com/v1/search?searchQuery=...&state=...&liveData=true` per founder Jordan Hansen's documentation. Confirmed pattern.
- **CourtListener**: REST v3 documented and stable. Token format: 40-char hex, header `Authorization: Token <hex>`.
- **sec-api.io**: POST + Lucene query body documented. Token via query param.

The known_answer test in each manifest exercises the shape end-to-end; if any of the assumptions are wrong, the pipeline will surface it in the first onboarding run.

## Selection rationale

All 5 vendors are documented as `Status=Active` (or `Pending eval` for Cobalt/sec-api/CourtListener pre-sign-up) in the Vendor Roster, with `Primary DEC` linking to DEC-20260430-A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)