### PR TITLE
chore(rename): Payee Assurance → Counterparty Assurance (internal)

### DIFF
--- a/apps/api/scripts/backfill-art22-classifications.ts
+++ b/apps/api/scripts/backfill-art22-classifications.ts
@@ -15,7 +15,7 @@ import { capabilities } from "../src/db/schema.js";
 
 const db = getDb();
 
-// Per the cert-audit's Payee Assurance Readiness analysis, the compliance
+// Per the cert-audit's Counterparty Assurance Readiness analysis, the compliance
 // capabilities + risk-synthesis cap are the rows where Art. 22 disclosure
 // matters. beneficial-ownership-lookup stays as data_lookup because it
 // returns factual UBO data; the customer's downstream KYB rules are what

--- a/apps/api/scripts/check-vendor-roster-drift.mjs
+++ b/apps/api/scripts/check-vendor-roster-drift.mjs
@@ -100,7 +100,7 @@ DEC-20260430-A read the Vendor Roster verbatim — but the Roster row
 for OpenSanctions still said Status=Self-built (a "planned migration")
 even though DEC-20260429-A had deferred it indefinitely the day before
 on a CC-BY-NonCommercial licensing finding. The stale Roster state
-propagated into the canonicalizing DEC, the Payee Assurance product
+propagated into the canonicalizing DEC, the Counterparty Assurance product
 page, and the session-end summary. Petter caught it; cleanup took
 ~30 minutes.
 

--- a/apps/api/scripts/empirical-screening-coverage.ts
+++ b/apps/api/scripts/empirical-screening-coverage.ts
@@ -1,5 +1,5 @@
 /**
- * Empirical coverage test for the three Payee Assurance screening capabilities.
+ * Empirical coverage test for the three Counterparty Assurance screening capabilities.
  *
  * - PEP: 2 known PEPs per jurisdiction × 30 (EU27 + UK + NO + CH) + 5 US PEPs
  *   via Strale /v1/do → pep-check. Tests breadth of OpenSanctions PEP coverage.

--- a/apps/api/scripts/empirical-vat-coverage.ts
+++ b/apps/api/scripts/empirical-vat-coverage.ts
@@ -1,9 +1,9 @@
 /**
- * Empirical VAT validation coverage across Payee Assurance target countries.
+ * Empirical VAT validation coverage across Counterparty Assurance target countries.
  * EU27 + UK + NO + CH for v1; v1.1 has no VAT (US uses sales tax).
  *
  * One real-world VAT per country, calls /v1/do, captures: provider, valid flag,
- * name returned (for Payee Assurance name-match), error if any.
+ * name returned (for Counterparty Assurance name-match), error if any.
  *
  * Goal: confirm the capability routes correctly to the right provider for each
  * jurisdiction and returns a structured response. Some VATs may be deregistered
@@ -119,7 +119,7 @@ for (const c of CASES) {
 const out: string[] = [];
 out.push(`# Empirical VAT Coverage — ${new Date().toISOString().slice(0, 10)}`);
 out.push("");
-out.push("**Method:** One real-world VAT per Payee Assurance target country, called via Strale /v1/do → vat-validate. Throttled 1.5s between calls (VIES rate limit). v1.1 (US) has no VAT — sales tax instead, out of scope for this capability.");
+out.push("**Method:** One real-world VAT per Counterparty Assurance target country, called via Strale /v1/do → vat-validate. Throttled 1.5s between calls (VIES rate limit). v1.1 (US) has no VAT — sales tax instead, out of scope for this capability.");
 out.push("");
 out.push("| Country | Code | VAT | valid | Name returned | Provider | Status | Notes |");
 out.push("|---|---|---|---|---|---|---|---|");
@@ -136,7 +136,7 @@ const hasName = results.filter((r) => r.has_name).length;
 out.push("");
 out.push("## Summary");
 out.push(`- Capability returned a structured response: ${ok} / ${results.length}`);
-out.push(`- Response included an entity name: ${hasName} / ${results.length} (Payee Assurance name-match availability per country)`);
+out.push(`- Response included an entity name: ${hasName} / ${results.length} (Counterparty Assurance name-match availability per country)`);
 
 const reportPath = resolve(import.meta.dirname, "../../../docs/research/2026-04-28-vat-coverage-empirical.md");
 await writeFile(reportPath, out.join("\n"));

--- a/apps/api/scripts/gleif-coverage-by-country.ts
+++ b/apps/api/scripts/gleif-coverage-by-country.ts
@@ -1,5 +1,5 @@
 /**
- * Probe GLEIF for total LEI registrations per Payee Assurance target jurisdiction.
+ * Probe GLEIF for total LEI registrations per Counterparty Assurance target jurisdiction.
  * Free, no auth. Just paginates the lei-records endpoint with filter[entity.legalAddress.country]
  * and reads meta.pagination.total.
  *

--- a/apps/api/scripts/trigger-screening-tests.ts
+++ b/apps/api/scripts/trigger-screening-tests.ts
@@ -1,5 +1,5 @@
 /**
- * Run two test rounds (65s apart) for the three Payee Assurance screening
+ * Run two test rounds (65s apart) for the three Counterparty Assurance screening
  * capabilities so their SQS freshness gate lifts after the audit-grade
  * hardening session on 2026-04-27.
  *

--- a/apps/api/src/capabilities/fr-bodacc-lookup.ts
+++ b/apps/api/src/capabilities/fr-bodacc-lookup.ts
@@ -7,7 +7,7 @@ import { registerCapability, type CapabilityInput } from "./index.js";
  * registry events: insolvency proceedings, sales, registry modifications,
  * incorporations, strikeoffs, annual-accounts deposits.
  *
- * For Payee Assurance the primary value is the insolvency signal —
+ * For Counterparty Assurance the primary value is the insolvency signal —
  * Procédures collectives (familleavis = "collective"). The executor
  * returns all announcement types for full history but elevates insolvency
  * count + most-recent-insolvency to top-level fields.

--- a/apps/api/src/capabilities/no-bankruptcy-check.ts
+++ b/apps/api/src/capabilities/no-bankruptcy-check.ts
@@ -20,9 +20,9 @@ import {
  *
  * The companion `norwegian-company-data` capability returns the broader
  * registry record but exposes bankruptcy as a coarse `status` enum only.
- * This capability is the dedicated litigation/bankruptcy leg for Payee
- * Assurance — the boolean signals plus the bankruptcy filing date are
- * what risk-decisioning code needs.
+ * This capability is the dedicated litigation/bankruptcy leg for
+ * Counterparty Assurance — the boolean signals plus the bankruptcy filing
+ * date are what risk-decisioning code needs.
  *
  * Shares the upstream Brreg fetch with norwegian-company-data via
  * lib/brreg-fetch.ts.

--- a/apps/api/src/capabilities/us-court-search.ts
+++ b/apps/api/src/capabilities/us-court-search.ts
@@ -21,7 +21,7 @@ import { registerCapability, type CapabilityInput } from "./index.js";
  * Two query modes:
  *   1. Search by case_name / party_name across all dockets.
  *   2. Filter by court_type=bankruptcy to get only bankruptcy filings
- *      (focused query for Payee Assurance risk decisions).
+ *      (focused query for Counterparty Assurance risk decisions).
  */
 
 const CL_API = "https://www.courtlistener.com/api/rest/v3";

--- a/apps/api/src/capabilities/vat-validate.ts
+++ b/apps/api/src/capabilities/vat-validate.ts
@@ -32,7 +32,7 @@ import type {
 // ---------------------------------------------------------------------------
 
 // 48h cache. VAT registration changes can happen — deregistration in
-// particular is a real failure mode for Payee Assurance — but most agents
+// particular is a real failure mode for Counterparty Assurance — but most agents
 // are validating the same handful of counterparties repeatedly. 48h trades
 // off freshness vs. upstream load and lands well within the "freshness lag"
 // already disclosed in the manifest's limitations.

--- a/apps/api/src/web3-assurance/evaluators/index.ts
+++ b/apps/api/src/web3-assurance/evaluators/index.ts
@@ -12,7 +12,7 @@
  *      mixer-graded classifier, Tenderly simulation, EAS, ERC-8004, sister-rug,
  *      ScamSniffer, Web3 Antivirus, REKT, audit-firm aggregation)
  *
- * Sanctions evaluation is delegated to the Payee Assurance sanctions substrate
+ * Sanctions evaluation is delegated to the Counterparty Assurance sanctions substrate
  * via the existing sanctions-check capability — not duplicated here.
  */
 

--- a/apps/api/src/web3-assurance/types.ts
+++ b/apps/api/src/web3-assurance/types.ts
@@ -2,9 +2,9 @@
  * Web3 Assurance — type definitions.
  *
  * Returns a decision-ready answer about an on-chain counterparty (wallet,
- * contract, token, protocol, bridge, or domain). Sister product to Payee
- * Assurance (off-chain KYB). PA's sanctions substrate is reused here;
- * everything else is crypto-native.
+ * contract, token, protocol, bridge, or domain). Sister product to
+ * Counterparty Assurance (off-chain KYB). The platform's sanctions
+ * substrate is reused here; everything else is crypto-native.
  *
  * Response shape is agent-first: verdict + reason_codes + suggested_action
  * surface at top level. Audit trail demoted to sidecar audit_url. Per


### PR DESCRIPTION
## Summary

Mechanical platform-positioning rename in internal code comments and docstrings. Comment-only — zero logic, zero public-API surface, zero field names changed.

## Verification

- ✅ Typecheck (\`npx tsc --noEmit -p apps/api\`)
- ✅ No tests touched (rename is in comments only)
- ✅ Internal sweep verified clean post-PR: \`grep \"Payee Assurance\" apps/api/src --include=\"*.ts\"\` returns only the 5 deferred customer-facing files (openapi.ts, llms-txt.ts, mcp-server-card.ts, methodology.ts, packages/mcp-server/src/tools.ts)

## Reviewer findings

**Pass A (technical) — MEDIUM:** PR scope deliberately excludes customer-facing surfaces. PR body should make this visible. ✅ Done — see "Customer-facing surfaces deferred" below.

**Pass B (product) — MEDIUM:** Two internal files initially missed (\`no-bankruptcy-check.ts:24\`, \`web3-assurance/types.ts:5-6\`). ✅ Fixed and added to this PR.

**Pass B observation (LOW, not actioned):** \`adverse-media-check.ts:24\` uses lowercase \"payee\" generically (Pay.UK CoP terminology — recipient of a payment). Kept as-is; not the product name.

## Customer-facing surfaces deferred (by design)

These will land alongside corresponding \`strale-frontend\` updates in a single coordinated cross-repo PR so the external rename is atomic from a customer's perspective:

- \`apps/api/src/openapi.ts\` — public OpenAPI spec
- \`apps/api/src/routes/llms-txt.ts\` — \`/llms.txt\` endpoint
- \`apps/api/src/routes/mcp-server-card.ts\` — MCP server card
- \`apps/api/src/web3-assurance/methodology.ts\` — public methodology page
- \`packages/mcp-server/src/tools.ts\` — npm-published comment

## Test plan

- [ ] CI green
- [ ] Reviewer to confirm grep for \"Payee Assurance\" returns only the 5 deferred files

🤖 Generated with [Claude Code](https://claude.com/claude-code)