### PR TITLE
chore(scripts): surface failure_type in window-failed-requests

### DIFF
--- a/apps/api/scripts/window-failed-requests.ts
+++ b/apps/api/scripts/window-failed-requests.ts
@@ -7,11 +7,22 @@ if (!from || !to) {
 const postgres = (await import("postgres")).default;
 const sql = postgres(process.env.DATABASE_URL!, { max: 1, ssl: "require" });
 const r = await sql`
-  SELECT task, category, max_price_cents, created_at
+  SELECT task, category, max_price_cents, failure_type, error_detail, created_at
   FROM failed_requests
   WHERE created_at >= ${from} AND created_at <= ${to}
   ORDER BY created_at DESC
 `;
 console.log('failed_requests in window:', r.length);
+
+const byType = new Map<string, number>();
+for (const row of r) {
+  const key = row.failure_type ?? 'unknown';
+  byType.set(key, (byType.get(key) ?? 0) + 1);
+}
+if (byType.size > 0) {
+  console.log('  by failure_type:', [...byType.entries()].map(([k, v]) => `${k}=${v}`).join(', '));
+  console.log('  note: only no_match is a true matcher miss.');
+  console.log('  missing_fields / input_misplaced / input_confusion mean the matcher resolved a capability but the caller passed bad input.');
+}
 for (const row of r) console.log('  ', JSON.stringify(row));
 await sql.end();


### PR DESCRIPTION
## Summary
- `apps/api/scripts/window-failed-requests.ts` previously printed only `task / category / max_price / created_at`, hiding `failure_type` and `error_detail`.
- That made every row look the same shape regardless of whether the matcher missed or the caller passed bad input. During an activity audit today, three input-validation rejects (`missing_fields` / `input_misplaced` on a free-tier `email-validate` call where the caller forgot the `email` field) were misclassified as matcher gaps.
- Patch surfaces both columns, prints a one-line breakdown by `failure_type`, and adds a clarifying note that only `no_match` is a true matcher miss.

## Verification
- `tsc --noEmit` (strict, NodeNext) on the patched file — clean.
- Ran live against today's window: `by failure_type: no_match=1, input_misplaced=1, missing_fields=2`. Matches the manual DB query that uncovered the misclassification.

## Reviewer findings — clean (technical + product)
Two LOW nits from the reviewers were applied during the pass:
- Extracted `failure_type ?? 'unknown'` into a `key` const so it's evaluated once per row.
- Split the long explanatory note into two `console.log` calls so it doesn't wrap awkwardly in narrow terminals.

PM lens flagged a worthwhile follow-up (out of scope for this PR): `do.ts` already emits `input_misplaced` vs `missing_fields` to the DB, but the 4xx response body uses the same `error_code: invalid_request` for both. If callers ever want to retry programmatically based on the failure mode, differentiating those error codes in the API response would help. Filing as a thought, not an action.

## Test plan
- [ ] Run `cd apps/api && npx tsx --env-file=../../.env scripts/window-failed-requests.ts <from-iso> <to-iso>` against any window — confirm the breakdown line appears at the top and the per-row JSON now includes `failure_type` and `error_detail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)