### PR TITLE
feat(capability): add marketplace_eligible flag + onboarding classification gate

### DIFF
--- a/apps/api/drizzle/0060_marketplace_eligible.sql
+++ b/apps/api/drizzle/0060_marketplace_eligible.sql
@@ -1,0 +1,20 @@
+-- Per DEC-20260503-A — `marketplace_eligible` controls whether a capability
+-- appears on strale.dev's public surfaces (capability listing, MCP card,
+-- A2A card, llms.txt, x402 manifest, /v1/suggest). Internal callers
+-- (do.ts, products, routing engine, lifecycle, audit, jobs) ignore this
+-- flag and continue to see all capabilities.
+--
+-- Default true: classified at onboarding time. Set false for thin
+-- passthroughs of paid 3rd-party vendors where strale.dev surfacing
+-- would constitute reseller-style competitor enablement, or for
+-- capabilities whose ToS forbids resale, or for fixed-cost vendors
+-- where a self-serve marketplace would burn the per-month budget.
+--
+-- All capabilities currently in the table default to true at this
+-- migration; classification of existing rows happens at chat decision
+-- time, not in this migration.
+ALTER TABLE "capabilities"
+  ADD COLUMN IF NOT EXISTS "marketplace_eligible" boolean DEFAULT true NOT NULL;
+
+ALTER TABLE "capabilities"
+  ADD COLUMN IF NOT EXISTS "marketplace_eligible_reason" text;

--- a/apps/api/drizzle/meta/0060_snapshot.json
+++ b/apps/api/drizzle/meta/0060_snapshot.json
@@ -1,0 +1,2724 @@
+{
+  "id": "8a346b22-c923-41bd-a5e3-be39ecac8134",
+  "prevId": "4a1bcfe9-d0cf-4cc3-945b-69a468c82ff1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.capabilities": {
+      "name": "capabilities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "avg_latency_ms": {
+          "name": "avg_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success_rate": {
+          "name": "success_rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transparency_tag": {
+          "name": "transparency_tag",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geography": {
+          "name": "geography",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_source": {
+          "name": "data_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_classification": {
+          "name": "data_classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processes_personal_data": {
+          "name": "processes_personal_data",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "personal_data_categories": {
+          "name": "personal_data_categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "freshness_category": {
+          "name": "freshness_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_update_cycle_days": {
+          "name": "data_update_cycle_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_last_updated": {
+          "name": "dataset_last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_free_tier": {
+          "name": "is_free_tier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capability_type": {
+          "name": "capability_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stable_api'"
+        },
+        "fallback_capability_slug": {
+          "name": "fallback_capability_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fallback_coverage": {
+          "name": "fallback_coverage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fallback_verification_level": {
+          "name": "fallback_verification_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_codes_json": {
+          "name": "error_codes_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qp_score": {
+          "name": "qp_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rp_score": {
+          "name": "rp_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_sqs": {
+          "name": "matrix_sqs",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matrix_sqs_raw": {
+          "name": "matrix_sqs_raw",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trend": {
+          "name": "trend",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'stable'"
+        },
+        "freshness_level": {
+          "name": "freshness_level",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'fresh'"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "freshness_decayed_at": {
+          "name": "freshness_decayed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guidance_usable": {
+          "name": "guidance_usable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guidance_strategy": {
+          "name": "guidance_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guidance_confidence": {
+          "name": "guidance_confidence",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_state": {
+          "name": "lifecycle_state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "deactivation_reason": {
+          "name": "deactivation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_field_reliability": {
+          "name": "output_field_reliability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_manifest": {
+          "name": "onboarding_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "degraded_recovery_count": {
+          "name": "degraded_recovery_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_tags": {
+          "name": "search_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "maintenance_class": {
+          "name": "maintenance_class",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scraping-fragile-target'"
+        },
+        "x402_enabled": {
+          "name": "x402_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "x402_method": {
+          "name": "x402_method",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POST'"
+        },
+        "marketplace_eligible": {
+          "name": "marketplace_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "marketplace_eligible_reason": {
+          "name": "marketplace_eligible_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gdpr_art_22_classification": {
+          "name": "gdpr_art_22_classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'data_lookup'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "capabilities_slug_unique": {
+          "name": "capabilities_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capability_health": {
+      "name": "capability_health",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_slug": {
+          "name": "capability_slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'closed'"
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_successes": {
+          "name": "total_successes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backoff_minutes": {
+          "name": "backoff_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "capability_health_capability_slug_unique": {
+          "name": "capability_health_capability_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "capability_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capability_limitations": {
+      "name": "capability_limitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_slug": {
+          "name": "capability_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limitation_text": {
+          "name": "limitation_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "affected_percentage": {
+          "name": "affected_percentage",
+          "type": "numeric(5, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workaround": {
+          "name": "workaround",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capability_limitations_slug_idx": {
+          "name": "capability_limitations_slug_idx",
+          "columns": [
+            {
+              "expression": "capability_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.digest_snapshots": {
+      "name": "digest_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "digest_snapshots_snapshot_date_unique": {
+          "name": "digest_snapshots_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispute_requests": {
+      "name": "dispute_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affected_field": {
+          "name": "affected_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "disposition_at": {
+          "name": "disposition_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disposition_notes": {
+          "name": "disposition_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dispute_requests_transaction_id_transactions_id_fk": {
+          "name": "dispute_requests_transaction_id_transactions_id_fk",
+          "tableFrom": "dispute_requests",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispute_requests_user_id_users_id_fk": {
+          "name": "dispute_requests_user_id_users_id_fk",
+          "tableFrom": "dispute_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_requests": {
+      "name": "failed_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_price_cents": {
+          "name": "max_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_type": {
+          "name": "failure_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_match'"
+        },
+        "error_detail": {
+          "name": "error_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "failed_requests_user_id_idx": {
+          "name": "failed_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "failed_requests_user_id_users_id_fk": {
+          "name": "failed_requests_user_id_users_id_fk",
+          "tableFrom": "failed_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_monitor_events": {
+      "name": "health_monitor_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_slug": {
+          "name": "capability_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "human_override": {
+          "name": "human_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_counters": {
+      "name": "rate_limit_counters",
+      "schema": "",
+      "columns": {
+        "bucket_key": {
+          "name": "bucket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_counters_window_idx": {
+          "name": "rate_limit_counters_window_idx",
+          "columns": [
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_counters_bucket_key_window_start_pk": {
+          "name": "rate_limit_counters_bucket_key_window_start_pk",
+          "columns": [
+            "bucket_key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solution_steps": {
+      "name": "solution_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "solution_id": {
+          "name": "solution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_slug": {
+          "name": "capability_slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_order": {
+          "name": "step_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_parallel": {
+          "name": "can_parallel",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parallel_group": {
+          "name": "parallel_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_map": {
+          "name": "input_map",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "solution_steps_solution_id_idx": {
+          "name": "solution_steps_solution_id_idx",
+          "columns": [
+            {
+              "expression": "solution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "solution_steps_solution_order_unique": {
+          "name": "solution_steps_solution_order_unique",
+          "columns": [
+            {
+              "expression": "solution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "solution_steps_solution_id_solutions_id_fk": {
+          "name": "solution_steps_solution_id_solutions_id_fk",
+          "tableFrom": "solution_steps",
+          "tableTo": "solutions",
+          "columnsFrom": [
+            "solution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "solution_steps_capability_slug_capabilities_slug_fk": {
+          "name": "solution_steps_capability_slug_capabilities_slug_fk",
+          "tableFrom": "solution_steps",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solutions": {
+      "name": "solutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "long_description": {
+          "name": "long_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_description": {
+          "name": "agent_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "component_sum_cents": {
+          "name": "component_sum_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_tier": {
+          "name": "value_tier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maintenance_level": {
+          "name": "maintenance_level",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geography": {
+          "name": "geography",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example_input": {
+          "name": "example_input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "example_output": {
+          "name": "example_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketing_name": {
+          "name": "marketing_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transparency_tag": {
+          "name": "transparency_tag",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extends_with": {
+          "name": "extends_with",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "compliance_coverage": {
+          "name": "compliance_coverage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_tags": {
+          "name": "search_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "x402_enabled": {
+          "name": "x402_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "solutions_slug_unique": {
+          "name": "solutions_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sqs_daily_snapshot": {
+      "name": "sqs_daily_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_slug": {
+          "name": "capability_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matrix_sqs": {
+          "name": "matrix_sqs",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qp_score": {
+          "name": "qp_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rp_score": {
+          "name": "rp_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qp_grade": {
+          "name": "qp_grade",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rp_grade": {
+          "name": "rp_grade",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trend": {
+          "name": "trend",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_state": {
+          "name": "health_state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runs_analyzed": {
+          "name": "runs_analyzed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sqs_daily_snapshot_slug_date_unique": {
+          "name": "sqs_daily_snapshot_slug_date_unique",
+          "columns": [
+            {
+              "expression": "capability_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sqs_daily_snapshot_slug_date_desc_idx": {
+          "name": "sqs_daily_snapshot_slug_date_desc_idx",
+          "columns": [
+            {
+              "expression": "capability_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggest_log": {
+      "name": "suggest_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query_length": {
+          "name": "query_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_count": {
+          "name": "result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_type": {
+          "name": "search_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_filter": {
+          "name": "type_filter",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo": {
+          "name": "geo",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "suggest_log_created_at_idx": {
+          "name": "suggest_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suggest_log_result_count_idx": {
+          "name": "suggest_log_result_count_idx",
+          "columns": [
+            {
+              "expression": "result_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_results": {
+      "name": "test_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_slug": {
+          "name": "capability_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actual_output": {
+          "name": "actual_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "output_hash": {
+          "name": "output_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_classification": {
+          "name": "failure_classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_fixed": {
+          "name": "auto_fixed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "test_results_capability_slug_idx": {
+          "name": "test_results_capability_slug_idx",
+          "columns": [
+            {
+              "expression": "capability_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_executed_at_idx": {
+          "name": "test_results_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_test_suite_id_idx": {
+          "name": "test_results_test_suite_id_idx",
+          "columns": [
+            {
+              "expression": "test_suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_slug_executed_idx": {
+          "name": "test_results_slug_executed_idx",
+          "columns": [
+            {
+              "expression": "capability_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_suite_executed_idx": {
+          "name": "test_results_suite_executed_idx",
+          "columns": [
+            {
+              "expression": "test_suite_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_results_test_suite_id_test_suites_id_fk": {
+          "name": "test_results_test_suite_id_test_suites_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_run_log": {
+      "name": "test_run_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tests": {
+          "name": "total_tests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "actual_cost_cents": {
+          "name": "actual_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "capability_slug": {
+          "name": "capability_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_output": {
+          "name": "expected_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_rules": {
+          "name": "validation_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule_tier": {
+          "name": "schedule_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'B'"
+        },
+        "estimated_cost_cents": {
+          "name": "estimated_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "baseline_output": {
+          "name": "baseline_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline_captured_at": {
+          "name": "baseline_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_status": {
+          "name": "test_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "quarantine_reason": {
+          "name": "quarantine_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_classification": {
+          "name": "last_classification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_remediation_log": {
+          "name": "auto_remediation_log",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_mode": {
+          "name": "test_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'live'"
+        },
+        "fixture_last_refreshed": {
+          "name": "fixture_last_refreshed",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_cost_cents": {
+          "name": "external_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "generation_capability_updated_at": {
+          "name": "generation_capability_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ground_truth_verified_at": {
+          "name": "ground_truth_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_suites_capability_slug_idx": {
+          "name": "test_suites_capability_slug_idx",
+          "columns": [
+            {
+              "expression": "capability_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transaction_quality": {
+      "name": "transaction_quality",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_latency_ms": {
+          "name": "upstream_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_conformant": {
+          "name": "schema_conformant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fields_returned": {
+          "name": "fields_returned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fields_expected": {
+          "name": "fields_expected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_completeness_pct": {
+          "name": "field_completeness_pct",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality_flags": {
+          "name": "quality_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_quality_transaction_id_transactions_id_fk": {
+          "name": "transaction_quality_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_quality",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transaction_quality_transaction_id_unique": {
+          "name": "transaction_quality_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "transaction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solution_slug": {
+          "name": "solution_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_trail": {
+          "name": "audit_trail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transparency_marker": {
+          "name": "transparency_marker",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ai_generated'"
+        },
+        "data_jurisdiction": {
+          "name": "data_jurisdiction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EU'"
+        },
+        "is_free_tier": {
+          "name": "is_free_tier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "integrity_hash": {
+          "name": "integrity_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compliance_hash_state": {
+          "name": "compliance_hash_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "integrity_hash_status": {
+          "name": "integrity_hash_status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "legal_hold": {
+          "name": "legal_hold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redacted_at": {
+          "name": "redacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_reason": {
+          "name": "deletion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip_hash": {
+          "name": "client_ip_hash",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'wallet'"
+        },
+        "x402_settlement_id": {
+          "name": "x402_settlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x402_payment_hash": {
+          "name": "x402_payment_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_usd": {
+          "name": "price_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_idempotency_key_unique": {
+          "name": "transactions_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "idempotency_key IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_user_id_idx": {
+          "name": "transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_status_idx": {
+          "name": "transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_x402_payment_hash_unique": {
+          "name": "transactions_x402_payment_hash_unique",
+          "columns": [
+            {
+              "expression": "x402_payment_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "x402_payment_hash IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_capability_id_capabilities_id_fk": {
+          "name": "transactions_capability_id_capabilities_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "capabilities",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_ip_hash": {
+          "name": "signup_ip_hash",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_spend_per_hour_cents": {
+          "name": "max_spend_per_hour_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "first_transaction_at": {
+          "name": "first_transaction_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activation_email_stage": {
+          "name": "activation_email_stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activation_completed_at": {
+          "name": "activation_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_reason": {
+          "name": "deletion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_accepted_at": {
+          "name": "tos_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_version": {
+          "name": "tos_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_api_key_hash_unique": {
+          "name": "users_api_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_transactions": {
+      "name": "wallet_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_transactions_stripe_session_id_unique": {
+          "name": "wallet_transactions_stripe_session_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "stripe_session_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_transactions_wallet_id_wallets_id_fk": {
+          "name": "wallet_transactions_wallet_id_wallets_id_fk",
+          "tableFrom": "wallet_transactions",
+          "tableTo": "wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_users_id_fk": {
+          "name": "wallets_user_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallets_user_id_unique": {
+          "name": "wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.x402_orphan_settlements": {
+      "name": "x402_orphan_settlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "settlement_id": {
+          "name": "settlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_slug": {
+          "name": "capability_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solution_slug": {
+          "name": "solution_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_usd": {
+          "name": "price_usd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_args": {
+          "name": "raw_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciliation_status": {
+          "name": "reconciliation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1777845600000,
       "tag": "0058_dispute_and_art22",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1777850861158,
+      "tag": "0060_marketplace_eligible",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/scripts/apply-migrations.ts
+++ b/apps/api/scripts/apply-migrations.ts
@@ -64,6 +64,22 @@ async function main() {
     console.log("[migration] actual_cost_cents already exists — skipping");
   }
 
+  // Migration 0060: marketplace_eligible flag on capabilities (DEC-20260503-A).
+  // Both ALTER TABLE statements use ADD COLUMN IF NOT EXISTS, so they are
+  // independently idempotent — no outer conditional. A previous wrapper that
+  // checked only the first column would skip both adds when a partial prior
+  // run left only `marketplace_eligible` present, leaving `..._reason` missing.
+  console.log("[migration] Ensuring capabilities.marketplace_eligible columns...");
+  await db.execute(sql`
+    ALTER TABLE "capabilities"
+      ADD COLUMN IF NOT EXISTS "marketplace_eligible" boolean DEFAULT true NOT NULL
+  `);
+  await db.execute(sql`
+    ALTER TABLE "capabilities"
+      ADD COLUMN IF NOT EXISTS "marketplace_eligible_reason" text
+  `);
+  console.log("[migration] marketplace_eligible columns ensured");
+
   // Migration 0062: paid-vendor suite cost classification per the
   // 2026-05-04 audit. The UPDATEs are idempotent because they only
   // touch rows where external_cost_cents = 0; a re-run is a no-op.

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -179,6 +179,19 @@ export const capabilities = pgTable("capabilities", {
   // × EUR_USD_RATE — there is no separate stored USD column.
   x402Enabled: boolean("x402_enabled").notNull().default(false),
   x402Method: varchar("x402_method", { length: 4 }).notNull().default("POST"),
+  // Per DEC-20260503-A — controls whether the capability appears on
+  // strale.dev's public surfaces (listing, MCP card, A2A card, llms.txt,
+  // x402 manifest, /v1/suggest). Internal callers (do.ts, products,
+  // routing, lifecycle) IGNORE this flag and see all capabilities.
+  // Default true: classified at onboarding time. Set false for thin
+  // passthroughs of paid 3rd-party vendors where strale.dev surfacing
+  // would constitute reseller-style competitor enablement, or for
+  // capabilities whose ToS forbids resale, or for fixed-cost vendors
+  // where a self-serve marketplace would burn the budget.
+  marketplaceEligible: boolean("marketplace_eligible")
+    .notNull()
+    .default(true),
+  marketplaceEligibleReason: text("marketplace_eligible_reason"),
   // Bucket C — GDPR Art. 22 classification per capability (migration 0058).
   // Surfaced in audit body so the customer (controller) sees the
   // automated-decision posture and the data subject can find the

--- a/apps/api/src/lib/capability-field-authority.ts
+++ b/apps/api/src/lib/capability-field-authority.ts
@@ -253,6 +253,20 @@ export const FIELD_CATEGORIES: Record<string, FieldAuthorityEntry> = {
     category: "hybrid",
     reason: "Defaults to 'public' on create; operator may tune to 'personal'/'public_financial_data'/etc. Backfill fills NULL; preserves set values.",
   },
+  marketplace_eligible: {
+    category: "hybrid",
+    reason:
+      "Per DEC-20260503-A: strale.dev marketplace surfacing decision. " +
+      "Manifest seeds the value on create; operator may override later " +
+      "(admin or direct DB) when vendor terms change. DB value preserved " +
+      "on backfill so manifest re-runs don't clobber an operator override.",
+  },
+  marketplace_eligible_reason: {
+    category: "hybrid",
+    reason:
+      "Per DEC-20260503-A: rationale text for marketplace_eligible. " +
+      "Same authority pattern as marketplace_eligible itself.",
+  },
 };
 
 /** Convert a snake_case field name to the Drizzle camelCase column key. */

--- a/apps/api/src/lib/capability-manifest-types.ts
+++ b/apps/api/src/lib/capability-manifest-types.ts
@@ -58,4 +58,15 @@ export interface Manifest {
   // Required for all new capabilities onboarded post-SA.2b.b.
   processes_personal_data?: boolean;
   personal_data_categories?: string[];
+  // Per DEC-20260503-A — strale.dev marketplace surfacing decision.
+  // Defaults to true in the DB if omitted from the manifest. Set false
+  // for thin passthroughs of paid 3rd-party vendors with significant
+  // fixed cost or ToS-prohibited resale terms; PAYG with low fixed cost
+  // is fine and stays true. When set false, marketplace_eligible_reason
+  // is REQUIRED (non-empty) — enforced by validateManifest and
+  // validateCapabilityStructure. See manifests/CLASSIFICATION.md for the
+  // full cost-shape, maintenance-burden, and ToS-posture criteria plus
+  // the decision tree and reason-string content guide.
+  marketplace_eligible?: boolean;
+  marketplace_eligible_reason?: string | null;
 }

--- a/apps/api/src/lib/capability-manifest.test.ts
+++ b/apps/api/src/lib/capability-manifest.test.ts
@@ -260,4 +260,42 @@ describe("Phase 4a authority enforcement in partial mode", () => {
       bypassAuthority: true,
     })).toThrow(/Authority violation/);
   });
+
+  // ── marketplace_eligible (DEC-20260503-A) ────────────────────────────────
+
+  it("marketplace_eligible: maps snake_case manifest field to camelCase row", () => {
+    const m = fullManifest({
+      marketplace_eligible: false,
+      marketplace_eligible_reason: "Wraps paid 3rd-party vendor X",
+    });
+    const row = normalizeManifestToRow(m);
+    expect(row.marketplaceEligible).toBe(false);
+    expect(row.marketplaceEligibleReason).toBe("Wraps paid 3rd-party vendor X");
+  });
+
+  it("marketplace_eligible: omitted manifest field → undefined in row → DB default true applies", () => {
+    // The field is OPTIONAL in the Manifest type. When omitted, the
+    // normalizer leaves it undefined and the DB column default (true)
+    // takes effect at INSERT time.
+    const row = normalizeManifestToRow(fullManifest());
+    expect(row.marketplaceEligible).toBeUndefined();
+    expect(row.marketplaceEligibleReason).toBeUndefined();
+  });
+
+  it("partial mode: hybrid marketplace_eligible with DB set → stripped (operator override preserved)", () => {
+    // The hybrid authority pattern: operator may have flipped the flag
+    // after onboarding (vendor ToS change, etc.). Backfill must not
+    // clobber that override.
+    const m = fullManifest({ marketplace_eligible: true });
+    const existingRow = { slug: "test-cap", marketplaceEligible: false };
+    const row = normalizeManifestToRow(m, { partial: true, existingRow });
+    expect(Object.prototype.hasOwnProperty.call(row, "marketplaceEligible")).toBe(false);
+  });
+
+  it("partial mode: hybrid marketplace_eligible with DB null → kept (manifest fills the gap)", () => {
+    const m = fullManifest({ marketplace_eligible: false });
+    const existingRow = { slug: "test-cap", marketplaceEligible: null };
+    const row = normalizeManifestToRow(m, { partial: true, existingRow });
+    expect(row.marketplaceEligible).toBe(false);
+  });
 });

--- a/apps/api/src/lib/capability-manifest.ts
+++ b/apps/api/src/lib/capability-manifest.ts
@@ -122,6 +122,12 @@ export function normalizeManifestToRow(
     // authority model hardens. For now, pass through when present.
     freshnessCategory: manifest.freshness_category,
     geography: manifest.geography,
+    // Per DEC-20260503-A — strale.dev marketplace surfacing. Hybrid
+    // field: manifest seeds on create, DB-preserved on backfill so an
+    // operator's later override (e.g. vendor ToS change) survives a
+    // manifest re-onboard.
+    marketplaceEligible: manifest.marketplace_eligible,
+    marketplaceEligibleReason: manifest.marketplace_eligible_reason,
   };
 
   if (!partial) {

--- a/apps/api/src/lib/onboarding-gates-orchestrator.test.ts
+++ b/apps/api/src/lib/onboarding-gates-orchestrator.test.ts
@@ -160,6 +160,61 @@ describe("validateCapability orchestrator (Cluster 2 Phase 2)", () => {
     const result = await validateCapability(manifest, existing, baseCtx({ mode: "backfill" }));
     expect(result.warnings.some((w) => w.gate === "authority" && w.detail.includes("transparency_tag"))).toBe(true);
   });
+
+  // ── DEC-20260503-A: marketplace_eligible cross-field rule ────────────────
+
+  it("accepts manifest with marketplace_eligible omitted (defaults to true)", async () => {
+    const m = validManifest();
+    delete (m as { marketplace_eligible?: boolean }).marketplace_eligible;
+    delete (m as { marketplace_eligible_reason?: string | null }).marketplace_eligible_reason;
+    const result = await validateCapability(m, null, baseCtx());
+    expect(result.violations).toEqual([]);
+  });
+
+  it("accepts manifest with marketplace_eligible: true and no reason", async () => {
+    const m = validManifest({ marketplace_eligible: true });
+    const result = await validateCapability(m, null, baseCtx());
+    expect(result.violations).toEqual([]);
+  });
+
+  it("accepts manifest with marketplace_eligible: false and a non-empty reason", async () => {
+    const m = validManifest({
+      marketplace_eligible: false,
+      marketplace_eligible_reason: "Vendor X Basic tier $300/mo minimum; thin passthrough margin negative.",
+    });
+    const result = await validateCapability(m, null, baseCtx());
+    expect(result.violations).toEqual([]);
+  });
+
+  it("rejects manifest with marketplace_eligible: false and missing reason", async () => {
+    const m = validManifest({ marketplace_eligible: false });
+    const result = await validateCapability(m, null, baseCtx());
+    expect(result.violations.some((v) =>
+      v.gate === "gate1_manifest" && v.detail.includes("marketplace_eligible_reason")
+    )).toBe(true);
+  });
+
+  it("rejects manifest with marketplace_eligible: false and empty-string reason", async () => {
+    const m = validManifest({
+      marketplace_eligible: false,
+      marketplace_eligible_reason: "   ",
+    });
+    const result = await validateCapability(m, null, baseCtx());
+    expect(result.violations.some((v) =>
+      v.gate === "gate1_manifest" && v.detail.includes("marketplace_eligible_reason")
+    )).toBe(true);
+  });
+
+  it("rejects manifest with marketplace_eligible: false and null reason", async () => {
+    const m = validManifest({
+      marketplace_eligible: false,
+      marketplace_eligible_reason: null,
+    });
+    const result = await validateCapability(m, null, baseCtx());
+    expect(result.violations.some((v) =>
+      v.gate === "gate1_manifest" && v.detail.includes("marketplace_eligible_reason")
+    )).toBe(true);
+  });
 });
 
 // ── GateViolationError ──────────────────────────────────────────────────────

--- a/apps/api/src/lib/onboarding-gates.ts
+++ b/apps/api/src/lib/onboarding-gates.ts
@@ -288,6 +288,10 @@ export function validateCapabilityStructure(cap: {
   personalDataCategories?: string[] | null;
   // Bucket C — optional; default 'data_lookup' applied at the DB layer.
   gdprArt22Classification?: string | null;
+  // Per DEC-20260503-A — marketplace surfacing flag. NOT NULL with DB
+  // default true; reason required only when explicitly set false.
+  marketplaceEligible?: boolean | null;
+  marketplaceEligibleReason?: string | null;
 }): GateViolation[] {
   const violations: GateViolation[] = [];
 
@@ -394,6 +398,22 @@ export function validateCapabilityStructure(cap: {
       severity: "error",
       detail: `${cap.slug}: gdpr_art_22_classification '${cap.gdprArt22Classification}' is not valid. Options: ${VALID_GDPR_ART_22_CLASSIFICATIONS.join(", ")} (or omit for the 'data_lookup' default).`,
     });
+  }
+
+  // Check 16 (DEC-20260503-A): marketplace_eligible cross-field rule.
+  // Mirrors the validateManifest gate for DB-row re-validation: when a
+  // capability is explicitly hidden from the strale.dev marketplace, an
+  // operator-readable rationale is required. See CLASSIFICATION.md for
+  // the cost-shape, maintenance-burden, and ToS-posture criteria.
+  if (cap.marketplaceEligible === false) {
+    const reason = cap.marketplaceEligibleReason;
+    if (!reason || typeof reason !== "string" || reason.trim().length === 0) {
+      violations.push({
+        gate: "gate1_structure",
+        severity: "error",
+        detail: `${cap.slug}: marketplace_eligible_reason is required and must be non-empty when marketplace_eligible is false. See manifests/CLASSIFICATION.md.`,
+      });
+    }
   }
 
   return violations;
@@ -518,6 +538,23 @@ export function validateManifest(m: Manifest, discover: boolean): string[] {
     }
     if (m.processes_personal_data === false && m.personal_data_categories.length > 0) {
       errors.push("personal_data_categories is populated but processes_personal_data is false. Either set processes_personal_data: true, or clear the categories.");
+    }
+  }
+
+  // Per DEC-20260503-A — marketplace_eligible cross-field rule.
+  // Field is optional; omitted/undefined → DB default true applies.
+  // When the manifest explicitly sets false, a non-empty rationale is
+  // required so future operators can audit why the capability is hidden
+  // from strale.dev. See CLASSIFICATION.md (capability onboarding dir)
+  // for the cost-shape, maintenance-burden, and ToS-posture criteria.
+  if (m.marketplace_eligible === false) {
+    const reason = m.marketplace_eligible_reason;
+    if (!reason || typeof reason !== "string" || reason.trim().length === 0) {
+      errors.push(
+        "marketplace_eligible_reason is required and must be non-empty when marketplace_eligible is false. " +
+          "See manifests/CLASSIFICATION.md for the cost-shape, " +
+          "maintenance-burden, and ToS-posture criteria.",
+      );
     }
   }
 

--- a/apps/api/src/lib/suggest.ts
+++ b/apps/api/src/lib/suggest.ts
@@ -256,6 +256,9 @@ async function loadCatalog(): Promise<CatalogItem[]> {
           and(
             eq(capabilities.isActive, true),
             eq(capabilities.visible, true),
+            // strale.dev surfacing per DEC-20260503-A — semantic suggest
+            // mirrors the public marketplace.
+            eq(capabilities.marketplaceEligible, true),
             inArray(capabilities.lifecycleState, ["active", "degraded"]),
           ),
         );

--- a/apps/api/src/routes/a2a.ts
+++ b/apps/api/src/routes/a2a.ts
@@ -104,7 +104,13 @@ async function buildAgentCard(): Promise<{ card: object; etag: string }> {
       isFreeTier: capabilities.isFreeTier,
     })
     .from(capabilities)
-    .where(eq(capabilities.isActive, true));
+    .where(
+      and(
+        eq(capabilities.isActive, true),
+        // strale.dev surfacing per DEC-20260503-A.
+        eq(capabilities.marketplaceEligible, true),
+      ),
+    );
 
   // Fetch active solutions
   const solRows = await db

--- a/apps/api/src/routes/capabilities.ts
+++ b/apps/api/src/routes/capabilities.ts
@@ -44,6 +44,9 @@ capabilitiesRoute.get("/", async (c) => {
       and(
         eq(capabilities.isActive, true),
         eq(capabilities.visible, true),
+        // strale.dev surfacing per DEC-20260503-A — internal callers
+        // (do.ts, products, routing, lifecycle) bypass this filter.
+        eq(capabilities.marketplaceEligible, true),
         inArray(capabilities.lifecycleState, ["active", "degraded"]),
       ),
     );
@@ -122,6 +125,8 @@ capabilitiesRoute.get("/:slug", async (c) => {
       and(
         eq(capabilities.slug, slug),
         eq(capabilities.isActive, true),
+        // strale.dev surfacing per DEC-20260503-A.
+        eq(capabilities.marketplaceEligible, true),
         inArray(capabilities.lifecycleState, ["active", "degraded"]),
       ),
     )

--- a/apps/api/src/routes/llms-txt.ts
+++ b/apps/api/src/routes/llms-txt.ts
@@ -7,7 +7,7 @@
  */
 
 import { Hono } from "hono";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { capabilities } from "../db/schema.js";
 import { computePlatformFacts } from "../lib/platform-facts.js";
@@ -170,7 +170,13 @@ async function buildFullText(): Promise<string> {
   const rows = await db
     .select({ slug: capabilities.slug, category: capabilities.category })
     .from(capabilities)
-    .where(eq(capabilities.isActive, true));
+    .where(
+      and(
+        eq(capabilities.isActive, true),
+        // strale.dev surfacing per DEC-20260503-A.
+        eq(capabilities.marketplaceEligible, true),
+      ),
+    );
 
   // Group by category
   const grouped = new Map<string, string[]>();

--- a/apps/api/src/routes/mcp-server-card.ts
+++ b/apps/api/src/routes/mcp-server-card.ts
@@ -6,7 +6,7 @@
  */
 
 import { Hono } from "hono";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { capabilities } from "../db/schema.js";
 
@@ -27,7 +27,13 @@ async function buildCard(): Promise<object> {
   const rows = await db
     .select({ slug: capabilities.slug })
     .from(capabilities)
-    .where(eq(capabilities.isActive, true));
+    .where(
+      and(
+        eq(capabilities.isActive, true),
+        // strale.dev surfacing per DEC-20260503-A.
+        eq(capabilities.marketplaceEligible, true),
+      ),
+    );
   const count = rows.length;
 
   const card = {

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -121,6 +121,10 @@ async function ensureCache(): Promise<void> {
       .where(and(
         eq(capabilities.x402Enabled, true),
         eq(capabilities.isActive, true),
+        // strale.dev surfacing per DEC-20260503-A — the x402 manifest
+        // mirrors the marketplace, so non-eligible capabilities are
+        // hidden from the facilitator/discovery layer too.
+        eq(capabilities.marketplaceEligible, true),
         // Only serve active or probation capabilities via x402
         // Block degraded/suspended to prevent serving known-broken capabilities
         inArray(capabilities.lifecycleState, ["active", "probation"]),

--- a/manifests/CLASSIFICATION.md
+++ b/manifests/CLASSIFICATION.md
@@ -1,0 +1,160 @@
+# Marketplace Eligibility Classification
+
+**Authority:** DEC-20260503-A (Decisions DB)
+**Enforced at:** capability onboarding pipeline (`validateManifest` +
+`validateCapabilityStructure` in `apps/api/src/lib/onboarding-gates.ts`)
+**Field:** `marketplace_eligible: boolean` (optional; default `true`)
+**Required when false:** `marketplace_eligible_reason: string` (non-empty)
+
+---
+
+## What this controls
+
+`marketplace_eligible` decides whether a capability appears on the
+strale.dev public marketplace surfaces:
+
+- `GET /v1/capabilities` (public listing)
+- `GET /v1/capabilities/:slug` (public detail)
+- MCP server card (`/mcp` capability tool list)
+- A2A agent card (`/.well-known/agent-card.json`)
+- `llms.txt`
+- x402 catalog (`/.well-known/x402.json`, `/x402/catalog`)
+- `POST /v1/suggest` (semantic search)
+
+It does **not** disable the capability. Internal pathways — direct
+`POST /v1/do`, solution composition, routing, lifecycle, audit, and the
+test scheduler — bypass the filter. A `marketplace_eligible: false`
+capability is still callable; it is just hidden from the front door.
+
+---
+
+## When to set `marketplace_eligible: false`
+
+Set the flag false **at onboarding time** if the capability fails ANY
+of the criteria below. Otherwise leave it omitted (defaults to true).
+
+### Criterion 1 — Cost shape (hard gate)
+
+Set false if the capability is a thin passthrough of a paid third-party
+vendor with **significant fixed cost** that Strale absorbs regardless
+of usage (subscription minimum, monthly retainer, seat fees, prepaid
+quota that expires).
+
+**OK to leave true:**
+- PAYG vendors (Anthropic, OpenAI, Serper, Browserless on per-call billing)
+- Free APIs (registry portals, government open data, Open-Meteo, ip-api)
+- Low fixed cost (< €100/month effective floor)
+- Pure-computation capabilities (no external call)
+
+**Set false:**
+- Vendor demands a Basic+/Pro+/Enterprise minimum that bites at low volume
+- Strale eats the floor while the customer pays per call → margin collapses
+
+### Criterion 2 — Maintenance burden (soft constraint)
+
+Soft signal that should rarely trigger a `false` on its own. Capabilities
+in `scraping-fragile-target` or `requires-domain-expertise` maintenance
+classes need extra justification to remain on the marketplace, but the
+maintenance class itself is not the gate — SQS and the test runner are.
+Use this criterion only when the marketplace surface would actively
+mislead customers (e.g. a brittle scraper that's currently broken but
+not yet deactivated). Prefer fixing or deactivating the capability over
+hiding it.
+
+### Criterion 3 — ToS posture (hard gate)
+
+Set false if the upstream vendor's terms of service prohibit resale,
+embedding, or third-party redistribution of the data **and** Strale
+has not negotiated a clean redistribution license.
+
+This dovetails with DEC-20260428-A (third-party scraping doctrine,
+three tiers): Tier-2 vendor consumption requires documented
+redistribution rights. If those rights are absent for a specific
+vendor, the capability can still execute for an authenticated customer
+with their own contractual posture (internal-only callers), but it
+should not appear on the marketplace surfacing the data to anyone.
+
+---
+
+## Decision tree
+
+```
+1. Pure-computation OR free-API OR PAYG-low-fixed-cost?
+   YES → leave omitted (default true). DONE.
+   NO  → continue.
+
+2. Vendor has significant fixed cost (>€100/mo effective floor)?
+   YES → false. Reason: vendor + fixed-cost description.
+   NO  → continue.
+
+3. Vendor ToS prohibits redistribution AND no negotiated license?
+   YES → false. Reason: vendor + specific ToS clause.
+   NO  → continue.
+
+4. scraping-fragile and currently broken/misleading?
+   YES → consider deactivating instead. If keeping, false with reason.
+   NO  → leave omitted (default true).
+```
+
+---
+
+## `marketplace_eligible_reason` content guide
+
+When setting `marketplace_eligible: false`, the reason string MUST
+record the specific criterion that triggered the classification so a
+future operator can audit and revisit. Include:
+
+- **Vendor name** (if Criterion 1 or 3)
+- **The triggering fact** — fixed-cost amount, ToS clause reference,
+  maintenance class + status
+
+**Good examples:**
+
+```yaml
+marketplace_eligible: false
+marketplace_eligible_reason: "Cobalt Intelligence US-company-data:
+  Basic tier minimum $300/mo before per-call charges; thin passthrough
+  on the marketplace would erode margin at low volume."
+```
+
+```yaml
+marketplace_eligible: false
+marketplace_eligible_reason: "Vendor X ToS §4.2 prohibits making the
+  data available to third parties without separate enterprise license;
+  capability remains callable for direct API customers under their own
+  contracts but is hidden from public marketplace."
+```
+
+**Bad examples (rejected by validation):**
+
+- `""` (empty)
+- `"hidden"` (no rationale)
+- `"vendor pricing"` (no specific fact)
+
+---
+
+## Backfill posture
+
+The flag is `hybrid` in `FIELD_CATEGORIES` (`capability-field-authority.ts`).
+On manifest backfill:
+
+- Manifest seeds the field on **first onboarding**.
+- DB-canonical thereafter. An operator override (e.g. setting `false`
+  via SQL after a vendor ToS change) survives a manifest re-onboard,
+  unless the operator passes `--force-override-authority` to reset the
+  field to the manifest value.
+
+This means: changing your mind about classification *after* a
+capability ships requires either editing the DB column directly or
+re-onboarding with the override flag. The manifest is not authoritative
+on a live row.
+
+---
+
+## See also
+
+- DEC-20260503-A — marketplace surfacing decision (Notion Decisions DB)
+- DEC-20260428-A — third-party scraping doctrine (three-tier framework)
+- `apps/api/src/lib/capability-field-authority.ts` — `hybrid` category
+- `apps/api/src/lib/onboarding-gates.ts` — `validateManifest` /
+  `validateCapabilityStructure` cross-field gate


### PR DESCRIPTION
## Summary

Per **DEC-20260503-A**, capabilities exposed standalone on strale.dev are governed by a `marketplace_eligible` flag on the capability table. This PR adds the flag, the public-surface filter, and the onboarding-pipeline classification gate.

- **Mechanism**: `marketplace_eligible` (boolean, NOT NULL, default `true`) + `marketplace_eligible_reason` (text, nullable)
- **Filter scope**: public marketplace surfaces only (`/v1/capabilities`, MCP card, A2A, llms.txt, x402 catalog, `/v1/suggest`). Internal callers (do.ts, products, routing, lifecycle, audit, jobs) intentionally see all rows.
- **Classification policy**: all 8 currently-shipped paid-vendor wrappers default to `true`. Future capabilities with significant fixed cost or ToS-prohibited resale terms get classified `false` at onboarding time, NOT retroactively.
- **Onboarding gate**: `validateManifest` + `validateCapabilityStructure` reject manifests/rows where `marketplace_eligible: false` but the reason is missing/empty/null.
- **Authoring guide**: `manifests/CLASSIFICATION.md` documents cost-shape, maintenance-burden, ToS-posture criteria + decision tree + reason-string content guide.

## Verification

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 425 pass, 4 skipped (no regressions; 10 new tests for this PR)
- [x] `lint:no-bare-catch`, `lint:no-new-console`, `lint:migration-prefixes` pass
- [x] No existing manifest declares `marketplace_eligible: false`, so the new gate is forward-only
- [x] Migration is reversible (additive `ADD COLUMN IF NOT EXISTS` with default; safe to re-run)
- [ ] Apply migration on production (Railway auto-runs `apply-migrations.ts` on deploy)

## Reviewer findings

Two HIGH=0 reviews ran in parallel (technical + product). Aggregate: **HIGH 0, MEDIUM 4 — 2 fixed in this PR, 2 deferred.**

### Fixed in this PR (after initial review)

1. **`apply-migrations.ts` idempotency guard was incomplete** — the outer conditional checked only the first new column. A partial prior run leaving only `marketplace_eligible` would have skipped the second `ADD COLUMN`, leaving `marketplace_eligible_reason` missing. Removed the wrapper; both `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` are independently idempotent at the SQL level.
2. **Validation error messages referenced "the capability onboarding directory"** — that directory does not exist. Updated both `validateManifest` and `validateCapabilityStructure` error strings to point at the actual path `manifests/CLASSIFICATION.md` (matching the `capability-manifest-types.ts` doc comment).

### Deferred (not introduced by this PR)

3. **`mcp-server-card.ts` count query missing `visible` and `lifecycleState` filters** — pre-existing bug. Other public-surface queries (`routes/capabilities.ts`, `lib/suggest.ts`) apply all four filters; the MCP card query applies only `isActive` + `marketplaceEligible`. The PR touches the file but expanding scope to fix unrelated filter inconsistency would bloat. Worth a follow-up PR.
4. **`marketplace_eligible_reason` only validates non-empty, no minimum substantive content** — a string like `"Vendor X"` (8 chars) passes the gate but has no audit value. CLASSIFICATION.md's "bad examples" section communicates the intent but the validator does not enforce it. Decided to defer: enforcing structural content (min length, required tokens) risks false positives and adds complexity for a future hypothetical. The empty-string case is blocked, which catches the worst scenario. Revisit if the first real `false` classification produces a low-quality reason.

## Cross-repo

- `strale-frontend/public/llms.txt` — no change needed today (capability count visible to public is unchanged because all rows default to `true`). Will need to revisit only when a future capability is classified `false`.

## Test plan

- [ ] Merge to `main`; confirm Railway deploy applies migration 0060 cleanly (look for `[migration] marketplace_eligible columns ensured` in logs)
- [ ] After deploy, `SELECT marketplace_eligible, COUNT(*) FROM capabilities GROUP BY 1` should return all-true (no rows touched by this PR)
- [ ] Hit `GET /v1/capabilities` and confirm catalog count unchanged
- [ ] Smoke-test the onboarding gate: write a test manifest with `marketplace_eligible: false` and no reason, run `npx tsx scripts/onboard.ts --manifest <path>`, verify it errors with the reference to `manifests/CLASSIFICATION.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)