### PR TITLE
fix(do): correct Date encoding in spendCapWouldExceed in-tx check

### DIFF
--- a/apps/api/src/routes/do.spend-cap.test.ts
+++ b/apps/api/src/routes/do.spend-cap.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression test for the in-tx authoritative spend-cap re-check
+ * (`spendCapWouldExceed` in do.ts).
+ *
+ * Bug shipped 2026-04-30 in commit 6613bd7 (cert-audit A-7 TOCTOU fix).
+ * The function interpolated a raw `Date` object into a sql`` template:
+ *
+ *   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+ *   await tx.execute(sql`... AND created_at >= ${oneHourAgo}`);
+ *
+ * postgres-js's bind-parameter encoder couldn't serialize the Date
+ * through the sql-template path (it falls through to
+ * Buffer.byteLength(date) and throws). The throw was masked by the
+ * Hono `app.onError` handler as `{"error_code":"internal_error"}`,
+ * returning hard 500s for every authenticated paid /v1/do call by a
+ * user with `maxSpendPerHourCents` set. Free-tier path was unaffected
+ * (skips the spend-cap check). The pre-check at do.ts:754 was
+ * unaffected (uses Drizzle column-query form, which serializes Date
+ * via the column's mapToDriverValue).
+ *
+ * The assertions below would have caught the bug at PR-review time:
+ *   1. No `Date` instance reaches `tx.execute(sql``)` as a bind param.
+ *   2. Function returns null when projected spend ≤ cap.
+ *   3. Function returns { spent } when projected spend > cap.
+ *
+ * Why a unit test, not an integration test: the codebase has no
+ * Postgres-backed test harness for /v1/do; existing route-tangent
+ * tests (e.g. free-tier-rate-limit.test.ts) reimplement pure logic.
+ * Standing up a route-level integration harness is out of scope for a
+ * one-line bug fix and is flagged in the PR description as deferred.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { SQL } from "drizzle-orm";
+
+import { spendCapWouldExceed } from "./do.js";
+
+interface MockTxState {
+  spendSumCents: number;
+  executeCalls: SQL[];
+  whereCalls: unknown[];
+}
+
+function makeMockTx(state: MockTxState) {
+  return {
+    // Drizzle's typed-column query path. The fixed implementation goes
+    // here; under the hood Drizzle serializes Date params through each
+    // column's `mapToDriverValue`, so postgres-js never sees a raw Date.
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn((cond: unknown) => {
+          state.whereCalls.push(cond);
+          return Promise.resolve([{ total: String(state.spendSumCents) }]);
+        }),
+      })),
+    })),
+    // Raw sql-template execute path. The unfixed implementation lived
+    // here and shipped a `Date` chunk in queryChunks — postgres-js's
+    // encoder threw "Received an instance of Date" at Bind time.
+    execute: vi.fn(async (sqlTag: SQL) => {
+      state.executeCalls.push(sqlTag);
+      return [{ total: String(state.spendSumCents) }];
+    }),
+  };
+}
+
+/**
+ * Detects raw `Date` instances anywhere in a Drizzle SQL tag's
+ * `queryChunks`. Drizzle's sql`` tag stores interpolated values
+ * directly in queryChunks (alongside `StringChunk` literals), so a
+ * raw Date interpolation surfaces as `chunk instanceof Date`.
+ *
+ * This is the postgres-js-incompatible shape the original bug had.
+ */
+function findDateChunks(sqlTag: SQL): unknown[] {
+  const chunks = (sqlTag as unknown as { queryChunks?: unknown[] }).queryChunks ?? [];
+  return chunks.filter((c) => c instanceof Date);
+}
+
+describe("spendCapWouldExceed (in-tx authoritative spend-cap re-check)", () => {
+  it("never passes a raw Date through tx.execute(sql``) — postgres-js bind encoder can't serialize it", async () => {
+    const state: MockTxState = { spendSumCents: 50, executeCalls: [], whereCalls: [] };
+    const tx = makeMockTx(state);
+
+    await spendCapWouldExceed(tx, "user-uuid", 25, 100);
+
+    // Either tx.execute is never called (the fix uses the typed-column
+    // path) or it is called but no Date reaches the bind parameters.
+    // Reverting to raw `sql`...${oneHourAgo}\`` would fail this.
+    for (const call of state.executeCalls) {
+      const dateChunks = findDateChunks(call);
+      expect(
+        dateChunks,
+        "Date instance in tx.execute(sql``) — postgres-js bind encoder cannot serialize Date through the sql-template path. See do.ts spendCapWouldExceed and the Bind-error stack from production logs (2026-05-04).",
+      ).toEqual([]);
+    }
+  });
+
+  it("returns null when current spend + requested ≤ cap (under-cap success path)", async () => {
+    const state: MockTxState = { spendSumCents: 50, executeCalls: [], whereCalls: [] };
+    const tx = makeMockTx(state);
+
+    const result = await spendCapWouldExceed(tx, "user-uuid", 25, 100);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null at the exact cap boundary (50 + 50 = 100 ≤ 100)", async () => {
+    const state: MockTxState = { spendSumCents: 50, executeCalls: [], whereCalls: [] };
+    const tx = makeMockTx(state);
+
+    const result = await spendCapWouldExceed(tx, "user-uuid", 50, 100);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns { spent } when current spend + requested > cap (over-cap rejection path)", async () => {
+    const state: MockTxState = { spendSumCents: 80, executeCalls: [], whereCalls: [] };
+    const tx = makeMockTx(state);
+
+    const result = await spendCapWouldExceed(tx, "user-uuid", 25, 100);
+
+    expect(result).toEqual({ spent: 80 });
+  });
+
+  it("returns spent=0 + null when no prior transactions in the window", async () => {
+    const state: MockTxState = { spendSumCents: 0, executeCalls: [], whereCalls: [] };
+    const tx = makeMockTx(state);
+
+    const result = await spendCapWouldExceed(tx, "user-uuid", 25, 100);
+
+    expect(result).toBeNull();
+  });
+
+  it("uses the typed-column query path (regression: do not revert to raw sql template)", async () => {
+    const state: MockTxState = { spendSumCents: 0, executeCalls: [], whereCalls: [] };
+    const tx = makeMockTx(state);
+
+    await spendCapWouldExceed(tx, "user-uuid", 25, 100);
+
+    // The fix path runs through tx.select(...).from(...).where(...).
+    // If a future change reverts to tx.execute(sql``), this fails and
+    // the assertion above (no Date chunks) becomes the safety net.
+    expect(tx.select).toHaveBeenCalledTimes(1);
+    expect(state.whereCalls.length).toBe(1);
+  });
+});

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { eq, and, gte, isNull, sql } from "drizzle-orm";
+import { eq, and, gte, inArray, isNull, sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import {
   wallets,
@@ -335,22 +335,32 @@ type CapabilityInfo = {
  * close the window but at the cost of a more complex query for a
  * benign over-rejection case. Documented; not fixed.
  */
-async function spendCapWouldExceed(
+// Exported for the regression test at do.spend-cap.test.ts. The unit test
+// asserts no `Date` instance is ever passed through `tx.execute(sql``)` —
+// the bug at commit 6613bd7 (2026-04-30) interpolated a Date directly into
+// a sql-template, and postgres-js's bind-parameter encoder couldn't
+// serialize it (Buffer.byteLength on a Date throws). Every authenticated
+// paid /v1/do call for a user with maxSpendPerHourCents set 500'd as a
+// result. The fix below uses Drizzle's typed column query so the Date
+// goes through the column's mapToDriverValue serializer.
+export async function spendCapWouldExceed(
   tx: any,
   userId: string,
   requestedCents: number,
   capCents: number,
 ): Promise<{ spent: number } | null> {
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
-  const result = await tx.execute(
-    sql`SELECT COALESCE(SUM(price_cents), 0)::text AS total
-        FROM transactions
-        WHERE user_id = ${userId}
-          AND status IN ('completed', 'executing')
-          AND created_at >= ${oneHourAgo}`,
-  );
-  const rows: any[] = Array.isArray(result) ? result : (result?.rows ?? []);
-  const spent = Number(rows[0]?.total ?? 0);
+  const [row] = await tx
+    .select({ total: sql<string>`COALESCE(SUM(price_cents), 0)::text` })
+    .from(transactions)
+    .where(
+      and(
+        eq(transactions.userId, userId),
+        inArray(transactions.status, ["completed", "executing"]),
+        gte(transactions.createdAt, oneHourAgo),
+      ),
+    );
+  const spent = Number(row?.total ?? 0);
   if (spent + requestedCents > capCents) return { spent };
   return null;
 }


### PR DESCRIPTION
## Summary

- Production `/v1/do` returns `internal_error` for **every authenticated paid sync/async call** by a user with `maxSpendPerHourCents` configured. Reproduced on `google-search`, `vat-validate`, `swift-validate`. Free-tier path (`email-validate` etc.) unaffected.
- Root cause: `spendCapWouldExceed` ([apps/api/src/routes/do.ts:344-350](apps/api/src/routes/do.ts#L344-L350)) interpolated a raw `Date` into a `sql\`\`` template; postgres-js's parameter encoder can't serialize Date through that path (falls through to `Buffer.byteLength(date)` and throws). Hono's `app.onError` masked the throw as `internal_error`.
- Pre-check at L754 uses Drizzle's typed column query (`gte(transactions.createdAt, oneHourAgo)`) and was always correct — the column type drives the serializer.
- Origin: commit 6613bd7 (cert-audit A-7 TOCTOU fix, 2026-04-30). Silently broken in prod for ~4 days. Customer-impact small because few users have the spend cap set today; high blast radius if adoption grows.

## Fix

Rewrite `spendCapWouldExceed` to use Drizzle's typed column query, consistent with the pre-check style. Status filter preserves `('completed','executing')` per the cert-audit comment.

## Test plan

- [x] New regression test (`apps/api/src/routes/do.spend-cap.test.ts`, 6 cases) covers under-cap success, over-cap rejection, exact-boundary, empty-window, plus two structural assertions catching the bug shape:
  - No `Date` instance reaches `tx.execute(sql\`\`)` queryChunks
  - Function uses `tx.select(...)` not `tx.execute()`
- [x] Verified the test **fails** against the unfixed code (2 of 6 cases trip) and **passes** against the fix.
- [x] Full suite: `npx vitest run` — 421 passed / 4 skipped / 0 failed across 38 files.
- [x] Typecheck: `tsc --noEmit` clean.
- [ ] Route-level integration smoke (google-search / vat-validate / swift-validate via real /v1/do) — deferred. The codebase has no Postgres-backed harness for /v1/do today (closest is `free-tier-rate-limit.test.ts` which reimplements pure logic). Standing one up is bigger than this fix.

## Structural follow-up

Reference: commit 6613bd7. The same review that introduced the bug shipped without test coverage of the in-tx spend-cap path — that gap is what let it ship. This PR closes the gap for `spendCapWouldExceed`. A broader pattern (cert-audit follow-up commits introducing new code paths must include regression tests) is worth a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)