### PR TITLE
fix(scheduler): skip-bumper UPDATE crashed on Postgres array binding

### DIFF
--- a/apps/api/src/jobs/test-scheduler-skip-bumper.test.ts
+++ b/apps/api/src/jobs/test-scheduler-skip-bumper.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression test for the test-scheduler skip-bumper SQL bug.
+ *
+ * Bug shape (pre-fix, lived in `apps/api/src/jobs/test-scheduler.ts` for
+ * the lifetime of the skip-marker block):
+ *
+ *   await getDb().execute(sql`
+ *     UPDATE capabilities
+ *     SET last_tested_at = NOW(),
+ *         freshness_level = 'unverified'
+ *     WHERE slug = ANY(${skippedSlugs})       -- <-- skippedSlugs is a JS array
+ *   `);
+ *
+ * Drizzle's sql-template interpolation expanded the JS array into a row
+ * constructor — `WHERE slug = ANY(($1, $2, $3, $4, $5))` — which Postgres
+ * rejects: `op ANY/ALL (array) requires array on right side at character 144`.
+ *
+ * Production-log evidence: every ~5 min for hours leading up to the
+ * 2026-05-04 postgres crash, the scheduler tried to bump unhealthy-
+ * provider skipped capabilities and the UPDATE failed silently inside
+ * the surrounding try/catch. The skipped capabilities therefore
+ * permanently occupied the queue head and starved the rest of the
+ * catalog — the exact failure mode the skip-marker was added to prevent.
+ *
+ * Fix: switch from raw sql template to drizzle's typed UPDATE +
+ * inArray(), which compiles the array as separate bound parameters
+ * (`WHERE slug IN ($1, $2, $3, $4, $5)`) — Postgres-safe.
+ */
+
+import { describe, expect, it } from "vitest";
+import { inArray } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { capabilities } from "../db/schema.js";
+
+describe("test-scheduler skip-bumper SQL shape", () => {
+  const dialect = new PgDialect();
+
+  /**
+   * The fixed query as the scheduler now builds it. PgDialect.sqlToQuery
+   * compiles a Drizzle SQL chunk to a {sql, params} pair without
+   * touching the wire — exactly what we need to assert the rendered
+   * shape without prod DB access.
+   */
+  it("inArray-based WHERE compiles to per-element bound parameters", () => {
+    const skippedSlugs = ["alpha", "beta", "gamma", "delta", "epsilon"];
+    const where = inArray(capabilities.slug, skippedSlugs);
+
+    const compiled = dialect.sqlToQuery(where);
+
+    // Expect exactly one bind per slug — the IN-list shape Postgres
+    // expects. The buggy form would have produced a single array bind
+    // or a row-constructor expansion.
+    expect(compiled.params).toHaveLength(skippedSlugs.length);
+    for (const param of compiled.params) {
+      expect(typeof param).toBe("string");
+      expect(skippedSlugs).toContain(param);
+    }
+
+    // Rendered SQL: drizzle's inArray() emits `"slug" in ($1,...)` —
+    // standard SQL IN-list. The buggy form had `slug = ANY(...)` with
+    // a JS array on the right; the new form does not contain `ANY`.
+    expect(compiled.sql.toLowerCase()).toMatch(/"slug"\s+in\s*\(/);
+    expect(compiled.sql.toLowerCase()).not.toMatch(/=\s*any\s*\(/);
+  });
+
+  /**
+   * Single-element arrays are the boundary case. Drizzle still emits
+   * an IN-list for them; we verify it does not collapse to `=`.
+   */
+  it("handles single-element skippedSlugs without collapsing to =", () => {
+    const skippedSlugs = ["only-one"];
+    const where = inArray(capabilities.slug, skippedSlugs);
+    const compiled = dialect.sqlToQuery(where);
+
+    expect(compiled.params).toEqual(["only-one"]);
+    expect(compiled.sql.toLowerCase()).toMatch(/"slug"\s+in\s*\(/);
+  });
+
+  /**
+   * Empty-array boundary: the production code-path is gated by
+   * `if (skippedSlugs.length > 0)` so the UPDATE never runs with an
+   * empty array. Asserted here for completeness — drizzle's inArray
+   * with an empty array is documented as `false` (no rows match), not
+   * a runtime error, but the scheduler relies on the outer guard.
+   */
+  it("documents the empty-array boundary (caller must guard)", () => {
+    const where = inArray(capabilities.slug, []);
+    const compiled = dialect.sqlToQuery(where);
+    // Drizzle emits `false` for empty IN — safe but pointless. The
+    // scheduler's outer length-check is what keeps the query from
+    // running in this case.
+    expect(compiled.sql.toLowerCase()).not.toMatch(/=\s*any\s*\(/);
+  });
+});

--- a/apps/api/src/jobs/test-scheduler.ts
+++ b/apps/api/src/jobs/test-scheduler.ts
@@ -552,12 +552,21 @@ async function pollCycle(): Promise<void> {
       // ordering hint that respects the Scoring Integrity Protocol.
       if (skippedSlugs.length > 0) {
         try {
-          await getDb().execute(sql`
-            UPDATE capabilities
-            SET last_tested_at = NOW(),
-                freshness_level = 'unverified'
-            WHERE slug = ANY(${skippedSlugs})
-          `);
+          // Use drizzle's typed UPDATE + inArray — the previous raw-SQL
+          // form `WHERE slug = ANY(${skippedSlugs})` interpolated the JS
+          // array as a tuple `($1,$2,$3)` (row constructor) which Postgres
+          // rejects with "op ANY/ALL (array) requires array on right side".
+          // Production logs from 2026-04-30 onward show this firing every
+          // 5 min while the scheduler ticked at 5-min cadence; PR #46
+          // moved that to 1-min cadence which would have amplified the
+          // failure rate 5×. Bug pre-existed PR #46 — fixing here.
+          await getDb()
+            .update(capabilities)
+            .set({
+              lastTestedAt: new Date(),
+              freshnessLevel: "unverified",
+            })
+            .where(inArray(capabilities.slug, skippedSlugs));
           jobLog.info(
             { label: "test-scheduler-skip-bumped", count: skippedSlugs.length },
             "test-scheduler-skip-bumped",


### PR DESCRIPTION
## Summary

Pre-existing P1 bug in the test-scheduler's skip-bumper block, surfaced by Postgres logs leading up to the 2026-05-04 crash. The block fires whenever the scheduler skips overdue capabilities due to unhealthy upstream providers — it bumps their \`last_tested_at\` so they don't permanently occupy the queue head.

The buggy form interpolated a JS array into a raw \`sql\` template:

\`\`\`ts
WHERE slug = ANY(\${skippedSlugs})  // skippedSlugs is string[]
\`\`\`

Drizzle's sql-template tag rendered that as a row constructor \`($1, $2, $3, …)\`. Postgres rejects \`ANY\` against a row constructor:

\`\`\`
ERROR: op ANY/ALL (array) requires array on right side at character 144
\`\`\`

The error fired every ~5 min for hours. The surrounding try/catch swallowed it silently — the scheduler logged \`test-scheduler-skip-bump-failed\` at error level but kept iterating, and **skipped capabilities permanently occupied the queue head** (the exact failure mode the skip-marker was added to prevent).

## Why this matters now

PR #46 (merged 09:28 UTC) moved \`POLL_INTERVAL_MS\` from 5 min → 1 min. The bug existed before PR #46, but its rate **scales with poll cadence**. Post-PR-46 the failed UPDATE fires up to 5× more often. Whether or not that contributed to the 09:23–09:30 UTC postgres crash is open (logs visible to me cut off at 05:27 UTC; deeper investigation needs the recovery logs), but the bug needs to be gone before the scheduler ramps back up regardless.

## Fix

Switch from raw \`sql\` template to drizzle's typed UPDATE + \`inArray()\`:

\`\`\`ts
await getDb()
  .update(capabilities)
  .set({ lastTestedAt: new Date(), freshnessLevel: \"unverified\" })
  .where(inArray(capabilities.slug, skippedSlugs));
\`\`\`

\`inArray\` compiles to \`WHERE \"slug\" in (\$1, \$2, …)\` — the standard IN-list shape. Each slug becomes its own bound parameter; no array shoved into a single bind slot.

## Tests

3 new in \`apps/api/src/jobs/test-scheduler-skip-bumper.test.ts\`. Uses \`PgDialect.sqlToQuery\` to compile the fixed WHERE clause without prod DB access (which is unavailable right now anyway):

- inArray-based WHERE compiles to per-element bound parameters
- single-element arrays don't collapse to \`=\`
- empty-array boundary documented (caller's \`length > 0\` guard is what actually keeps it from running)

## Verification

- \`tsc --noEmit\` clean
- \`vitest run\` — 441 pass, 11 skipped, 0 fail (3 new regression tests)
- Linters: \`lint:no-bare-catch\`, \`lint:no-new-console\`, \`lint:migration-prefixes\` all clean
- Cannot \`.execute()\` against prod (postgres is crashed) — but the fix is structural and the test suite proves the SQL shape is now what Postgres accepts

## Deploy ordering

This fix should land **before** Postgres comes back online, so the first scheduler tick after recovery doesn't reignite the failed-UPDATE loop. If Postgres recovery happens before this PR merges, paused scheduler ticks will pile up; consider pausing the scheduler env-side until the fix is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)