### PR TITLE
chore(uk-cop-check): document test_outcome=MATCHED bypass + cost-classification dependency

### DIFF
--- a/manifests/uk-cop-check.yaml
+++ b/manifests/uk-cop-check.yaml
@@ -126,6 +126,16 @@ personal_data_categories:
   - name
   - financial
 geography: uk
+# test_outcome=MATCHED is load-bearing for cost classification.
+# eSortcode does not deduct credits when test_outcome is set; the test
+# scheduler's runs against this fixture therefore burn no credits in
+# practice. The capability still bills per call in production (Pay.UK
+# CoP scheme — eSortcode is the gateway), so test_suites.external_cost_cents
+# is set to 1 to keep the hourly scheduler from running paid suites
+# (PR #49 + DEC-20260503-B). If you change the fixture input below,
+# leave test_outcome set to one of the 14 eSortcode CoP codes
+# (MATCHED, CLOSE_MATCH, NO_MATCH, NO_ACCOUNT, etc.) — removing it
+# silently causes scheduled tests to burn real credits.
 test_fixtures:
   known_answer:
     input:
@@ -133,7 +143,7 @@ test_fixtures:
       account_number: "00110022"
       account_holder_name: Joe Bloggs
       account_type: PERSONAL
-      test_outcome: MATCHED
+      test_outcome: MATCHED  # zero-credit bypass — see manifest header note
     expected_fields:
       - field: match_status
         operator: equals
@@ -186,7 +196,7 @@ test_fixtures:
     account_number: "00110022"
     account_holder_name: Joe Bloggs
     account_type: PERSONAL
-    test_outcome: MATCHED
+    test_outcome: MATCHED  # zero-credit bypass — see manifest header note above test_fixtures
 output_field_reliability:
   match_status: guaranteed
   cop_code: guaranteed


### PR DESCRIPTION
## Summary

Defensive YAML-comment note in `manifests/uk-cop-check.yaml`. Closes the documentation gap surfaced by the 2026-05-04 paid-vendor audit.

The eSortcode CoP API does not deduct credits when `test_outcome` is set on the request. The executor passes it through verbatim ([uk-cop-check.ts:88–112](apps/api/src/capabilities/uk-cop-check.ts#L88-L112)) and eSortcode returns a deterministic test response. This makes the test scheduler's runs against the current fixture cost-free in practice, while a real production call (no `test_outcome` parameter) bills per call against the Pay.UK CoP scheme.

PR #49 set `test_suites.external_cost_cents = 1` for `uk-cop-check` live suites **despite** the bypass — the rationale was that classification should reflect the per-call billing model so a future fixture change that silently loses the bypass doesn't quietly start burning credits. This PR documents the dependency in the manifest itself so the rationale is visible to anyone editing the test fixture.

## What's added

- Multi-line comment block above `test_fixtures:` explaining the bypass + the cost-classification implication
- Inline comment `# zero-credit bypass — see manifest header note` on each `test_outcome: MATCHED` line so an editor scanning the input fields sees the warning at the line they're about to change

## Verification

- YAML still parses cleanly via `js-yaml` (verified locally; `m.test_fixtures.known_answer.input.test_outcome === 'MATCHED'`, same for `health_check_input`)
- No code path touched. No DB schema. No tests required. The manifest pipeline reads the file for content; YAML comments are not roundtripped to DB but are visible at the source.

## Why a separate PR

PR #49 was already merged when this came up. Could've folded into a hypothetical PR #49 follow-up commit, but a focused doc-only chore is cleaner than reopening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)