### PR TITLE
refactor(admin-migrations): single source of truth via runStartupMigrations + 0030/0031 backport

### DIFF
--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -22,7 +22,12 @@ export type ErrorCode =
   // UPDATE failed. Wallet has been refunded. Distinct from execution_failed
   // so callers can retry the same inputs safely (execution happened; only
   // the record did not).
-  | "transaction_finalization_failed";
+  | "transaction_finalization_failed"
+  // Internal admin surface only — POST /v1/internal/tests/admin/
+  // apply-migrations returns this when runStartupMigrations() throws
+  // (e.g. block 0062 post-condition violation). Not exposed on the
+  // public DEC-19 contract; the admin endpoint is admin-only.
+  | "migration_failed";
 
 export interface ApiError {
   error_code: ErrorCode;

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -30,8 +30,11 @@ import { describe, expect, it } from "vitest";
 import { sql, type SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 import {
+  BLOCKS,
   runMigration0028_sqsDailySnapshot,
   runMigration0029_actualCostCents,
+  runMigration0030_complianceColumns,
+  runMigration0031_testResultsCompositeIdx,
   runMigration0060_marketplaceEligible,
   runMigration0062_paidVendorCosts,
   type MigrationExecutor,
@@ -161,6 +164,57 @@ describe("startup-migrations — block 0062 (paid-vendor costs)", () => {
     await expect(runMigration0062_paidVendorCosts(stub)).rejects.toThrow(
       /post-condition failed.*1 paid-vendor suites/i,
     );
+  });
+});
+
+describe("startup-migrations — block 0030 (compliance columns)", () => {
+  it("first run: adds 3 columns + index when integrity_hash is absent", async () => {
+    const stub = makeStub({ queue: [[{ cnt: "0" }]] });
+    const result = await runMigration0030_complianceColumns(stub);
+    expect(result.outcome).toMatch(/added/i);
+    // 1 information_schema check + 3 ALTER TABLE + 1 CREATE INDEX = 5 queries.
+    expect(stub.captured).toHaveLength(5);
+    expect(stub.renderedSql.some((s) => /alter table.*integrity_hash/i.test(s))).toBe(true);
+    expect(stub.renderedSql.some((s) => /alter table.*previous_hash/i.test(s))).toBe(true);
+    expect(stub.renderedSql.some((s) => /alter table.*legal_hold.*not null/i.test(s))).toBe(true);
+    expect(stub.renderedSql.some((s) => /create index if not exists.*integrity_hash/i.test(s))).toBe(true);
+  });
+
+  it("second run: skips when integrity_hash column already exists", async () => {
+    const stub = makeStub({ queue: [[{ cnt: "1" }]] });
+    const result = await runMigration0030_complianceColumns(stub);
+    expect(result.outcome).toMatch(/skipped/i);
+    expect(stub.captured).toHaveLength(1); // only the check ran
+    expect(stub.renderedSql.some((s) => /alter table/i.test(s))).toBe(false);
+  });
+});
+
+describe("startup-migrations — block 0031 (test_results composite index)", () => {
+  it("emits CREATE INDEX IF NOT EXISTS unconditionally — Postgres-level idempotent", async () => {
+    const stub = makeStub({});
+    const result = await runMigration0031_testResultsCompositeIdx(stub);
+    expect(result.outcome).toMatch(/composite index/i);
+    expect(stub.captured).toHaveLength(1);
+    expect(stub.renderedSql[0].toLowerCase()).toMatch(/create index if not exists/);
+    expect(stub.renderedSql[0].toLowerCase()).toMatch(/test_results_suite_executed_idx/);
+  });
+});
+
+describe("startup-migrations — BLOCKS list (canonical block set)", () => {
+  it("exports the expected 6 blocks in historical order", () => {
+    // Pin the canonical block list so an accidental scope-creep edit
+    // (adding a block to BLOCKS without updating tests / admin endpoint
+    // expectations) trips a test failure. Order matters because the
+    // historical numbering is the audit trail.
+    const blockNames = BLOCKS.map((fn) => fn.name);
+    expect(blockNames).toEqual([
+      "runMigration0028_sqsDailySnapshot",
+      "runMigration0029_actualCostCents",
+      "runMigration0030_complianceColumns",
+      "runMigration0031_testResultsCompositeIdx",
+      "runMigration0060_marketplaceEligible",
+      "runMigration0062_paidVendorCosts",
+    ]);
   });
 });
 

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -151,6 +151,69 @@ export async function runMigration0029_actualCostCents(
   };
 }
 
+// ─── Block 0030: compliance infrastructure (transactions hash chain) ────────
+//
+// Adds three columns to the transactions table for the EU AI Act / DEC-
+// 20260428-B audit-trail engine: hash-chained integrity, parent-link, and
+// a legal-hold flag. Plus an index on the integrity_hash for chain-walk
+// performance.
+//
+// information_schema check + skip pattern matches blocks 0028 / 0029.
+// Cannot use a bare ADD COLUMN IF NOT EXISTS for `legal_hold` because the
+// NOT NULL DEFAULT false would re-apply on a pre-existing column without
+// the conditional — at best a no-op, at worst confusing in audit logs.
+
+export async function runMigration0030_complianceColumns(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  const check = await tx.execute(sql`
+    SELECT count(*)::text AS cnt FROM information_schema.columns
+    WHERE table_name = 'transactions' AND column_name = 'integrity_hash'
+  `);
+  const rows = Array.isArray(check) ? check : (check as { rows?: unknown[] })?.rows ?? [];
+  const exists = (rows[0] as { cnt?: string })?.cnt !== "0";
+
+  if (exists) {
+    return {
+      block: "0030_compliance_columns",
+      outcome: "skipped (columns already exist)",
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+
+  await tx.execute(sql`ALTER TABLE "transactions" ADD COLUMN "integrity_hash" varchar(128)`);
+  await tx.execute(sql`ALTER TABLE "transactions" ADD COLUMN "previous_hash" varchar(128)`);
+  await tx.execute(sql`ALTER TABLE "transactions" ADD COLUMN "legal_hold" boolean DEFAULT false NOT NULL`);
+  await tx.execute(sql`CREATE INDEX IF NOT EXISTS "transactions_integrity_hash_idx" ON "transactions" ("integrity_hash")`);
+
+  return {
+    block: "0030_compliance_columns",
+    outcome: "added integrity_hash + previous_hash + legal_hold + index",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+// ─── Block 0031: test_results composite index ───────────────────────────────
+//
+// CREATE INDEX IF NOT EXISTS — idempotent at the SQL level. On re-run
+// Postgres detects the existing index and is a no-op.
+
+export async function runMigration0031_testResultsCompositeIdx(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS "test_results_suite_executed_idx"
+    ON "test_results" ("test_suite_id", "executed_at" DESC)
+  `);
+  return {
+    block: "0031_test_results_suite_executed_idx",
+    outcome: "ensured composite index on (test_suite_id, executed_at DESC)",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Block 3: marketplace_eligible columns ──────────────────────────────────
 //
 // Both ALTER TABLE statements use ADD COLUMN IF NOT EXISTS, so they're
@@ -252,10 +315,19 @@ export async function runMigration0062_paidVendorCosts(
 
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
-/** Block set executed in order at API boot. New migrations append. */
-const BLOCKS: Array<(tx: MigrationExecutor) => Promise<BlockResult>> = [
+/**
+ * Block set executed in order. Append new migrations here. Order is
+ * historical (oldest first); idempotency makes the order operationally
+ * irrelevant on existing prod, but it's the audit-trail-friendly shape.
+ *
+ * Exported so the admin endpoint regression test can introspect the
+ * canonical block list and assert it matches what the endpoint returns.
+ */
+export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResult>> = [
   runMigration0028_sqsDailySnapshot,
   runMigration0029_actualCostCents,
+  runMigration0030_complianceColumns,
+  runMigration0031_testResultsCompositeIdx,
   runMigration0060_marketplaceEligible,
   runMigration0062_paidVendorCosts,
 ];
@@ -265,8 +337,13 @@ const BLOCKS: Array<(tx: MigrationExecutor) => Promise<BlockResult>> = [
  * failure — the caller in index.ts has the catch that exits the
  * process with a fatal log. Don't catch internally; missing schema
  * is not something the API can run with.
+ *
+ * Returns the per-block summary so callers (the admin endpoint) can
+ * surface it as an HTTP response. The startup wiring in index.ts
+ * ignores the return value; the throw-on-failure semantics is what
+ * matters there.
  */
-export async function runStartupMigrations(): Promise<void> {
+export async function runStartupMigrations(): Promise<BlockResult[]> {
   const startedAt = Date.now();
   const db = getDb();
   const results: BlockResult[] = [];
@@ -301,4 +378,6 @@ export async function runStartupMigrations(): Promise<void> {
     },
     "startup-migrations-complete",
   );
+
+  return results;
 }

--- a/apps/api/src/routes/admin-apply-migrations.test.ts
+++ b/apps/api/src/routes/admin-apply-migrations.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Regression tests for the refactored
+ * POST /v1/internal/tests/admin/apply-migrations endpoint.
+ *
+ * Pre-PR-#52, the endpoint had its own inline block set (0028, 0029,
+ * 0030, 0031) that drifted from the startup-time set in
+ * apply-migrations.ts (0028, 0029, 0060, 0062). The drift was the
+ * underlying cause of the 2026-05-04 PR-#42 deploy outage — apply-
+ * migrations.ts itself was never invoked at deploy time, but even if
+ * an operator had hit the admin endpoint manually, it was missing the
+ * 0060 + 0062 blocks the new code expected.
+ *
+ * Post-PR-#52, the endpoint delegates to runStartupMigrations() in
+ * lib/startup-migrations.ts. Adding a block to startup-migrations.ts
+ * automatically extends admin-endpoint coverage. These tests pin the
+ * contract:
+ *
+ *   1. The endpoint calls runStartupMigrations() exactly once per request
+ *      (the single source of truth — not duplicated inline).
+ *   2. On success, returns 200 with { ok, block_count, blocks } shape.
+ *   3. On any block throwing, mirrors the boot-time failure semantics —
+ *      returns 500 with the error message; no silent partial success.
+ *   4. Auth gate (admin secret) still enforced before the migration runs.
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+
+// Mock the DB layer — runStartupMigrations is mocked too, so the DB
+// stub only needs to satisfy module-load assertions in app.ts.
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({
+    execute: () => Promise.resolve([]),
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+        innerJoin: () => ({ where: () => ({ orderBy: () => Promise.resolve([]) }) }),
+      }),
+    }),
+  }),
+  closeDbPool: () => Promise.resolve(),
+}));
+
+// Mock MCP for the same reason internal-auth.test.ts does — the
+// strale-mcp workspace package isn't resolvable in vitest without a
+// prior build.
+vi.mock("./mcp.js", () => {
+  const { Hono } = require("hono");
+  return { mcpRoute: new Hono() };
+});
+
+// THE mock under test: capture calls to runStartupMigrations and
+// substitute scriptable behaviour (success / throw).
+const mockRunStartupMigrations = vi.fn();
+vi.mock("../lib/startup-migrations.js", () => ({
+  runStartupMigrations: () => mockRunStartupMigrations(),
+}));
+
+const ADMIN_TOKEN = "unit-test-admin-secret-plenty-of-entropy-0123456789";
+
+beforeAll(() => {
+  process.env.ADMIN_SECRET = ADMIN_TOKEN;
+  process.env.AUDIT_HMAC_SECRET =
+    "unit-test-audit-secret-plenty-of-entropy-0123456789";
+});
+
+async function loadApp() {
+  const { app } = await import("./../app.js");
+  return app;
+}
+
+describe("POST /v1/internal/tests/admin/apply-migrations — auth gate", () => {
+  it("returns 401 without Authorization header (and does not call runStartupMigrations)", async () => {
+    mockRunStartupMigrations.mockReset();
+    const app = await loadApp();
+    const res = await app.request("/v1/internal/tests/admin/apply-migrations", {
+      method: "POST",
+    });
+    expect(res.status).toBe(401);
+    expect(mockRunStartupMigrations).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 with wrong admin secret (and does not call runStartupMigrations)", async () => {
+    mockRunStartupMigrations.mockReset();
+    const app = await loadApp();
+    const res = await app.request("/v1/internal/tests/admin/apply-migrations", {
+      method: "POST",
+      headers: { Authorization: "Bearer wrong-value" },
+    });
+    expect(res.status).toBe(401);
+    expect(mockRunStartupMigrations).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /v1/internal/tests/admin/apply-migrations — success path", () => {
+  it("delegates to runStartupMigrations exactly once and returns the per-block summary", async () => {
+    const fakeBlocks = [
+      { block: "0028_sqs_daily_snapshot", outcome: "skipped (table already exists)", duration_ms: 5 },
+      { block: "0029_actual_cost_cents", outcome: "skipped (column already exists)", duration_ms: 4 },
+      { block: "0030_compliance_columns", outcome: "skipped (columns already exist)", duration_ms: 6 },
+      { block: "0031_test_results_suite_executed_idx", outcome: "ensured composite index on (test_suite_id, executed_at DESC)", duration_ms: 3 },
+      { block: "0060_marketplace_eligible", outcome: "ensured marketplace_eligible + marketplace_eligible_reason columns", duration_ms: 7 },
+      { block: "0062_paid_vendor_costs", outcome: "no rows to update (already classified)", rows_affected: 0, duration_ms: 12 },
+    ];
+    mockRunStartupMigrations.mockReset();
+    mockRunStartupMigrations.mockResolvedValueOnce(fakeBlocks);
+
+    const app = await loadApp();
+    const res = await app.request("/v1/internal/tests/admin/apply-migrations", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockRunStartupMigrations).toHaveBeenCalledTimes(1);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      ok: true,
+      block_count: 6,
+      blocks: fakeBlocks,
+    });
+  });
+
+  it("response shape is the canonical per-block summary; no inline duplication detectable", async () => {
+    // Smoke: every entry the endpoint returns must have come from the
+    // mocked function. If someone adds a parallel inline block in the
+    // future, this test would either drift or surface it (because the
+    // mock returns N blocks but the endpoint would return N+1).
+    const fake = [{ block: "0028_sqs_daily_snapshot", outcome: "skipped", duration_ms: 1 }];
+    mockRunStartupMigrations.mockReset();
+    mockRunStartupMigrations.mockResolvedValueOnce(fake);
+
+    const app = await loadApp();
+    const res = await app.request("/v1/internal/tests/admin/apply-migrations", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+    });
+    const body = await res.json();
+    expect(body.block_count).toBe(1);
+    expect(body.blocks).toEqual(fake);
+  });
+});
+
+describe("POST /v1/internal/tests/admin/apply-migrations — failure-aborts semantics", () => {
+  it("returns 500 with error message when runStartupMigrations throws (no silent partial success)", async () => {
+    mockRunStartupMigrations.mockReset();
+    mockRunStartupMigrations.mockRejectedValueOnce(
+      new Error("0062_paid_vendor_costs post-condition failed: 1 paid-vendor suites still at external_cost_cents = 0"),
+    );
+
+    const app = await loadApp();
+    const res = await app.request("/v1/internal/tests/admin/apply-migrations", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+    });
+
+    expect(res.status).toBe(500);
+    expect(mockRunStartupMigrations).toHaveBeenCalledTimes(1);
+
+    const body = await res.json();
+    expect(body.error_code).toBe("migration_failed");
+    expect(body.message).toContain("post-condition failed");
+    expect(body.message).toContain("paid-vendor suites still at external_cost_cents = 0");
+  });
+
+  it("converts non-Error throws to a string in the response (defensive)", async () => {
+    mockRunStartupMigrations.mockReset();
+    mockRunStartupMigrations.mockRejectedValueOnce("opaque string failure");
+
+    const app = await loadApp();
+    const res = await app.request("/v1/internal/tests/admin/apply-migrations", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.message).toContain("opaque string failure");
+  });
+});

--- a/apps/api/src/routes/internal-tests.ts
+++ b/apps/api/src/routes/internal-tests.ts
@@ -1267,106 +1267,46 @@ internalTestsRoute.get("/cost-summary", async (c) => {
 });
 
 // POST /v1/internal/tests/admin/apply-migrations — Apply pending DB migrations
-// Admin-only, secured with ADMIN_SECRET
+//
+// Single source of truth: delegates to runStartupMigrations() in
+// lib/startup-migrations.ts. Pre-PR-#52 this endpoint had its own
+// inline block set (0028, 0029, 0030, 0031) that drifted from the
+// startup-time set (which had 0028, 0029, 0060, 0062). The drift
+// caused PR #42's columns to never reach prod via either path until
+// the 2026-05-04 outage forced a manual recovery.
+//
+// Now there's one block list and one set of per-block functions.
+// Adding a migration to startup-migrations.ts automatically extends
+// admin-endpoint coverage. The endpoint stays as an emergency-rerun
+// path that mirrors what would run on the next deploy, with the same
+// blocking-on-throw semantics.
+//
+// Admin auth gate retained as-is.
 internalTestsRoute.post("/admin/apply-migrations", async (c) => {
   if (!isValidAdminAuth(c.req.header("Authorization"))) {
     return c.json(apiError("unauthorized", "Admin authentication required"), 401);
   }
 
-  const db = getDb();
-  const results: string[] = [];
+  const { runStartupMigrations } = await import("../lib/startup-migrations.js");
 
-  // Migration 0028: sqs_daily_snapshot
   try {
-    const check1 = await db.execute(sql`
-      SELECT count(*)::text as cnt FROM information_schema.tables
-      WHERE table_name = 'sqs_daily_snapshot'
-    `);
-    const rows1 = Array.isArray(check1) ? check1 : (check1 as any)?.rows ?? [];
-    if (rows1[0]?.cnt === "0") {
-      await db.execute(sql`
-        CREATE TABLE IF NOT EXISTS "sqs_daily_snapshot" (
-          "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-          "capability_slug" text NOT NULL,
-          "snapshot_date" date NOT NULL,
-          "matrix_sqs" numeric(5, 2) NOT NULL,
-          "qp_score" numeric(5, 2),
-          "rp_score" numeric(5, 2),
-          "qp_grade" varchar(2),
-          "rp_grade" varchar(2),
-          "trend" varchar(20),
-          "health_state" varchar(20),
-          "runs_analyzed" integer,
-          "created_at" timestamp with time zone DEFAULT now() NOT NULL
-        )
-      `);
-      await db.execute(sql`
-        CREATE UNIQUE INDEX IF NOT EXISTS "sqs_daily_snapshot_slug_date_unique"
-        ON "sqs_daily_snapshot" ("capability_slug", "snapshot_date")
-      `);
-      await db.execute(sql`
-        CREATE INDEX IF NOT EXISTS "sqs_daily_snapshot_slug_date_desc_idx"
-        ON "sqs_daily_snapshot" ("capability_slug", "snapshot_date" DESC)
-      `);
-      results.push("0028: sqs_daily_snapshot created");
-    } else {
-      results.push("0028: sqs_daily_snapshot already exists");
-    }
+    const blocks = await runStartupMigrations();
+    return c.json({
+      ok: true as const,
+      block_count: blocks.length,
+      blocks,
+    });
   } catch (err) {
-    results.push(`0028: FAILED — ${err instanceof Error ? err.message : err}`);
+    // Mirror the boot-time blocking semantics: a failure aborts the
+    // operation rather than silently continuing. The endpoint returns
+    // a 500 with the error message so the operator running the manual
+    // recovery sees what failed.
+    const message = err instanceof Error ? err.message : String(err);
+    return c.json(
+      apiError("migration_failed", `runStartupMigrations failed: ${message}`),
+      500,
+    );
   }
-
-  // Migration 0029: actual_cost_cents on test_run_log
-  try {
-    const check2 = await db.execute(sql`
-      SELECT count(*)::text as cnt FROM information_schema.columns
-      WHERE table_name = 'test_run_log' AND column_name = 'actual_cost_cents'
-    `);
-    const rows2 = Array.isArray(check2) ? check2 : (check2 as any)?.rows ?? [];
-    if (rows2[0]?.cnt === "0") {
-      await db.execute(sql`
-        ALTER TABLE "test_run_log" ADD COLUMN "actual_cost_cents" integer DEFAULT 0 NOT NULL
-      `);
-      results.push("0029: actual_cost_cents added");
-    } else {
-      results.push("0029: actual_cost_cents already exists");
-    }
-  } catch (err) {
-    results.push(`0029: FAILED — ${err instanceof Error ? err.message : err}`);
-  }
-
-  // Migration 0030: compliance infrastructure (integrity_hash, previous_hash, legal_hold)
-  try {
-    const check3 = await db.execute(sql`
-      SELECT count(*)::text as cnt FROM information_schema.columns
-      WHERE table_name = 'transactions' AND column_name = 'integrity_hash'
-    `);
-    const rows3 = Array.isArray(check3) ? check3 : (check3 as any)?.rows ?? [];
-    if (rows3[0]?.cnt === "0") {
-      await db.execute(sql`ALTER TABLE "transactions" ADD COLUMN "integrity_hash" varchar(128)`);
-      await db.execute(sql`ALTER TABLE "transactions" ADD COLUMN "previous_hash" varchar(128)`);
-      await db.execute(sql`ALTER TABLE "transactions" ADD COLUMN "legal_hold" boolean DEFAULT false NOT NULL`);
-      await db.execute(sql`CREATE INDEX IF NOT EXISTS "transactions_integrity_hash_idx" ON "transactions" ("integrity_hash")`);
-      results.push("0030: compliance columns added (integrity_hash, previous_hash, legal_hold)");
-    } else {
-      results.push("0030: compliance columns already exist");
-    }
-  } catch (err) {
-    results.push(`0030: FAILED — ${err instanceof Error ? err.message : err}`);
-  }
-
-  // Migration 0031: composite index on test_results(test_suite_id, executed_at DESC)
-  try {
-    await db.execute(sql`
-      CREATE INDEX IF NOT EXISTS "test_results_suite_executed_idx"
-      ON "test_results" ("test_suite_id", "executed_at" DESC)
-    `);
-    results.push("0031: test_results_suite_executed_idx created (or already exists)");
-  } catch (err) {
-    results.push(`0031: FAILED — ${err instanceof Error ? err.message : err}`);
-  }
-
-  return c.json({ migrations: results });
 });
 
 // POST /v1/internal/tests/admin/run-script — Run a post-deploy script


### PR DESCRIPTION
## Summary
- Refactor `POST /v1/internal/tests/admin/apply-migrations` to delegate to `runStartupMigrations()` — eliminates the drift bug class that caused the 2026-05-04 PR-#42 deploy outage at the structural level.
- Backport blocks 0030 (compliance columns) and 0031 (test_results composite index) from the admin endpoint's frozen inline set into `src/lib/startup-migrations.ts`. After this PR the startup wiring covers all 6 historical blocks (0028, 0029, 0030, 0031, 0060, 0062).
- Per DEC-20260504-A audit-followup test coverage protocol: regression tests pin the new contract — the admin endpoint MUST call `runStartupMigrations()` exactly once per request, mirror per-block summary in the response, and propagate (not swallow) thrown errors.

## Why this PR exists
PR #51 introduced `runStartupMigrations()` in `src/lib/` and wired it into `index.ts:69` (boot-blocking, before `validateSchema()`). But `routes/internal-tests.ts:/admin/apply-migrations` still carried its own inline copy of the block set (0028, 0029, 0030, 0031) — drift was inevitable. This PR closes that gap: one source of truth, one place to add a block, no possibility of the admin endpoint and startup wiring diverging again.

## Changes per file
- `src/lib/startup-migrations.ts` — added `runMigration0030_complianceColumns` (information_schema check + skip; on first run: 3 ALTER TABLE + 1 CREATE INDEX IF NOT EXISTS) and `runMigration0031_testResultsCompositeIdx` (CREATE INDEX IF NOT EXISTS, Postgres-level idempotent). BLOCKS array now readonly with 6 entries. Return type tightened from `Promise<void>` to `Promise<BlockResult[]>` so the admin endpoint can surface the summary.
- `src/routes/internal-tests.ts` — replaced ~100 lines of inline blocks with a try/catch that calls `runStartupMigrations()` and returns either `{ ok, block_count, blocks }` (200) or `apiError(\"migration_failed\", ...)` (500). Auth gate unchanged.
- `src/lib/errors.ts` — added `\"migration_failed\"` to the ErrorCode union (internal admin surface only — not exposed on the public DEC-19 contract).
- `src/lib/startup-migrations.test.ts` — extended with 4 new tests: 0030 first-run, 0030 second-run, 0031 unconditional CREATE INDEX, BLOCKS list pin (asserts the canonical 6 block functions in historical order).
- `src/routes/admin-apply-migrations.test.ts` — new file, 6 tests: auth gate (no header / wrong secret) does not invoke `runStartupMigrations`; success path delegates exactly once and returns the per-block summary; inline-duplication smoke (response block_count equals mock return length); failure path produces 500 + `migration_failed`; defensive non-Error throw still produces a well-formed 500.

## Verification
- `npx tsc --noEmit --project apps/api/tsconfig.json` — clean.
- `npx vitest run` — 479 pass / 11 skipped / 0 fail. 10 new tests this PR.
- Linters (no-bare-catch, no-new-console, migration-prefixes) — all clean.

## Reviewer findings — clean (technical + product)
Both passes returned no HIGH or MEDIUM findings. Six-lens review covered: senior dev (correctness), security (SSRF / SQLi / secrets / auth gate / side-effect imports), system architect (single source of truth eliminates a drift bug class), CTO (aligns with DEC-20260504-A), PM (operational fix, no user-facing surface change), UX (error message preserves the underlying block-level message — actionable for the operator), founder (response shape is canonical: `block_count` integer, `blocks[]` per-block summary, no formatted-string drift).

## Test plan
- Reviewer: confirm the diff in `routes/internal-tests.ts` deletes the inline block functions entirely (no dead helpers left behind).
- Reviewer: confirm `BLOCKS` in `startup-migrations.ts` lists the 6 functions in historical order — the test pins this and would fail if reordered.
- Reviewer: confirm `\"migration_failed\"` is documented as admin-only in the ErrorCode union comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>