### PR TITLE
docs(claude-md): codify DEC-20260504-B (bulk-op deploy) + DEC-20260504-C (deploy-mech verification)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,63 @@ scheduler excludes them from all runs (test-runner.ts line 117). They are never 
 
 **Test-harness exemption:** if the relevant test harness doesn't exist in the repo (e.g. route-level integration testing for `/v1/do` requires a Postgres-backed harness that hasn't been built), the commit may ship with a unit-level regression test that captures the structural shape of the bug, plus an explicit reference to the missing harness in the PR description and Journal entry. The exemption does not apply to cases where the harness exists and the author skipped writing a test.
 
+### Bulk-Operation Deploy Protocol (DEC-20260504-B)
+
+**MANDATORY — applies to ANY deploy that fixes a long-silent bulk operation (retention, archival, reconciliation, batch processing, periodic cleanup).**
+
+**Rule:** When fixing a long-silent bulk operation, the deploy must include either: (a) a pre-fix backlog drain plan, or (b) a self-throttling fix that bounds resource usage per tick (e.g., LIMIT-paginated DELETE). Do NOT treat this as a normal bug fix. The first successful run after fixing a long-silent bulk operation is a workload-resumption event, not a routine execution. Audit accumulated workload BEFORE deploying. If accumulated workload could exceed infrastructure capacity (disk, memory, connection pool, rate limits, WAL volume), pre-cleaning or throttling is required.
+
+**Background:** 2026-05-04 Postgres crash incident (Journal entry `35667c87-082c-8148-ae24-faee34f01c1d`). PR #44's retention fix re-enabled bulk DELETE on accumulated rows that had been silently failing for the prior outage window. The first successful run filled the volume; Postgres crash-looped for 28 minutes. The fix itself was correct in isolation — the failure mode was treating "first successful execution after a long silent failure" as a routine deploy.
+
+**Required steps (non-negotiable):**
+
+1. **Identify the latency.** If a bulk operation has been silently failing or unscheduled for >24h, the next successful run is a workload-resumption event. Treat it as one.
+2. **Audit accumulated workload before merge.** Query the table(s) the operation touches and estimate the row count, byte volume, and downstream effects (WAL bytes, replication lag, rate-limit consumption, connection-pool occupancy). Document the estimate in the PR body.
+3. **Pick a deploy strategy explicitly:**
+   - (a) **Pre-drain:** ship a one-shot script that processes the backlog under operator supervision, then deploy the fix. The fix's first run sees a clean state.
+   - (b) **Self-throttle:** ship a fix that bounds per-tick resource usage (LIMIT-paginated DELETE, batch-size cap, time-budgeted loop with early exit). The fix processes the backlog over many ticks.
+4. **Reject the third option.** "Just deploy the fix and let it run" is the failure mode this protocol exists to prevent. If the deploy strategy is "ship and pray," stop and pick (a) or (b).
+
+**At session end, report:**
+- The accumulated-workload estimate and the chosen deploy strategy.
+- The first-successful-run outcome (rows processed, duration, peak resource usage).
+
+**Do NOT mark a bulk-operation fix as deployed if the accumulated-workload audit was skipped.** Report what's missing.
+
+**This rule does NOT override:**
+- The Scoring Integrity Protocol.
+- The Capability Onboarding Protocol (DEC-20260320-B).
+- The Distribution PR Integrity Protocol (DEC-20260422-A).
+- The Audit-Follow-up Test Coverage Protocol (DEC-20260504-A).
+
+### Deploy Mechanism Verification Protocol (DEC-20260504-C)
+
+**MANDATORY — applies to ANY PR that adds a code path which depends on a deploy-pipeline behavior (migrations running, env vars read, build steps, startup hooks, scheduled jobs, cron triggers).**
+
+**Rule:** When a PR adds a code path that depends on a deploy-pipeline behavior, the pre-merge audit MUST verify the deploy mechanism actually does what's expected. "Code is correct" is not the same as "deploy of code will produce expected effect on prod." Verification means reading the actual deploy mechanism (Dockerfile, build config, startup wiring, package.json scripts, CI workflows) and confirming the new code path will execute as intended. Do NOT assume historical patterns hold without verification. A clean post-deploy log is not verification — query prod for the expected effect of the change.
+
+**Background:** 2026-05-04 PR #42 outage (28-minute customer-facing 500s). `apps/api/scripts/apply-migrations.ts` had been a dead file — never compiled (excluded by `tsconfig.json` rootDir), never invoked by Dockerfile CMD. PR #42's pre-merge audit was thorough on PR contents but didn't verify the deploy mechanism actually ran the script. Compounded by PR #49's UPDATE blocks also silently never running for 7 hours under the same dead-file mechanism. The structural fix shipped in PR #51 + PR #52 (`runStartupMigrations()` wired into `index.ts:69`, single source of truth between admin endpoint and startup wiring).
+
+**Required steps (non-negotiable):**
+
+1. **Identify the deploy-pipeline dependency.** If the new code path depends on something other than its own module being imported and called from request-handler code, name the dependency: which deploy step has to fire? Which env var has to be read? Which startup hook has to invoke it?
+2. **Read the actual deploy mechanism.** Open the Dockerfile, the `CMD` line, `package.json` scripts, `index.ts` startup wiring, the relevant CI workflow, the cron config — whatever produces the dependency. Confirm the new code path is reached.
+3. **Confirm reach by file path, not by historical pattern.** "Migrations have always run" or "env vars are always loaded" is not verification. The verification is: this specific file is on the import graph from `index.ts` (or whichever entry point fires at deploy time), or this specific script is invoked by a specific line in the Dockerfile / package.json.
+4. **Post-deploy: query prod for the expected effect.** A clean log line proves the line was emitted. It does not prove the schema changed, the row was written, the env var was read, the cron fired. Query the actual artifact: `\d table` for a column add, `SELECT COUNT(*)` for a backfill, `GET /health/version` for a build SHA, etc.
+
+**At session end, report:**
+- The deploy-pipeline dependency identified, and the file/line that proves the dependency is satisfied.
+- The post-deploy prod query and its result.
+
+**Do NOT mark a deploy-mechanism-dependent change as done if the verification step was skipped.** Report what's missing.
+
+**This rule does NOT override:**
+- The Scoring Integrity Protocol.
+- The Capability Onboarding Protocol (DEC-20260320-B).
+- The Distribution PR Integrity Protocol (DEC-20260422-A).
+- The Audit-Follow-up Test Coverage Protocol (DEC-20260504-A).
+- The Bulk-Operation Deploy Protocol (DEC-20260504-B).
+
 ### Quick Session Checklist
 1. Declare session intent
 2. Connectivity check (Git + handoff; Notion if needed). Log failures.

--- a/apps/api/src/lib/claude-md-protocols.test.ts
+++ b/apps/api/src/lib/claude-md-protocols.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Sanity check: CLAUDE.md must list every always-enforce protocol DEC by ID.
+ *
+ * Per DEC-20260504-A this file is documentation-only (no new code path), so
+ * no behavioural regression test is required. But the protocols are only
+ * enforced if Claude Code can find them in CLAUDE.md at session start. If a
+ * future edit drops a DEC ID by accident (rebase conflict, file rewrite),
+ * this test fails and forces the author to notice.
+ *
+ * Add the new DEC ID here when a new always-enforce protocol lands.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const CLAUDE_MD_PATH = resolve(__dirname, "../../../../CLAUDE.md");
+
+const REQUIRED_DEC_IDS = [
+  "DEC-20260320-B", // Capability Onboarding Protocol
+  "DEC-20260422-A", // Distribution PR Integrity Protocol
+  "DEC-20260504-A", // Audit-Follow-up Test Coverage Protocol
+  "DEC-20260504-B", // Bulk-Operation Deploy Protocol
+  "DEC-20260504-C", // Deploy Mechanism Verification Protocol
+];
+
+describe("CLAUDE.md — always-enforce protocol DEC IDs", () => {
+  const contents = readFileSync(CLAUDE_MD_PATH, "utf-8");
+
+  for (const decId of REQUIRED_DEC_IDS) {
+    it(`contains ${decId}`, () => {
+      expect(contents).toContain(decId);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Adds two always-enforce protocols to CLAUDE.md, codifying the structural lessons from the 2026-05-04 incidents.
- Documentation-only — no production code paths changed. Per DEC-20260504-A, no behavioural regression test required.
- Sanity-check test pins all five always-enforce DEC IDs in CLAUDE.md so a future rebase/rewrite can't silently drop a protocol.

## DEC-20260504-B — Bulk-Operation Deploy Protocol
The first successful run after fixing a long-silent bulk operation is a workload-resumption event, not a routine execution. Deploy must include either (a) a pre-fix backlog drain plan, or (b) a self-throttling fix that bounds resource usage per tick. Audit accumulated workload before merge.

**Source:** 2026-05-04 Postgres crash incident (Journal entry `35667c87-082c-8148-ae24-faee34f01c1d`). PR-#44's retention fix re-enabled bulk DELETE on accumulated rows; first successful run filled the volume; Postgres crash-looped for 28 minutes. The fix was correct in isolation — the failure mode was treating "first successful execution after a long silent failure" as a routine deploy.

## DEC-20260504-C — Deploy Mechanism Verification Protocol
"Code is correct" is not the same as "deploy of code will produce expected effect on prod." When a PR adds a code path that depends on a deploy-pipeline behavior (migrations, env vars, build steps, startup hooks, scheduled jobs), the pre-merge audit must read the actual deploy mechanism and confirm the new code path will execute. A clean post-deploy log line is not verification — query prod for the expected effect.

**Source:** 2026-05-04 PR-#42 outage (28-minute customer-facing 500s). `apps/api/scripts/apply-migrations.ts` had been a dead file (excluded by `tsconfig.json` rootDir, never invoked by Dockerfile CMD). The pre-merge audit was thorough on PR contents but didn't verify the deploy mechanism ran the script. Structural fix landed in PR-#51 + PR-#52.

## Sanity-check test
`apps/api/src/lib/claude-md-protocols.test.ts` reads CLAUDE.md and asserts the five always-enforce DEC IDs are present:
- DEC-20260320-B (Capability Onboarding)
- DEC-20260422-A (Distribution PR Integrity)
- DEC-20260504-A (Audit-Follow-up Test Coverage)
- DEC-20260504-B (Bulk-Operation Deploy)  ← new
- DEC-20260504-C (Deploy Mechanism Verification)  ← new

This is a sanity check, not a behavioural regression test (per the user's instruction). When a sixth always-enforce protocol lands, add its DEC ID to the array.

## Verification
- `npx tsc --noEmit --project apps/api/tsconfig.json` — clean.
- `npx vitest run src/lib/claude-md-protocols.test.ts` — 5 pass / 0 fail.

## Notion
- DEC-20260504-B page: https://www.notion.so/35667c87082c81fabc3cf9ecc4871d90
- DEC-20260504-C page: https://www.notion.so/35667c87082c81e7af49fc042371f566
- Both filed in Decisions DB with full context, Status=active, Scope=global, Confidence=high.

## Reviewer findings — clean (technical + product)
Documentation-only PR with a single sanity-check test. No new code paths, no security surface, no API/wire-shape change, no protocol overrides. The protocols themselves are post-incident codifications of two real outages (PR-#42 dead-migration-file + PR-#44 first-successful-run-fills-disk).

## Test plan
- Reviewer: confirm both DEC sections in CLAUDE.md are inserted under always-enforce rules (between DEC-20260504-A and `### Quick Session Checklist`).
- Reviewer: confirm both new protocols include the standard four-part shape: rule + background + required steps + reporting + does-not-override.
- Reviewer: confirm the sanity-check test runs in standard `npx vitest run` (no special harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>