### PR TITLE
fix(invoice-extract): reclassify paid-vendor suite cost; stop hourly Anthropic-Haiku bleed

### DIFF
--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -37,6 +37,7 @@ import {
   runMigration0031_testResultsCompositeIdx,
   runMigration0060_marketplaceEligible,
   runMigration0062_paidVendorCosts,
+  runMigration0063_invoiceExtractCostReclassify,
   type MigrationExecutor,
 } from "./startup-migrations.js";
 
@@ -200,8 +201,62 @@ describe("startup-migrations — block 0031 (test_results composite index)", () 
   });
 });
 
+describe("startup-migrations — block 0063 (invoice-extract cost reclassify)", () => {
+  it("first run: updates 4 rows when invoice-extract suites are at 0; post-check passes", async () => {
+    // Queue: UPDATE returns 4 (the 4 paid-burning suites flipped from 0 → 1);
+    // post-check returns 0 (none remaining at 0).
+    const stub = makeStub({
+      queue: [{ count: 4 }, [{ remaining_zero: 0 }]],
+    });
+    const result = await runMigration0063_invoiceExtractCostReclassify(stub);
+    expect(result.rows_affected).toBe(4);
+    expect(result.outcome).toContain("invoice-extract suites reclassified: 4");
+    expect(stub.captured).toHaveLength(2);
+
+    // The UPDATE shape — single capability_slug, exactly the 4 paid test_types,
+    // active+live filter, and the = 0 idempotency filter.
+    const updateSql = stub.renderedSql[0].toLowerCase();
+    expect(updateSql).toContain("update test_suites");
+    expect(updateSql).toContain("set external_cost_cents = 1");
+    expect(updateSql).toContain("capability_slug = 'invoice-extract'");
+    expect(updateSql).toContain("active = true");
+    expect(updateSql).toMatch(/test_mode = 'live'/);
+    expect(updateSql).toContain("'known_answer'");
+    expect(updateSql).toContain("'edge_case'");
+    expect(updateSql).toContain("'negative'");
+    expect(updateSql).toContain("'known_bad'");
+    // Negative assertion: the two probe types must NOT be in the list —
+    // they legitimately stay at 0 (auth-less probe pattern, no paid call).
+    expect(updateSql).not.toContain("'dependency_health'");
+    expect(updateSql).not.toContain("'schema_check'");
+    // Idempotency filter:
+    expect(updateSql).toContain("external_cost_cents = 0");
+  });
+
+  it("second run: idempotent — UPDATE returns 0 rows; outcome reports already-classified", async () => {
+    const stub = makeStub({
+      queue: [{ count: 0 }, [{ remaining_zero: 0 }]],
+    });
+    const result = await runMigration0063_invoiceExtractCostReclassify(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to update.*already classified/i);
+    expect(stub.captured).toHaveLength(2);
+  });
+
+  it("post-condition violation throws (would fail boot)", async () => {
+    // Imagine a new invoice-extract suite landed at cost=0 between deploys.
+    // The UPDATE captures 4, but the post-check finds a leftover.
+    const stub = makeStub({
+      queue: [{ count: 4 }, [{ remaining_zero: 1 }]],
+    });
+    await expect(runMigration0063_invoiceExtractCostReclassify(stub)).rejects.toThrow(
+      /post-condition failed.*1 invoice-extract suites/i,
+    );
+  });
+});
+
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 6 blocks in historical order", () => {
+  it("exports the expected 7 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -214,6 +269,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0031_testResultsCompositeIdx",
       "runMigration0060_marketplaceEligible",
       "runMigration0062_paidVendorCosts",
+      "runMigration0063_invoiceExtractCostReclassify",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -313,6 +313,77 @@ export async function runMigration0062_paidVendorCosts(
   };
 }
 
+// ─── Block 0063: invoice-extract paid-vendor cost reclassification ──────────
+//
+// Sibling of block 0062. Prod query 2026-05-04 found that all 4 active
+// non-probe live test suites for `invoice-extract` had external_cost_cents
+// = 0, which causes the DEC-20260503-B scheduler to schedule them hourly
+// — paying Anthropic Haiku vision to extract invoice fields from the
+// `httpbin.org/image/jpeg` placeholder fixture (a JPEG of a dog) on a
+// cadence that was supposed to be excluded for paid vendors. The fixture
+// itself is a separate hygiene to-do; this block stops the scheduled
+// bleed by reclassifying the suites' cost above the scheduler's skip
+// threshold.
+//
+// 1¢ floor matches the PR #49 / block 0062 defensible-minimum pattern
+// for paid vendors where calibrated cost isn't yet available. Real
+// per-call cost on a small JPEG via Haiku is below 1¢, but the floor's
+// only operational job is to flip the scheduler-skip semantic; precise
+// calibration is the existing P2 to-do on Anthropic-Haiku cost across
+// all vision-using capabilities.
+//
+// Idempotent via `external_cost_cents = 0` in the WHERE clause — once a
+// row is set to 1, a re-run won't match it. dependency_health and
+// schema_check are NOT included: those use the auth-less-probe pattern
+// (no paid call), legitimately stay at 0.
+
+export async function runMigration0063_invoiceExtractCostReclassify(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const update = await tx.execute(sql`
+    UPDATE test_suites
+    SET external_cost_cents = 1, updated_at = NOW()
+    WHERE capability_slug = 'invoice-extract'
+      AND active = true
+      AND test_mode = 'live'
+      AND test_type IN ('known_answer', 'edge_case', 'negative', 'known_bad')
+      AND external_cost_cents = 0
+  `);
+  const updateCount = (update as { count?: number }).count ?? 0;
+
+  // Post-condition: no active live non-probe suite for invoice-extract
+  // may remain at 0 after this block. If a new suite shows up at 0,
+  // fail boot so the operator notices.
+  const checkRows = await tx.execute(sql`
+    SELECT COUNT(*)::int AS remaining_zero
+    FROM test_suites
+    WHERE capability_slug = 'invoice-extract'
+      AND active = true
+      AND test_mode = 'live'
+      AND test_type IN ('known_answer', 'edge_case', 'negative', 'known_bad')
+      AND external_cost_cents = 0
+  `);
+  const checkResultRows = Array.isArray(checkRows) ? checkRows : (checkRows as { rows?: unknown[] })?.rows ?? [];
+  const remainingZero = (checkResultRows[0] as { remaining_zero?: number })?.remaining_zero ?? 0;
+  if (remainingZero > 0) {
+    throw new Error(
+      `0063_invoice_extract_cost_reclassify post-condition failed: ${remainingZero} invoice-extract suites still at external_cost_cents = 0`,
+    );
+  }
+
+  return {
+    block: "0063_invoice_extract_cost_reclassify",
+    outcome:
+      updateCount === 0
+        ? "no rows to update (already classified)"
+        : `invoice-extract suites reclassified: ${updateCount}`,
+    rows_affected: updateCount,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -330,6 +401,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0031_testResultsCompositeIdx,
   runMigration0060_marketplaceEligible,
   runMigration0062_paidVendorCosts,
+  runMigration0063_invoiceExtractCostReclassify,
 ];
 
 /**


### PR DESCRIPTION
## Summary
Block 0063 — sibling of block 0062 (PR #49 paid-vendor classification), single-capability variant for `invoice-extract`. Stops the scheduled bleed found via the prod query in PR #54's report.

## Why
Prod query 2026-05-04:

```
| test_type          | active | external_cost_cents |
|--------------------|--------|---------------------|
| dependency_health  | true   |                   0 |
| edge_case          | true   |                   0 |
| known_answer       | true   |                   0 |
| known_bad          | true   |                   0 |
| negative           | true   |                   0 |
| schema_check       | true   |                   0 |
```

Per DEC-20260503-B the scheduler skips suites with `external_cost_cents > 0` for paid vendors; at 0, the four non-probe suites (`known_answer`, `edge_case`, `negative`, `known_bad`) were scheduled hourly and paying Anthropic Haiku vision to extract invoice fields from `httpbin.org/image/jpeg` (a JPEG of a dog). This is the same bug-shape PR #49 fixed for the Dilisense / risk-narrative-generate family.

## What
```sql
UPDATE test_suites
SET external_cost_cents = 1, updated_at = NOW()
WHERE capability_slug = 'invoice-extract'
  AND active = true
  AND test_mode = 'live'
  AND test_type IN ('known_answer', 'edge_case', 'negative', 'known_bad')
  AND external_cost_cents = 0
```

`dependency_health` and `schema_check` are explicitly excluded — they use the auth-less probe pattern (no paid call), legitimately stay at 0.

**1¢ floor matches the PR #49 / block 0062 defensible-minimum pattern.** Actual Haiku-vision cost on a small JPEG is below 1¢; the floor's operational role is purely the scheduler-skip semantic flip. Precise per-call calibration is the existing P2 to-do on Anthropic-Haiku cost across all vision-using capabilities (~80 caps).

## Idempotency + post-condition
- WHERE clause includes `external_cost_cents = 0` → re-run captures zero rows.
- Post-condition assertion: a `SELECT COUNT(*)` for any active live non-probe invoice-extract suite still at 0 throws and fails boot. If a new suite shows up at 0, the operator notices.

## Tests (DEC-20260504-A)
- **first-run shape:** UPDATE returns 4, post-check 0 → outcome reports `invoice-extract suites reclassified: 4`. SQL captures: `UPDATE test_suites`, `SET external_cost_cents = 1`, single capability_slug filter, exactly the 4 paid `test_type` values, `active = true`, `test_mode = 'live'`, the `= 0` idempotency filter. **Negative assertion:** the SQL must NOT include `'dependency_health'` or `'schema_check'`.
- **idempotent re-run:** UPDATE returns 0 → outcome reports `no rows to update (already classified)`.
- **post-condition violation:** UPDATE returns 4 but post-check finds 1 leftover → block throws.
- **BLOCKS pin:** updated to 7 entries with `runMigration0063_invoiceExtractCostReclassify` in historical position.

All 16 tests in `startup-migrations.test.ts` pass. tsc clean.

## Per active protocols
- **DEC-20260504-A:** regression tests above cover the new code path with both directional assertions (UPDATE shape + post-condition) and idempotency/violation paths.
- **DEC-20260504-C:** this is a startup-migrations block; PR-#51/#52 wired `runStartupMigrations()` to fire blocking before `validateSchema()` at every API restart. No deploy-mechanism risk — the block runs on Railway redeploy by the same path verified after PR #52 (block 0028, 0029, 0030, 0031, 0060, 0062 boot logs at 2026-05-04T20:42:13Z all fired and the new 0063 will join them).
- **DEC-20260504-B:** not applicable — this is a 4-row UPDATE bounded by a `capability_slug` predicate, not a long-silent bulk operation.

## Open question — fixture itself
Per Petter's call, the dog-JPEG fixture is left in place. Once block 0063 lands the suite is no longer scheduled, so fixture quality becomes moot. The Notion to-do (`35667c87-082c-817f-9905-cfad380b8ae3`) will be marked Done with notes that bleed was stopped via reclassification, fixture left intentionally.

## Reviewer findings — clean (technical + product)
Six-lens review covered: senior dev (idempotent UPDATE + post-condition assertion match the 0062 precedent), security (no SQL injection — all values literal in the WHERE; no user input), architect (pattern reuse from block 0062 is the right move, not a premature abstraction yet — second instance), CTO (aligns with DEC-20260503-B + DEC-20260504-A), PM (operational fix, no user-facing surface), UX (no error message changes), founder (the "scheduler is paying for a dog photo" framing is exactly the kind of operational surprise that needs to land in DEC bookkeeping).

## Test plan
- Reviewer: confirm the new block exclusion list (`'dependency_health'`, `'schema_check'` NOT in the test_type IN clause) matches the auth-less-probe Principle A in CLAUDE.md.
- Reviewer: confirm the BLOCKS pin update from 6 → 7 entries.
- Post-deploy: log line `startup-migration-block 0063_invoice_extract_cost_reclassify` should appear with `outcome: invoice-extract suites reclassified: 4` on first deploy, then `no rows to update (already classified)` on every subsequent boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>