### PR TITLE
test(startup-migrations): close two regression-net gaps from retro review

### DIFF
--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -26,9 +26,20 @@
  * query and returns canned results. No prod DB connection.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { sql, type SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
+
+// Mock the DB layer so the orchestrator-level test below can inject a
+// stub executor via getDb(). Per-block tests pass their stub directly
+// into the per-block function and don't touch getDb, so they're not
+// affected by this mock.
+const mockGetDb = vi.fn();
+vi.mock("../db/index.js", () => ({
+  getDb: () => mockGetDb(),
+  closeDbPool: () => Promise.resolve(),
+}));
+
 import {
   BLOCKS,
   runMigration0028_sqsDailySnapshot,
@@ -38,6 +49,7 @@ import {
   runMigration0060_marketplaceEligible,
   runMigration0062_paidVendorCosts,
   runMigration0063_invoiceExtractCostReclassify,
+  runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
 
@@ -274,16 +286,65 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
   });
 });
 
-describe("startup-migrations — failure-aborts-boot semantics", () => {
-  it("if a block throws, runStartupMigrations propagates (no catch-and-continue)", async () => {
-    // Use the post-condition-violation block as the failure trigger:
-    // dili UPDATE 0, rng UPDATE 0, post-check returns 1 → block throws.
-    // We invoke the block directly here because runStartupMigrations()
-    // pulls getDb() from the real DB; the per-block test is the
-    // behavioural assertion.
-    const stub = makeStub({
-      queue: [{ count: 0 }, { count: 0 }, [{ remaining_zero: 5 }]],
+describe("startup-migrations — failure-aborts-boot semantics (orchestrator)", () => {
+  // These tests target runStartupMigrations() itself — not per-block
+  // functions — to pin the orchestrator's contract: if any block throws
+  // for any reason, the throw propagates and aborts boot. Per
+  // DEC-20260504-A this regression test must fail against the un-applied
+  // fix: if a future engineer wraps the BLOCKS for-loop in a try/catch
+  // (turning the orchestrator into catch-and-continue), this test fails.
+
+  it("propagates a throw from a block (executor-level failure on first query)", async () => {
+    // Stub getDb() to return an executor whose every execute() throws.
+    // Block 0028 runs first; its information_schema check is the very
+    // first execute() call. The throw must bubble up through the for-loop
+    // into runStartupMigrations()'s caller.
+    mockGetDb.mockReturnValueOnce({
+      async execute() {
+        throw new Error("simulated executor failure on first query");
+      },
     });
-    await expect(runMigration0062_paidVendorCosts(stub)).rejects.toThrow();
+
+    await expect(runStartupMigrations()).rejects.toThrow(
+      /simulated executor failure on first query/,
+    );
+  });
+
+  it("propagates a post-condition violation thrown by a later block", async () => {
+    // Realistic scenario: blocks 0028–0060 take their no-op paths (table
+    // exists / column exists / IF NOT EXISTS no-op), 0062's UPDATEs
+    // capture 0 rows, but the post-condition SELECT finds remaining_zero
+    // > 0 — block 0062 throws and the orchestrator must propagate.
+    //
+    // Order of execute() calls across all blocks until the throw:
+    //   0028: information_schema → cnt:"1" (skip)              [1]
+    //   0029: information_schema → cnt:"1" (skip)              [2]
+    //   0030: information_schema → cnt:"1" (skip)              [3]
+    //   0031: CREATE INDEX IF NOT EXISTS                       [4]
+    //   0060: ADD COLUMN IF NOT EXISTS marketplace_eligible    [5]
+    //   0060: ADD COLUMN IF NOT EXISTS marketplace_eligible_…  [6]
+    //   0062: UPDATE dilisense → {count: 0}                    [7]
+    //   0062: UPDATE risk-narrative-generate → {count: 0}      [8]
+    //   0062: SELECT remaining_zero → 1 → THROWS               [9]
+    const queue: unknown[] = [
+      [{ cnt: "1" }],
+      [{ cnt: "1" }],
+      [{ cnt: "1" }],
+      undefined,
+      undefined,
+      undefined,
+      { count: 0 },
+      { count: 0 },
+      [{ remaining_zero: 1 }],
+    ];
+    mockGetDb.mockReturnValueOnce({
+      async execute() {
+        return queue.length > 0 ? queue.shift() : { count: 0 };
+      },
+    });
+
+    await expect(runStartupMigrations()).rejects.toThrow(
+      /0062_paid_vendor_costs post-condition failed/,
+    );
   });
 });

--- a/apps/api/src/routes/admin-apply-migrations.test.ts
+++ b/apps/api/src/routes/admin-apply-migrations.test.ts
@@ -100,6 +100,7 @@ describe("POST /v1/internal/tests/admin/apply-migrations — success path", () =
       { block: "0031_test_results_suite_executed_idx", outcome: "ensured composite index on (test_suite_id, executed_at DESC)", duration_ms: 3 },
       { block: "0060_marketplace_eligible", outcome: "ensured marketplace_eligible + marketplace_eligible_reason columns", duration_ms: 7 },
       { block: "0062_paid_vendor_costs", outcome: "no rows to update (already classified)", rows_affected: 0, duration_ms: 12 },
+      { block: "0063_invoice_extract_cost_reclassify", outcome: "no rows to update (already classified)", rows_affected: 0, duration_ms: 4 },
     ];
     mockRunStartupMigrations.mockReset();
     mockRunStartupMigrations.mockResolvedValueOnce(fakeBlocks);
@@ -116,7 +117,7 @@ describe("POST /v1/internal/tests/admin/apply-migrations — success path", () =
     const body = await res.json();
     expect(body).toEqual({
       ok: true,
-      block_count: 6,
+      block_count: 7,
       blocks: fakeBlocks,
     });
   });


### PR DESCRIPTION
## Summary
Two test-honesty fixes surfaced by the retrospective six-lens review on this session's four merged PRs (#52/#53/#54/#55). Both items independently rated **MEDIUM** by the technical + product reviewer passes. Test-only PR — no production code changes.

- **Item #1 (founder lens, confidence 88):** `fakeBlocks` fixture in `apps/api/src/routes/admin-apply-migrations.test.ts` was stale at 6 entries / `block_count: 6` after PR #55 added block 0063. Test still passed (the mock returns whatever you hand it), but the file now contradicted `startup-migrations.test.ts`'s BLOCKS pin which correctly lists 7 entries. Fixture extended to 7 entries, `block_count: 7`.
- **Item #4 (senior dev lens, confidence 82):** the orchestrator failure-aborts test at `startup-migrations.test.ts:277-289` called `runMigration0062_paidVendorCosts(stub)` directly — pinning per-block behaviour, not the orchestrator's contract. A future engineer adding `try/catch/continue` around the BLOCKS loop in `runStartupMigrations()` wouldn't see this test fail. Per DEC-20260504-A, the regression test must fail against the un-applied fix; this one passed regardless. Replaced with two tests that mock `getDb()` via `vi.mock` and call `runStartupMigrations()` directly: (1) executor-level failure on first query, (2) realistic post-condition violation in block 0062 with 9 canned responses scripting the path through 0028-0062.

## Verification
- `npx tsc --noEmit --project apps/api/tsconfig.json` — clean.
- `npx vitest run src/lib/startup-migrations.test.ts src/routes/admin-apply-migrations.test.ts` — **23 pass / 0 fail** (+2 new orchestrator tests; 21 → 23).
- Both new tests verified to fail against the hypothetical un-applied fix: with a `try/catch/continue` wrapper around the BLOCKS loop, `runStartupMigrations()` would resolve cleanly and `rejects.toThrow` would fail. ✓

## Per active protocols
- **DEC-20260504-A:** this PR *is* the regression-net honesty fix the protocol describes. The meta-test (BLOCKS pin) catches the same drift class going forward.
- **DEC-20260504-B / -C:** not applicable (tests only).

## Reviewer findings — clean (technical + product)
This PR is itself the response to the prior retro review's MEDIUM findings #1 and #4. Items #2 (postgres-js `::int` type-coercion runtime check), #3 (admin-handler 503 first-guard pattern), and #5 (`BlockResult.outcome` shape decision) are tracked separately — #2 will get its own PR after a one-shot prod probe confirms whether the assertion is broken or just stylistically inconsistent; #3 and #5 are filed as Notion to-dos.

## Test plan
- Reviewer: confirm `fakeBlocks` in `admin-apply-migrations.test.ts` now has 7 entries with `0063_invoice_extract_cost_reclassify` last, and `block_count: 7`.
- Reviewer: confirm the new orchestrator tests use `vi.mock("../db/index.js", ...)` to inject the executor stub, and that they call `runStartupMigrations()` (not a per-block function).
- Reviewer: confirm the two new tests' assertions match-pattern the actual error messages (one is the simulated executor failure, the other is the 0062 post-condition string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>