### PR TITLE
docs(startup-migrations): document postgres-js coercion shapes per audit

### DIFF
--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -67,6 +67,7 @@ export async function runMigration0028_sqsDailySnapshot(
   tx: MigrationExecutor,
 ): Promise<BlockResult> {
   const startedAt = Date.now();
+  // information_schema column counts return bigint; coerce via text to avoid postgres-js's bigint→string default.
   const check = await tx.execute(sql`
     SELECT count(*)::text AS cnt FROM information_schema.tables
     WHERE table_name = 'sqs_daily_snapshot'
@@ -125,6 +126,7 @@ export async function runMigration0029_actualCostCents(
   tx: MigrationExecutor,
 ): Promise<BlockResult> {
   const startedAt = Date.now();
+  // information_schema column counts return bigint; coerce via text to avoid postgres-js's bigint→string default.
   const check = await tx.execute(sql`
     SELECT count(*)::text AS cnt FROM information_schema.columns
     WHERE table_name = 'test_run_log' AND column_name = 'actual_cost_cents'
@@ -167,6 +169,7 @@ export async function runMigration0030_complianceColumns(
   tx: MigrationExecutor,
 ): Promise<BlockResult> {
   const startedAt = Date.now();
+  // information_schema column counts return bigint; coerce via text to avoid postgres-js's bigint→string default.
   const check = await tx.execute(sql`
     SELECT count(*)::text AS cnt FROM information_schema.columns
     WHERE table_name = 'transactions' AND column_name = 'integrity_hash'
@@ -281,6 +284,7 @@ export async function runMigration0062_paidVendorCosts(
   // If any are, a new suite was added since the last apply or a manual
   // edit cleared the value. Fail boot in that case so the operator
   // notices.
+  // COUNT(*)::int → postgres-js coerces int4 to JS number; assertion fires correctly.
   const checkRows = await tx.execute(sql`
     SELECT COUNT(*)::int AS remaining_zero
     FROM test_suites
@@ -356,6 +360,7 @@ export async function runMigration0063_invoiceExtractCostReclassify(
   // Post-condition: no active live non-probe suite for invoice-extract
   // may remain at 0 after this block. If a new suite shows up at 0,
   // fail boot so the operator notices.
+  // COUNT(*)::int → postgres-js coerces int4 to JS number; assertion fires correctly.
   const checkRows = await tx.execute(sql`
     SELECT COUNT(*)::int AS remaining_zero
     FROM test_suites


### PR DESCRIPTION
## Summary
Five one-line comments documenting verified postgres-js driver behaviour for the two distinct coercion patterns in `apps/api/src/lib/startup-migrations.ts`. **Pure documentation; no behaviour change.**

Preserves the conclusion of the 2026-05-04 retro-review item #2 audit (probe against prod confirmed `COUNT(*)::int` is reliably coerced to JS `number` by postgres-js, so post-condition assertions fire correctly) directly in the codebase.

## Why not the consistency PR?
The retro review initially proposed aligning the two patterns to a single `::text + parseInt` shape. The audit established that the inconsistency is **intentional signal**:

- `information_schema count(*)` returns `bigint`. postgres-js's default serialization of `bigint` is **string**. The blocks 0028 / 0029 / 0030 patterns cast via `::text` and string-compare against `"0"` to avoid that ambiguity.
- `COUNT(*)::int` produces `int4`. postgres-js reliably coerces `int4` to JS `number`. Blocks 0062 / 0063's post-condition assertions compare numerically.

Aligning the two would obscure the real distinction between `int4` (reliable) and `bigint` (driver-default-string). Documenting the rationale preserves the finding without the consistency churn.

## Five comments added (one each)
- Block 0028 (line 70): `// information_schema column counts return bigint; coerce via text to avoid postgres-js's bigint→string default.`
- Block 0029 (line 129): same.
- Block 0030 (line 171): same.
- Block 0062 (line 285): `// COUNT(*)::int → postgres-js coerces int4 to JS number; assertion fires correctly.`
- Block 0063 (line 317): same.

## Verification
- `npx tsc --noEmit --project apps/api/tsconfig.json` — clean.
- `npx vitest run src/lib/startup-migrations.test.ts` — 17 pass / 0 fail (no behaviour change).

## Per active protocols
- DEC-20260504-A: comments only, no new code path. No regression test required.
- DEC-20260504-B / -C: not applicable.

## Reviewer findings — clean (technical + product)
Documentation-only PR derived from a runtime probe against prod. The probe code itself was a one-shot `/tmp` script per the audit instruction; not committed.

## Test plan
- Reviewer: confirm each comment lands directly above the relevant `tx.execute(sql\`...\`)` block.
- Reviewer: confirm the rationale text matches what the audit established (int4 → number, bigint → string-via-text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>