### PR TITLE
fix(browserless): pass Chrome flags per-request — Browserless v2 LAUNCH_ARGS env is deprecated

### DIFF
--- a/apps/api/src/capabilities/annual-report-extract.ts
+++ b/apps/api/src/capabilities/annual-report-extract.ts
@@ -67,7 +67,10 @@ async function findAnnualReportPdf(
 
   // Strategy 1: Try Allabolag's annual report page which links to PDF downloads
   const allabolagUrl = `https://www.allabolag.se/${cleanOrg}/arsredovisning`;
-  const contentUrl = `${browserlessUrl}/content?token=${browserlessKey}`;
+  // buildBrowserlessRequestUrl appends ?launch= per-request — Browserless v2's
+  // LAUNCH_ARGS env var is deprecated/ignored. See lib/browserless-launch.ts.
+  const { buildBrowserlessRequestUrl } = await import("../lib/browserless-launch.js");
+  const contentUrl = buildBrowserlessRequestUrl(browserlessUrl, "/content", browserlessKey);
 
   const pageResponse = await fetch(contentUrl, {
     method: "POST",

--- a/apps/api/src/capabilities/company-enrich.ts
+++ b/apps/api/src/capabilities/company-enrich.ts
@@ -36,7 +36,10 @@ async function scrapeUrl(url: string): Promise<string> {
     throw new Error("BROWSERLESS_URL and BROWSERLESS_API_KEY are required.");
   }
 
-  const contentUrl = `${browserlessUrl}/content?token=${browserlessKey}`;
+  // buildBrowserlessRequestUrl appends ?launch= per-request — Browserless v2's
+  // LAUNCH_ARGS env var is deprecated/ignored. See lib/browserless-launch.ts.
+  const { buildBrowserlessRequestUrl } = await import("../lib/browserless-launch.js");
+  const contentUrl = buildBrowserlessRequestUrl(browserlessUrl, "/content", browserlessKey);
   const response = await fetch(contentUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/api/src/capabilities/estonian-company-data.ts
+++ b/apps/api/src/capabilities/estonian-company-data.ts
@@ -33,7 +33,10 @@ async function extractCompanyName(text: string): Promise<string> {
 async function fetchApiViaProxy(apiUrl: string): Promise<unknown> {
   const { url, key } = getBrowserlessConfig();
   // Browserless v2 cloud uses ?token= query auth — Bearer is rejected at edge.
-  const resp = await fetch(`${url}/content?token=${encodeURIComponent(key)}`, {
+  // buildBrowserlessRequestUrl also appends ?launch= per-request, required by
+  // Browserless v2 (LAUNCH_ARGS env var is deprecated). See lib/browserless-launch.ts.
+  const { buildBrowserlessRequestUrl } = await import("../lib/browserless-launch.js");
+  const resp = await fetch(buildBrowserlessRequestUrl(url, "/content", key), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/apps/api/src/capabilities/html-to-pdf.ts
+++ b/apps/api/src/capabilities/html-to-pdf.ts
@@ -1,5 +1,6 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { getBrowserlessConfig } from "./lib/browserless-extract.js";
+import { buildBrowserlessRequestUrl } from "../lib/browserless-launch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
 registerCapability("html-to-pdf", async (input: CapabilityInput) => {
@@ -13,7 +14,9 @@ registerCapability("html-to-pdf", async (input: CapabilityInput) => {
   const margins = (input.margins as Record<string, string>) ?? { top: "1cm", right: "1cm", bottom: "1cm", left: "1cm" };
 
   const { url: blessUrl, key } = getBrowserlessConfig();
-  const endpoint = `${blessUrl}/pdf?token=${key}`;
+  // buildBrowserlessRequestUrl appends ?launch= per-request, required by
+  // Browserless v2 (LAUNCH_ARGS env var is deprecated). See lib/browserless-launch.ts.
+  const endpoint = buildBrowserlessRequestUrl(blessUrl, "/pdf", key);
 
   const bodyObj: Record<string, unknown> = {
     options: {

--- a/apps/api/src/capabilities/lib/web-provider.ts
+++ b/apps/api/src/capabilities/lib/web-provider.ts
@@ -20,6 +20,7 @@
  * `fetchPage` is the only layer we own for tiers 2 and 3.
  */
 
+import { buildBrowserlessRequestUrl } from "../../lib/browserless-launch.js";
 import { safeFetch } from "../../lib/safe-fetch.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -284,7 +285,10 @@ export async function fetchPage(
     // Browserless v2 cloud (production-*.browserless.io) uses ?token= query
     // string auth, not Authorization: Bearer. Bearer is rejected at the
     // openresty edge with HTTP 500 before reaching the account.
-    const contentUrl = `${url}/content?token=${encodeURIComponent(key)}`;
+    // buildBrowserlessRequestUrl also appends the per-request `?launch=`
+    // query param Browserless v2 requires for Chrome flags (LAUNCH_ARGS
+    // env var is deprecated and ignored — see lib/browserless-launch.ts).
+    const contentUrl = buildBrowserlessRequestUrl(url, "/content", key);
 
     let lastError: Error | null = null;
 

--- a/apps/api/src/capabilities/screenshot-url.ts
+++ b/apps/api/src/capabilities/screenshot-url.ts
@@ -1,5 +1,6 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { getBrowserlessConfig } from "./lib/browserless-extract.js";
+import { buildBrowserlessRequestUrl } from "../lib/browserless-launch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
 registerCapability("screenshot-url", async (input: CapabilityInput) => {
@@ -17,7 +18,9 @@ registerCapability("screenshot-url", async (input: CapabilityInput) => {
   await validateUrl(fullUrl);
 
   const { url: blessUrl, key } = getBrowserlessConfig();
-  const endpoint = `${blessUrl}/screenshot?token=${key}`;
+  // buildBrowserlessRequestUrl appends ?launch= per-request, required by
+  // Browserless v2 (LAUNCH_ARGS env var is deprecated). See lib/browserless-launch.ts.
+  const endpoint = buildBrowserlessRequestUrl(blessUrl, "/screenshot", key);
 
   const gotoOptions: Record<string, unknown> = { waitUntil: "networkidle0", timeout: 25000 };
 

--- a/apps/api/src/capabilities/web-extract.ts
+++ b/apps/api/src/capabilities/web-extract.ts
@@ -34,7 +34,10 @@ registerCapability("web-extract", async (input: CapabilityInput) => {
   }
 
   // Step 1: Render page with Browserless
-  const contentUrl = `${browserlessUrl}/content?token=${browserlessKey}`;
+  // buildBrowserlessRequestUrl appends ?launch= per-request — Browserless v2's
+  // LAUNCH_ARGS env var is deprecated/ignored. See lib/browserless-launch.ts.
+  const { buildBrowserlessRequestUrl } = await import("../lib/browserless-launch.js");
+  const contentUrl = buildBrowserlessRequestUrl(browserlessUrl, "/content", browserlessKey);
 
   const renderResponse = await fetch(contentUrl, {
     method: "POST",

--- a/apps/api/src/lib/browserless-launch.test.ts
+++ b/apps/api/src/lib/browserless-launch.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Per DEC-20260504-A: regression test for the Browserless v2 per-request
+ * launch-args helper. Asserts both the encoding shape (so a future edit
+ * can't silently swap to a broken format) and the URL builder shape (so
+ * call sites importing it can rely on the contract).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  BROWSERLESS_LAUNCH_ARGS,
+  LAUNCH_QUERY_PARAM,
+  buildBrowserlessRequestUrl,
+} from "./browserless-launch.js";
+
+describe("BROWSERLESS_LAUNCH_ARGS", () => {
+  it("contains the four flags required for Railway-hosted chromium to launch", () => {
+    expect([...BROWSERLESS_LAUNCH_ARGS]).toEqual([
+      "--no-sandbox",
+      "--disable-dev-shm-usage",
+      "--disable-gpu",
+      "--disable-setuid-sandbox",
+    ]);
+  });
+});
+
+describe("LAUNCH_QUERY_PARAM", () => {
+  it("is a base64-encoded JSON object with an `args` array equal to BROWSERLESS_LAUNCH_ARGS", () => {
+    expect(LAUNCH_QUERY_PARAM.startsWith("launch=")).toBe(true);
+    const base64 = LAUNCH_QUERY_PARAM.slice("launch=".length);
+    const decoded = Buffer.from(base64, "base64").toString("utf-8");
+    const parsed = JSON.parse(decoded);
+    expect(parsed).toEqual({ args: [...BROWSERLESS_LAUNCH_ARGS] });
+  });
+
+  it("does not contain raw special characters that would need URL-encoding (the whole point of base64)", () => {
+    expect(LAUNCH_QUERY_PARAM).not.toMatch(/[{}",\[\]]/);
+  });
+});
+
+describe("buildBrowserlessRequestUrl", () => {
+  it("composes baseUrl + path + token + launch query in the canonical order", () => {
+    const url = buildBrowserlessRequestUrl(
+      "http://chromium.railway.internal:8080",
+      "/content",
+      "strale-browser-2026",
+    );
+    expect(url).toBe(
+      "http://chromium.railway.internal:8080/content?token=strale-browser-2026&" +
+        LAUNCH_QUERY_PARAM,
+    );
+  });
+
+  it("URL-encodes tokens with reserved characters", () => {
+    const url = buildBrowserlessRequestUrl(
+      "https://example.com",
+      "/content",
+      "tok+with/special=chars",
+    );
+    expect(url).toContain("token=tok%2Bwith%2Fspecial%3Dchars");
+    expect(url).toContain(LAUNCH_QUERY_PARAM);
+  });
+
+  it("works against the public hosted Browserless URL shape (regression for the post-flip rollback path)", () => {
+    const url = buildBrowserlessRequestUrl(
+      "https://production-sfo.browserless.io",
+      "/content",
+      "abc123",
+    );
+    expect(url).toBe(
+      "https://production-sfo.browserless.io/content?token=abc123&" +
+        LAUNCH_QUERY_PARAM,
+    );
+  });
+});

--- a/apps/api/src/lib/browserless-launch.ts
+++ b/apps/api/src/lib/browserless-launch.ts
@@ -1,0 +1,50 @@
+/**
+ * Browserless v2 ignores the `LAUNCH_ARGS` env var — it's listed in the
+ * `deprecatedConfig` enum and silently dropped at process start with a
+ * deprecation warning. Chrome flags MUST be passed per-request via the
+ * `?launch=<base64 JSON>` query parameter on every Browserless API call.
+ *
+ * See https://github.com/browserless/browserless/blob/main/src/config.ts
+ * (search `deprecatedConfig`) — confirmed during 2026-05-04 chromium-
+ * service repair when the Railway-hosted instance was discovered to be
+ * crash-looping on every Chrome launch.
+ *
+ * Without `--no-sandbox` + `--disable-dev-shm-usage`, Chrome on Railway
+ * containers crashes during startup reading
+ * `/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq` and then
+ * triggers `pthread_create: Resource temporarily unavailable` (EAGAIN)
+ * on every request. Both failure modes were documented in
+ * `apps/api/railway-config.md` against Browserless v1's env-var
+ * pass-through; v2 dropped that mechanism but the docs were never
+ * updated.
+ *
+ * The hosted service (`production-sfo.browserless.io`) tolerates these
+ * defaults because its container runtime exposes the cpufreq files;
+ * the failure is specific to Railway's containerd runtime, which
+ * doesn't.
+ */
+
+const BROWSERLESS_LAUNCH_ARGS = [
+  "--no-sandbox",
+  "--disable-dev-shm-usage",
+  "--disable-gpu",
+  "--disable-setuid-sandbox",
+] as const;
+
+const LAUNCH_QUERY_PARAM =
+  "launch=" +
+  Buffer.from(JSON.stringify({ args: BROWSERLESS_LAUNCH_ARGS })).toString("base64");
+
+export { BROWSERLESS_LAUNCH_ARGS, LAUNCH_QUERY_PARAM };
+
+/**
+ * Build a Browserless v2 request URL with token auth + launch args.
+ * `path` includes the leading slash (e.g. `/content`).
+ */
+export function buildBrowserlessRequestUrl(
+  baseUrl: string,
+  path: string,
+  token: string,
+): string {
+  return `${baseUrl}${path}?token=${encodeURIComponent(token)}&${LAUNCH_QUERY_PARAM}`;
+}

--- a/apps/api/src/lib/chromium-health.ts
+++ b/apps/api/src/lib/chromium-health.ts
@@ -15,6 +15,7 @@
 import { eq } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { capabilities } from "../db/schema.js";
+import { buildBrowserlessRequestUrl } from "./browserless-launch.js";
 import { fireAndForget } from "./fire-and-forget.js";
 import { log, logError, logWarn } from "./log.js";
 
@@ -102,7 +103,10 @@ export async function probeChromiumHealth(): Promise<boolean> {
 
   try {
     // Browserless v2 cloud uses ?token= query auth — Bearer is rejected at edge.
-    const res = await fetch(`${url}/content?token=${encodeURIComponent(key)}`, {
+    // buildBrowserlessRequestUrl also appends the per-request `?launch=` query
+    // param required by Browserless v2 (LAUNCH_ARGS env var is deprecated and
+    // ignored — see browserless-launch.ts for the discovery context).
+    const res = await fetch(buildBrowserlessRequestUrl(url, "/content", key), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- New helper `apps/api/src/lib/browserless-launch.ts` exporting `buildBrowserlessRequestUrl(baseUrl, path, token)` which appends both the `?token=` auth and the `?launch=<base64 JSON>` per-request Chrome flags.
- Wired into all 8 Browserless call sites: probe + 7 capability paths.
- 6 regression tests covering base64-JSON shape, args list, URL builder shape, and token URL-encoding.

## Why this PR exists (2026-05-04 chromium service repair)
Tonight's audit of the Railway-hosted chromium service (`chromium.railway.internal:8080`) found it crash-looping every Chrome launch. Read Browserless v2's `src/config.ts` directly: **`LAUNCH_ARGS` is in the `deprecatedConfig` enum** and the value is silently dropped at startup with a deprecation warning. v2 takes Chrome flags ONLY per-request via `?launch=<base64 JSON>` query param on every API call.

Source: https://github.com/browserless/browserless/blob/main/src/config.ts

Without `--no-sandbox` + `--disable-dev-shm-usage`, Chrome on Railway's containerd runtime (which lacks `/sys/devices/system/cpu/cpu0/cpufreq/*`) crashes during startup reading `scaling_max_freq`, then `pthread_create` fails with EAGAIN as the sandbox tries to spawn renderer processes under tightened resource isolation. With these flags, Chrome runs as a single process tree — works on Railway.

The hosted service (`production-sfo.browserless.io`) tolerates the v2 defaults because its container runtime exposes the cpufreq files. The self-hosted Railway container does not. `apps/api/railway-config.md` was written against Browserless v1's env-var pass-through; v2 dropped that mechanism and the docs were never updated.

## Touch sites
| File | Endpoint | Change |
|---|---|---|
| `src/lib/browserless-launch.ts` | — | new helper |
| `src/lib/browserless-launch.test.ts` | — | 6 regression tests |
| `src/lib/chromium-health.ts` | `/content` | probe |
| `src/capabilities/lib/web-provider.ts` | `/content` | most caps via fetchPage |
| `src/capabilities/annual-report-extract.ts` | `/content` | inline |
| `src/capabilities/company-enrich.ts` | `/content` | inline |
| `src/capabilities/estonian-company-data.ts` | `/content` | inline |
| `src/capabilities/web-extract.ts` | `/content` | inline |
| `src/capabilities/screenshot-url.ts` | `/screenshot` | direct |
| `src/capabilities/html-to-pdf.ts` | `/pdf` | direct |

## Verification (this PR)
- `npx tsc --noEmit --project apps/api/tsconfig.json` — clean.
- `npx vitest run src/lib/browserless-launch.test.ts` — **6 pass / 0 fail**.
- No runtime change against the public hosted Browserless service — the helper appends a query param the hosted service has always accepted, so the rollback path remains the previous env-var values.

## Per active protocols
- **DEC-20260504-A**: `browserless-launch.test.ts` asserts both encoding shape (base64 JSON with the expected `args` list) and URL builder shape (correct ordering, URL-encoded token, no raw special chars in `launch=`). The test fails without the helper file (no exports to import) and passes with it.
- **DEC-20260504-C**: this PR is the prerequisite code change. The env-var routing flip + 5x probe stability + real `/v1/do screenshot-url` + 10-min monitoring is the next-step verification path. Code change without env flip is a no-op for the chromium service path; with env flip, the change is what makes the route work.
- **DEC-20260504-B**: not applicable (not a long-silent bulk operation).

## Reviewer findings — clean (technical + product)
Single conceptual change (per-request launch args), uniformly applied. The dynamic `await import()` pattern in 4 of the inline-call-site files is matching the existing dynamic-import idiom in those files (e.g. annual-report-extract.ts already does this for url-validator); not introduced by this PR. Helper module avoids 8-way duplication.

## Test plan
- Reviewer: confirm `BROWSERLESS_LAUNCH_ARGS` contains the four required flags in the right order.
- Reviewer: confirm comment in `browserless-launch.ts` references the v2 source line where `LAUNCH_ARGS` is in `deprecatedConfig`.
- Reviewer: post-merge, confirm strale env vars get flipped to internal targets and the chromium service starts logging `Current period usage` with `successful > 0` (currently zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>