### PR TITLE
feat(capability): german-company-data via OpenRegister Free tier

### DIFF
--- a/apps/api/src/capabilities/auto-register.ts
+++ b/apps/api/src/capabilities/auto-register.ts
@@ -164,15 +164,11 @@ const DEACTIVATED = new Map<string, string>([
     // (via Colegio de Registradores) or a multi-country licensed aggregator.
     "empresia.es / infocif.es scraping prohibited by ToS; pending licensed ES registry or aggregator contract (see DEC-20260427-I)",
   ],
-  [
-    "german-company-data",
-    // DEC-20260427-I-5: Runtime fetched northdata.com. Manifest acknowledged "via
-    // northdata.com" (transport-divergence — at least honest), but the underlying
-    // ToS-prohibited scrape remains.
-    // Reactivation trigger: licensed contract with Handelsregister Bundesanzeiger
-    // (via Bundesanzeiger Verlag) or a multi-country licensed aggregator.
-    "northdata.com scraping prohibited by ToS; pending licensed Handelsregister or aggregator contract (see DEC-20260427-I)",
-  ],
+  // german-company-data REACTIVATED 2026-05-06: migrated from northdata.com
+  // ToS-prohibited scrape (DEC-20260427-I-5) to direct OpenRegister API
+  // (api.openregister.de). Free tier 50 req/mo per DEC-20260505-H +
+  // DEC-20260506-G; auth via OPENREGISTER_API_KEY. acquisition_method:
+  // direct_api per DEC-20260428-A Tier 2.
   [
     "austrian-company-data",
     // DEC-20260427-I-6: Primary runtime fetched firmenbuch.finapu.com (commercial

--- a/apps/api/src/capabilities/german-company-data.ts
+++ b/apps/api/src/capabilities/german-company-data.ts
@@ -1,96 +1,268 @@
-import Anthropic from "@anthropic-ai/sdk";
 import { registerCapability, type CapabilityInput } from "./index.js";
-import { searchNorthdata } from "./lib/northdata.js";
 
-/*
- * German Company Data — northdata.com JSON-LD extraction
- *
- * Accepts company name (e.g. "BMW", "Siemens"), HRB number + court,
- * or any natural-language input. Abbreviations are expanded to full
- * legal names via LLM before searching northdata.com.
- *
- * Bug fix causal chain (2026-04-10):
- * - HRB/HRA numbers are per-court, not globally unique.
- * - northdata needs legal names, not abbreviations ("BMW" fails,
- *   "Bayerische Motoren Werke" succeeds).
- * - Fix (2026-04-12): LLM expands abbreviations before search.
- */
+// German company data via OpenRegister (https://api.openregister.de).
+// Replaces the deactivated northdata.com scraper (DEC-20260427-I) with a
+// licensed Tier-2 partner-API path per DEC-20260505-H. Free tier: 50 req/mo.
+//
+// Inputs accepted (in priority order):
+//   - company_id       OpenRegister canonical id, e.g. "DE-HRB-F1103-267645"
+//   - hrb_number       Handelsregister number ("HRB 2001"), with court (Registergericht)
+//   - company_name     fuzzy text — resolved via /v1/autocomplete/company
+//
+// Real-time fetches (?realtime=true, +10 credits per call) are intentionally
+// NOT exposed — out of scope per DEC-20260506-G. OpenRegister's stored data is
+// refreshed every ≤4 weeks with daily updates for financials and new
+// incorporations, which is the correct cadence for the Free tier price point.
 
-const HRB_RE = /^(HRB|HRA|GnR|PR|VR)\s*\d+$/i;
+const API = "https://api.openregister.de";
+const TIMEOUT_MS = 10_000;
 
-async function expandCompanyName(input: string): Promise<string> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) return input; // fallback: use input as-is
-  const client = new Anthropic({ apiKey });
-  const r = await client.messages.create({
-    model: "claude-haiku-4-5-20251001",
-    max_tokens: 150,
-    messages: [{
-      role: "user",
-      content: `You are looking up a German company. The user provided: "${input}"
+// OpenRegister canonical id: "DE-{REGISTER_TYPE}-{COURT_CODE}-{NUMBER}".
+const COMPANY_ID_RE = /^DE-(HRB|HRA|GnR|PR|VR|GsR)-[A-Z0-9]+-\d+$/i;
+const HRB_RE = /^(HRB|HRA|GnR|PR|VR|GsR)\s*\d+$/i;
 
-If this is an abbreviation or short name (like "BMW", "VW", "SAP"), expand it to the full legal company name as registered in the German Handelsregister. Include the legal form suffix (AG, GmbH, SE, etc.).
+interface AutocompleteResult {
+  company_id: string;
+  name: string;
+  country: string;
+  register_number: string;
+  register_type: string;
+  register_court: string;
+  active: boolean;
+  legal_form: string | null;
+}
 
-If it's already a full legal name, return it as-is.
+interface AutocompleteResponse {
+  results?: AutocompleteResult[];
+}
 
-Return ONLY the company name, nothing else. No explanation.`,
-    }],
-  });
-  const name = r.content[0].type === "text" ? r.content[0].text.trim().replace(/^["']|["']$/g, "") : "";
-  return name || input;
+interface CompanyV1 {
+  id: string;
+  register?: { type?: string | null; number?: string | null; court?: string | null } | null;
+  status?: string | null;
+  name?: string | null;
+  names?: Array<{ value?: string | null; type?: string | null }> | null;
+  address?: {
+    street?: string | null;
+    house_number?: string | null;
+    postal_code?: string | null;
+    city?: string | null;
+    country?: string | null;
+    co?: string | null;
+  } | null;
+  purpose?: string | null;
+  capital?: { amount?: number | null; currency?: string | null } | null;
+  representation?: Array<{
+    name?: string | null;
+    first_name?: string | null;
+    last_name?: string | null;
+    role?: string | null;
+    type?: string | null;
+  }> | null;
+  legal_form?: string | null;
+  lei?: string | null;
+  incorporated_at?: string | null;
+  terminated_at?: string | null;
+  industry_codes?: Array<{ code?: string | null; description?: string | null }> | null;
+  sources?: Array<Record<string, unknown>> | null;
+}
+
+function getApiKey(): string {
+  const key = process.env.OPENREGISTER_API_KEY;
+  if (!key) {
+    throw new Error(
+      "OPENREGISTER_API_KEY is required. Register at https://openregister.de/keys (50 free req/mo).",
+    );
+  }
+  return key;
+}
+
+function authHeaders(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${getApiKey()}`,
+    Accept: "application/json",
+  };
+}
+
+function classifyHttp(status: number, body: unknown): never {
+  // Free-tier exhaustion or burst-rate limit. Surface as graceful unavailability —
+  // the framework's circuit breaker (recordFailure in do.ts) will trip after
+  // 3 consecutive failures and protect downstream callers.
+  if (status === 429) {
+    throw new Error(
+      "capability-unavailable: OpenRegister rate limit hit (HTTP 429). " +
+      "Free tier is capped at 50 requests/month and resets on the 1st. " +
+      "Try again next billing cycle or upgrade per DEC-20260505-H.",
+    );
+  }
+  if (status === 401 || status === 403) {
+    throw new Error(`OpenRegister rejected the API key (HTTP ${status}).`);
+  }
+  if (status === 404) {
+    throw new Error("OpenRegister returned 404 — company not found.");
+  }
+  if (status >= 500) {
+    throw new Error(`OpenRegister upstream error (HTTP ${status}). Retry advised.`);
+  }
+  const detail = typeof body === "object" && body !== null && "message" in body
+    ? String((body as { message?: unknown }).message)
+    : "";
+  throw new Error(
+    `OpenRegister returned HTTP ${status}${detail ? `: ${detail.slice(0, 160)}` : ""}.`,
+  );
+}
+
+async function autocomplete(query: string): Promise<AutocompleteResult> {
+  const url = `${API}/v1/autocomplete/company?query=${encodeURIComponent(query)}`;
+  const r = await fetch(url, { headers: authHeaders(), signal: AbortSignal.timeout(TIMEOUT_MS) });
+  if (!r.ok) {
+    const body = (await r.json().catch(() => ({}))) as unknown;
+    classifyHttp(r.status, body);
+  }
+  const data = (await r.json()) as AutocompleteResponse;
+  const top = data.results?.[0];
+  if (!top || !top.company_id) {
+    throw new Error(`No German company found matching "${query}".`);
+  }
+  return top;
+}
+
+async function fetchCompany(companyId: string): Promise<CompanyV1> {
+  const url = `${API}/v1/company/${encodeURIComponent(companyId)}`;
+  const r = await fetch(url, { headers: authHeaders(), signal: AbortSignal.timeout(TIMEOUT_MS) });
+  if (!r.ok) {
+    const body = (await r.json().catch(() => ({}))) as unknown;
+    classifyHttp(r.status, body);
+  }
+  const data = (await r.json()) as CompanyV1;
+  if (!data || !data.id) {
+    throw new Error(`OpenRegister returned no record for ${companyId}.`);
+  }
+  return data;
+}
+
+function normaliseStatus(raw: string | null | undefined, terminatedAt: string | null | undefined): {
+  status: "active" | "terminated" | "unknown";
+  is_active: boolean | null;
+} {
+  if (terminatedAt) return { status: "terminated", is_active: false };
+  const v = (raw ?? "").toLowerCase();
+  if (v.includes("active") || v === "ok") return { status: "active", is_active: true };
+  if (v.includes("liquidat") || v.includes("terminated") || v.includes("dissolved")) {
+    return { status: "terminated", is_active: false };
+  }
+  if (!v) return { status: "unknown", is_active: null };
+  return { status: "unknown", is_active: null };
+}
+
+function buildAddress(a: CompanyV1["address"]): Record<string, string | null> | null {
+  if (!a) return null;
+  const street = [a.street, a.house_number].filter((s): s is string => !!s && s.trim().length > 0).join(" ").trim() || null;
+  const postal_code = a.postal_code?.trim() || null;
+  const city = a.city?.trim() || null;
+  const country = a.country?.trim() || "Deutschland";
+  const co_address = a.co?.trim() || null;
+  if (!street && !postal_code && !city) return null;
+  return { street, postal_code, city, country, co_address };
+}
+
+function buildDirectors(reps: CompanyV1["representation"]): Array<{ name: string; role: string | null }> {
+  if (!reps) return [];
+  return reps
+    .map((r) => {
+      const name = r.name?.trim()
+        || [r.first_name, r.last_name].filter((s): s is string => !!s && s.trim().length > 0).join(" ").trim();
+      if (!name) return null;
+      return { name, role: r.role?.trim() || null };
+    })
+    .filter((x): x is { name: string; role: string | null } => x !== null);
+}
+
+function formatRegistrationNumber(reg: CompanyV1["register"]): string | null {
+  if (!reg) return null;
+  const type = reg.type?.trim();
+  const num = reg.number?.trim();
+  if (type && num) return `${type} ${num}`;
+  return num ?? type ?? null;
+}
+
+function buildSources(sources: CompanyV1["sources"], fetchedAt: string): Array<Record<string, unknown>> {
+  if (!sources || sources.length === 0) {
+    return [{ source: "openregister", fetched_at: fetchedAt }];
+  }
+  return sources.map((s) => ({ ...s, fetched_at: fetchedAt }));
 }
 
 registerCapability("german-company-data", async (input: CapabilityInput) => {
+  const companyId = (input.company_id as string)?.trim() ?? "";
   const hrbNumber = (input.hrb_number as string)?.trim() ?? "";
   const companyName = (input.company_name as string)?.trim() ?? "";
   const court = (input.court as string)?.trim() ?? "";
   const task = (input.task as string)?.trim() ?? "";
 
-  // Determine which input path we're on
-  const raw = hrbNumber || companyName || task;
-  if (!raw) {
-    throw new Error("'hrb_number' or 'company_name' is required. Provide a Handelsregister number (e.g. HRB 86891) with court, or a company name.");
+  let resolvedId = "";
+
+  if (COMPANY_ID_RE.test(companyId)) {
+    resolvedId = companyId;
+  } else if (HRB_RE.test(hrbNumber)) {
+    if (!court) {
+      throw new Error(
+        "German HRB/HRA numbers are not unique across courts. 'court' (Registergericht) is required when providing a registration number. Example: { \"hrb_number\": \"HRB 2001\", \"court\": \"Amtsgericht Landsberg a. Lech\" }",
+      );
+    }
+    const courtName = court.replace(/^Amtsgericht\s+/i, "").trim();
+    const top = await autocomplete(`${hrbNumber} ${courtName}`);
+    resolvedId = top.company_id;
+  } else {
+    const query = companyName || hrbNumber || task;
+    if (!query) {
+      throw new Error(
+        "'company_id', 'hrb_number' (with 'court'), or 'company_name' is required.",
+      );
+    }
+    const top = await autocomplete(query);
+    resolvedId = top.company_id;
   }
 
-  // Detect if someone put a company name in the hrb_number field
-  const isRegNumber = HRB_RE.test(hrbNumber || raw);
-  const isNameInHrbField = hrbNumber && !isRegNumber && !companyName;
-
-  if (isRegNumber && !court) {
-    throw new Error(
-      "German HRB/HRA numbers are not unique across courts. " +
-      "'court' (Registergericht) is required when providing a registration number. " +
-      "Example: { \"hrb_number\": \"HRB 2001\", \"court\": \"Amtsgericht Landsberg a. Lech\" }",
-    );
-  }
-
-  // For name searches, expand abbreviations to full legal names
-  let searchQuery = raw;
-  if (!isRegNumber) {
-    const nameInput = isNameInHrbField ? hrbNumber : (companyName || task);
-    searchQuery = await expandCompanyName(nameInput);
-  } else if (court) {
-    const courtCity = court.replace(/^Amtsgericht\s+/i, "").trim();
-    searchQuery = `${raw} ${courtCity}`;
-  }
-
-  const output = await searchNorthdata(searchQuery, "Germany", {
-    company_name: companyName || (isNameInHrbField ? hrbNumber : null),
-    registration_number: isRegNumber ? (hrbNumber || raw) : null,
-  }, court || undefined) as unknown as Record<string, unknown>;
-
-  // Include court in output — either user-provided or auto-extracted from northdata
-  if (court) {
-    output.court = court;
-  } else if (output.court) {
-    // Court was auto-extracted from northdata HTML — keep it
-  }
+  const company = await fetchCompany(resolvedId);
+  const fetchedAt = new Date().toISOString();
+  const status = normaliseStatus(company.status, company.terminated_at);
+  const registrationNumber = formatRegistrationNumber(company.register);
 
   return {
-    output,
+    output: {
+      company_name: company.name?.trim() || null,
+      company_id: company.id,
+      registration_number: registrationNumber,
+      register_type: company.register?.type?.trim() || null,
+      court: company.register?.court?.trim() || null,
+      country_code: "DE",
+      legal_form: company.legal_form?.trim() || null,
+      status: status.status,
+      is_active: status.is_active,
+      registered_address: buildAddress(company.address),
+      business_description: company.purpose?.trim() || null,
+      industry_codes: (company.industry_codes ?? [])
+        .map((c) => ({
+          code: (c.code ?? "").trim(),
+          description: (c.description ?? "").trim() || null,
+        }))
+        .filter((c) => c.code),
+      directors: buildDirectors(company.representation),
+      capital: company.capital?.amount != null
+        ? { amount: company.capital.amount, currency: company.capital.currency ?? "EUR" }
+        : null,
+      lei: company.lei?.trim() || null,
+      incorporated_at: company.incorporated_at ? company.incorporated_at.split("T")[0] : null,
+      terminated_at: company.terminated_at ? company.terminated_at.split("T")[0] : null,
+    },
     provenance: {
-      source: "northdata.com",
-      fetched_at: new Date().toISOString(),
+      source: "OpenRegister",
+      source_url: `${API}/v1/company/${company.id}`,
+      fetched_at: fetchedAt,
+      sources: buildSources(company.sources, fetchedAt),
+      attribution: "Source: Handelsregister / Bundesanzeiger via OpenRegister",
+      acquisition_method: "direct_api",
     },
   };
 });

--- a/apps/api/src/capabilities/german-company-data.ts
+++ b/apps/api/src/capabilities/german-company-data.ts
@@ -36,29 +36,53 @@ interface AutocompleteResponse {
   results?: AutocompleteResult[];
 }
 
+// OpenRegister CompanyV1 actual response shape (verified against live API
+// 2026-05-06 against SAP SE / DE-HRB-B1601-719915). The published OpenAPI
+// summary lists field names but not their structure — three were objects
+// not strings (name, purpose) and the register sub-object uses register_*
+// prefixed keys, not the flat type/number/court shape suggested by the
+// autocomplete result.
+interface CompanyV1Name {
+  name?: string | null;
+  legal_form?: string | null;
+  start_date?: string | null;
+}
+interface CompanyV1Purpose {
+  purpose?: string | null;
+  start_date?: string | null;
+}
+interface CompanyV1Register {
+  company_id?: string | null;
+  register_court?: string | null;
+  register_number?: string | null;
+  register_type?: string | null;
+  start_date?: string | null;
+}
+interface CompanyV1Address {
+  street?: string | null;
+  postal_code?: string | null;
+  city?: string | null;
+  country?: string | null;
+  formatted_value?: string | null;
+  co?: string | null;
+}
+interface CompanyV1Representative {
+  name?: string | null;
+  role?: string | null;
+  type?: string | null;
+  natural_person?: { first_name?: string | null; last_name?: string | null } | null;
+  legal_person?: { name?: string | null } | null;
+}
 interface CompanyV1 {
   id: string;
-  register?: { type?: string | null; number?: string | null; court?: string | null } | null;
+  register?: CompanyV1Register | null;
   status?: string | null;
-  name?: string | null;
-  names?: Array<{ value?: string | null; type?: string | null }> | null;
-  address?: {
-    street?: string | null;
-    house_number?: string | null;
-    postal_code?: string | null;
-    city?: string | null;
-    country?: string | null;
-    co?: string | null;
-  } | null;
-  purpose?: string | null;
+  name?: CompanyV1Name | null;
+  names?: CompanyV1Name[] | null;
+  address?: CompanyV1Address | null;
+  purpose?: CompanyV1Purpose | null;
   capital?: { amount?: number | null; currency?: string | null } | null;
-  representation?: Array<{
-    name?: string | null;
-    first_name?: string | null;
-    last_name?: string | null;
-    role?: string | null;
-    type?: string | null;
-  }> | null;
+  representation?: CompanyV1Representative[] | null;
   legal_form?: string | null;
   lei?: string | null;
   incorporated_at?: string | null;
@@ -157,21 +181,34 @@ function normaliseStatus(raw: string | null | undefined, terminatedAt: string | 
 
 function buildAddress(a: CompanyV1["address"]): Record<string, string | null> | null {
   if (!a) return null;
-  const street = [a.street, a.house_number].filter((s): s is string => !!s && s.trim().length > 0).join(" ").trim() || null;
+  const street = a.street?.trim() || null;
   const postal_code = a.postal_code?.trim() || null;
   const city = a.city?.trim() || null;
-  const country = a.country?.trim() || "Deutschland";
+  const country = a.country?.trim() || "DE";
   const co_address = a.co?.trim() || null;
   if (!street && !postal_code && !city) return null;
   return { street, postal_code, city, country, co_address };
+}
+
+function repName(r: CompanyV1Representative): string | null {
+  const direct = r.name?.trim();
+  if (direct) return direct;
+  const np = r.natural_person;
+  if (np) {
+    const composed = [np.first_name, np.last_name]
+      .filter((s): s is string => !!s && s.trim().length > 0)
+      .join(" ")
+      .trim();
+    if (composed) return composed;
+  }
+  return r.legal_person?.name?.trim() || null;
 }
 
 function buildDirectors(reps: CompanyV1["representation"]): Array<{ name: string; role: string | null }> {
   if (!reps) return [];
   return reps
     .map((r) => {
-      const name = r.name?.trim()
-        || [r.first_name, r.last_name].filter((s): s is string => !!s && s.trim().length > 0).join(" ").trim();
+      const name = repName(r);
       if (!name) return null;
       return { name, role: r.role?.trim() || null };
     })
@@ -180,17 +217,17 @@ function buildDirectors(reps: CompanyV1["representation"]): Array<{ name: string
 
 function formatRegistrationNumber(reg: CompanyV1["register"]): string | null {
   if (!reg) return null;
-  const type = reg.type?.trim();
-  const num = reg.number?.trim();
+  const type = reg.register_type?.trim();
+  const num = reg.register_number?.trim();
   if (type && num) return `${type} ${num}`;
   return num ?? type ?? null;
 }
 
 function buildSources(sources: CompanyV1["sources"], fetchedAt: string): Array<Record<string, unknown>> {
-  if (!sources || sources.length === 0) {
+  if (!Array.isArray(sources) || sources.length === 0) {
     return [{ source: "openregister", fetched_at: fetchedAt }];
   }
-  return sources.map((s) => ({ ...s, fetched_at: fetchedAt }));
+  return sources.map((s) => ({ ...(s ?? {}), fetched_at: fetchedAt }));
 }
 
 registerCapability("german-company-data", async (input: CapabilityInput) => {
@@ -229,26 +266,31 @@ registerCapability("german-company-data", async (input: CapabilityInput) => {
   const status = normaliseStatus(company.status, company.terminated_at);
   const registrationNumber = formatRegistrationNumber(company.register);
 
+  const resolvedName = company.name?.name?.trim() || company.names?.[0]?.name?.trim() || null;
+  const businessDescription = company.purpose?.purpose?.trim() || null;
+
   return {
     output: {
-      company_name: company.name?.trim() || null,
+      company_name: resolvedName,
       company_id: company.id,
       registration_number: registrationNumber,
-      register_type: company.register?.type?.trim() || null,
-      court: company.register?.court?.trim() || null,
+      register_type: company.register?.register_type?.trim() || null,
+      court: company.register?.register_court?.trim() || null,
       country_code: "DE",
       legal_form: company.legal_form?.trim() || null,
       status: status.status,
       is_active: status.is_active,
       registered_address: buildAddress(company.address),
-      business_description: company.purpose?.trim() || null,
-      industry_codes: (company.industry_codes ?? [])
-        .map((c) => ({
-          code: (c.code ?? "").trim(),
-          description: (c.description ?? "").trim() || null,
-        }))
-        .filter((c) => c.code),
-      directors: buildDirectors(company.representation),
+      business_description: businessDescription,
+      industry_codes: Array.isArray(company.industry_codes)
+        ? company.industry_codes
+            .map((c) => ({
+              code: (c?.code ?? "").trim(),
+              description: (c?.description ?? "").trim() || null,
+            }))
+            .filter((c) => c.code)
+        : [],
+      directors: Array.isArray(company.representation) ? buildDirectors(company.representation) : [],
       capital: company.capital?.amount != null
         ? { amount: company.capital.amount, currency: company.capital.currency ?? "EUR" }
         : null,

--- a/manifests/german-company-data.yaml
+++ b/manifests/german-company-data.yaml
@@ -1,65 +1,104 @@
 slug: german-company-data
-name: German Company Data
+name: German Company Data (OpenRegister)
 description: >-
-  [TEMPORARILY UNAVAILABLE 2026-04-29 — pending licensed Handelsregister or aggregator contract per DEC-20260428-A.]
-  Look up German company data from the Handelsregister. Accepts HRB/HRA number with court (Registergericht), or a fuzzy
-  company name.
-category: data-extraction
-price_cents: 80
+  Look up German Handelsregister company data via OpenRegister. Returns name, registration number, court, legal form,
+  status, address, directors, capital, LEI, incorporation and termination dates.
+category: company-data
+price_cents: 5
 is_free_tier: false
+avg_latency_ms: 600
 input_schema:
   type: object
   required: []
   properties:
+    company_id:
+      type: string
+      description: >-
+        OpenRegister canonical id, e.g. "DE-HRB-F1103-267645". Preferred when known —
+        skips name resolution and consumes one fewer API call.
     hrb_number:
       type: string
       description: >-
-        Handelsregister number (e.g. HRB 2001) or company name.
-        When providing a registration number, 'court' is also required.
+        Handelsregister number (e.g. "HRB 2001"). When provided, 'court' is also required —
+        HRB/HRA numbers are per-court and not globally unique.
     court:
       type: string
       description: >-
-        Registergericht (German commercial court). Required when providing
-        a registration number. HRB/HRA numbers are per-court and not globally
-        unique. Example: 'Amtsgericht Landsberg a. Lech'
+        Registergericht (German commercial court). Required when providing 'hrb_number'.
+        Example: "Amtsgericht Landsberg a. Lech".
     company_name:
       type: string
-      description: Company name for fuzzy search (alternative to hrb_number)
+      description: Company name for fuzzy search via /v1/autocomplete/company.
 output_schema:
   type: object
-  example:
-    status: active
-    address: "Siegfried-Meister-Str. 1, 86899, Landsberg a. Lech, Germany"
-    industry: "Food industry"
-    directors: "Stadelmann, Peter Daniel (CEO)"
-    company_name: "RATIONAL AG"
-    business_type: "AG"
-    registration_date: "1999-02-09"
-    registration_number: "HRB 2001"
-    court_used: "Amtsgericht Landsberg a. Lech"
   properties:
-    vat_number:
+    company_name:
+      type:
+        - string
+        - "null"
+    company_id:
+      type: string
+    registration_number:
+      type:
+        - string
+        - "null"
+    register_type:
+      type:
+        - string
+        - "null"
+    court:
+      type:
+        - string
+        - "null"
+    country_code:
+      type: string
+    legal_form:
       type:
         - string
         - "null"
     status:
+      enum:
+        - active
+        - terminated
+        - unknown
       type: string
-    address:
-      type: string
-    company_name:
-      type: string
-    business_type:
-      type: string
-    registration_number:
-      type: string
-    court_used:
-      type: string
-data_source: Handelsregister (German Commercial Register) via northdata.com
-data_source_type: scrape
-transparency_tag: ai_generated
+    is_active:
+      type:
+        - boolean
+        - "null"
+    registered_address:
+      type:
+        - object
+        - "null"
+    business_description:
+      type:
+        - string
+        - "null"
+    industry_codes:
+      type: array
+    directors:
+      type: array
+    capital:
+      type:
+        - object
+        - "null"
+    lei:
+      type:
+        - string
+        - "null"
+    incorporated_at:
+      type:
+        - string
+        - "null"
+    terminated_at:
+      type:
+        - string
+        - "null"
+data_source: OpenRegister (api.openregister.de)
+data_source_type: api
+transparency_tag: algorithmic
 freshness_category: live-fetch
-maintenance_class: scraping-stable-target
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
+maintenance_class: free-stable-api
 processes_personal_data: true
 personal_data_categories:
   - name
@@ -69,47 +108,81 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      hrb_number: "HRB 2001"
-      court: "Amtsgericht Landsberg a. Lech"
+      company_name: "SAP SE"
     expected_fields:
       - field: company_name
         operator: contains
         reliability: guaranteed
-        value: "RATIONAL"
-      - field: registration_number
-        operator: contains
+        value: "SAP"
+      - field: country_code
+        operator: equals
         reliability: guaranteed
-        value: "HRB 2001"
+        value: "DE"
+      - field: company_id
+        operator: not_null
+        reliability: guaranteed
       - field: status
         operator: not_null
         reliability: guaranteed
   health_check_input:
-    company_name: "Rational AG"
+    company_name: "SAP SE"
 output_field_reliability:
-  status: guaranteed
-  address: guaranteed
   company_name: guaranteed
-  business_type: guaranteed
+  company_id: guaranteed
   registration_number: guaranteed
-  court_used: common
-  industry: common
+  register_type: guaranteed
+  court: guaranteed
+  country_code: guaranteed
+  legal_form: common
+  status: guaranteed
+  is_active: guaranteed
+  registered_address: common
+  business_description: common
+  industry_codes: common
   directors: common
-  registration_date: common
-  jurisdiction: guaranteed
+  capital: common
+  lei: rare
+  incorporated_at: common
+  terminated_at: rare
 limitations:
-  - title: HRB/HRA numbers require court (Registergericht)
+  - title: Free tier capped at 50 requests/month
     text: >-
-      German registration numbers are per-court, not globally unique.
-      The same HRB number can refer to different companies at different courts.
-      Court is required when looking up by registration number.
-    category: coverage
+      Per DEC-20260506-G this capability runs on OpenRegister's Free tier (50 req/mo, €0/mo).
+      Sustained traffic above that cap requires a Pro-tier upgrade decision gated on
+      (customer attachment) AND (audit-retention written confirmation) per DEC-20260505-H.
+      On HTTP 429 the executor returns a structured 'capability-unavailable' error and the
+      framework's circuit breaker (DEC-20260503-B) trips after 3 consecutive failures.
+    category: cost
     severity: warning
-  - title: Data sourced from northdata.com aggregator
+    workaround: >-
+      Cache results per Strale's stored-with-refresh primary architecture (caching is
+      permitted while the OpenRegister subscription is active).
+  - title: UBO data not covered
     text: >-
-      Company data is extracted from northdata.com, which aggregates from the
-      Handelsregister. Freshness depends on northdata's update cycle.
+      OpenRegister does not expose Transparenzregister (German UBO registry) data. UBO
+      lookups for AML-obliged customers require a separate BYO-credentials path against
+      the Transparenzregister, per the Coverage Matrix architectural note.
+    category: coverage
+    severity: info
+    workaround: Use a dedicated UBO capability with customer-supplied Transparenzregister credentials.
+  - title: Real-time fetches not implemented
+    text: >-
+      OpenRegister's `realtime=true` flag (which forces a live Handelsregister fetch at
+      +10 credits per call) is not exposed by this capability. The default cadence is
+      OpenRegister's stored-with-refresh model — stored data refreshed every ≤4 weeks
+      with daily updates for financials and new incorporations. Out of scope for v1.
     category: freshness
     severity: info
     workaround: >-
-      For authoritative data, check the official Handelsregister portal at
-      handelsregister.de
+      For agents that need same-day filings, consume the capability and treat
+      `provenance.fetched_at` as the freshness floor for stored data.
+  - title: HRB/HRA numbers require court (Registergericht)
+    text: >-
+      German registration numbers are per-court, not globally unique. The same HRB
+      number can refer to different companies at different courts. When passing
+      'hrb_number', 'court' is also required.
+    category: coverage
+    severity: warning
+    workaround: >-
+      Prefer 'company_id' (OpenRegister canonical, e.g. "DE-HRB-F1103-267645") when
+      known — it skips the autocomplete step and consumes one fewer Free-tier credit.


### PR DESCRIPTION
## Summary

Replaces the deactivated northdata.com scraper for `german-company-data` with a doctrine-compliant OpenRegister Free tier integration. Closes the DE Tier-1 ToS violation per DEC-20260427-I and lands DE Identity primary per DEC-20260505-H + DEC-20260506-G.

- `8b46146` — initial executor + manifest rewrite + DEACTIVATED removal
- `abc9c42` — fix CompanyV1 response shape after smoke surfaced two contract-assumption divergences (`name` is an object, `purpose` is an object, `register.register_*` keys, `Array.isArray` guards on `industry_codes` / `representation` / `sources`)

## Verification

- Type-check clean across both commits.
- Live smoke against SAP SE: Step 1 (structural), Step 2 (live execution — 17 fields returned in 602ms), Steps 4-11 all green. Step 3 (guaranteed fields) fails on stale DB field names from old manifest — self-heals on Phase 3 boot sync at deploy.

## Test plan

- [ ] Railway auto-deploys post-merge
- [ ] `/health` reports new build SHA
- [ ] `/v1/capabilities` shows `german-company-data` with `isActive: true`, `visible: true`, `category: company-data`, `dataSource: OpenRegister`
- [ ] DB `capability_limitations` count = 4 for slug
- [ ] DB `output_field_reliability` has 17 keys
- [ ] Production smoke passes all steps (including Step 3 after sync)
- [ ] Manual lifecycle transition from `degraded` to `active` if not auto-cleared

## Notes

- `vat_number` deliberately NOT in manifest — OpenRegister doesn't expose German VAT (granted by Bundeszentralamt für Steuern, separate from Handelsregister). Old manifest field is stale DB drift; resolves on deploy.
- Free tier 50 req/mo; real-time fetches (?realtime=true, +10 credits/call) intentionally not exposed per DEC-20260506-G.

🤖 Generated with [Claude Code](https://claude.com/claude-code)