### PR TITLE
fix: remove inaccurate OpenOwnership integration claim from product copy

### DIFF
--- a/apps/api/src/db/seed-solutions.ts
+++ b/apps/api/src/db/seed-solutions.ts
@@ -1751,7 +1751,7 @@ const SOLUTIONS: SolutionDef[] = [
     description:
       "Comprehensive due diligence on a company: registry verification, beneficial ownership, sanctions screening, PEP screening, and adverse media analysis. Returns everything a compliance officer needs in one call.",
     longDescription:
-      "Runs a full Enhanced Due Diligence (EDD) workflow: fetches official company registry data, looks up beneficial owners via OpenOwnership/Companies House, screens against international sanctions lists, checks for Politically Exposed Persons, and searches for adverse media coverage. All steps run in parallel where possible for fast results.",
+      "Runs a full Enhanced Due Diligence (EDD) workflow: fetches official company registry data, looks up beneficial owners via Companies House for UK companies, screens against international sanctions lists, checks for Politically Exposed Persons, and searches for adverse media coverage. All steps run in parallel where possible for fast results.",
     agentDescription:
       "full company due diligence, EDD check, enhanced due diligence company, KYC AML company check, compliance screening company, beneficial ownership sanctions PEP adverse media",
     category: "compliance",

--- a/manifests/gleif-l2-ubo-lookup.yaml
+++ b/manifests/gleif-l2-ubo-lookup.yaml
@@ -154,8 +154,8 @@ limitations:
     category: coverage
     severity: info
     workaround: >-
-      For SMEs without an LEI, use country-specific UBO sources (e.g. Companies House PSC for UK, OpenOwnership BODS for
-      UK/DK/SK).
+      For SMEs without an LEI, use country-specific UBO sources such as Companies House PSC for UK companies (exposed via the
+      beneficial-ownership-lookup capability).
   - title: Reporting exceptions are common
     text: >-
       Many entities report a structured "reporting exception" instead of naming a parent (NATURAL_PERSONS,

--- a/packages/strale-capabilities/capabilities.json
+++ b/packages/strale-capabilities/capabilities.json
@@ -4643,7 +4643,7 @@
     {
       "slug": "beneficial-ownership-lookup",
       "name": "Beneficial Ownership Lookup",
-      "description": "Look up beneficial ownership (UBO) information for a company. Returns individuals who ultimately own or control the entity, their ownership percentage, and the ownership chain. Uses OpenOwnership and Companies House for UK companies.",
+      "description": "Look up UK beneficial ownership (UBO / PSC) information for a company. Returns individuals who ultimately own or control the entity, their ownership percentage, and the ownership chain. Uses Companies House Persons of Significant Control. UK only; non-GB inputs return a coverage notice.",
       "category": "compliance",
       "price_cents": 25,
       "input_schema": {


### PR DESCRIPTION
## Summary

Removes false claims that Strale integrates with OpenOwnership from three customer-facing surfaces. Strale has no OpenOwnership / BODS integration in code; the capability `beneficial-ownership-lookup` covers UK only via Companies House PSC direct.

## Background

A read-only CC audit on 2026-05-07 (`cc-prompt-bods-dk-audit.md`) confirmed the gap. OpenOwnership BODS was evaluated 2026-04-02 in `apps/api/docs/ubo-resolve-uk-bods-evaluation.md` and explicitly deferred. The drift was introduced at the DEC-20260430-A v1 vendor stack canonicalisation pass, propagated via `seed-solutions.ts` and `capabilities.json`, and re-stated as a workaround tip in the GLEIF L2 UBO manifest.

The Active Vendor Stack page was corrected in the same session as the audit. The deferral entry (`DEF-20260507-B-DKUBO`) had its triggers reframed. A course-correction Journal entry was filed naming the broader pattern (aspirational-architecture-as-fact). This PR closes the last code-side surface where the false claim lived.

References:
- Course-correction Journal entry: https://www.notion.so/35967c87082c81dc905fceff85603fe5
- Deferral entry: https://www.notion.so/35967c87082c816194e3f1d56823e686
- Originating audit: `cc-prompt-bods-dk-audit.md` (chat-side prompt)
- DEC-20260430-A — canonicalisation point where the drift was introduced

## Changes

Three customer-facing strings:

1. **`apps/api/src/db/seed-solutions.ts:1754`** — `enhanced-due-diligence` solution longDescription. "via OpenOwnership/Companies House" → "via Companies House for UK companies".
2. **`packages/strale-capabilities/capabilities.json:4646`** — published catalog description for `beneficial-ownership-lookup`. Rewritten to match the actual UK-only scope and name Companies House PSC explicitly. Includes the honest "non-GB inputs return a coverage notice" limitation.
3. **`manifests/gleif-l2-ubo-lookup.yaml:157`** — limitation `workaround` text. Dropped the "OpenOwnership BODS for UK/DK/SK" recommendation (DK status uncertain post-Sept 2025 anyway); kept and clarified the Companies House PSC pointer with reference to Strale's `beneficial-ownership-lookup` capability. This field is surfaced via the public `GET /v1/internal/limitations/capabilities/:slug` endpoint, hence customer-facing.

Replacement copy passed Notion Brand & voice §1 (5-test publish check) and §2.5 (review checklist). No banned words, no em dashes added (one removed in YAML edit because the line wrap reorganised), specific data sources named per §5.3, institutional voice preserved, honest limitations included.

## Out of scope (flagged for follow-up)

The audit also surfaced two non-customer-facing OpenOwnership references in CI tooling — left untouched here:

- `apps/api/scripts/check-platform-facts-drift.mjs:58` — `CURRENT_VENDORS` hardcoded vendor map names `ubo_uk_dk_sk_smes: "OpenOwnership"`. Bonus finding: this whole map is drifted from `STATIC_FACTS.vendors` in `platform-facts.ts` (UBO/IBAN/US-registry/litigation entries on the script side don't exist in the runtime source-of-truth). Needs a separate alignment pass.
- `apps/api/scripts/check-provider-coverage-drift.mjs:80` — `KNOWN_GOV_REGISTRY_PROVIDERS` set includes `"OpenOwnership"` as if it were an active free public API.

Both are CI guards, not customer-facing prose, so removing them is structural rather than mechanical and was kept out of this PR's scope.

Also out-of-scope: line 1752 of `seed-solutions.ts` opens with "Comprehensive due diligence on a company..." — `comprehensive` is on the §2.1 banned-adjective list. Separate copy-rewrite session.

## Test plan

- [x] `cd apps/api && npx tsc --noEmit` — exit 0
- [x] `node -e "JSON.parse(require('fs').readFileSync('packages/strale-capabilities/capabilities.json'))"` — parses
- [x] `js-yaml` parse of `manifests/gleif-l2-ubo-lookup.yaml` — parses; folded scalar produces intended single-line text
- [x] `Grep openownership|bods` across `apps/`, `packages/`, `manifests/` — only legitimate retained references remain (eval doc + manifest comments naming OpenOwnership as a future option + the two CI scripts flagged above)
- [ ] **DB propagation:** `seed-solutions.ts` populates the `solutions` table at the seed-runner's next run. The corrected `longDescription` reaches the DB only on next seed execution. Petter to confirm whether a manual seed-run is required post-merge or whether the catalog deploy handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)