### PR TITLE
chore(allowlist): add audit-live-registries and dk-cvr-retry-2026-05-06 to console allowlist

### DIFF
--- a/apps/api/scripts/console-allowlist.json
+++ b/apps/api/scripts/console-allowlist.json
@@ -19,5 +19,7 @@
   "apps/api/src/db/seed-tests.ts": 8,
   "apps/api/src/diagnostics/self-heal-check.ts": 2,
   "apps/api/src/index.ts": 10,
-  "apps/api/src/lib/processing-location.ts": 1
+  "apps/api/src/lib/processing-location.ts": 1,
+  "apps/api/src/scripts/audit-live-registries.ts": 13,
+  "apps/api/src/scripts/dk-cvr-retry-2026-05-06.ts": 7
 }


### PR DESCRIPTION
Unblocks red main.

## Why

Two ad-hoc scripts landed on main without being added to the F-0-014 console-allowlist:
- `apps/api/src/scripts/audit-live-registries.ts` (13 `console.*` calls, commit f1ea723)
- `apps/api/src/scripts/dk-cvr-retry-2026-05-06.ts` (7 `console.*` calls, commit 95eaf72)

The lint guard walks the whole tree, so non-allowlisted files block every subsequent PR's CI. Main has been red since 2026-05-06; six open PRs are blocked.

## What

Adds the two file paths to `apps/api/scripts/console-allowlist.json` with their current console counts. Smallest possible diff to restore main to green.

## Why not migrate the scripts to the structured logger instead

Both scripts are one-off operational tools (one has a date in its filename). Allowlisting is the appropriate fix; the migration cost isn't justified for scripts that will be archeology by next month. The lint script's header comment notes Phase E5 will tighten the rule and migrate `apps/api/src/scripts/` — that's the right time for these migrations to happen, not now.

## Out of scope

How the two original commits bypassed the lint guard at merge time is a separate governance investigation, logged as a P3 To-do.

## Verification

- Lint guard passes locally (`F-0-014 guard: no new `console.*` calls.`, exit 0)
- TypeScript check passes locally (exit 0)
- After merge, CI on the five other open PRs (#62, #63, #60, #61, #45, #40) should be re-triggerable and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)