### PR TITLE
feat: add slovenian-company-data capability

### DIFF
--- a/apps/api/src/capabilities/slovenian-company-data.ts
+++ b/apps/api/src/capabilities/slovenian-company-data.ts
@@ -1,0 +1,179 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * Slovenian company data via the data.gov.si CKAN datastore API.
+ *
+ * Free, real-time JSON, no signup required. Data is published by AJPES
+ * (Agencija Republike Slovenije za javnopravne evidence in storitve)
+ * under CC-BY 4.0, which permits commercial redistribution with
+ * attribution. The dataset is the open subset of the Poslovni register
+ * Slovenije (PRS) per Zakon o Poslovnem registru Slovenije (ZPRS-1).
+ *
+ * Coverage caveat: AJPES publishes only the statutory open-data subset
+ * — registration number, full name, address, legal form, and registry
+ * authority. Status, registration date, NACE/SKD, directors, and VAT
+ * are NOT in this dataset. Customers needing those fields must use the
+ * paid AJPES restPrsInfo service (out of scope per DEC-20260507-A —
+ * AJPES ToU §7 prohibits redistribution under that contract).
+ */
+
+const SI_DATASTORE_API = "https://podatki.gov.si/api/3/action/datastore_search";
+// Resource ID for the "Poslovni register" CSV on podatki.gov.si.
+const SI_RESOURCE_ID = "beb70929-3d0d-41c6-9af2-25d525d906d3";
+
+// Matična številka: 7 digits identify the entity; an optional 3-digit
+// suffix identifies the establishment (000 = main entity, 001-999 =
+// branches). The published dataset uses the 10-digit form throughout.
+const REG_RE = /^\d{10}$/;
+
+function findReg(input: string): string | null {
+  const cleaned = input.replace(/[\s.-]/g, "");
+  if (REG_RE.test(cleaned)) return cleaned;
+  // Accept the bare 7-digit form by appending the main-entity suffix.
+  if (/^\d{7}$/.test(cleaned)) return `${cleaned}000`;
+  const tenDigit = input.match(/\d{10}/);
+  if (tenDigit) return tenDigit[0];
+  const sevenDigit = input.match(/\b\d{7}\b/);
+  return sevenDigit ? `${sevenDigit[0]}000` : null;
+}
+
+interface SiRecord {
+  "Matična številka": string;
+  "Popolno ime": string | null;
+  HSEID: string | null;
+  "Pravnoorganizacijska oblika": string | null;
+  "Registrski organ": string | null;
+  Ulica: string | null;
+  "Hišna št": string | null;
+  "Hišna št  dodatek": string | null;
+  Naselje: string | null;
+  "Poštna št": string | null;
+  Pošta: string | null;
+  Država: string | null;
+}
+
+interface DatastoreResponse {
+  success: boolean;
+  result: { records: SiRecord[]; total?: number };
+}
+
+async function callDatastore(qs: URLSearchParams): Promise<SiRecord[]> {
+  qs.set("resource_id", SI_RESOURCE_ID);
+  const url = `${SI_DATASTORE_API}?${qs.toString()}`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(15000),
+  });
+  if (!res.ok) {
+    throw new Error(`Slovenian Open Data Portal returned HTTP ${res.status}`);
+  }
+  const data = (await res.json()) as DatastoreResponse;
+  if (!data.success) {
+    throw new Error("Slovenian Open Data Portal returned success=false");
+  }
+  return data.result.records ?? [];
+}
+
+async function lookupByRegNumber(reg: string): Promise<SiRecord> {
+  const filters = JSON.stringify({ "Matična številka": reg });
+  const records = await callDatastore(new URLSearchParams({ filters, limit: "1" }));
+  if (!records.length) {
+    throw new Error(`No Slovenian company found for matična številka ${reg}.`);
+  }
+  return records[0];
+}
+
+async function lookupByName(name: string): Promise<SiRecord> {
+  const records = await callDatastore(new URLSearchParams({ q: name, limit: "10" }));
+  if (!records.length) {
+    throw new Error(`No Slovenian company found matching "${name}".`);
+  }
+  // CKAN keyword search ranks by relevance. The first hit is the best
+  // match; no further sorting signal is available because the source
+  // dataset has no status / activity column to prefer active entities.
+  return records[0];
+}
+
+function clean(s: string | null | undefined): string | null {
+  if (typeof s !== "string") return null;
+  const trimmed = s.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function formatAddress(r: SiRecord): string | null {
+  const street = [clean(r.Ulica), clean(r["Hišna št"]), clean(r["Hišna št  dodatek"])]
+    .filter((p): p is string => p !== null)
+    .join(" ")
+    .trim();
+  const postal = [clean(r["Poštna št"]), clean(r.Pošta)]
+    .filter((p): p is string => p !== null)
+    .join(" ")
+    .trim();
+  const city = clean(r.Naselje);
+  const country = clean(r.Država);
+  // Avoid duplicating city when Pošta and Naselje are identical (common
+  // for entities in the same locality as their post office).
+  const settlementLine = city && city !== clean(r.Pošta) ? city : "";
+  const parts = [street, settlementLine, postal, country].filter(
+    (p): p is string => p !== null && p.length > 0,
+  );
+  return parts.length ? parts.join(", ") : null;
+}
+
+registerCapability("slovenian-company-data", async (input: CapabilityInput) => {
+  const raw =
+    (input.reg_number as string) ??
+    (input.matricna_stevilka as string) ??
+    (input.company_name as string) ??
+    (input.task as string) ??
+    "";
+  if (typeof raw !== "string" || !raw.trim()) {
+    throw new Error(
+      "'reg_number' or 'company_name' is required. Provide a Slovenian matična številka (7 or 10 digits) or company name.",
+    );
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed.length < 2) {
+    throw new Error("Input must be at least 2 characters.");
+  }
+
+  const reg = findReg(trimmed);
+  const record = reg ? await lookupByRegNumber(reg) : await lookupByName(trimmed);
+
+  const output = {
+    company_name: clean(record["Popolno ime"]),
+    reg_number: clean(record["Matična številka"]),
+    hseid: clean(record.HSEID),
+    legal_form: clean(record["Pravnoorganizacijska oblika"]),
+    registration_office: clean(record["Registrski organ"]),
+    address: formatAddress(record),
+    settlement: clean(record.Naselje),
+    postal_code: clean(record["Poštna št"]),
+    post_office: clean(record.Pošta),
+    country: clean(record.Država),
+    jurisdiction: "SI",
+  };
+
+  const filterRef = encodeURIComponent(
+    JSON.stringify({ "Matična številka": output.reg_number ?? "" }),
+  );
+  const primarySourceUrl = `${SI_DATASTORE_API}?resource_id=${SI_RESOURCE_ID}&filters=${filterRef}`;
+
+  return {
+    output,
+    provenance: {
+      source: "podatki.gov.si",
+      source_url: "https://podatki.gov.si/dataset/poslovni-register-slovenije",
+      fetched_at: new Date().toISOString(),
+      acquisition_method: "direct_api" as const,
+      primary_source_reference: primarySourceUrl,
+      license: "CC BY 4.0",
+      license_url: "https://creativecommons.org/licenses/by/4.0/legalcode",
+      attribution:
+        "Poslovni register Slovenije, AGENCIJA REPUBLIKE SLOVENIJE ZA JAVNOPRAVNE EVIDENCE IN STORITVE",
+      source_note:
+        "Open subset of the Poslovni register Slovenije (PRS) per Zakon o Poslovnem registru Slovenije (ZPRS-1), refreshed twice monthly. Real-time API via CKAN datastore_search. Source coverage is limited to registration number, full name, address, legal form, and registry authority — see manifest limitations.",
+    },
+  };
+});

--- a/manifests/slovenian-company-data.yaml
+++ b/manifests/slovenian-company-data.yaml
@@ -1,0 +1,156 @@
+slug: slovenian-company-data
+name: Slovenian Company Data
+description: >-
+  Look up Slovenian company data from the Poslovni register Slovenije (PRS) via the data.gov.si CKAN datastore. Returns
+  registration number, full name, legal form, registry authority, and address. Free, CC-BY 4.0.
+category: company-data
+price_cents: 5
+is_free_tier: false
+data_source: >-
+  Poslovni register Slovenije via data.gov.si CKAN datastore (resource beb70929-3d0d-41c6-9af2-25d525d906d3) — CC-BY
+  4.0; attribution: Poslovni register Slovenije, AGENCIJA REPUBLIKE SLOVENIJE ZA JAVNOPRAVNE EVIDENCE IN STORITVE
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+avg_latency_ms: 1500
+input_schema:
+  type: object
+  required:
+    - reg_number
+  properties:
+    reg_number:
+      type: string
+      description: Slovenian matična številka (7-digit base or 10-digit including 3-digit branch suffix; main entity is suffix 000)
+    company_name:
+      type: string
+      description: Slovenian company name (fuzzy keyword match; first hit returned)
+    task:
+      type: string
+      description: Free-text input — first matching matična številka or company name is used
+output_schema:
+  type: object
+  example:
+    company_name: KRKA, tovarna zdravil, d.d., Novo mesto
+    reg_number: "5043611000"
+    hseid: "100400000138816776"
+    legal_form: Delniška družba d.d.
+    registration_office: Okrožno sodišče Novo mesto
+    address: Šmarješka cesta 006, Novo mesto, 8000 Novo mesto, SLOVENIJA
+    settlement: Novo mesto
+    postal_code: "8000"
+    post_office: Novo mesto
+    country: SLOVENIJA
+    jurisdiction: SI
+  properties:
+    company_name:
+      type: string
+    reg_number:
+      type: string
+    hseid:
+      type: string
+    legal_form:
+      type: string
+    registration_office:
+      type: string
+    address:
+      type: string
+    settlement:
+      type: string
+    postal_code:
+      type: string
+    post_office:
+      type: string
+    country:
+      type: string
+    jurisdiction:
+      type: string
+processes_personal_data: true
+personal_data_categories:
+  - name
+  - address
+  - professional
+geography: eu
+test_fixtures:
+  health_check_input:
+    reg_number: "5043611000"
+  known_answer:
+    input:
+      reg_number: "5043611000"
+    expected_fields:
+      - field: company_name
+        operator: not_null
+        reliability: guaranteed
+      - field: reg_number
+        operator: equals
+        reliability: guaranteed
+        value: "5043611000"
+      - field: hseid
+        operator: equals
+        reliability: guaranteed
+        value: "100400000138816776"
+      - field: legal_form
+        operator: not_null
+        reliability: guaranteed
+      - field: registration_office
+        operator: not_null
+        reliability: guaranteed
+      - field: address
+        operator: not_null
+        reliability: guaranteed
+      - field: settlement
+        operator: not_null
+        reliability: guaranteed
+      - field: postal_code
+        operator: equals
+        reliability: guaranteed
+        value: "8000"
+      - field: post_office
+        operator: not_null
+        reliability: guaranteed
+      - field: country
+        operator: equals
+        reliability: guaranteed
+        value: SLOVENIJA
+      - field: jurisdiction
+        operator: equals
+        reliability: guaranteed
+        value: SI
+limitations:
+  - title: Source dataset refreshes twice monthly
+    text: >-
+      AJPES publishes the Poslovni register Slovenije open-data CSV every two weeks (dvotedensko). Sub-fortnightly
+      registrations, address changes, name changes, or dissolutions will not be reflected in API responses until the
+      next snapshot. Other identity capabilities on Strale (IE, LV) refresh daily; SI does not. Customers requiring
+      real-time data must use the paid AJPES restPrsInfo service directly (not redistributable per AJPES ToU §7).
+    category: freshness
+    severity: info
+  - title: Open-data subset omits status, registration date, NACE, directors, and VAT
+    text: >-
+      The data.gov.si open-data dataset contains only the statutory open subset: matična številka, popolno ime,
+      pravnoorganizacijska oblika, registrski organ, and address. Active/dissolved status, registration date, SKD/NACE
+      activity codes, statutory representatives (directors), and VAT number are NOT in the open feed. Solutions that
+      filter on status or require those fields cannot meaningfully gate on SI output. Reactivation trigger: paid AJPES
+      restPrsInfo contract with redistribution rights, or a future EU High-Value-Dataset expansion.
+    category: coverage
+    severity: info
+  - title: Keyword search is unranked beyond CKAN relevance
+    text: >-
+      When resolving a Slovenian company name (rather than matična številka), the CKAN datastore_search keyword endpoint
+      returns the top relevance-ranked match with no further sorting. The source has no status or activity column to
+      prefer active entities over dissolved ones. Pass matična številka directly when the entity is known.
+    category: accuracy
+    severity: info
+    workaround: Pass matična številka (7 or 10 digits) directly when known.
+output_field_reliability:
+  company_name: guaranteed
+  reg_number: guaranteed
+  hseid: guaranteed
+  legal_form: guaranteed
+  registration_office: guaranteed
+  address: guaranteed
+  settlement: guaranteed
+  postal_code: guaranteed
+  post_office: guaranteed
+  country: guaranteed
+  jurisdiction: guaranteed


### PR DESCRIPTION
## Summary

- Adds `slovenian-company-data` capability via direct CKAN `datastore_search` against the Poslovni register Slovenije (PRS) open subset on `data.gov.si`. Free, no auth, CC-BY 4.0.
- Closes SI Gap-7 (was the last EU-Nordic registry gap aside from BG/RO/CY). Coverage shifts from 19 live + 5 mid-rebuild + 7 gap → 20 + 5 + 6.
- Authorised by DEC-20260507-A. Path B (paid AJPES restPrsInfo) was killed in chat the same day for three independent reasons: ToU §7 prohibits redistribution; order form is Slovenian-only; cheapest tier is €211 / 500 searches (no free or HVD tier). Path A is the only viable path.

## Coverage caveat (in manifest limitations)

The data.gov.si open subset is statutory and thin: 12 fields published (matična številka, popolno ime, pravnoorganizacijska oblika, registrski organ, plus 7 address components). Status, registration date, NACE/SKD, directors, and VAT are **not** in the open feed.

Manifest is explicit about this. Solutions filtering on `status = active` or requiring those fields cannot meaningfully gate on SI output — flagged in `limitations[1]`. Customers needing those fields must contract directly with AJPES under restPrsInfo (which we can't redistribute).

## Refresh cadence

Twice monthly (dvotedensko), slower than IE/LV daily. Called out in `limitations[0]`.

## Cross-sibling shape

- Includes `jurisdiction: "SI"` matching the IE/LV/LT convention (PR #61 audit identified this divergence; SK/CZ/BE/EE/PL backfill is a separate P3 to-do).
- Address is consolidated into a single `address` string from 7 source components, matching SK/IE/LV pattern.
- `legal_form` exposed as text only (the source has no separate code column — single field, not the SK/LV `legal_form` + `legal_form_code` pair).

## Field reliability

Pipeline `--discover` auto-generated all 11 output fields as `guaranteed`. Empirical sampling against 11 entities (KRKA, NLB, Petrol, Mercator, plus 6 dataset-position samples spanning the whole 259k-record dataset, plus 1 sole-proprietor) confirmed 100% population for all 11 output fields. **No reclassification needed** — the dataset's statutory-subset profile means there are no genuinely optional fields to demote. Reported here so the absence of demotions is intentional, not skipped.

## Verification

- `npx tsx scripts/onboard.ts --discover` exits 0; manifest enriched; 5 test suites generated; known_answer verified live against KRKA d.d. (matična številka 5043611000)
- `npx tsx scripts/smoke-test.ts --slug slovenian-company-data` — 11/11 steps green
- `npx tsx scripts/validate-capability.ts --slug slovenian-company-data` — 19/19 checks pass
- `npx tsc --noEmit` — clean

## Deploy mechanism (Rule 14)

`auto-register.ts` reads `manifests/*.yaml`, dynamic-imports `./<slug>.js` from `apps/api/src/capabilities/`, and validates `getExecutor(slug)` returns a registered handler. Both files are in place; capability self-registers on next boot. Post-deploy verification: `GET /v1/capabilities` will list `slovenian-company-data`.

## Test plan

- [ ] Wait for CI: lint, type-check, structural tests
- [ ] After merge + deploy: `curl /v1/capabilities | grep slovenian-company-data` returns the entry
- [ ] After merge + deploy: `POST /v1/do {"task": "lookup slovenian company", "input": {"reg_number": "5043611000"}}` returns KRKA d.d.
- [ ] Lifecycle promotion: post-deploy, set `is_active=true`, `visible=true`, `lifecycle_state='active'` once monitor confirms first 24h of test runs are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)