### PR TITLE
fix(adverse-media-check): remove fabricated timestamp + language literals

### DIFF
--- a/apps/api/src/capabilities/adverse-media-check.ts
+++ b/apps/api/src/capabilities/adverse-media-check.ts
@@ -197,16 +197,17 @@ async function querySerper(
 
   // Classify each result by category
   const categories: Record<string, number> = {};
-  const topArticles: Array<{ headline: string; source_link: string; timestamp: string; language: string; category: string }> = [];
+  const topArticles: Array<{ headline: string; source_link: string; timestamp: string | null; language: string | null; category: string }> = [];
 
   for (const r of results) {
     const category = classifyArticle(r.title, r.snippet);
     categories[category] = (categories[category] ?? 0) + 1;
+    // Serper does not return article publication date or language; emit null rather than fabricate (DEC-20260428-B).
     topArticles.push({
       headline: r.title,
       source_link: r.link,
-      timestamp: r.date ?? new Date().toISOString(),
-      language: "en",
+      timestamp: r.date ?? null,
+      language: null,
       category,
     });
   }

--- a/manifests/adverse-media-check.yaml
+++ b/manifests/adverse-media-check.yaml
@@ -98,9 +98,13 @@ output_schema:
           source_link:
             type: string
           timestamp:
-            type: string
+            type:
+              - string
+              - "null"
           language:
-            type: string
+            type:
+              - string
+              - "null"
           category:
             type: string
     lists_queried:


### PR DESCRIPTION
Doctrine compliance fix per do-not-fabricate (DEC-20260428-B). Two findings from the 2026-05-08 doctrine sweep audit, Serper fallback path:

**P0** — synthetic article timestamp via `r.date ?? new Date().toISOString()` corrupts compliance reporting that cites article freshness or "last 12 months" framing. The field is named `timestamp` and represents article publication time; stamping `now()` when Serper omits the date is dishonest.

**P1** — hardcoded `language: "en"` produces false language filters; Serper does not return language metadata, so the honest answer is unknown, not assumed-English.

Both literals replaced with `?? null` / `null`. TypeScript inline type widened to `string | null` on the Serper path; manifest `output_schema.properties.top_articles.items.properties.timestamp` and `.language` widened to `[string, "null"]` matching the manifest's existing nullable convention (`lists_queried` sub-fields).

**Doctrinal precedent:** PR #70 commit 6dc5a23 (BE `directors: []` removal). Path B per Rule 12 carve-out (no regression test required for code removal). Local verification: typecheck baseline 3 errors (pre-existing mcp.ts), unchanged with fix; `vitest run src/capabilities/` 31/31 pass.

**P2** (lists_queried `version` + `last_updated_at` always-null) is out of scope here — belongs to the DEC-20260428-B regulatory-grade lists-versioning workstream.