### PR TITLE
fix(sanctions-check, pep-check): remove fabricated classification + topics literals

### DIFF
--- a/apps/api/src/capabilities/pep-check.ts
+++ b/apps/api/src/capabilities/pep-check.ts
@@ -70,11 +70,13 @@ registerCapability("pep-check", async (input: CapabilityInput) => {
         is_pep: pepRecords.length > 0,
         match_count: pepRecords.length,
         total_results: pepRecords.length,
+        // classification = Dilisense pep_type passthrough (EU C/2023/724 function type
+        // when present); topic taxonomy is not exposed by Dilisense, do not fabricate
+        // (DEC-20260428-B).
         matches: pepRecords.slice(0, 10).map((r) => ({
           name: r.name,
           entity_id: r.source_id,
-          classification: "pep" as const,
-          topics: ["role.pep"],
+          classification: r.pep_type ?? null,
           positions: r.positions ?? [],
           countries: r.citizenship ?? [],
           datasets: [r.source_id],

--- a/apps/api/src/capabilities/sanctions-check.ts
+++ b/apps/api/src/capabilities/sanctions-check.ts
@@ -79,11 +79,11 @@ registerCapability("sanctions-check", async (input: CapabilityInput) => {
         is_sanctioned: sanctionRecords.length > 0,
         match_count: sanctionRecords.length,
         total_results: sanctionRecords.length,
+        // Dilisense exposes no per-record classification or topic taxonomy on the
+        // consolidated sanctions endpoint; do not fabricate (DEC-20260428-B).
         matches: sanctionRecords.slice(0, 10).map((r) => ({
           name: r.name,
           entity_id: r.source_id,
-          classification: "primary_sanction" as const,
-          topics: ["sanction"],
           datasets: [r.source_id],
           countries: r.citizenship ?? [],
           sanction_details: r.sanction_details ?? [],

--- a/manifests/pep-check.yaml
+++ b/manifests/pep-check.yaml
@@ -39,9 +39,7 @@ output_schema:
     matches:
       - name: Angela Dorothea Merkel
         entity_id: dilisense_pep
-        classification: pep
-        topics:
-          - role.pep
+        classification: head_of_state
         positions:
           - Chancellor of Germany
           - Member of the Bundestag
@@ -90,11 +88,10 @@ output_schema:
           entity_id:
             type: string
           classification:
-            type: string
-            enum:
-              - pep
-          topics:
-            type: array
+            type:
+              - string
+              - "null"
+            description: Dilisense pep_type passthrough (EU C/2023/724 function type when present)
           positions:
             type: array
           countries:

--- a/manifests/sanctions-check.yaml
+++ b/manifests/sanctions-check.yaml
@@ -3,7 +3,7 @@ name: Sanctions Check
 description: >-
   Check if a person or entity is on sanctions lists (EU, US OFAC, UN, UK OFSI, Swiss SECO, BIS, World
   Bank, EBRD, ADB + 125 national lists). Uses Dilisense consolidated database. Returns audit-grade
-  evidence: match results with classification, named source attribution, and country attribution.
+  evidence: match results with named source attribution and country attribution.
 category: compliance
 price_cents: 20
 is_free_tier: false
@@ -41,9 +41,6 @@ output_schema:
     matches:
       - name: Vladimir Vladimirovich Putin
         entity_id: us_ofac_sdn
-        classification: primary_sanction
-        topics:
-          - sanction
         datasets:
           - us_ofac_sdn
         countries:
@@ -98,12 +95,6 @@ output_schema:
             type: string
           entity_id:
             type: string
-          classification:
-            type: string
-            enum:
-              - primary_sanction
-          topics:
-            type: array
           datasets:
             type: array
           countries:


### PR DESCRIPTION
Doctrine compliance fix per do-not-fabricate (DEC-20260428-B). Two files, identical pattern from shared Dilisense origin. Found in 2026-05-08 doctrine sweep audit.

**sanctions-check.ts**: invariant \`classification: \"primary_sanction\" as const\` and \`topics: [\"sanction\"]\`. The Dilisense response interface declares only \`name\`, \`source_id\`, \`source_type\`, \`sanction_details\`, \`citizenship\`, \`last_updated\` — no per-record classification or topic taxonomy. The manifest's \`enum: [primary_sanction]\` single-value enum was the smoking gun. **Path B applied**: both fields dropped from executor + manifest example + output_schema. Description prose updated to drop "with classification" phrase.

**pep-check.ts**: invariant \`classification: \"pep\" as const\` and \`topics: [\"role.pep\"]\`. EU C/2023/724 distinguishes ~12 PEP function types but the executor flattened them all. The Dilisense interface DOES declare \`pep_type?: string\`. **Path A applied for classification**: \`r.pep_type ?? null\` passthrough. **Path B for topics**: dropped (no taxonomy source from Dilisense). Manifest example updated to \`head_of_state\` as representative EU C/2023/724 value; output_schema.classification widened to \`[string, \"null\"]\` with description noting the pep_type origin.

**Doctrinal precedents:** PR #70 (BE \`directors: []\`, commit 6dc5a23), PR #72 (adverse-media-check, commit 61913f9). Path B per Rule 12 carve-out; no test files exist.

**Local verification:** typecheck baseline 3 errors (pre-existing mcp.ts), unchanged with fix; \`vitest run src/capabilities/\` 31/31 pass.

**Downstream consumer scan:** zero references to \`match.classification\` or \`match.topics\` from sanctions-check / pep-check in apps/api/src. Unrelated \`.classification\` / \`.topics\` usages exist (web3-assurance evaluators, health-sweep, github-repo-compare) but none consume these match shapes. Drop is non-breaking.