### PR TITLE
fix(wallet-risk-score, token-security-check): null safety signals on no-data paths

### DIFF
--- a/apps/api/src/capabilities/token-security-check.ts
+++ b/apps/api/src/capabilities/token-security-check.ts
@@ -47,14 +47,19 @@ registerCapability("token-security-check", async (input: CapabilityInput) => {
   const now = new Date().toISOString();
 
   if (!entry || Object.keys(entry).length === 0) {
+    // No GoPlus entry for this token: emit null binary signals rather than
+    // fabricate green-light is_honeypot=false / zero taxes for a token we
+    // have no data on (DEC-20260428-B). Web3 swap UIs treat these as
+    // green-light — clearing unindexed tokens (typical for new contracts,
+    // the highest-risk surface) is the inverse of safety-conscious default.
     return {
       output: {
         contract_address: contractAddress,
         chain_id: chainId,
         risk_level: "unknown",
-        is_honeypot: false,
-        sell_tax: "0",
-        buy_tax: "0",
+        is_honeypot: null,
+        sell_tax: null,
+        buy_tax: null,
         note: "No security data available for this token on the specified chain.",
       },
       provenance: { source: "api.gopluslabs.io", fetched_at: now },

--- a/apps/api/src/capabilities/wallet-risk-score.ts
+++ b/apps/api/src/capabilities/wallet-risk-score.ts
@@ -52,12 +52,14 @@ registerCapability("wallet-risk-score", async (input: CapabilityInput) => {
   const entry = isFlat ? result : (result[address.toLowerCase()] ?? result[Object.keys(result)[0]] ?? null);
 
   if (!entry || Object.keys(entry).length === 0) {
+    // No GoPlus entry for this address: emit null binary signals rather than
+    // fabricate a green-light is_malicious=false (DEC-20260428-B).
     return {
       output: {
         address,
         chain_id: chainId,
         risk_level: "unknown",
-        is_malicious: false,
+        is_malicious: null,
         risk_labels: [],
         details: null,
         note: "No security data available for this address on the specified chain.",

--- a/manifests/token-security-check.yaml
+++ b/manifests/token-security-check.yaml
@@ -48,17 +48,23 @@ output_schema:
     can_take_back_ownership: false
   properties:
     buy_tax:
-      type: string
+      type:
+        - string
+        - "null"
     chain_id:
       type: string
     is_proxy:
       type: boolean
     sell_tax:
-      type: string
+      type:
+        - string
+        - "null"
     risk_level:
       type: string
     is_honeypot:
-      type: boolean
+      type:
+        - boolean
+        - "null"
     is_mintable:
       type: boolean
     hidden_owner:

--- a/manifests/wallet-risk-score.yaml
+++ b/manifests/wallet-risk-score.yaml
@@ -57,7 +57,9 @@ output_schema:
       items:
         type: string
     is_malicious:
-      type: boolean
+      type:
+        - boolean
+        - "null"
 data_source: GoPlus Labs (Address Security API)
 data_source_type: api
 transparency_tag: algorithmic


### PR DESCRIPTION
Doctrine compliance fix per do-not-fabricate (DEC-20260428-B). Two GoPlus-derived files, identical pattern: no-data paths emit hardcoded falsy values for safety-signaling fields, producing dishonest binary signals to consumers who don't read \`risk_level\`.

**wallet-risk-score.ts**: \`is_malicious: false\` → \`null\` on the no-data path. A compliance reviewer trusting \`is_malicious\` would clear addresses we have zero data on.

**token-security-check.ts**: \`is_honeypot: false\`, \`sell_tax: "0"\`, \`buy_tax: "0"\` → \`null\` on the no-data path. **Higher-stakes:** Web3 swap UIs and bot trading systems use these as green-light signals to allow swaps. The current behavior clears unindexed tokens (typical for new contracts, the highest-risk surface) — the inverse of the safety-conscious default.

**Success paths untouched** — when GoPlus explicitly says is_malicious=false / is_honeypot=false, that's a real value and stays.

Manifest \`output_schema.properties\` widened: \`is_malicious\` / \`is_honeypot\` → \`[boolean, "null"]\`; \`sell_tax\` / \`buy_tax\` → \`[string, "null"]\`. Examples (Vitalik wallet / USDC token) reflect success-path shapes — unchanged.

**Doctrinal precedents:** PR #70 (BE \`directors: []\`), PR #72 (adverse-media-check), PR #73 (sanctions+pep). Path B per Rule 12 carve-out; no test files exist.

**Local verification:** typecheck baseline 3 errors (pre-existing mcp.ts), unchanged with fix; \`vitest run src/capabilities/\` 31/31 pass.

**Downstream consumer scan:**
- \`web3-assurance/verdict.ts\` wraps with \`getBool()\` / \`getNum()\` — null-safe (line 71: \`sellTax !== null && sellTax > 0.5\` already null-checks)
- \`web3-assurance/disagreement.ts\` wraps with \`getBool()\`
- \`web3-assurance/explanation.ts\` uses \`?? "unknown"\` — null-safe
- \`db/seed-tests.ts\` validation rules \`isFalse("is_malicious")\` / \`isFalse("is_honeypot")\` use Vitalik wallet + USDC contract (heavily-indexed → hit success path with real false from GoPlus). Fix only affects no-data path → tests unaffected.