### PR TITLE
fix(us-company-data-cobalt): drop officers/filings from not-found envelope; null on success path

### DIFF
--- a/apps/api/src/capabilities/us-company-data-cobalt.ts
+++ b/apps/api/src/capabilities/us-company-data-cobalt.ts
@@ -64,6 +64,9 @@ registerCapability("us-company-data-cobalt", async (input: CapabilityInput) => {
     throw new Error(`Cobalt rejected the API key (HTTP ${res.status}). Verify COBALT_API_KEY.`);
   }
   if (res.status === 404) {
+    // found: false envelope carries no officers/filings — empty arrays would
+    // claim "the entity has no officers" when the truth is "we didn't find an
+    // entity to query" (DEC-20260428-B).
     return {
       output: {
         found: false,
@@ -75,8 +78,6 @@ registerCapability("us-company-data-cobalt", async (input: CapabilityInput) => {
         formed_date: null,
         address: null,
         registered_agent: null,
-        officers: [],
-        filings: [],
         data_source: "Cobalt Intelligence (50-state SoS live)",
       },
       provenance: { source: "cobaltintelligence.com", fetched_at: new Date().toISOString() },
@@ -103,8 +104,6 @@ registerCapability("us-company-data-cobalt", async (input: CapabilityInput) => {
         formed_date: null,
         address: null,
         registered_agent: null,
-        officers: [],
-        filings: [],
         data_source: "Cobalt Intelligence (50-state SoS live)",
       },
       provenance: { source: "cobaltintelligence.com", fetched_at: new Date().toISOString() },
@@ -124,8 +123,11 @@ registerCapability("us-company-data-cobalt", async (input: CapabilityInput) => {
         result.address ??
         (result.principalAddress ? Object.values(result.principalAddress).filter(Boolean).join(", ") : null),
       registered_agent: result.registeredAgent ?? result.agent ?? null,
-      officers: Array.isArray(result.officers) ? result.officers : [],
-      filings: Array.isArray(result.filings) ? result.filings.slice(0, 25) : [],
+      // Cobalt's response shape varies by US state — some SoS feeds carry
+      // officers/filings, some don't. Null is the honest answer to "this
+      // state's feed didn't surface this data" (DEC-20260428-B).
+      officers: result.officers ?? null,
+      filings: result.filings?.slice(0, 25) ?? null,
       sos_url: result.sosUrl ?? null,
       data_source: "Cobalt Intelligence (50-state SoS live)",
     },

--- a/manifests/us-company-data-cobalt.yaml
+++ b/manifests/us-company-data-cobalt.yaml
@@ -36,8 +36,8 @@ output_schema:
     formed_date: "1977-01-03"
     address: "One Apple Park Way, Cupertino, CA 95014"
     registered_agent: CT CORPORATION SYSTEM
-    officers: []
-    filings: []
+    officers: null
+    filings: null
     sos_url: https://bizfileonline.sos.ca.gov/...
     data_source: Cobalt Intelligence (50-state SoS live)
   properties:
@@ -74,9 +74,21 @@ output_schema:
         - string
         - "null"
     officers:
-      type: array
+      type:
+        - array
+        - "null"
+      description: >-
+        Officer roster when surfaced by the state's SoS feed; null when the
+        feed does not carry officer data OR when found=false. Absent fields
+        in a found=false envelope are not listed (data fields are dropped
+        entirely on not-found).
     filings:
-      type: array
+      type:
+        - array
+        - "null"
+      description: >-
+        Up to 25 most-recent filings when surfaced by the state's SoS feed;
+        null when the feed does not carry filing data OR when found=false.
     sos_url:
       type:
         - string
@@ -142,7 +154,9 @@ limitations:
   - title: Officer / filing depth varies per state
     text: >-
       Some states publish full officer rosters and 10+ years of filings; others publish only the
-      registered agent and incorporation event. Empty officers/filings arrays are normal for some
-      jurisdictions, not necessarily a coverage gap.
+      registered agent and incorporation event. When the state's SoS feed does not surface officer
+      or filing data, the corresponding field is null (not an empty array — empty would falsely
+      claim "this entity has no officers"). On a found=false envelope, the officers and filings
+      fields are absent entirely.
     category: coverage
     severity: info


### PR DESCRIPTION
Doctrine compliance fix per do-not-fabricate (DEC-20260428-B). Doctrinal twin of BE \`directors: []\` (PR #70). Three findings, two paths.

**Success path (P1):** \`officers: Array.isArray(...) ? ... : []\` and the equivalent filings line → \`result.officers ?? null\` / \`result.filings?.slice(0, 25) ?? null\`. Cobalt's response shape varies by US state — some SoS feeds carry officers, some don't. Empty arrays falsely claimed "this entity has no officers" when the truth is "this state's feed didn't surface officer data" (false-positive on cross-state filters).

**Not-found envelopes (P2):** \`officers: []\` and \`filings: []\` removed from BOTH \`found: false\` return paths (404 and null-result). The not-found semantics are "we didn't have anything to query" — carrying data fields blurred that with "we found and it's empty." Remaining not-found shape is a discriminated-union companion to the success shape; consumers reading from \`output: Record<string, unknown>\` (the permissive \`CapabilityResult\` type) check \`found\` first.

**Manifest updated coherently:**
- \`output_schema.example.officers/filings\`: \`[]\` → \`null\`
- \`output_schema.properties.officers/filings.type\`: \`array\` → \`[array, null]\` with descriptions explaining null vs absence
- limitation "Officer / filing depth varies per state" rewritten to describe null-not-empty + not-found-absent contracts

**Doctrinal precedents:** PR #70 (BE), PR #72 (adverse-media), PR #73 (sanctions+pep), PR #74 (wallet-risk + token-security).

**Downstream consumer scan: zero naive consumers.** Test files reference slug-string only. Other \`.officers\`/\`.filings\` accesses are for unrelated capabilities (officer-search reads UK Companies House; sec-filing-events reads SEC EDGAR). Drop is non-breaking.

**Local verification:** typecheck baseline 3 errors (pre-existing mcp.ts), unchanged with fix; \`vitest run src/capabilities/\` 31/31 pass.