### PR TITLE
fix(insolvency-check): drop data fields from error envelopes; remove status heuristic; date_ended Path B

### DIFF
--- a/apps/api/src/capabilities/insolvency-check.ts
+++ b/apps/api/src/capabilities/insolvency-check.ts
@@ -37,14 +37,18 @@ registerCapability("insolvency-check", async (input: CapabilityInput) => {
     }
 
     if (!number) {
+      // Not-found-via-search envelope: explicit `found: false` discriminator;
+      // data fields dropped per discriminated-runtime-shape pattern (PR #75,
+      // DEC-20260428-B). `proceedings: []` would falsely claim "we looked
+      // and there are none" when the truth is "we couldn't resolve the
+      // company to look up."
       return {
         output: {
           query: companyName || companyNumber,
           country_code: "GB",
           supported_country: true,
-          has_insolvency_proceedings: null,
-          proceedings: [],
-          error: "Company not found in Companies House.",
+          found: false,
+          message: "Company not found in Companies House.",
           data_source: "companies-house-uk",
         },
         provenance: { source: "companies-house-uk", fetched_at: new Date().toISOString() },
@@ -89,11 +93,16 @@ registerCapability("insolvency-check", async (input: CapabilityInput) => {
         country_code: "GB",
         supported_country: true,
         has_insolvency_proceedings: cases.length > 0,
+        // date_ended dropped: Companies House `dates` array structure is not
+        // verified empirically in this repo's fixtures; emitting `null`
+        // unconditionally claimed "the proceeding has not ended" which is
+        // a positive claim we can't substantiate (DEC-20260428-B). Status
+        // heuristic dropped: `c.dates?.length > 0 → "active"` wrongly tagged
+        // proceedings with closure-date entries as active.
         proceedings: cases.map((c: any) => ({
           type: c.type ?? null,
           date_started: c.dates?.[0]?.date ?? null,
-          date_ended: null,
-          status: c.status ?? (c.dates?.length > 0 ? "active" : "unknown"),
+          status: c.status ?? "unknown",
           practitioners: (c.practitioners ?? []).map((p: any) => ({
             name: p.name ?? null,
             role: p.role ?? null,
@@ -106,14 +115,15 @@ registerCapability("insolvency-check", async (input: CapabilityInput) => {
     };
   }
 
-  // Unsupported countries
+  // Unsupported-country envelope: `supported_country: false` discriminator;
+  // data fields dropped per discriminated-runtime-shape pattern (PR #75,
+  // DEC-20260428-B). `proceedings: []` would produce false "no proceedings"
+  // signals to compliance reviewers screening non-supported jurisdictions.
   return {
     output: {
       query: companyName || companyNumber,
       country_code: countryCode,
       supported_country: false,
-      has_insolvency_proceedings: null,
-      proceedings: [],
       message: `Insolvency checks are not yet available for '${countryCode}'. Currently supported: GB (UK via Companies House).`,
       data_source: null,
     },

--- a/manifests/insolvency-check.yaml
+++ b/manifests/insolvency-check.yaml
@@ -25,13 +25,32 @@ output_schema:
   type: object
   properties:
     has_insolvency_proceedings:
-      type: boolean
+      type:
+        - boolean
+        - "null"
+      description: >-
+        Boolean on the success path (company resolved). Absent entirely on
+        `found: false` and `supported_country: false` envelopes — discriminated
+        runtime shape; check the discriminator before reading.
     proceedings:
-      type: array
+      type:
+        - array
+        - "null"
+      description: >-
+        Array of proceedings on the success path (may be empty when the
+        company is found but has no insolvency cases). Absent entirely on
+        `found: false` and `supported_country: false` envelopes.
     supported_country:
       type: boolean
+    found:
+      type: boolean
+      description: >-
+        Present on the UK path when name/number resolution was attempted.
+        `false` indicates the company could not be resolved.
     data_source:
-      type: string
+      type:
+        - string
+        - "null"
 data_source: Companies House (UK)
 data_source_type: api
 transparency_tag: algorithmic
@@ -70,10 +89,11 @@ test_fixtures:
     company_number: "00445790"
 output_field_reliability:
   query: guaranteed
-  has_insolvency_proceedings: guaranteed
-  proceedings: guaranteed
   supported_country: guaranteed
-  data_source: guaranteed
+  has_insolvency_proceedings: common
+  proceedings: common
+  data_source: common
+  found: rare
   company_number: common
 limitations:
   - title: Currently UK only


### PR DESCRIPTION
Doctrine compliance fix per do-not-fabricate (DEC-20260428-B). Four findings from the 2026-05-08 doctrine sweep audit on insolvency-check.ts.

**P1 unsupported-country envelope:** dropped \`has_insolvency_proceedings: null\` and \`proceedings: []\`. Envelope now carries only \`query\`, \`country_code\`, \`supported_country: false\`, \`message\`, \`data_source\`. Compliance reviewers ignoring \`supported_country: false\` and reading \`proceedings: []\` would have gotten false-clean signals on non-supported jurisdictions.

**P2 not-found-via-search envelope:** dropped data fields and the ambiguous \`error\` field (which conflated not-found with system errors). Added explicit \`found: false\` discriminator matching PR #75 precedent. Renamed \`error\` → \`message\`. **Not touched:** the 404 path is semantically a success (company resolved, zero insolvency cases — Companies House \`/insolvency\` returns 404 specifically when there are no cases). \`proceedings: []\` there is literal truth.

**P2 date_ended: Path B applied** — dropped from proceeding-item shape. Companies House \`dates\` array structure is not verified empirically (no fixtures in this repo); emitting \`date_ended: null\` unconditionally claimed "the proceeding has not ended" — a positive claim we can't substantiate. Path A (parsing closure-type entries) deferred until empirical evidence exists.

**P2 status heuristic:** dropped \`c.dates?.length > 0 → \"active\"\` inference. Now emits \`c.status ?? \"unknown\"\`. The heuristic wrongly tagged proceedings with closure-date entries as active.

**Manifest updated coherently:**
- \`output_schema.properties.has_insolvency_proceedings\` + \`proceedings\`: type widened to nullable with description noting they're absent on found:false / supported_country:false envelopes
- \`output_schema.properties.found\` added as new boolean discriminator
- \`output_schema.properties.data_source\` widened to nullable
- \`output_field_reliability\`: \`has_insolvency_proceedings\` and \`proceedings\` demoted \`guaranteed\` → \`common\`; \`found\` added as \`rare\`

**Note on divergence from audit:** audit recommended \`throw\` for both error envelopes. This PR uses discriminated-shape pattern (matching PR #75) instead — throwing reserved for system-level errors, routine outcomes use envelope-with-no-data. The existing \`supported_country: false\` field already signaled intent toward discriminated-shape.

**Doctrinal precedents:** PR #70 (BE), PR #72 (adverse-media), PR #73 (sanctions+pep), PR #74 (wallet-risk + token-security), PR #75 (us-company-data-cobalt — closest precedent).

**Downstream consumer scan: zero naive consumers.** seed.ts:2685,2688 holds a stale \`outputSchema\` declaration (declares fields without nullability) but is metadata-only, not a runtime consumer; manifest is canonical per PR #75 pattern. Out of scope here.

**Local verification:** typecheck baseline 3 errors (pre-existing mcp.ts), unchanged with fix; \`vitest run src/capabilities/\` 31/31 pass.