### PR TITLE
fix(beneficial-ownership-lookup): drop data fields from non-UK envelope; add supported_jurisdiction discriminator

### DIFF
--- a/apps/api/src/capabilities/beneficial-ownership-lookup.ts
+++ b/apps/api/src/capabilities/beneficial-ownership-lookup.ts
@@ -35,15 +35,18 @@ registerCapability("beneficial-ownership-lookup", async (input: CapabilityInput)
   }
 
   if (jurisdiction !== "gb" && jurisdiction !== "uk") {
+    // Unsupported-jurisdiction envelope: `supported_jurisdiction: false`
+    // discriminator; data fields dropped per discriminated-runtime-shape
+    // pattern (PR #75/#76, DEC-20260428-B). `total_beneficial_owners: 0`
+    // and `beneficial_owners: []` would falsely claim "this company has no
+    // UBO" when the truth is "we don't support this jurisdiction yet."
     return {
       output: {
         company_name: companyName || null,
         company_number: companyNumber ?? null,
         jurisdiction,
-        beneficial_owners: [],
-        total_beneficial_owners: 0,
-        has_psc_data: false,
-        error: "Beneficial ownership lookup is currently available for UK companies only. More jurisdictions coming soon.",
+        supported_jurisdiction: false,
+        message: "Beneficial ownership lookup is currently available for UK companies only. More jurisdictions coming soon.",
         supported_jurisdictions: ["gb"],
       },
       provenance: { source: "none", fetched_at: new Date().toISOString() },

--- a/manifests/beneficial-ownership-lookup.yaml
+++ b/manifests/beneficial-ownership-lookup.yaml
@@ -28,7 +28,13 @@ output_schema:
     query:
       type: string
     beneficial_owners:
-      type: array
+      type:
+        - array
+        - "null"
+      description: >-
+        Array of resolved PSCs on the success path. Absent entirely on the
+        `supported_jurisdiction: false` envelope (non-UK jurisdictions —
+        discriminated runtime shape, check the discriminator before reading).
     total_owners:
       type: integer
     company_match:
@@ -37,6 +43,11 @@ output_schema:
       type: string
     lookup_date:
       type: string
+    supported_jurisdiction:
+      type: boolean
+      description: >-
+        Present on the non-UK path. `false` indicates the executor does not
+        currently cover this jurisdiction; data fields are absent.
 data_source: Companies House Persons of Significant Control (UK)
 data_source_type: api
 transparency_tag: algorithmic
@@ -76,7 +87,7 @@ test_fixtures:
     jurisdiction: "GB"
 output_field_reliability:
   query: guaranteed
-  beneficial_owners: guaranteed
+  beneficial_owners: common
   total_owners: guaranteed
   company_match: common
   data_source: guaranteed
@@ -84,6 +95,7 @@ output_field_reliability:
   jurisdiction: common
   company_number: common
   coverage_note: common
+  supported_jurisdiction: rare
 limitations:
   - title: UK only — non-GB inputs return a coverage notice
     text: This capability calls Companies House Persons of Significant Control. Non-GB jurisdictions return a structured coverage notice rather than a result. Adding non-UK coverage requires a separate real UBO source (OpenOwnership integration or aggregator wrap per DEC-20260428-A).


### PR DESCRIPTION
Doctrine compliance fix per do-not-fabricate (DEC-20260428-B). One P2 finding from the 2026-05-08 doctrine sweep audit.

**Non-UK jurisdiction envelope:** dropped \`beneficial_owners: []\`, \`total_beneficial_owners: 0\`, \`has_psc_data: false\`. Added explicit \`supported_jurisdiction: false\` discriminator. Renamed \`error\` → \`message\` (routine outcome, not system error). \`total_beneficial_owners: 0\` was the highest-stakes fabrication — customers ignoring the message field would read it as "this company has no UBO" when the truth is "we don't support this jurisdiction yet."

**The 404 PSC-not-filed path is unchanged** — Companies House actually returning "no PSC data filed" for a UK company with \`has_psc_data: false\` is literal truth from the source contract, not fabrication. Same distinction made in PR #76 for the insolvency-check 404 path.

**Manifest updated:**
- \`output_schema.properties.beneficial_owners\`: type widened to \`[array, "null"]\` with description noting absent on \`supported_jurisdiction: false\` envelope
- \`output_schema.properties.supported_jurisdiction\` added as new boolean discriminator
- \`output_field_reliability\`: \`beneficial_owners\` demoted \`guaranteed\` → \`common\`; \`supported_jurisdiction\` added as \`rare\`

(Note: manifest has pre-existing staleness unrelated to this fix — declares \`total_owners\`/\`company_match\`/\`lookup_date\` which don't exist in executor; omits \`company_number\`/\`jurisdiction\`/\`total_beneficial_owners\`/\`has_psc_data\` which do. Out of scope.)

**Audit divergence:** audit recommended \`throw\` for non-UK; this PR uses discriminated-shape pattern matching PR #75 (us-company-data-cobalt) and PR #76 (insolvency-check) precedents.

**Doctrinal precedents:** PR #70 (BE), PR #72 (adverse-media), PR #73 (sanctions+pep), PR #74 (wallet-risk + token-security), PR #75 (us-company-data-cobalt), PR #76 (insolvency-check — closest precedent).

**Downstream consumer scan: zero naive consumers.** \`seed-tests.ts:626-632\` uses Tesco PLC + jurisdiction=GB → success or 404 path → unaffected. \`seed.ts:2607\` outputSchema metadata-only stale. \`seed-solutions.ts:1778\` is static fixture.

**Local verification:** typecheck baseline 3 errors (pre-existing mcp.ts), unchanged with fix; \`vitest run src/capabilities/\` 31/31 pass.