### PR TITLE
fix(P2 doctrine sweep): null instead of fabricated defaults across 5 capabilities

### DIFF
--- a/apps/api/src/capabilities/austrian-company-data.ts
+++ b/apps/api/src/capabilities/austrian-company-data.ts
@@ -41,9 +41,24 @@ interface FinapuSearchResult {
   rechtsform: string;
   sitz: string;
   activity: string | null;
-  status: "active" | "inactive";
+  status: string;
   initDate: string | null;
   endDate: string | null;
+}
+
+// Three-way status mapping matching german-company-data.ts:168-180 precedent.
+// The previous binary collapse (active vs inactive) silently lost fidelity:
+// in-liquidation, terminated, dissolved, and unknown all became "inactive"
+// (DEC-20260428-B).
+function normaliseAtStatus(raw: string | undefined, endDate: string | null): "active" | "terminated" | "unknown" {
+  if (endDate) return "terminated";
+  const v = (raw ?? "").toLowerCase();
+  if (v.includes("active") || v === "ok") return "active";
+  if (v.includes("liquidat") || v.includes("terminated") || v.includes("dissolved") || v.includes("aufgel")) {
+    return "terminated";
+  }
+  if (!v) return "unknown";
+  return "unknown";
 }
 
 interface FinapuDetails {
@@ -112,7 +127,7 @@ async function lookupViaFinapu(query: string, isFn: boolean): Promise<Record<str
         business_type: RECHTSFORM[details.rechtsform?.code] ?? details.rechtsform?.text ?? null,
         address: formatAddress(details.adresse),
         city: details.sitz,
-        status: details.status === "active" ? "active" : "inactive",
+        status: normaliseAtStatus(details.status, details.endDate),
         activity: details.activity || null,
         lei: details.lei || null,
         eu_vat_ids: details.euids?.length ? details.euids : null,
@@ -146,7 +161,7 @@ async function lookupViaFinapu(query: string, isFn: boolean): Promise<Record<str
       business_type: RECHTSFORM[details.rechtsform?.code] ?? details.rechtsform?.text ?? null,
       address: formatAddress(details.adresse),
       city: details.sitz,
-      status: details.status === "active" ? "active" : "inactive",
+      status: normaliseAtStatus(details.status, details.endDate),
       activity: details.activity || null,
       lei: details.lei || null,
       eu_vat_ids: details.euids?.length ? details.euids : null,
@@ -166,7 +181,7 @@ async function lookupViaFinapu(query: string, isFn: boolean): Promise<Record<str
       fn_number: `FN ${best.fnr}`,
       business_type: RECHTSFORM[best.rechtsform] ?? best.rechtsform ?? null,
       city: best.sitz,
-      status: best.status === "active" ? "active" : "inactive",
+      status: normaliseAtStatus(best.status, best.endDate),
       activity: best.activity || null,
     };
   }

--- a/apps/api/src/capabilities/email-pattern-discover.ts
+++ b/apps/api/src/capabilities/email-pattern-discover.ts
@@ -91,7 +91,7 @@ registerCapability("email-pattern-discover", async (input: CapabilityInput) => {
         mx_records: [],
         email_provider: null,
         patterns: [],
-        generic_addresses: [],
+        common_pattern_addresses: [],
         recommendation: `${targetDomain} does not have MX records configured. This domain may not accept email.`,
       },
       provenance: {
@@ -101,16 +101,14 @@ registerCapability("email-pattern-discover", async (input: CapabilityInput) => {
     };
   }
 
-  // Step 2: Check which generic addresses exist (catch-all detection)
-  const genericResults: Array<{ address: string; likely_exists: boolean }> = [];
-  for (const prefix of COMMON_PREFIXES.slice(0, 6)) {
-    // We can't do full SMTP verification without sending mail,
-    // but we can report common patterns
-    genericResults.push({
-      address: `${prefix}@${targetDomain}`,
-      likely_exists: ["info", "contact", "hello", "sales", "support"].includes(prefix),
-    });
-  }
+  // Step 2: Construct candidate generic addresses from common prefixes.
+  // These are heuristic prefix matches, NOT verified deliverable addresses
+  // (DEC-20260428-B). The previous `likely_exists` filter was a hardcoded
+  // prefix-membership check masquerading as deliverability evidence; it has
+  // been dropped. Use email-validate downstream for actual verification.
+  const commonPatternAddresses: string[] = COMMON_PREFIXES.slice(0, 6).map(
+    (prefix) => `${prefix}@${targetDomain}`,
+  );
 
   // Step 3: Determine likely email patterns based on provider and domain analysis
   // Google Workspace and Microsoft 365 commonly use first.last@ or firstlast@
@@ -164,7 +162,7 @@ registerCapability("email-pattern-discover", async (input: CapabilityInput) => {
       inferred_pattern: inferredPattern,
       patterns,
       public_emails_found: publicEmails,
-      generic_addresses: genericResults.filter(g => g.likely_exists).map(g => g.address),
+      common_pattern_addresses: commonPatternAddresses,
       recommendation: emailProvider
         ? `${targetDomain} uses ${emailProvider}. Most common pattern is first.last@${targetDomain}. Verify individual addresses with email-validate before sending.`
         : `${targetDomain} accepts email. Try first.last@${targetDomain} as the most common pattern. Verify with email-validate before sending.`,

--- a/apps/api/src/capabilities/french-company-data.ts
+++ b/apps/api/src/capabilities/french-company-data.ts
@@ -47,9 +47,19 @@ async function searchCompany(query: string): Promise<Record<string, unknown>> {
   const c = results[0];
   const siege = c.siege || {};
 
+  // company_name and siren: null instead of "" when missing — empty string
+  // implies "we got a value, it was empty" rather than "the source omitted
+  // the field" (DEC-20260428-B).
+  // Directors: keep the slice(0, 3) but expose truncation transparency via
+  // companion fields so consumers know more directors exist beyond the slice.
+  const allDirectors = Array.isArray(c.dirigeants) ? c.dirigeants : [];
+  const directors = allDirectors.slice(0, 3).map((d: any) =>
+    `${d.prenoms || ""} ${d.nom || ""}`.trim() + (d.qualite ? ` (${d.qualite})` : ""),
+  );
+
   return {
-    company_name: c.nom_complet || c.nom_raison_sociale || "",
-    siren: c.siren || "",
+    company_name: c.nom_complet || c.nom_raison_sociale || null,
+    siren: c.siren || null,
     siret: siege.siret || null,
     business_type: c.nature_juridique || null,
     address: siege.adresse || siege.geo_adresse || null,
@@ -59,10 +69,10 @@ async function searchCompany(query: string): Promise<Record<string, unknown>> {
     creation_date: c.date_creation || null,
     employee_range: c.tranche_effectif_salarie || null,
     status: c.etat_administratif === "A" ? "active" : c.etat_administratif === "C" ? "closed" : c.etat_administratif || "unknown",
-    vat_number: deriveVatFR(c.siren || ""),
-    directors: (c.dirigeants || []).slice(0, 3).map((d: any) =>
-      `${d.prenoms || ""} ${d.nom || ""}`.trim() + (d.qualite ? ` (${d.qualite})` : ""),
-    ),
+    vat_number: c.siren ? deriveVatFR(c.siren) : null,
+    directors,
+    directors_truncated: allDirectors.length > 3,
+    total_directors: allDirectors.length,
   };
 }
 

--- a/apps/api/src/capabilities/german-company-data.ts
+++ b/apps/api/src/capabilities/german-company-data.ts
@@ -291,8 +291,11 @@ registerCapability("german-company-data", async (input: CapabilityInput) => {
             .filter((c) => c.code)
         : [],
       directors: Array.isArray(company.representation) ? buildDirectors(company.representation) : [],
+      // Capital currency passthrough; do not default to "EUR". A German
+      // subsidiary in CHF or USD silently rewriting to EUR is a fabrication
+      // (DEC-20260428-B).
       capital: company.capital?.amount != null
-        ? { amount: company.capital.amount, currency: company.capital.currency ?? "EUR" }
+        ? { amount: company.capital.amount, currency: company.capital.currency ?? null }
         : null,
       lei: company.lei?.trim() || null,
       incorporated_at: company.incorporated_at ? company.incorporated_at.split("T")[0] : null,

--- a/apps/api/src/capabilities/ip-risk-score.ts
+++ b/apps/api/src/capabilities/ip-risk-score.ts
@@ -46,10 +46,15 @@ registerCapability("ip-risk-score", async (input: CapabilityInput) => {
     const parts = ip.split(".").map(Number);
     if (parts[0] === 10 || (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
         (parts[0] === 192 && parts[1] === 168) || parts[0] === 127) {
+      // Private RFC1918 IPs are correctly not-VPN, not-proxy, not-Tor, not-
+      // datacenter — those `false` values are honest. But `is_residential`
+      // can't be determined from the IP alone (a 192.168.x.x is residential
+      // on a home network, but is also valid in offices, datacenters, etc.);
+      // null instead of fabricated false (DEC-20260428-B).
       return {
         output: {
           ip, risk_score: 0, risk_level: "none",
-          is_vpn: false, is_proxy: false, is_tor: false, is_datacenter: false, is_residential: false,
+          is_vpn: false, is_proxy: false, is_tor: false, is_datacenter: false, is_residential: null,
           note: "Private/reserved IP address — not routable on the public internet",
         },
         provenance: { source: "strale-ip-risk", fetched_at: new Date().toISOString() },

--- a/manifests/austrian-company-data.yaml
+++ b/manifests/austrian-company-data.yaml
@@ -52,6 +52,14 @@ output_schema:
         - "null"
     status:
       type: string
+      enum:
+        - active
+        - terminated
+        - unknown
+      description: >-
+        Three-way enum matching german-company-data.ts:168-180 precedent.
+        Replaces the prior binary collapse (active/inactive) which lost
+        fidelity (in-liquidation, terminated, dissolved all became inactive).
     address:
       type: string
     company_name:

--- a/manifests/email-pattern-discover.yaml
+++ b/manifests/email-pattern-discover.yaml
@@ -62,7 +62,7 @@ output_field_reliability:
   email_provider: common
   inferred_pattern: rare
   public_emails_found: rare
-  generic_addresses: common
+  common_pattern_addresses: common
 limitations:
   - title: Pattern inference is heuristic, not verified per-address
     text: Returned patterns are based on email-provider conventions and any public emails found on the domain's homepage. Individual addresses must still be validated with email-validate before sending.

--- a/manifests/french-company-data.yaml
+++ b/manifests/french-company-data.yaml
@@ -37,7 +37,9 @@ output_schema:
     employee_range: "51"
   properties:
     siren:
-      type: string
+      type:
+        - string
+        - "null"
     siret:
       type: string
     status:
@@ -46,8 +48,18 @@ output_schema:
       type: string
     directors:
       type: array
+      description: >-
+        Up to 3 directors from the registry (slice cap for payload). When
+        the registry lists more than 3, `directors_truncated` is true and
+        `total_directors` carries the full count.
+    directors_truncated:
+      type: boolean
+    total_directors:
+      type: integer
     company_name:
-      type: string
+      type:
+        - string
+        - "null"
     activity_code:
       type: string
 data_source: INSEE / Registre du Commerce (France)

--- a/manifests/ip-risk-score.yaml
+++ b/manifests/ip-risk-score.yaml
@@ -32,7 +32,13 @@ output_schema:
     is_datacenter:
       type: boolean
     is_residential:
-      type: boolean
+      type:
+        - boolean
+        - "null"
+      description: >-
+        Boolean on the public-IP path. Null on the private-IP path —
+        residential vs office vs datacenter cannot be inferred from a
+        private RFC1918 address alone.
 data_source: ip-api.com + Strale risk engine (ASN lists, datacenter detection)
 data_source_type: computed
 transparency_tag: mixed


### PR DESCRIPTION
Final PR in the 2026-05-08 doctrine sweep audit. Closes 5 P2 findings across 5 capability files per do-not-fabricate (DEC-20260428-B). After this lands, **all 13 audit findings are shipped**.

**email-pattern-discover.ts:** \`likely_exists\` was a hardcoded prefix-match heuristic; \`generic_addresses\` was filtered to "likely" addresses, implying verification when there's only prefix membership. Renamed \`generic_addresses\` → \`common_pattern_addresses\`. Dropped the filter — customers see all candidates and use email-validate for actual verification. **Path C.**

**austrian-company-data.ts:** \`status === "active" ? "active" : "inactive"\` binary collapse lost fidelity (in-liquidation / terminated / dissolved / unknown all became "inactive"). Three sites replaced with new \`normaliseAtStatus(raw, endDate)\` helper matching the german-company-data:168-180 precedent. Now three-way: active / terminated / unknown. **Path B.**

**german-company-data.ts:** \`currency ?? "EUR"\` — German subsidiaries in CHF/USD were silently rewritten. Now \`?? null\`. **Path B.**

**french-company-data.ts:** Two findings. (1) \`company_name\` and \`siren\` empty-string defaults → null. Also fixed \`deriveVatFR(c.siren || "")\` → siren-conditional. (2) \`directors\` silent truncation to top-3 → kept slice but added \`directors_truncated\` and \`total_directors\` companion fields. **Path B + Path C.**

**ip-risk-score.ts:** Private-IP path emitted \`is_residential: false\` — but a 192.168.x.x can be residential, office, or datacenter (can't be inferred from the address alone). Now null. Other private-IP booleans (is_vpn, is_proxy, is_tor, is_datacenter) correctly stay false. **Path B.**

**Manifests updated coherently:**
- email-pattern-discover: \`output_field_reliability\` key renamed
- austrian-company-data: status enum \`[active, terminated, unknown]\` + description
- french-company-data: siren/company_name widened nullable; directors_truncated + total_directors added
- ip-risk-score: is_residential widened to \`[boolean, "null"]\` + description
- german-company-data: capital sub-properties not declared at manifest level (capital is \`[object, "null"]\`), no manifest change

**Doctrinal precedents:** PR #70 (BE), #72 (adverse-media), #73 (sanctions+pep), #74 (wallet-risk + token-security), #75 (us-company-data-cobalt), #76 (insolvency-check), #77 (beneficial-ownership-lookup).

**Downstream consumer scan:** zero naive consumers. Only \`generic_addresses\` appeared in field-level grep beyond the executor + manifest (rename limited to those two files).

**Local verification:** typecheck baseline 3 errors (pre-existing mcp.ts), unchanged with fix; \`vitest run src/capabilities/\` 31/31 pass; all 5 cross-check greps confirm patterns gone.

**Doctrine sweep complete after this merge:** all 13 audit findings shipped across PR #70 (BE precedent) and PRs #72–#77 + this PR.