### PR TITLE
chore: add prune-claude-worktrees janitor script

### DIFF
--- a/WORKTREES.md
+++ b/WORKTREES.md
@@ -47,3 +47,31 @@ Update this file in the same PR.
 
 The branch (if any) persists in `.git/`. Use `git branch -d <branch>` to
 clean up the branch ref if no longer needed.
+
+## Janitor: pruning orphan agent-isolation worktrees
+
+Despite Rule 3, CC sub-agents occasionally leave filesystem residue under
+`.claude/worktrees/*` that isn't registered in `git worktree list`. These
+are orphans — directories without git-tracked context, often paired with
+abandoned `claude/<adjective-name>` branches.
+
+The janitor script `apps/api/scripts/prune-claude-worktrees.ts` cleans
+these up safely.
+
+Run on demand (or after a CC session that may have spawned isolation
+worktrees):
+
+    npx tsx apps/api/scripts/prune-claude-worktrees.ts
+
+The script is **safe-by-construction**:
+
+- Never removes a directory registered in `git worktree list`.
+- Never force-deletes a branch (uses `git branch -d`, not `-D`).
+- Refused branches (those with unmerged work) are logged for operator
+  review, not deleted.
+- Idempotent — running twice is harmless.
+
+Output: list of directories removed, branches deleted, branches refused.
+
+Run frequency: after any session that uses agent isolation, OR weekly as
+a sweep. Not yet wired to CI; a future hook could automate this.

--- a/apps/api/scripts/prune-claude-worktrees.ts
+++ b/apps/api/scripts/prune-claude-worktrees.ts
@@ -1,0 +1,154 @@
+/**
+ * Janitor for orphan agent-isolation worktrees under `.claude/worktrees/*`.
+ *
+ * WORKTREES.md Rule 3 bans `Agent({isolation: "worktree"})` but the rule is
+ * advisory — CC sub-agents occasionally leave filesystem residue (directories
+ * that aren't registered in `git worktree list`), often paired with abandoned
+ * `claude/<adjective-name>` branches.
+ *
+ * This script removes those orphans safely:
+ *   - Never touches a directory registered in `git worktree list --porcelain`.
+ *   - Only safe-deletes branches (`git branch -d`); never `-D`. Branches with
+ *     unmerged work are logged and left for operator review.
+ *   - Idempotent: running twice in a row produces a clean second run.
+ *
+ * Usage:
+ *   npx tsx apps/api/scripts/prune-claude-worktrees.ts
+ *
+ * Run on demand after a session that may have spawned isolation worktrees,
+ * or weekly as a sweep.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
+const WORKTREES_DIR = join(REPO_ROOT, ".claude", "worktrees");
+
+function canon(p: string): string {
+  return resolve(p).replace(/\\/g, "/").toLowerCase();
+}
+
+function git(...args: string[]): string {
+  return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" });
+}
+
+function getRegisteredWorktreePaths(): Set<string> {
+  const out = git("worktree", "list", "--porcelain");
+  const paths = new Set<string>();
+  for (const line of out.split(/\r?\n/)) {
+    if (line.startsWith("worktree ")) {
+      paths.add(canon(line.slice("worktree ".length)));
+    }
+  }
+  return paths;
+}
+
+function listClaudeBranches(): string[] {
+  const out = git("branch", "--list", "claude/*");
+  return out
+    .split(/\r?\n/)
+    .map((l) => l.replace(/^[\s*+]+/, "").trim())
+    .filter((l) => l.length > 0);
+}
+
+function main(): void {
+  if (!existsSync(WORKTREES_DIR)) {
+    console.log(`No .claude/worktrees/ directory at ${WORKTREES_DIR} — nothing to prune.`);
+    return;
+  }
+
+  const registered = getRegisteredWorktreePaths();
+
+  // Phase 1: directory cleanup
+  const removedDirs: string[] = [];
+  const skippedRegistered: string[] = [];
+  for (const entry of readdirSync(WORKTREES_DIR)) {
+    const full = join(WORKTREES_DIR, entry);
+    let isDir = false;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+
+    if (registered.has(canon(full))) {
+      skippedRegistered.push(entry);
+      continue;
+    }
+
+    try {
+      rmSync(full, { recursive: true, force: true });
+      removedDirs.push(entry);
+    } catch (err) {
+      console.error(`[error] failed to remove ${full}: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  }
+
+  // Phase 2: branch cleanup. Re-read worktree list post-removal in case any
+  // registered worktree paths changed (defensive — they shouldn't).
+  const registeredAfter = getRegisteredWorktreePaths();
+  const branchesUsedByLiveWorktrees = new Set<string>();
+  // Parse `git worktree list --porcelain` more fully to extract branch refs.
+  for (const line of git("worktree", "list", "--porcelain").split(/\r?\n/)) {
+    if (line.startsWith("branch ")) {
+      // Format: "branch refs/heads/<name>"
+      const ref = line.slice("branch ".length).replace(/^refs\/heads\//, "");
+      branchesUsedByLiveWorktrees.add(ref);
+    }
+  }
+
+  const branches = listClaudeBranches();
+  const deletedBranches: string[] = [];
+  const refusedBranches: { name: string; reason: string }[] = [];
+  const skippedLiveBranches: string[] = [];
+
+  for (const branch of branches) {
+    if (branchesUsedByLiveWorktrees.has(branch)) {
+      skippedLiveBranches.push(branch);
+      continue;
+    }
+    try {
+      execFileSync("git", ["branch", "-d", branch], { cwd: REPO_ROOT, stdio: "pipe" });
+      deletedBranches.push(branch);
+    } catch (err) {
+      const stderr = ((err as { stderr?: Buffer }).stderr ?? Buffer.from("")).toString().trim();
+      const reason = stderr.split(/\r?\n/)[0] ?? "unknown";
+      refusedBranches.push({ name: branch, reason });
+    }
+  }
+
+  // Summary
+  console.log("=== prune-claude-worktrees summary ===");
+  console.log(`Registered worktrees skipped: ${skippedRegistered.length}`);
+  for (const e of skippedRegistered) console.log(`  - ${e} (live)`);
+  console.log(`Directories removed: ${removedDirs.length}`);
+  for (const e of removedDirs) console.log(`  - ${e}`);
+  console.log(`Branches deleted via -d: ${deletedBranches.length}`);
+  for (const b of deletedBranches) console.log(`  - ${b}`);
+  console.log(`Branches refused (left for operator review): ${refusedBranches.length}`);
+  for (const { name, reason } of refusedBranches) {
+    console.log(`  - ${name}: ${reason}`);
+  }
+  console.log(`Branches skipped (live worktree using them): ${skippedLiveBranches.length}`);
+  for (const b of skippedLiveBranches) console.log(`  - ${b}`);
+
+  // Sanity invariant: registered worktrees post-cleanup must equal pre-cleanup
+  // count (we never remove registered worktrees).
+  if (registeredAfter.size !== registered.size) {
+    console.error(
+      `[error] registered worktree count changed during run (${registered.size} -> ${registeredAfter.size}); investigate.`,
+    );
+    process.exit(1);
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`[error] ${(err as Error).message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
Adds \`apps/api/scripts/prune-claude-worktrees.ts\` — safe-by-construction janitor for filesystem-residue orphans under \`.claude/worktrees/*\` and their corresponding orphan \`claude/<name>\` branches.

WORKTREES.md Rule 3 bans \`Agent({isolation: "worktree"})\` but the rule is advisory documentation. CC continues to spawn isolation worktrees and leave imperfect cleanup behind — 3 new orphans appeared during today's earlier cleanup of 21 prior orphans (PR #81).

**The janitor:**
- Removes \`.claude/worktrees/*\` directories not registered in \`git worktree list --porcelain\`.
- Deletes corresponding \`claude/*\` branches via safe \`-d\` (never \`-D\`).
- Refused branches (unmerged) logged for operator review, not deleted.
- Idempotent.
- Sanity invariant: post-run registered-worktree count must equal pre-run count; bails if not.

WORKTREES.md updated with usage docs in a new "Janitor" section. Run after sessions that use agent isolation, or weekly as a sweep.