### PR TITLE
chore: promote 5 handoff notes to tracked

### DIFF
--- a/handoff/_general/from-code/2026-05-06-chromium-phase3-halt-partial-flag-survival.md
+++ b/handoff/_general/from-code/2026-05-06-chromium-phase3-halt-partial-flag-survival.md
@@ -1,0 +1,90 @@
+Intent: Phase 3 (Harden) of the 2026-05-04 chromium bug fix — pin chromium service to Browserless v1, re-flip strale env vars, verify all 4 launch flags reach Chrome unfiltered, run smoke + spot-checks. Halted at flag verification: only 2 of 4 flags survived under v1. Rolled back per protocol.
+
+## What shipped (repo)
+
+Commit `b547385`: `fix(chromium): pin to Browserless v1 (v2 OSS tier filters launch flags)`.
+
+- `apps/api/railway-config.md`: documents the v1 pin (`browserless/chrome:1.61.1-chrome-stable`), the "Why v1" reasoning, the "When to revisit" criteria, and the `PORT=8080` env var requirement.
+- `apps/api/docker-compose.dev.yml`: pinned to the same v1 tag for local dev; added `LAUNCH_ARGS` env-var fallback.
+- `apps/api/src/lib/chromium-flag-filtering.test.ts`: 3 regression tests codifying the v2-filtering failure mode. Asserts the canonical 4-flag list reaches the encoded `?launch=` payload byte-for-byte. Per DEC-20260504-A.
+
+Tests: 14/14 pass. Typecheck clean. `/health.commit = b5473857...` confirmed live in prod.
+
+## What shipped (operations, by Petter)
+
+Chromium service (Railway dashboard) flipped to `browserless/chrome:1.61.1-chrome-stable`. Service Online, listening on `:8080` (existing PORT mapping survived the image swap — v1 picked up the existing PORT env or defaulted appropriately). v1-style log keys present (`FUNCTION_BUILT_INS`, `WORKSPACE_DIR`, `Running on port 8080`).
+
+## The observation that triggered halt
+
+Strale-side `chromium-probe-url` log under v1 (post-flip, 19:48:43 UTC):
+```
+contentUrl="http://chromium.railway.internal:8080/content?token=<redacted>&launch=eyJhcmdzIjpbIi0tbm8tc2FuZGJveCIsIi0tZGlzYWJsZS1kZXYtc2htLXVzYWdlIiwiLS1kaXNhYmxlLWdwdSIsIi0tZGlzYWJsZS1zZXR1aWQtc2FuZGJveCJdfQ=="
+```
+Decoded: `{"args":["--no-sandbox","--disable-dev-shm-usage","--disable-gpu","--disable-setuid-sandbox"]}` — all 4 flags reach the wire as expected (helper unchanged).
+
+Strale-side probe result: `chromium-health-ok` at 19:48:44 UTC. Chrome rendered example.com successfully.
+
+**Chromium service debug log** (the decisive observation under v1):
+```
+2026-05-06T19:48:43.477Z browserless:chrome-helper Launching Chrome with args: {
+  "args": [
+    "--no-sandbox",                         ← ours ✓
+    "--enable-logging",                     (v1 default)
+    "--v1=1",                               (v1 default — verbosity)
+    "--disable-dev-shm-usage",              ← ours ✓
+    "--no-first-run",                       (v1 default)
+    "--remote-debugging-port=41643",        (v1 default)
+    "--user-data-dir=/tmp/browserless-data-dir-hi0zzG"  (v1 default)
+  ],
+  ...
+  "ignoreDefaultArgs": false,
+  ...
+  "executablePath": "/usr/bin/google-chrome"
+}
+```
+
+**2 of 4 flags survived; `--disable-gpu` and `--disable-setuid-sandbox` are absent** from Chrome's launched args.
+
+This pattern held for both the post-flip `?launch=`-bearing request AND a request without the `launch=` query param — meaning v1 is producing the same args list regardless of the per-request payload. v1 appears to be using its own internal default-arg list (which contains `--no-sandbox` + `--disable-dev-shm-usage` from the chromium service's `LAUNCH_ARGS` env var) and either dropping per-request supplemental args, or deduping against an internal allowlist that excludes `--disable-gpu` and `--disable-setuid-sandbox`.
+
+Operationally, Chrome is NOT crashing. The two missing flags are functionally redundant with what's present:
+- `--disable-gpu` → already implicit in `headless: "new"`; Railway has no GPU.
+- `--disable-setuid-sandbox` → redundant when `--no-sandbox` is set.
+
+The two flags that DID survive are exactly the load-bearing ones: `--no-sandbox` (avoids zygote+helper forks → no `pthread_create` EAGAIN) and `--disable-dev-shm-usage` (avoids small `/dev/shm` → no SIGABRT).
+
+## Why I halted (rule conflict, surfaced to Petter)
+
+Phase 3 prompt explicitly states:
+> If the chromium-service debug log shows even ONE of the 4 flags missing from Chrome's `args`, halt. This is the "v1 doesn't fix it after all" scenario — escalate to chat for Phase 4 (probably `--single-process`).
+
+Two flags are missing. Strict letter says halt. The rule was framed for "Chrome can't boot," which isn't what's happening here — Chrome boots cleanly, probe is green. But CC does not reconcile silently. Surfaced to Petter at the halt; my pre-authored wakeup conditional independently directed the rollback path. Both align: roll back env vars, leave chromium image pinned to v1.
+
+## Production state at halt
+
+- chromium service: `browserless/chrome:1.61.1-chrome-stable`, Online, listening :8080. **Pin stays.**
+- strale API: env vars rolled back to hosted: `BROWSERLESS_URL=https://production-sfo.browserless.io`, original API key.
+- `/health.commit = b5473857...` (Phase 3 commit).
+- 32 scraping caps remain in pre-existing degraded state. No regression beyond pre-Phase-3 condition.
+- Working tree clean. HEAD on `main` at `b547385`.
+
+## Two paths forward — Petter to choose
+
+1. **Accept v1's deduping behaviour, declare Phase 3 complete.** Operational evidence: probe green, Chrome boots, two missing flags are functionally redundant. Re-flip env vars to internal, run smoke + spot-checks, file post-close to-do, mark Phase 3 to-do Done. Document the v1-deduping behaviour as the new "expected steady state" in `railway-config.md` so future audits don't re-trigger the halt.
+
+2. **Investigate why v1 isn't honouring the per-request `launch=` payload.** Cleanest path: set `ignoreDefaultArgs: true` in the `?launch=` payload so v1 uses ONLY our list verbatim. Code change in `apps/api/src/lib/browserless-launch.ts`:
+   ```ts
+   const LAUNCH_QUERY_PARAM =
+     "launch=" +
+     Buffer.from(JSON.stringify({
+       args: BROWSERLESS_LAUNCH_ARGS,
+       ignoreDefaultArgs: true,    // force v1 to use OUR list
+     })).toString("base64");
+   ```
+   Then re-flip env vars, re-verify all 4 flags appear. Risk: setting `ignoreDefaultArgs: true` strips v1's `--user-data-dir` and `--remote-debugging-port` defaults — those would need to be added to our `BROWSERLESS_LAUNCH_ARGS` list, or v1 would fail to attach to the Chrome instance. This is non-trivial Phase 4 work.
+
+Recommendation: path 1 is operationally correct and cheaper. The structural test in `chromium-flag-filtering.test.ts` already protects the helper-side contract. Document the v1-deduping behaviour and ship.
+
+## Phase 2 instrumentation status
+
+The `chromium-probe-url` log line (Phase 2's structural gate) continues to fire and stays useful regardless of which path Petter picks. The Phase 3 commit's regression test continues to guard the helper-side contract. Both stay in production.

--- a/handoff/_general/from-code/2026-05-06-dk-cvr-breaker-open-phase1-containment.md
+++ b/handoff/_general/from-code/2026-05-06-dk-cvr-breaker-open-phase1-containment.md
@@ -1,0 +1,74 @@
+Intent: Phase 1 (Contain) of the bug fix framework on the cvrapi.dk quota failure surfaced in this morning's `audit/live-registry-coverage-2026-05-06` — verify the failure is still live, and if so, prevent customer calls to `danish-company-data` from silently hitting the quota error until Phase 2 (Understand) lands.
+
+# What shipped
+
+## Diagnostic script (1 commit, merged + pushed to main)
+
+- **`95eaf72`** `chore(scripts): add dk-cvr quota retry diagnostic` — adds `apps/api/src/scripts/dk-cvr-retry-2026-05-06.ts`. Mirrors the audit driver's pattern: dotenv → clear `DATABASE_URL` → autoRegister → `getExecutor("danish-company-data")(...)`. Emits JSON `{kind, started_at, latency_ms, message}`. Reusable for future Phase 1 retries against any single capability.
+- Branch was `chore/dk-cvr-retry-diagnostic-2026-05-06`, fast-forward merged into main and deleted locally.
+
+## Production data write (no commit — direct DB)
+
+Opened the DK circuit breaker manually:
+
+```sql
+UPDATE capability_health
+SET state='open',
+    opened_at=NOW(),
+    next_retry_at=NOW()+INTERVAL '6 hours',
+    updated_at=NOW()
+WHERE capability_slug='danish-company-data';
+```
+
+Verified state on prod after apply:
+- `state=open`
+- `opened_at=2026-05-06T10:39:41Z`
+- `next_retry_at=2026-05-06T16:39:41Z` (exactly +6h)
+- `updated_at=2026-05-06T10:39:41Z`
+
+Customer effect: POST /v1/do calls to `danish-company-data` now return HTTP 503 `capability_unavailable` with `next_retry_at` until 16:39 UTC, at which point the breaker auto-transitions to `half_open` on the next call. The half_open call's outcome decides whether the breaker closes (DK recovered) or re-opens with backoff.
+
+# Retry result that triggered the apply
+
+Re-invoked with A.P. Møller-Mærsk A/S CVR 22756214 at 2026-05-06T10:08:42Z:
+- `kind: error`, `latency_ms: 221`, `message: "The Danish business registry API quota has been temporarily exceeded. Please try again in a few hours."`
+
+Same error string as the audit yesterday. Fast-fail (no 5xx, no timeout) — the upstream is genuinely returning the quota-exceeded JSON body.
+
+# Two rule-vs-prompt halts during execution
+
+Worth flagging because both reflect doctrine the prompt assumed but the codebase no longer matches:
+
+1. **Substrate mismatch — `source_health` does not exist.** The prompt's action (b) called for `UPDATE source_health SET status='degraded'`. The actual table is `capability_health` (circuit-breaker shape with states `closed | open | half_open`). `source_health` is queued for PR2+ of the SQS-engine cleanup per `apps/api/src/lib/lifecycle.ts:148` and `apps/api/src/jobs/invariant-checker.ts:78`. Resolved by switching to the live circuit-breaker substrate (option α).
+
+2. **Deploy-mechanism mismatch — `drizzle-kit migrate` is not the live path.** The prompt's deploy step said `railway run npx drizzle-kit migrate` per "Rule 8 standard workflow." But `_journal.json` stops at idx 60 (`0060_marketplace_eligible`); the live path for hand-written migrations is `runStartupMigrations()` in `apps/api/src/lib/startup-migrations.ts` (the `BLOCKS` array). drizzle-kit-migrate would have been a no-op for any new hand-written file and the verification SELECT would have come back unchanged — exactly the Rule 14 (DEC-20260504-C) failure mode. Resolved by Path B (direct UPDATE), since this is operational data not schema.
+
+# Non-obvious learnings
+
+- **psql is not installed locally.** `railway run psql ...` fails with "command not found." Workaround used: `railway ssh --service strale -- 'echo <b64> | base64 -d > /app/_dk_breaker.mjs && cd /app && node _dk_breaker.mjs'`. The `cd /app` is load-bearing — Node ESM resolution from `/tmp` doesn't traverse to `/app/node_modules`, so `import postgres from "postgres"` fails. Future ad-hoc DB writes from local should follow the same pattern, or install `psql`.
+- **`railway connect Postgres` invokes local psql** — same problem. The Railway internal hostname `postgres.railway.internal` doesn't resolve from outside the Railway network, so `railway run` (which runs locally with env injected) can't reach the DB either. Effective options from local: ssh into a Railway service, install psql locally, or expose a TCP proxy.
+- **Stdin pipe to `railway ssh -- 'cat > file'` hangs silently.** The base64 inline approach worked; heredoc-piped stdin did not.
+- **The breaker's auto-recovery is the right shape for a quota issue.** No follow-up cron needed — at 16:39 UTC the next customer call to DK transitions to `half_open` and decides closed-vs-reopened organically. If the underlying CVR quota window has reset, DK comes back automatically.
+
+# What's open
+
+## Phase 2 (Understand) — handed to Claude chat for Notion governance
+
+Per the prompt's closing instruction: Petter / Claude chat handle the Notion governance writes:
+- DEC-20260506-D — `danish-company-data` breaker manually opened pending Phase 2; mechanism choice (psql/path B) noted as carve-out from drizzle-kit/path A.
+- Active Vendor Stack page — DK status update (live → degraded/breaker-open).
+- Phase 2 To-do — "Characterize CVR API rate limit and design Phase 3 harden approach."
+- Journal course-correction entry — flag that the prompt referenced `source_health` and `drizzle-kit migrate` while the live substrate is `capability_health` and `runStartupMigrations()`. Worth a memo so the next prompt's audit phase catches it earlier.
+
+## Code follow-ups (none scheduled)
+
+Phase 2 design (rate-limit characterization) and Phase 3 harden (e.g. local rate-limit tracking, fallback provider, datacvr.virk.dk migration per the comment at `apps/api/src/capabilities/danish-company-data.ts:6-9`) are deferred to follow-up prompts. The Phase 1 prompt only authorized Contain.
+
+## Session close-check finding
+
+`session-close-check.ts` reports 1 red — `danish-company-data` breaker opened this session. **This is the deliberate containment, not a hidden regression.** The script doesn't distinguish "breaker tripped by user traffic" from "breaker manually opened by operator." Future-self reading this: don't panic.
+
+# Cost
+
+- One Anthropic API call (Haiku 4.5) inside the DK retry, ≈€0.0001.
+- One UPDATE on `capability_health`. No deploy, no rebuild.

--- a/handoff/_general/from-code/2026-05-07-drift-check-refactor-and-branch-protection.md
+++ b/handoff/_general/from-code/2026-05-07-drift-check-refactor-and-branch-protection.md
@@ -1,0 +1,105 @@
+Intent: Trace and fix the OpenOwnership/BODS aspirational-architecture drift across customer surfaces and CI tooling, then close the structural gap that let the related 2026-05-06 red-main incident happen at all.
+
+# What shipped
+
+The day's arc walked the same defect class — aspirational architecture treated as fact — through four layers, then sealed it with branch protection.
+
+## Layer 1 — Customer-facing copy (PR #62, merge `1943d28`)
+
+`fix: remove inaccurate OpenOwnership integration claim from product copy`
+
+Three surfaces still claimed Strale integrates with OpenOwnership BODS for UBO supplement; Strale has no such integration (the eval doc at `apps/api/docs/ubo-resolve-uk-bods-evaluation.md` from 2026-04-02 explicitly deferred it). Removed:
+- `apps/api/src/db/seed-solutions.ts:1754` — `enhanced-due-diligence` longDescription "via OpenOwnership/Companies House" → "via Companies House for UK companies"
+- `packages/strale-capabilities/capabilities.json:4646` — published catalog description rewritten to match the manifest's actual UK-only scope
+- `manifests/gleif-l2-ubo-lookup.yaml:157` — limitation `workaround` text dropped the OpenOwnership BODS recommendation
+
+Voice check applied per Notion Brand & voice canonical page (§1 5-test publish + §2.5 review checklist). Three customer-facing instances; six other OpenOwnership references retained as factual evaluation context.
+
+## Layer 2 — CI infrastructure Phase A (PR #63, merge `3dfce8f`)
+
+`fix(drift-checks): remove stale entries from static maps + add refactor proposal`
+
+The drift-check scripts that exist to catch this defect class were themselves carrying it:
+- `check-platform-facts-drift.mjs:CURRENT_VENDORS` had `ubo_uk_dk_sk_smes: "OpenOwnership"` — removed; "OpenOwnership" added to STALE_VENDORS so future re-introductions in scanned surfaces are caught.
+- `check-provider-coverage-drift.mjs:KNOWN_GOV_REGISTRY_PROVIDERS` listed "OpenOwnership" alongside genuine gov registries — removed (set was dead code, never referenced after declaration).
+
+Phase A also added `apps/api/docs/drift-check-refactor-proposal.md` — 8-section design doc for the structural fix.
+
+Verified parity: all three drift checks pass identically pre/post Phase A.
+
+## Layer 3 — CI infrastructure Phase B (PR #65, merge `41c0542`)
+
+`refactor(drift-checks): convert .mjs to .ts and import canonical lists from platform-facts`
+
+Two commits:
+- **`bbf686c feat(platform-facts)`** — additive expansion of `STATIC_FACTS.vendors` with 4 new categories (us_company_registry: Cobalt Intelligence, us_ein: Liberty Data, ubo_supplement_global: GLEIF L2, fr_litigation: BODACC). Added `STALE_VENDORS` export at canonical, `getActiveVendorNames()` and `getStaleVendorNames()` helpers, 5 new test invariants — including the structural "every name in `getActiveVendorNames()` corresponds to a shipped capability slug" assertion that closes the "vendor listed without integration" mode.
+- **`bfa6f2d refactor(drift-checks)`** — three drift scripts converted from `.mjs` to `.ts`, static maps deleted, imports from canonical. `weekly-drift.yml` updated to invoke `.ts` paths via `tsx` (matching `sweep-manifest-drift.ts` precedent).
+
+The 6 (not 7) Uncertain entries from Phase A's audit resolved cleanly:
+- 4 Active (all shipped 2026-05-01, ~24h after the `CURRENT_VENDORS` block was introduced 2026-04-30) → moved into canonical.
+- 2 Aspirational drift (Digiteal, eSortcode IBAN name-match) → dropped along with the deleted `CURRENT_VENDORS` map.
+
+Verdict on `CURRENT_VENDORS` history: **by-design aspirational at creation**. The block predated its corresponding capabilities; the script's "mirroring STATIC_FACTS" header comment was inaccurate from day one. Phase B closed the gap by making canonical the authoritative declaration and asserting the invariant in tests.
+
+DEC drafted in PR #65 description, awaiting log: **DEC-20260507-X** (chat assigns letter) on drift-check substrate moving to `platform-facts.ts`.
+
+## Layer 4 — Branch protection (Phase 3 Harden)
+
+`gh api PUT repos/strale-io/strale/branches/main/protection`
+
+Investigation prompt earlier in the day traced the 2026-05-06 red-main incident root cause: **`main` had no branch protection at all**. F-0-014 lint guard fired correctly on both offending pushes (08:11Z and 10:49Z 2026-05-06) but failure was informational, not gating. Two ad-hoc scripts pushed direct via `git push origin main`, bypassing every PR-based safety the team relies on.
+
+Fix applied via single `gh api PUT`:
+- Required PR before merging
+- Required status check: `check` (the single CI job)
+- Strict base — branches must be up to date with main
+- `enforce_admins: true`
+- `allow_force_pushes: false`, `allow_deletions: false`
+
+Read-back check (Rule F structural enforcement): direct push attempt now returns verbatim
+```
+remote: error: GH006: Protected branch update failed for refs/heads/main.
+remote: - Changes must be made through a pull request.
+remote: - Required status check "check" is expected.
+ ! [remote rejected] HEAD -> main (protected branch hook declined)
+```
+
+Both rules fire correctly. The 2026-05-06 mechanism cannot recur.
+
+DEC drafted, awaiting log: **DEC-20260507-C** on branch protection.
+
+## Side incidents resolved
+
+- **Console-allowlist unblock (PR #64, merge `60053ba`):** main was red since 2026-05-06 because two ad-hoc scripts (`audit-live-registries.ts` 13 console.* calls; `dk-cvr-retry-2026-05-06.ts` 7 calls) landed without allowlist entries. Single-line allowlist additions; unblocked the queued PRs.
+- **Railway deploy failure on PR #65 first deploy:** `/health/deep` healthcheck timed out at the 10s window during cold start (~3s container start + variance crossed budget). No code defect — runtime ran for 6 minutes serving traffic before SIGTERM. Redeployed from the same build artifact; second attempt passed cleanly. PR #65 is live in production at `41c05426b21d`.
+
+## What's open
+
+These are flagged for chat to action; CC did not mutate any of them.
+
+1. **DEC-20260507-X (drift-check substrate)** — DEC text in PR #65 description, ready to log.
+2. **DEC-20260507-C (branch protection)** — DEC text in the branch-protection session report, ready to log.
+3. **Notion P3 To-do `35967c87082c81c7aa0df1ee04eed4a1` (healthcheck widening)** — investigated; halted at Path B (config is dashboard-only in Railway CLI 4.30.5). Petter applies via Railway dashboard → strale → Settings → Deploy → Healthcheck Timeout: 10 → 20.
+4. **Notion P3 To-do `35967c87082c817684e8e60c0c5a6515` (F-0-014 bypass)** — closed by DEC-20260507-C; mark Done.
+5. **Course-correction Journal entry** for the F-0-014 incident — Phase 3 prompt drafted the ≥3-step causal chain (no branch protection → direct pushes allowed + post-commit CI informational only → 2026-05-06 ad-hoc scripts pushed direct, red main 31h → all open PRs DOSed → Phase 3 closed the gap).
+6. **Three out-of-scope flags from PR #65:**
+   - Notion "How this workspace works" Rule 13 references drift scripts at `.mjs` paths (now `.ts`)
+   - `apps/api/src/lib/platform-facts.ts:46` comment references wrong repo+wrong-extension path
+   - Memory references drift scripts at `.mjs` paths
+7. **Other open PRs** (#61, #60, #45, #40) — all stuck on stale main. Each needs its own `gh pr update-branch + merge` workflow when ready. Not on critical path.
+
+## Non-obvious learnings
+
+1. **`CURRENT_VENDORS` was aspirational at creation, not drift.** Git history shows the block landed before the capabilities it described. The script's header comment ("mirroring STATIC_FACTS") was wrong from day one — chat had assumed it was once accurate and drifted later. This shifts the framing: the original author chose forward-looking declaration over runtime mirror without writing down that intent. The new test invariant (every active vendor must have a shipped slug) replaces the unwritten convention with a structural check.
+
+2. **The Railway 10s healthcheck window is tight by design.** Cold start to HTTP bind is ~3s; remaining budget is ~7s for DB pool warmup + plan-cache miss on the CTE probe. PR #65's failure was statistical, not structural — same code path, same Dockerfile, just one cold-start variance excursion. Petter's planned dashboard widening to 20s removes the variance risk; the deeper option (startup-aware `/health/deep` that skips the CTE probe in the first 10s) remains available if a second incident occurs after widening.
+
+3. **`gh pr merge --merge --delete-branch` hits worktree-locked-by-strale-spike intermittently.** When it does, the merge succeeds server-side but local cleanup fails, which aborts the remote-branch deletion. Manual `gh api -X DELETE refs/heads/<branch>` cleans up. Same workaround applied 2-3 times today; not always; root cause is `gh`'s post-merge `git fetch+pull` against the worktree-locked main.
+
+4. **The 6-vs-7 entry count.** The Phase B prompt anticipated possibly 7 Uncertain entries; only 6 existed. CC didn't invent a 7th; reported the actual count.
+
+5. **Branch protection takes a single `gh api PUT` (~30 seconds).** The cost-of-fix is trivial. The cost of NOT having it for ~5 weeks since repo creation was a 31-hour outage of the merge pipeline plus 6+ cascading sessions of cleanup work. The asymmetry is striking — chat's call to gate this behind a CTO decision was correct, but the gate is now closed.
+
+## Cost
+
+Nothing tracked separately (no paid API calls beyond standard CI runs). Petter's time tomorrow: ~5 minutes to log DEC-20260507-X and DEC-20260507-C, ~30 seconds in Railway dashboard, ~1 minute marking Notion to-dos Done.

--- a/handoff/_general/from-code/2026-05-07-slovak-company-data-shipped.md
+++ b/handoff/_general/from-code/2026-05-07-slovak-company-data-shipped.md
@@ -1,0 +1,38 @@
+Intent: ship Slovak identity capability via the Slovak RPO (Register of Legal Persons) direct REST, closing SK Gap-7 per DEC-20260507-A.
+
+## What shipped
+
+- `apps/api/src/capabilities/slovak-company-data.ts` — direct REST against `https://api.statistics.sk/rpo/v1/`. Two-call pattern: `GET /search?identifier={ico}` resolves an internal id, `GET /entity/{id}` returns the full record. Free, no auth, CC-BY 4.0 under Act 272/2015 §§ 7, 7a. 60 rpm/IP unauthenticated cap (shared across Strale's egress — error message says so).
+- `manifests/slovak-company-data.yaml` — minimal manifest with `marketplace_eligible: true` (zero-cost, low-maintenance, CC-BY 4.0 redistribution-permissive — all three CLASSIFICATION.md criteria pass), `avg_latency_ms: 1500`, 14 output fields (6 guaranteed / 8 common after reliability review), 3 honest limitations.
+- DB row active (`lifecycle_state=active, visible=true, is_active=true`).
+- PR https://github.com/strale-io/strale/pull/61 — branch `feat/sk-company-data`, two commits (`790498b` initial + `2cdf083` /go review fixes).
+
+Output fields: `ico, company_name, address, legal_form, legal_form_code, registration_date, status, source_register, registration_office, registration_number, nace_code, nace_description, directors[], last_updated`. Status derived from whether the current address, legal form, and identifier records are still open (no `validTo`) — RPO does not publish an explicit dissolved flag. Name is excluded from the witness set because rebrands close the prior name without dissolving the company.
+
+Reuse: `normalizeIco` imported from `apps/api/src/lib/cz-validation.ts`. Czech and Slovak IČO share the 8-digit zero-padded format inherited from pre-1993 Czechoslovakia. The checksum rules differ; the SK exec doesn't use the checksum half.
+
+## Verification
+
+- `tsc --noEmit` clean
+- `validate-capability.ts --slug slovak-company-data` 19/19
+- `smoke-test.ts --slug slovak-company-data` 11/11 (live execution 514 ms, well under the 1500 ms manifest budget)
+- `checkReadiness("slovak-company-data")` `ready: true, issues: []`
+
+Six-lens review (technical + product) ran in parallel. One HIGH (junk input < 4 digits would burn an API call — fixed by adding a length-floor before the live fetch), four MEDIUMs fixed (`last_updated` reliability mis-asserted as guaranteed; rate-limit message conflated caller IP with Strale's egress IP; `deriveStatus` walked time-versioned arrays twice; manifest prose said 4 status witnesses but code uses 3). Two MEDIUMs deferred — flagged in PR body, see "Open" below.
+
+## Open / deferred
+
+- **Rename `lib/cz-validation.ts` → `lib/ico-normalize.ts`** (or extract the normalizer). Once a Slovak consumer imports from a `cz-` named file, future contributors can break SK by adding Czech-specific behaviour. Architect lens flagged it; deferred to scope this PR. Do next time the file is touched.
+- **CZ backfill — `legal_form` + `nace_codes` shape divergence.** SK emits `legal_form` (human-readable) + `legal_form_code`, CZ emits only `legal_form_code`. SK emits singular `nace_code` / `nace_description`, CZ emits plural `nace_codes` array. The SK shape is correct for its source (RPO returns a single primary activity); CZ should be backfilled to align. Filing rather than degrading SK.
+- **Notion + memory updates** are chat's responsibility per the build prompt: Active Vendor Stack `35367c87082c812e88d1dc6bdbfbd4f5` (SK Gap-7 → Live, counts shift), Coverage Matrix `35767c87082c8184ba34e116f673a1d6`, Vendor Roster row for api.statistics.sk RPO (Active, Primary DEC link DEC-20260507-A), Provider-Coverage DB. Memory note `project_business_registry_state.md` lists SK in Gap-7 — needs flip to Live.
+
+## Non-obvious learnings
+
+- The diligence doc claimed `rpo.statistics.sk/rpo/v1/` was 404. The actually-working host is **`api.statistics.sk/rpo/v1/`** (different subdomain). Worth recording so the next gap-coverage audit doesn't reject SK based on the wrong host.
+- The RPO API uses HAL-style time-versioned arrays for every field (`fullNames[]`, `addresses[]`, `legalForms[]`, etc., each with `validFrom` / optional `validTo`). The "current" entry is the one with no `validTo`; if all entries are bounded (rare, only dissolved cases), the latest `validFrom` wins. New helper `pickCurrent<T>` lives in the executor file — promote to `lib/` if a second time-versioned registry lands.
+- The 60 rpm rate limit applies per IP at the RPO edge, and that IP is Strale's shared Railway egress, not the caller's. Hitting the cap in production would block all Slovak lookups platform-wide for ~60 seconds, not per tenant. Authenticated access (registration with ŠÚ SR) lifts the cap; revisit if SK lookup volume becomes meaningful.
+- The build prompt's planning assumption of "single by-IČO endpoint" turned out to be a two-call pattern (search → entity). Acceptable per the prompt's exception clause ("if a single by-IČO endpoint exists, use that as the primary; halt only if the only path is search-by-name"). Documented as a `coverage`-category limitation in the manifest.
+
+## Cost
+
+Zero external cost — RPO is free CC-BY 4.0. Anthropic spend during this session was ~6× model calls for the parallel review agents and a few small follow-ups; all within normal session budget.

--- a/handoff/_general/from-code/2026-05-07-slovenian-company-data-shipped.md
+++ b/handoff/_general/from-code/2026-05-07-slovenian-company-data-shipped.md
@@ -1,0 +1,59 @@
+Intent: Audit, build, and merge a `slovenian-company-data` capability — closing SI Gap-7 in the EU coverage matrix using the data.gov.si CKAN datastore (Path A, free + CC-BY 4.0); Path B (paid AJPES restPrsInfo) was killed by chat the same day for ToU §7 redistribution prohibition.
+
+## Outcome
+
+Three sequential CC sessions (audit → build → merge), all green:
+
+1. **Audit (read-only).** Walked the codebase, confirmed no existing bulk-ingest sibling exists (the BE KBO bulk pattern referenced in Notion is a 2026-04-29 spec only, not built). Discovered that the data.gov.si CSV resource has `datastore_active: true` — meaning Path A is **live-fetch CKAN datastore_search**, not bulk-ingest, and the right sibling template is `latvian-company-data.ts` / `irish-company-data.ts`. Notion's "M effort, mirrors BE KBO bulk pattern" was wrong on both counts. Surveyed cross-sibling field-shape divergences; surfaced one new divergence (`jurisdiction` field present on IE/LV/LT, absent on SK/CZ/BE/EE/PL — SK shipped without it 2026-05-07).
+
+2. **Build.** Created `apps/api/src/capabilities/slovenian-company-data.ts` (174 lines) and `manifests/slovenian-company-data.yaml`. Mirrored the LV/IE CKAN pattern. Pipeline `--discover` ran clean against KRKA d.d. (matična številka 5043611000) — auto-generated 11 expected_fields and 5 test suites. Smoke 11/11, validate 19/19, type-check clean (one TS18047 nullability fix on the address-format filter).
+
+3. **Merge.** PR #66 merged 2026-05-07T20:19:25Z, commit `b4a70d0`. No rebase needed (1 ahead, 0 behind). Branch `feat/slovenian-company-data` merged via `gh pr merge --merge` server-side (main locked at `strale-spike` worktree; same workaround as PR #61).
+
+**Capability ships in `lifecycle_state=validating, visible=false`.** Production `/v1/capabilities` will not list the slug until lifecycle promotion ~24h post-merge — that's a separate manual step tracked in Notion.
+
+## Coverage scope (manifest is explicit on this)
+
+- **Output:** 11 fields — company_name, reg_number, hseid, legal_form, registration_office, address (consolidated from 7 source components), settlement, postal_code, post_office, country, jurisdiction.
+- **Source omits:** status, registration_date, NACE/SKD, directors, VAT. These are NOT in the data.gov.si open subset — they exist only behind paid AJPES restPrsInfo, which prohibits redistribution per ToU §7. Manifest limitation 2 is explicit so solutions can't silently filter on absent fields.
+- **Refresh cadence:** twice monthly (dvotedensko), slower than IE/LV daily. Manifest limitation 1.
+- **Includes `jurisdiction: "SI"`** matching IE/LV/LT convention. SK/CZ/BE/EE/PL backfill is a separate P3 to-do.
+
+## Field reliability — empirical, not auto-default
+
+Pipeline `--discover` defaulted all 11 fields to `guaranteed`. Empirical sampling against 11 entities (KRKA, NLB, Petrol, Mercator + 6 dataset-position samples spanning the 259k-record dataset + 1 sole-proprietor sample) confirmed 100% population for all 11 output fields. **No reclassification needed.** The verification criterion expected ≥1 demotion, but the dataset's statutory-subset profile means there are no genuinely optional fields. Bending reality to satisfy the metric would falsify the manifest. Reported the no-demotion outcome explicitly.
+
+The only frequently empty source field is `Hišna št  dodatek` (house-number addendum, ~83% empty across samples), and it's used only as an optional sub-component of consolidated `address`, never exposed as a standalone output field.
+
+## Non-obvious learnings
+
+1. **The Notion-claimed dataset name "OD_FIRME" is wrong.** The canonical data.gov.si slug is `poslovni-register-slovenije`. Likely a stale internal AJPES file-naming convention; the audit caught this before the build ran.
+
+2. **The actual API field names contain a double space:** `Hišna št  dodatek` (two spaces between `št` and `dodatek`), and `Hišna št` is "Hišna" not "Hiša" as the prior audit transcribed. Used the verbatim strings.
+
+3. **Path B was killed by chat on the same day.** AJPES Terms of Use Article 7 prohibits redistribution to third parties under the paid restPrsInfo contract — structurally incompatible with Strale's marketplace model regardless of price. Two other reasons compounded: Slovenian-only order form and no free/HVD-eligible tier (cheapest is €211 / 500 searches). This means Path A is the only viable path; if SI customer demand requires status/reg-date/NACE/directors, the answer is "AJPES restPrsInfo direct contract under their own ToU" not "Strale ships those fields."
+
+4. **CKAN `datastore_active: true` on a resource is the signal that distinguishes "live-fetch CKAN" from "bulk-only ZIP."** Worth checking on every future open-data registry audit; the LV pattern uses it, IE uses it, SI uses it. The BE KBO Open Data SFTP feed does NOT have a CKAN endpoint — that's why BE genuinely needs bulk ingest, and SI doesn't.
+
+5. **Cross-sibling divergence: `jurisdiction` field.** New finding from this audit. IE/LV/LT (the 2026-04-29 Tier-1 cleanup wave) added `jurisdiction: "<CC>"`; SK/CZ/BE/EE/PL did not. SK shipped without it 2026-05-07. SI ships with it. Worth a small follow-up to either backfill or accept the divergence as intentional — chat can decide.
+
+## Cost
+
+Zero direct external cost (data.gov.si is free CC-BY 4.0). Three CC sessions of work, plus Petter's chat-side verification of AJPES Path B nonviability.
+
+## Open / followups for chat or future sessions
+
+- **Lifecycle promotion to `active`** ~24h after merge per Notion to-do `35967c87082c818881ffcc8cddb369aa`. After clean test runs, set `is_active=true, visible=true, lifecycle_state='active'`. Memory file's `validating` flag should be removed at that time.
+- **Spec deviation: `category: company-data` not `identity`.** Build prompt said `category: identity`; all 8 sibling identity capabilities use `category: company-data`. Followed sibling convention. Flagged in build closing report; chat to confirm.
+- **`jurisdiction` field unification** across SK/CZ/BE/EE/PL is the open P3 reconciliation item.
+
+## Files touched
+
+- `apps/api/src/capabilities/slovenian-company-data.ts` (new, 174 lines)
+- `manifests/slovenian-company-data.yaml` (new, 156 lines after pipeline auto-fill)
+- `~/.claude/projects/c--Users-pette-Projects-strale/memory/project_business_registry_state.md` (added SI to Live; removed from gap list; references PR #66 + commit b4a70d0)
+
+## Commits
+
+- `f90c666` feat(capability): slovenian-company-data via data.gov.si CKAN datastore
+- Merge: `b4a70d0` (PR #66)


### PR DESCRIPTION
Promotes 5 of 8 untracked notes from \`handoff/_general/from-code/\` to tracked status per the inventory audit (chat session 2026-05-10).

**Promoted (5):**
- 2026-05-06-chromium-phase3-halt-partial-flag-survival.md — path-1-vs-path-2 decision rationale
- 2026-05-06-dk-cvr-breaker-open-phase1-containment.md — manual circuit-breaker runbook
- 2026-05-07-drift-check-refactor-and-branch-protection.md — PR #62-#65 narrative + branch protection
- 2026-05-07-slovak-company-data-shipped.md — RPO host, HAL arrays, IP rate limits
- 2026-05-07-slovenian-company-data-shipped.md — CKAN semantics, AJPES §7

Each contains 'Non-obvious learnings' or runbook content reusable in future sessions.

The 3 DISCARD notes (pure session narrative) are removed from trunk's filesystem post-merge — not part of this PR since they were never tracked.

No .gitignore change. Soft discipline going forward: promote-or-delete at session end.