### PR TITLE
fix: bump external_cost_cents on always-llm capabilities to gate hourly testing

### DIFF
--- a/apps/api/src/lib/llm-capability-costs.test.ts
+++ b/apps/api/src/lib/llm-capability-costs.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Phase 3 (Harden) regression test for the May 2026 Haiku cost-leak.
+ * Audit PR #84 + follow-up: PR #46 (2026-05-04) coupled scheduler
+ * dispatch to `test_suites.external_cost_cents`, so any LLM-using
+ * capability whose suite cost was 0 was scheduled hourly with real
+ * Anthropic billing. PR #49 + PR #55 closed 6 caps; this PR's
+ * migration block 0064 closes 73 more.
+ *
+ * The compound-PR failure pattern that produced the leak (cadence
+ * change ships while compensating cost-bump deferred, deferral isn't a
+ * hard merge-block) can recur unless we make "LLM capability with cost
+ * = 0" a structural impossibility in CI. This test is that gate.
+ *
+ * Every file under `apps/api/src/capabilities/` that imports
+ * `@anthropic-ai/sdk` must be registered in one of:
+ *   - ALWAYS_LLM_CAPABILITY_COSTS (with value > 0)
+ *   - CONDITIONAL_LLM_CAPABILITIES (with documented bypass)
+ *   - DEACTIVATED in capabilities/auto-register.ts
+ *
+ * A new LLM-using capability whose author forgets to register a cost
+ * fails this test with an actionable message naming the slug.
+ *
+ * The test reads the capability source tree directly via fs — no DB
+ * connection required, runs in CI under the standard `vitest run`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  ALWAYS_LLM_CAPABILITY_COSTS,
+  BLOCK_0064_SLUGS,
+  CONDITIONAL_LLM_CAPABILITIES,
+} from "./llm-capability-costs.js";
+import { getDeactivatedCapabilities } from "../capabilities/auto-register.js";
+
+/** Resolve the capabilities source directory from the running test file. */
+function capabilitiesDir(): string {
+  // __dirname equivalent for ESM via import.meta.dirname.
+  // apps/api/src/lib/ + ../capabilities/ → apps/api/src/capabilities/
+  return resolve(import.meta.dirname, "..", "capabilities");
+}
+
+/**
+ * Walk apps/api/src/capabilities/*.ts (top level only — skip lib/,
+ * providers/, *.test.ts, index.ts, auto-register.ts) and return every
+ * file that imports `@anthropic-ai/sdk`.
+ *
+ * Slug = filename without `.ts`. Matches the registry's `registerCapability`
+ * key convention (every capability file is named `<slug>.ts`).
+ */
+function findAnthropicSdkImporters(): string[] {
+  const dir = capabilitiesDir();
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const importers: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue; // skip lib/, providers/
+    if (!entry.name.endsWith(".ts")) continue;
+    if (entry.name.endsWith(".test.ts")) continue;
+    if (entry.name === "index.ts") continue;
+    if (entry.name === "auto-register.ts") continue;
+
+    const filePath = resolve(dir, entry.name);
+    const contents = readFileSync(filePath, "utf8");
+    // Match `import ... from "@anthropic-ai/sdk"` (any quote style, any
+    // import shape — default, named, namespace).
+    if (/from\s+["']@anthropic-ai\/sdk["']/.test(contents)) {
+      importers.push(entry.name.replace(/\.ts$/, ""));
+    }
+  }
+
+  return importers.sort();
+}
+
+describe("llm-capability-costs — Phase 3 CI gate", () => {
+  it("every Anthropic-SDK-importing capability is registered as always-LLM, conditional-LLM, or deactivated", () => {
+    const importers = findAnthropicSdkImporters();
+    const deactivated = getDeactivatedCapabilities();
+
+    const unregistered: string[] = [];
+    for (const slug of importers) {
+      if (slug in ALWAYS_LLM_CAPABILITY_COSTS) continue;
+      if (CONDITIONAL_LLM_CAPABILITIES.has(slug)) continue;
+      if (deactivated.has(slug)) continue;
+      unregistered.push(slug);
+    }
+
+    if (unregistered.length > 0) {
+      const message = unregistered
+        .map(
+          (slug) =>
+            `  - "${slug}" imports @anthropic-ai/sdk but is not registered. ` +
+            `Add to ALWAYS_LLM_CAPABILITY_COSTS in apps/api/src/lib/llm-capability-costs.ts ` +
+            `(with cost in cents, typically 1 for Haiku), OR to CONDITIONAL_LLM_CAPABILITIES ` +
+            `(with a comment naming the bypass), OR to DEACTIVATED in auto-register.ts.`,
+        )
+        .join("\n");
+      throw new Error(
+        `${unregistered.length} LLM-using capabilities have no registered cost or status:\n${message}\n\n` +
+          `This gate exists because the test scheduler dispatches on \`test_suites.external_cost_cents = 0\` ` +
+          `and an LLM-using capability at cost 0 is scheduled hourly with real Anthropic billing. ` +
+          `See PR #84 (audit) and the May 2026 Haiku cost-leak follow-up.`,
+      );
+    }
+
+    expect(unregistered).toEqual([]);
+  });
+
+  it("every always-LLM cost entry has a value > 0", () => {
+    const zeroOrNegative = Object.entries(ALWAYS_LLM_CAPABILITY_COSTS).filter(
+      ([, cost]) => cost <= 0,
+    );
+    expect(zeroOrNegative).toEqual([]);
+  });
+
+  it("ALWAYS_LLM and CONDITIONAL_LLM sets are disjoint", () => {
+    const overlap = Object.keys(ALWAYS_LLM_CAPABILITY_COSTS).filter((slug) =>
+      CONDITIONAL_LLM_CAPABILITIES.has(slug),
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  it("BLOCK_0064_SLUGS excludes the slugs owned by earlier blocks (0062 risk-narrative, 0063 invoice-extract)", () => {
+    expect(BLOCK_0064_SLUGS).not.toContain("risk-narrative-generate");
+    expect(BLOCK_0064_SLUGS).not.toContain("invoice-extract");
+  });
+
+  it("BLOCK_0064_SLUGS covers exactly the Haiku always-LLM caps (Object.keys(ALWAYS_LLM_CAPABILITY_COSTS) minus the two earlier-block slugs)", () => {
+    const expected = Object.keys(ALWAYS_LLM_CAPABILITY_COSTS)
+      .filter((s) => s !== "risk-narrative-generate" && s !== "invoice-extract")
+      .sort();
+    expect([...BLOCK_0064_SLUGS]).toEqual(expected);
+  });
+});

--- a/apps/api/src/lib/llm-capability-costs.ts
+++ b/apps/api/src/lib/llm-capability-costs.ts
@@ -1,0 +1,202 @@
+/**
+ * Canonical registry of capabilities that invoke the Anthropic SDK,
+ * with their per-call `external_cost_cents` for scheduler-skip purposes.
+ *
+ * **Why this exists.** The test scheduler dispatch query in
+ * apps/api/src/jobs/test-scheduler.ts:262 filters on
+ * `test_suites.external_cost_cents = 0`. Any capability with a suite at
+ * 0 is scheduled hourly. That's correct for free capabilities. It's
+ * disastrous for paid LLM capabilities whose suite cost was never set:
+ * the scheduler will execute them 24× per day each, with each execution
+ * making real Anthropic calls. The May 2026 cost ramp (audit PR #84)
+ * was exactly this — PR #46 (2026-05-04) cut the cadence from 24h → 1h,
+ * and ~73 always-LLM Haiku capabilities had `external_cost_cents = 0`,
+ * so they were being hammered hourly. PR #49 fixed 5 caps (Dilisense ×
+ * 3 + eSortcode + Sonnet) and PR #55 fixed invoice-extract; PR #49's
+ * commit body explicitly deferred "Anthropic-Haiku bulk set (~80 caps)"
+ * which is the gap this file closes.
+ *
+ * **The CI gate.** `llm-capability-costs.test.ts` walks
+ * `apps/api/src/capabilities/*.ts`, identifies every file that imports
+ * `@anthropic-ai/sdk`, and asserts each one is registered in one of:
+ *
+ *   - `ALWAYS_LLM_CAPABILITY_COSTS` (always invokes LLM on a successful
+ *     call — must have cost > 0 so the scheduler skips it)
+ *   - `CONDITIONAL_LLM_CAPABILITIES` (LLM only fires on a code path the
+ *     standard test fixture does NOT hit — legitimately keeps cost = 0
+ *     so scheduled testing still covers the registry-API / native path)
+ *   - `DEACTIVATED` from `capabilities/auto-register.ts` (executor file
+ *     exists but is not registered at startup)
+ *
+ * Adding a new LLM-using capability requires adding it to one of those
+ * three sets. The CI gate fails with a slug-named message otherwise.
+ *
+ * This is the **interim** structural guard. The deeper fix is to
+ * decouple scheduling eligibility from billing data — introduce a
+ * dedicated `test_suites.scheduled_testing_eligible` column — tracked
+ * as a separate Notion To-do.
+ */
+
+/**
+ * Slug → per-call cost in cents (€-denominated; matches the
+ * `external_cost_cents` column on `test_suites`).
+ *
+ * - Sonnet 4.6 caps: 3¢, calibrated against a 4K-input + 1.5K-output
+ *   typical call. PR #49 established this value for risk-narrative-
+ *   generate; this file is the canonical store going forward.
+ * - Haiku 4.5 caps: 1¢, the defensible-minimum floor matching PR #49 /
+ *   PR #55. Real per-call Haiku cost on typical inputs is below 1¢
+ *   (€0.005–0.014 for 700-input + 1000-output); the floor's operational
+ *   role is purely the scheduler-skip flip, not cost accuracy. Precise
+ *   per-cap calibration is the separate P2 to-do.
+ *
+ * Slugs are sorted alphabetically inside each band for diff hygiene.
+ */
+export const ALWAYS_LLM_CAPABILITY_COSTS: Readonly<Record<string, number>> = Object.freeze({
+  // ─── Sonnet 4.6 — owned by block 0062 (PR #49) ──────────────────────────────
+  // Listed here so the CI gate sees a registered cost; the runtime
+  // UPDATE for this slug fires from block 0062, not block 0064.
+  "risk-narrative-generate": 3,
+
+  // ─── Haiku 4.5 vision — owned by block 0063 (PR #55) ────────────────────────
+  // Same pattern: listed for CI; runtime UPDATE fires from block 0063.
+  "invoice-extract": 1,
+
+  // ─── Haiku 4.5 — owned by block 0064 (this file) ────────────────────────────
+  "address-parse": 1,
+  "agent-trace-analyze": 1,
+  "api-docs-generate": 1,
+  "api-mock-response": 1,
+  "blog-post-outline": 1,
+  "brand-mention-search": 1,
+  "changelog-generate": 1,
+  "classify-text": 1,
+  "code-convert": 1,
+  "code-review": 1,
+  "commit-message-generate": 1,
+  "company-enrich": 1,
+  "company-industry-classify": 1,
+  "company-tech-stack": 1,
+  "competitor-compare": 1,
+  "context-window-optimize": 1,
+  "contract-extract": 1,
+  "cookie-scan": 1,
+  "crontab-generate": 1,
+  "curl-to-code": 1,
+  "customs-duty-lookup": 1,
+  "diff-review": 1,
+  "dockerfile-generate": 1,
+  "docstring-generate": 1,
+  "email-draft": 1,
+  "env-template-generate": 1,
+  "error-explain": 1,
+  "eu-regulation-search": 1,
+  "eu-trademark-search": 1,
+  "fake-data-generate": 1,
+  "gdpr-fine-lookup": 1,
+  "github-actions-generate": 1,
+  "github-repo-analyze": 1,
+  "hs-code-lookup": 1,
+  "image-to-text": 1,
+  "job-posting-analyze": 1,
+  "jsdoc-generate": 1,
+  "landing-page-roast": 1,
+  "meeting-notes-extract": 1,
+  "nginx-config-generate": 1,
+  "openapi-generate": 1,
+  "pdf-extract": 1,
+  "pii-redact": 1,
+  "pr-description-generate": 1,
+  "price-compare": 1,
+  "pricing-page-extract": 1,
+  "privacy-policy-analyze": 1,
+  "product-reviews-extract": 1,
+  "product-search": 1,
+  "prompt-compress": 1,
+  "prompt-optimize": 1,
+  "readme-generate": 1,
+  "receipt-categorize": 1,
+  "regex-explain": 1,
+  "regex-generate": 1,
+  "release-notes-generate": 1,
+  "resume-parse": 1,
+  "return-policy-extract": 1,
+  "schema-migration-generate": 1,
+  "sentiment-analyze": 1,
+  "seo-audit": 1,
+  "social-post-generate": 1,
+  "sql-explain": 1,
+  "sql-generate": 1,
+  "sql-optimize": 1,
+  "structured-scrape": 1,
+  "summarize": 1,
+  "terms-of-service-extract": 1,
+  "test-case-generate": 1,
+  "translate": 1,
+  "web-extract": 1,
+  "webhook-test-payload": 1,
+  "youtube-summarize": 1,
+});
+
+/**
+ * Slugs owned by block 0064's UPDATE. Derived: every key in
+ * `ALWAYS_LLM_CAPABILITY_COSTS` except the two that earlier blocks
+ * already cover (0062 for risk-narrative-generate, 0063 for
+ * invoice-extract). The migration emits one UPDATE filtered by this
+ * list at cost = 1.
+ *
+ * Sorted lexicographically so the rendered SQL is stable across
+ * environments — important for the test snapshot to bind.
+ */
+export const BLOCK_0064_SLUGS: readonly string[] = Object.freeze(
+  Object.keys(ALWAYS_LLM_CAPABILITY_COSTS)
+    .filter((slug) => slug !== "risk-narrative-generate" && slug !== "invoice-extract")
+    .sort(),
+);
+
+/**
+ * Capabilities that import the Anthropic SDK but legitimately keep
+ * `external_cost_cents = 0` because the standard test fixture exercises
+ * a code path that does NOT invoke the LLM. Bumping their cost would
+ * remove the registry-API / native-fetch coverage from scheduled
+ * testing.
+ *
+ * Each entry must carry an inline comment explaining the bypass.
+ *
+ * Adding a new conditional-LLM capability: include the slug here AND
+ * confirm via the executor source that the standard `health_check_input`
+ * (from `manifests/<slug>.yaml`) reaches the early-return branch before
+ * the `messages.create` call.
+ */
+export const CONDITIONAL_LLM_CAPABILITIES: ReadonlySet<string> = new Set([
+  // ─── Country-data caps with numeric-registry-code fixtures ─────────────────
+  // For each of these, the executor's natural-language → reg-code
+  // resolver (`extractCompanyName` / `name-resolver.ts`) only fires
+  // when the input is NOT a numeric registry code. Manifest
+  // `health_check_input` uses the country's registry-code format
+  // (CNPJ, CIN, CVR, registry code, Y-tunnus, SIREN, organisasjonsnummer,
+  // company number, EIN, etc.), which bypasses the LLM call. Scheduled
+  // testing exercises the direct registry-API path (free).
+  "brazilian-company-data",
+  "cz-company-data",
+  "danish-company-data",
+  "estonian-company-data",
+  "finnish-company-data",
+  "french-company-data",
+  "norwegian-company-data",
+  "uk-company-data",
+  "us-company-data",
+
+  // ─── Domain-input cap with cached / structured-extract fast path ───────────
+  // website-to-company: LLM fires only when the structured-data
+  // extraction (JSON-LD, meta tags) doesn't surface a company name.
+  // Test fixture uses a site with rich structured data; LLM bypassed.
+  "website-to-company",
+
+  // ─── Carrier-ambiguity-only LLM ────────────────────────────────────────────
+  // container-track: ISO 6346 validation + carrier-prefix mapping
+  // resolves > 95% of inputs without LLM. LLM fires only when the
+  // carrier prefix doesn't match the static map. Test fixture uses a
+  // well-known carrier prefix (Maersk MAEU/MSKU/MRKU).
+  "container-track",
+]);

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -48,9 +48,11 @@ import {
   runMigration0060_marketplaceEligible,
   runMigration0062_paidVendorCosts,
   runMigration0063_invoiceExtractCostReclassify,
+  runMigration0064_alwaysLlmHaikuCosts,
   runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
+import { BLOCK_0064_SLUGS } from "./llm-capability-costs.js";
 
 const dialect = new PgDialect();
 
@@ -244,6 +246,80 @@ describe("startup-migrations — block 0063 (invoice-extract cost reclassify)", 
   });
 });
 
+describe("startup-migrations — block 0064 (always-LLM Haiku costs)", () => {
+  it("first run: updates rows when always-LLM Haiku suites are at 0; post-check passes", async () => {
+    // Queue: UPDATE returns N (the suites flipped from 0 → 1);
+    // post-check returns 0 (none remaining at 0).
+    const stub = makeStub({
+      queue: [{ count: 219 }, [{ remaining_zero: 0 }]],
+    });
+    const result = await runMigration0064_alwaysLlmHaikuCosts(stub);
+    expect(result.rows_affected).toBe(219);
+    expect(result.outcome).toMatch(/always-LLM Haiku suites reclassified across \d+ capabilities: 219/);
+    expect(stub.captured).toHaveLength(2);
+
+    // The UPDATE shape — IN-list of BLOCK_0064_SLUGS, exactly the 4 paid
+    // test_types, active+live filter, and the = 0 idempotency filter.
+    const updateSql = stub.renderedSql[0].toLowerCase();
+    expect(updateSql).toContain("update test_suites");
+    expect(updateSql).toContain("set external_cost_cents = 1");
+    expect(updateSql).toContain("active = true");
+    expect(updateSql).toMatch(/test_mode = 'live'/);
+    expect(updateSql).toContain("'known_answer'");
+    expect(updateSql).toContain("'edge_case'");
+    expect(updateSql).toContain("'negative'");
+    expect(updateSql).toContain("'known_bad'");
+    // Negative assertion: the two probe types must NOT be in the list —
+    // they legitimately stay at 0 (auth-less probe pattern, no paid call).
+    expect(updateSql).not.toContain("'dependency_health'");
+    expect(updateSql).not.toContain("'schema_check'");
+    // Idempotency filter:
+    expect(updateSql).toContain("external_cost_cents = 0");
+    // Earlier-block slugs are NOT in the IN-list (avoid stomping on
+    // 0062's 3¢ risk-narrative-generate, or duplicating 0063's invoice-extract).
+    expect(updateSql).not.toContain("'risk-narrative-generate'");
+    expect(updateSql).not.toContain("'invoice-extract'");
+  });
+
+  it("second run: idempotent — UPDATE returns 0 rows; outcome reports already-classified", async () => {
+    const stub = makeStub({
+      queue: [{ count: 0 }, [{ remaining_zero: 0 }]],
+    });
+    const result = await runMigration0064_alwaysLlmHaikuCosts(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to update.*already classified/i);
+    expect(stub.captured).toHaveLength(2);
+  });
+
+  it("post-condition violation throws (would fail boot)", async () => {
+    // Imagine a new always-LLM Haiku suite landed at cost=0 between
+    // deploys. The UPDATE captures some, but the post-check finds a
+    // leftover.
+    const stub = makeStub({
+      queue: [{ count: 219 }, [{ remaining_zero: 1 }]],
+    });
+    await expect(runMigration0064_alwaysLlmHaikuCosts(stub)).rejects.toThrow(
+      /post-condition failed.*1 always-LLM Haiku suites/i,
+    );
+  });
+
+  it("UPDATE binds every slug in BLOCK_0064_SLUGS as a parameter (no string concat)", async () => {
+    // Build-time parameterisation check: the rendered SQL should
+    // contain N placeholders ($1 etc.) at least equal to the number
+    // of slugs in BLOCK_0064_SLUGS, not the slug strings inline.
+    // (sql.join + sql`${s}` pushes each as a bind parameter.)
+    const stub = makeStub({
+      queue: [{ count: 0 }, [{ remaining_zero: 0 }]],
+    });
+    await runMigration0064_alwaysLlmHaikuCosts(stub);
+    const updateSql = stub.renderedSql[0];
+    // Count placeholders in the UPDATE-line — at least one per slug
+    // (the UPDATE has the IN-list; the post-check has its own).
+    const placeholderCount = (updateSql.match(/\$\d+/g) ?? []).length;
+    expect(placeholderCount).toBeGreaterThanOrEqual(BLOCK_0064_SLUGS.length);
+  });
+});
+
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
   it("exports the expected 7 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
@@ -258,6 +334,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0060_marketplaceEligible",
       "runMigration0062_paidVendorCosts",
       "runMigration0063_invoiceExtractCostReclassify",
+      "runMigration0064_alwaysLlmHaikuCosts",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -39,6 +39,7 @@
 import { sql, type SQL } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { log } from "./log.js";
+import { BLOCK_0064_SLUGS } from "./llm-capability-costs.js";
 
 /**
  * Minimal executor surface — matches what `getDb().execute()` returns
@@ -335,6 +336,88 @@ export async function runMigration0063_invoiceExtractCostReclassify(
   };
 }
 
+// ─── Block 0064: always-LLM Haiku capability cost reclassification ─────────
+//
+// Phase 1 (Contain) for the May 2026 Haiku cost-leak follow-up to audit
+// PR #84. PR #46 (2026-05-04) flipped the scheduler cadence from 24h →
+// 1h while filtering on `test_suites.external_cost_cents = 0`. PR #49
+// covered 5 paid-vendor caps that day (Dilisense × 3, eSortcode,
+// risk-narrative-generate) and PR #55 covered invoice-extract. PR #49's
+// commit body explicitly deferred "Anthropic-Haiku bulk set (~80 caps)".
+// This block closes that gap.
+//
+// Slug list lives in `llm-capability-costs.ts` (`BLOCK_0064_SLUGS`) so a
+// CI assertion can also consume it — adding a new Anthropic-importing
+// capability without registering its cost fails CI. See the
+// `llm-capability-costs.test.ts` regression for the structural gate.
+//
+// 1¢ floor matches the PR #49 / block 0062 / block 0063 defensible-
+// minimum pattern. Real per-call Haiku cost on typical inputs is below
+// 1¢; the floor's only operational job is to flip the scheduler-skip
+// semantic. Precise calibration is the existing P2 to-do.
+//
+// Idempotent via `external_cost_cents = 0` in the WHERE clause — once a
+// row is set to 1, a re-run won't match it. dependency_health and
+// schema_check are NOT included: those use the auth-less-probe pattern
+// (no paid call), legitimately stay at 0.
+
+export async function runMigration0064_alwaysLlmHaikuCosts(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  // sql.join builds a parameterised IN-list — slugs flow through bind
+  // parameters, not string concatenation. Sorted at the constant site
+  // so the rendered SQL is stable test-run to test-run.
+  const slugList = sql.join(
+    BLOCK_0064_SLUGS.map((s) => sql`${s}`),
+    sql`, `,
+  );
+
+  const update = await tx.execute(sql`
+    UPDATE test_suites
+    SET external_cost_cents = 1, updated_at = NOW()
+    WHERE capability_slug IN (${slugList})
+      AND active = true
+      AND test_mode = 'live'
+      AND test_type IN ('known_answer', 'edge_case', 'negative', 'known_bad')
+      AND external_cost_cents = 0
+  `);
+  const updateCount = (update as { count?: number }).count ?? 0;
+
+  // Post-condition: no active live non-probe suite for any of the
+  // always-LLM Haiku slugs may remain at 0 after this block. If a new
+  // suite (or new cap) landed at 0 between deploys, fail boot.
+  // COUNT(*)::int → postgres-js coerces int4 to JS number; assertion
+  // fires correctly.
+  const checkRows = await tx.execute(sql`
+    SELECT COUNT(*)::int AS remaining_zero
+    FROM test_suites
+    WHERE capability_slug IN (${slugList})
+      AND active = true
+      AND test_mode = 'live'
+      AND test_type IN ('known_answer', 'edge_case', 'negative', 'known_bad')
+      AND external_cost_cents = 0
+  `);
+  const checkResultRows = Array.isArray(checkRows) ? checkRows : (checkRows as { rows?: unknown[] })?.rows ?? [];
+  const remainingZero = (checkResultRows[0] as { remaining_zero?: number })?.remaining_zero ?? 0;
+  if (remainingZero > 0) {
+    throw new Error(
+      `0064_always_llm_haiku_costs post-condition failed: ${remainingZero} always-LLM Haiku suites still at external_cost_cents = 0`,
+    );
+  }
+
+  return {
+    block: "0064_always_llm_haiku_costs",
+    outcome:
+      updateCount === 0
+        ? "no rows to update (already classified)"
+        : `always-LLM Haiku suites reclassified across ${BLOCK_0064_SLUGS.length} capabilities: ${updateCount}`,
+    rows_affected: updateCount,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -352,6 +435,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0060_marketplaceEligible,
   runMigration0062_paidVendorCosts,
   runMigration0063_invoiceExtractCostReclassify,
+  runMigration0064_alwaysLlmHaikuCosts,
 ];
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to audit PR #84. Closes the May 2026 Haiku cost leak via Phase 1 (Contain), Phase 2 (Understand), and Phase 3 (Harden).

- **Phase 1.** New startup-migration block 0064 bumps `test_suites.external_cost_cents` to 1¢ on the 73 always-LLM Haiku capabilities whose suites were still at 0. PR #49 (2026-05-04) explicitly deferred this bulk-set; the test scheduler dispatch query in `apps/api/src/jobs/test-scheduler.ts:262` filters on `external_cost_cents = 0`, so until this fix every always-LLM Haiku cap was being executed hourly with real Anthropic billing.
- **Phase 2.** Notion Journal entry posted (will be linked in this PR after merge). Named failure pattern: **Compound-PR cost leak** — cadence change ships while compensating cost-bump deferred, the deferral isn't a hard merge-block, and the gap leaks until the next audit.
- **Phase 3.** New `apps/api/src/lib/llm-capability-costs.ts` holds the canonical map (`ALWAYS_LLM_CAPABILITY_COSTS`) + `CONDITIONAL_LLM_CAPABILITIES` exclusion set + `BLOCK_0064_SLUGS` derived list. New `llm-capability-costs.test.ts` walks `apps/api/src/capabilities/*.ts` and fails if any `@anthropic-ai/sdk` importer is not registered as always-LLM, conditional-LLM, or DEACTIVATED. Adding a new LLM-using capability without registering its cost fails CI.

### Slug-count reconciliation vs. audit PR #84

Audit estimated ~50. Full grep ((imports `@anthropic-ai/sdk`) ∩ (not DEACTIVATED) ∩ (not in PR #49/#55) ∩ (not conditional-LLM)) yields **73**. The audit's table called out 53 "pure-LLM" caps as "selected examples"; the additional 20 are Browserless + LLM caps (cookie-scan, gdpr-fine-lookup, terms-of-service-extract, privacy-policy-analyze, return-policy-extract, product-reviews-extract, product-search, price-compare, seo-audit, structured-scrape, web-extract, pdf-extract, youtube-summarize, landing-page-roast, container-track was actually conditional and excluded, etc.) and miscellaneous always-LLM caps the audit didn't enumerate (company-enrich, brand-mention-search, contract-extract, customs-duty-lookup, eu-regulation-search, eu-trademark-search). 73 is within the prompt's halt range (<30 or >80).

The 11 conditional-LLM caps live in `CONDITIONAL_LLM_CAPABILITIES`: 10 country-data caps (brazilian/cz/danish/estonian/finnish/french/norwegian/uk/us-company-data, website-to-company) where test fixtures use numeric registry codes that bypass the LLM, and container-track where ISO 6346 + carrier-prefix mapping resolves > 95% of inputs without LLM. Bumping these to 1¢ would gate the registry-API / native-fetch path from scheduled testing — that's coverage we want to keep.

### Mechanism verification

Block 0064 follows the PR #49 / PR #55 pattern: idempotent WHERE clause (`external_cost_cents = 0`) + post-condition SELECT that throws on remaining_zero > 0. Wired into `runStartupMigrations()` via `BLOCKS` list. PR #51/#52 already wired `runStartupMigrations()` into API boot — no new deploy-pipeline dependency.

## Test plan

- [x] All 24 startup-migration / cost-map tests pass locally.
- [x] **Negative test #1:** removing a slug from the map → CI gate fails with actionable message naming the slug. Reverted.
- [x] **Negative test #2:** setting a slug to cost = 0 → CI gate fails. Reverted.
- [x] Full vitest suite: 536 passed / 1 pre-existing failure (`src/app.classify-error.test.ts`, fails on `main` without these changes — unrelated `strale-mcp/tools` import issue).
- [ ] **Post-deploy (chat/Petter, NOT a merge gate):** Anthropic Console > Usage daily Haiku tokens drop to ~10–15% of current within 48h. If they don't, the audit's attribution was wrong — that's a signal for a new audit session, **not** a rollback trigger. The data fix and CI assertion are correct independent of attribution.
- [ ] **Post-deploy:** `SELECT COUNT(*) FROM test_suites WHERE external_cost_cents = 0` count drops by ~219 (73 caps × roughly 3 live non-probe test types each); record exact delta in merge comment.

## Stop conditions evaluated

- ✅ Slug count 73 is within 30–80 range.
- ✅ PR #49's UPDATE shape present in `startup-migrations.ts` (block 0062).
- ⚠️ CI gate would catch caps "beyond the ~50 expected" — yes, 73 vs audit's 50 sample. **Proceeded:** the audit explicitly described 53 as "selected examples"; the true count being higher strengthens the case for the fix.
- ⚠️ CI gate would also flag conditional-LLM caps. **Resolution:** explicit `CONDITIONAL_LLM_CAPABILITIES` set with documented bypass per cap. Matches the prompt's "explicit exclusion list" option.

## Structural follow-up (not in this PR)

Notion To-do: "Decouple `scheduled_testing_eligible` from `external_cost_cents`." The dispatch query's coupling of billing data to scheduling eligibility is the deeper structural issue; a dedicated boolean column makes the compound-PR pattern impossible at the data model. CI assertion shipped here is the interim guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)