### PR TITLE
fix: close leaky-cap residual + bypass-set hygiene cleanup

### DIFF
--- a/apps/api/src/capabilities/brazilian-company-data.ts
+++ b/apps/api/src/capabilities/brazilian-company-data.ts
@@ -1,4 +1,3 @@
-import Anthropic from "@anthropic-ai/sdk";
 import { registerCapability, type CapabilityInput } from "./index.js";
 
 /**
@@ -24,20 +23,6 @@ function findCnpj(input: string): string | null {
   const match = input.replace(/[\s]/g, "").match(/\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2}/);
   if (match) return match[0].replace(/[\.\-/]/g, "");
   return null;
-}
-
-async function extractCompanyName(text: string): Promise<string> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is required.");
-  const client = new Anthropic({ apiKey });
-  const r = await client.messages.create({
-    model: "claude-haiku-4-5-20251001",
-    max_tokens: 100,
-    messages: [{ role: "user", content: `Extract the Brazilian company name from this request. Return ONLY the company name, nothing else.\n\nRequest: "${text}"` }],
-  });
-  const name = r.content[0].type === "text" ? r.content[0].text.trim().replace(/^["']|["']$/g, "") : "";
-  if (!name) throw new Error(`Could not identify a company name from: "${text}".`);
-  return name;
 }
 
 async function fetchByCnpj(cnpj: string): Promise<Record<string, unknown>> {

--- a/apps/api/src/lib/llm-capability-costs.test.ts
+++ b/apps/api/src/lib/llm-capability-costs.test.ts
@@ -121,14 +121,20 @@ describe("llm-capability-costs — Phase 3 CI gate", () => {
     expect(overlap).toEqual([]);
   });
 
-  it("BLOCK_0064_SLUGS excludes the slugs owned by earlier blocks (0062 risk-narrative, 0063 invoice-extract)", () => {
+  it("BLOCK_0064_SLUGS excludes slugs owned by other blocks (0062 risk-narrative, 0063 invoice-extract, 0065 website-to-company)", () => {
     expect(BLOCK_0064_SLUGS).not.toContain("risk-narrative-generate");
     expect(BLOCK_0064_SLUGS).not.toContain("invoice-extract");
+    expect(BLOCK_0064_SLUGS).not.toContain("website-to-company");
   });
 
-  it("BLOCK_0064_SLUGS covers exactly the Haiku always-LLM caps (Object.keys(ALWAYS_LLM_CAPABILITY_COSTS) minus the two earlier-block slugs)", () => {
+  it("BLOCK_0064_SLUGS covers exactly the Haiku always-LLM caps (Object.keys(ALWAYS_LLM_CAPABILITY_COSTS) minus slugs owned by other blocks)", () => {
     const expected = Object.keys(ALWAYS_LLM_CAPABILITY_COSTS)
-      .filter((s) => s !== "risk-narrative-generate" && s !== "invoice-extract")
+      .filter(
+        (s) =>
+          s !== "risk-narrative-generate" &&
+          s !== "invoice-extract" &&
+          s !== "website-to-company",
+      )
       .sort();
     expect([...BLOCK_0064_SLUGS]).toEqual(expected);
   });

--- a/apps/api/src/lib/llm-capability-costs.ts
+++ b/apps/api/src/lib/llm-capability-costs.ts
@@ -62,6 +62,14 @@ export const ALWAYS_LLM_CAPABILITY_COSTS: Readonly<Record<string, number>> = Obj
   // Same pattern: listed for CI; runtime UPDATE fires from block 0063.
   "invoice-extract": 1,
 
+  // ─── Haiku 4.5 — owned by block 0065 (PR #86 follow-up) ────────────────────
+  // website-to-company: PR #86 traced the cap and found llmExtractCompanyName
+  // fires whenever meta-extract returns any title/site_name (i.e. every real
+  // site), and the cap also chains into a country-specific registry that
+  // can itself trigger another LLM call. The "structured-data bypasses LLM"
+  // bypass premise was wrong; promoting to the always-LLM band.
+  "website-to-company": 1,
+
   // ─── Haiku 4.5 — owned by block 0064 (this file) ────────────────────────────
   "address-parse": 1,
   "agent-trace-analyze": 1,
@@ -150,9 +158,23 @@ export const ALWAYS_LLM_CAPABILITY_COSTS: Readonly<Record<string, number>> = Obj
  */
 export const BLOCK_0064_SLUGS: readonly string[] = Object.freeze(
   Object.keys(ALWAYS_LLM_CAPABILITY_COSTS)
-    .filter((slug) => slug !== "risk-narrative-generate" && slug !== "invoice-extract")
+    .filter(
+      (slug) =>
+        slug !== "risk-narrative-generate" &&
+        slug !== "invoice-extract" &&
+        slug !== "website-to-company",
+    )
     .sort(),
 );
+
+/**
+ * Slugs owned by block 0065's cost UPDATE. PR #86 follow-up: the cap was
+ * previously in `CONDITIONAL_LLM_CAPABILITIES` but the audit's trace
+ * showed the bypass premise was wrong — `llmExtractCompanyName` fires
+ * on every real site URL. Block 0065 bumps it to 1¢ to flip the
+ * scheduler-skip semantic; same flat-cost-1¢ shape as block 0064.
+ */
+export const BLOCK_0065_SLUGS: readonly string[] = Object.freeze(["website-to-company"]);
 
 /**
  * Capabilities that import the Anthropic SDK but legitimately keep
@@ -174,10 +196,14 @@ export const CONDITIONAL_LLM_CAPABILITIES: ReadonlySet<string> = new Set([
   // resolver (`extractCompanyName` / `name-resolver.ts`) only fires
   // when the input is NOT a numeric registry code. Manifest
   // `health_check_input` uses the country's registry-code format
-  // (CNPJ, CIN, CVR, registry code, Y-tunnus, SIREN, organisasjonsnummer,
-  // company number, EIN, etc.), which bypasses the LLM call. Scheduled
+  // (CIN, CVR, registry code, Y-tunnus, SIREN, organisasjonsnummer,
+  // company number), which bypasses the LLM call. Scheduled
   // testing exercises the direct registry-API path (free).
-  "brazilian-company-data",
+  //
+  // brazilian-company-data was removed 2026-05-11 (PR #86 follow-up): the
+  // capability never reached its LLM helper from the registered executor;
+  // dead-code helper + SDK import were deleted, so the cap no longer
+  // imports `@anthropic-ai/sdk` and falls outside the CI gate entirely.
   "cz-company-data",
   "danish-company-data",
   "estonian-company-data",
@@ -185,18 +211,21 @@ export const CONDITIONAL_LLM_CAPABILITIES: ReadonlySet<string> = new Set([
   "french-company-data",
   "norwegian-company-data",
   "uk-company-data",
+  // us-company-data: SDK is reached only on alphanumeric / ticker inputs in
+  // production. The scheduled-test fixture was changed (PR #86 follow-up)
+  // from "AAPL" (ticker, fails `findCik` regex → LLM path) to a numeric
+  // CIK ("320193"), which matches `/^\d{1,10}$/` and routes directly to
+  // the SEC EDGAR API. Hourly outage detection on EDGAR is preserved.
   "us-company-data",
 
-  // ─── Domain-input cap with cached / structured-extract fast path ───────────
-  // website-to-company: LLM fires only when the structured-data
-  // extraction (JSON-LD, meta tags) doesn't surface a company name.
-  // Test fixture uses a site with rich structured data; LLM bypassed.
-  "website-to-company",
-
-  // ─── Carrier-ambiguity-only LLM ────────────────────────────────────────────
+  // ─── Invalid-format early-return ─────────────────────────────────────────────
   // container-track: ISO 6346 validation + carrier-prefix mapping
-  // resolves > 95% of inputs without LLM. LLM fires only when the
-  // carrier prefix doesn't match the static map. Test fixture uses a
-  // well-known carrier prefix (Maersk MAEU/MSKU/MRKU).
+  // resolves real container numbers without LLM. LLM (Browserless +
+  // Haiku tracking-page extraction) fires only when validation passes.
+  // The scheduled-test fixture is the placeholder string "test_value",
+  // which fails `validateContainerNumber` → invalid-format early-return
+  // path → no Browserless fetch, no LLM call. PR #86 corrected the
+  // bypass justification (was previously claimed to be a well-known
+  // carrier prefix); the verdict is unchanged.
   "container-track",
 ]);

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -49,6 +49,7 @@ import {
   runMigration0062_paidVendorCosts,
   runMigration0063_invoiceExtractCostReclassify,
   runMigration0064_alwaysLlmHaikuCosts,
+  runMigration0065_pr86LeakyCapsCleanup,
   runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
@@ -320,8 +321,95 @@ describe("startup-migrations — block 0064 (always-LLM Haiku costs)", () => {
   });
 });
 
+describe("startup-migrations — block 0065 (PR #86 leaky-cap cleanup)", () => {
+  it("first run: bumps website-to-company cost AND fixes us-company-data fixture", async () => {
+    // Queue: cost-bump UPDATE returns 4 (4 live non-probe suites);
+    //        fixture-fix UPDATE returns 4 (4 AAPL rows replaced);
+    //        cost post-check returns 0;
+    //        fixture post-check returns 0.
+    const stub = makeStub({
+      queue: [
+        { count: 4 },
+        { count: 4 },
+        [{ remaining_zero: 0 }],
+        [{ remaining_aapl: 0 }],
+      ],
+    });
+    const result = await runMigration0065_pr86LeakyCapsCleanup(stub);
+    expect(result.rows_affected).toBe(8);
+    expect(result.outcome).toContain("website-to-company cost-bumped=4");
+    expect(result.outcome).toContain("us-company-data fixture-fixed=4");
+    expect(stub.captured).toHaveLength(4);
+
+    // Cost-bump UPDATE shape
+    const costSql = stub.renderedSql[0].toLowerCase();
+    expect(costSql).toContain("update test_suites");
+    expect(costSql).toContain("set external_cost_cents = 1");
+    expect(costSql).toMatch(/test_mode = 'live'/);
+    expect(costSql).toContain("external_cost_cents = 0");
+    expect(costSql).not.toContain("'dependency_health'");
+    expect(costSql).not.toContain("'schema_check'");
+
+    // Fixture-fix UPDATE shape
+    const fixSql = stub.renderedSql[1].toLowerCase();
+    expect(fixSql).toContain("update test_suites");
+    expect(fixSql).toContain("jsonb_set");
+    expect(fixSql).toContain("'{company}'");
+    expect(fixSql).toContain("'\"320193\"'");
+    expect(fixSql).toContain("'us-company-data'");
+    expect(fixSql).toContain("'aapl'"); // idempotency filter (lowercased by toLowerCase)
+  });
+
+  it("second run: idempotent — both UPDATEs return 0 rows; outcome reports already-fixed", async () => {
+    const stub = makeStub({
+      queue: [
+        { count: 0 },
+        { count: 0 },
+        [{ remaining_zero: 0 }],
+        [{ remaining_aapl: 0 }],
+      ],
+    });
+    const result = await runMigration0065_pr86LeakyCapsCleanup(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to update.*already classified.*fixed/i);
+    expect(stub.captured).toHaveLength(4);
+  });
+
+  it("post-condition violation (cost) throws (would fail boot)", async () => {
+    // Cost UPDATE captured some, fixture UPDATE captured 0, post-check
+    // (cost) finds a leftover at external_cost_cents = 0.
+    const stub = makeStub({
+      queue: [
+        { count: 4 },
+        { count: 0 },
+        [{ remaining_zero: 1 }],
+        [{ remaining_aapl: 0 }],
+      ],
+    });
+    await expect(runMigration0065_pr86LeakyCapsCleanup(stub)).rejects.toThrow(
+      /post-condition failed.*1 website-to-company suites/i,
+    );
+  });
+
+  it("post-condition violation (fixture) throws (would fail boot)", async () => {
+    // Cost UPDATE clean, fixture UPDATE clean, but post-check (fixture)
+    // finds a leftover AAPL row.
+    const stub = makeStub({
+      queue: [
+        { count: 4 },
+        { count: 4 },
+        [{ remaining_zero: 0 }],
+        [{ remaining_aapl: 1 }],
+      ],
+    });
+    await expect(runMigration0065_pr86LeakyCapsCleanup(stub)).rejects.toThrow(
+      /post-condition failed.*1 us-company-data suites.*'AAPL'/i,
+    );
+  });
+});
+
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 7 blocks in historical order", () => {
+  it("exports the expected 8 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -335,6 +423,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0062_paidVendorCosts",
       "runMigration0063_invoiceExtractCostReclassify",
       "runMigration0064_alwaysLlmHaikuCosts",
+      "runMigration0065_pr86LeakyCapsCleanup",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -39,7 +39,7 @@
 import { sql, type SQL } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { log } from "./log.js";
-import { BLOCK_0064_SLUGS } from "./llm-capability-costs.js";
+import { BLOCK_0064_SLUGS, BLOCK_0065_SLUGS } from "./llm-capability-costs.js";
 
 /**
  * Minimal executor surface — matches what `getDb().execute()` returns
@@ -418,6 +418,115 @@ export async function runMigration0064_alwaysLlmHaikuCosts(
   };
 }
 
+// ─── Block 0065: PR #86 follow-up — leaky-cap cleanup ──────────────────────
+//
+// Two narrow UPDATEs against `test_suites`, bundled because both close
+// residual leak surface that PR #86's bypass-justification audit
+// surfaced. Idempotent via filter clauses; post-condition checks fire
+// on first deploy and re-run as no-ops thereafter.
+//
+// 1. `website-to-company` cost bump (mirrors block 0064 pattern).
+//    The bypass premise was that structured-data extraction (JSON-LD,
+//    meta tags) bypasses the LLM. PR #86 found this wrong:
+//    `llmExtractCompanyName` fires whenever meta-extract returns any
+//    title/site_name (i.e. every real site). Bumping to 1¢ flips the
+//    scheduler-skip semantic.
+//
+// 2. `us-company-data` fixture fix. The scheduled-test suites have
+//    `input = {"company": "AAPL"}` (ticker symbol) which fails
+//    `findCik`'s `/^\d{1,10}$/` regex → falls into the LLM
+//    extractCompanyName path on every dispatch. Swapping to a numeric
+//    CIK ("320193", Apple) routes directly to the SEC EDGAR API. The
+//    manifest update is hygiene; this UPDATE is what makes the fix
+//    effective in prod (the test_suites row was populated by
+//    onboard.ts at capability-creation time and no longer tracks the
+//    manifest).
+
+export async function runMigration0065_pr86LeakyCapsCleanup(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  // (1) website-to-company cost bump
+  const slugList = sql.join(
+    BLOCK_0065_SLUGS.map((s) => sql`${s}`),
+    sql`, `,
+  );
+  const costBump = await tx.execute(sql`
+    UPDATE test_suites
+    SET external_cost_cents = 1, updated_at = NOW()
+    WHERE capability_slug IN (${slugList})
+      AND active = true
+      AND test_mode = 'live'
+      AND test_type IN ('known_answer', 'edge_case', 'negative', 'known_bad')
+      AND external_cost_cents = 0
+  `);
+  const costBumpCount = (costBump as { count?: number }).count ?? 0;
+
+  // (2) us-company-data fixture fix — only touches rows whose current
+  // input is the broken "AAPL" ticker. New rows or re-onboarded ones
+  // (the manifest is now corrected) won't match the filter and stay.
+  const fixtureFix = await tx.execute(sql`
+    UPDATE test_suites
+    SET input = jsonb_set(input, '{company}', '"320193"'::jsonb), updated_at = NOW()
+    WHERE capability_slug = 'us-company-data'
+      AND active = true
+      AND test_mode = 'live'
+      AND test_type IN ('known_answer', 'edge_case', 'negative', 'known_bad')
+      AND input->>'company' = 'AAPL'
+  `);
+  const fixtureFixCount = (fixtureFix as { count?: number }).count ?? 0;
+
+  // Post-condition (1): no website-to-company live non-probe suite may
+  // remain at external_cost_cents = 0 after this block.
+  const checkCostRows = await tx.execute(sql`
+    SELECT COUNT(*)::int AS remaining_zero
+    FROM test_suites
+    WHERE capability_slug IN (${slugList})
+      AND active = true
+      AND test_mode = 'live'
+      AND test_type IN ('known_answer', 'edge_case', 'negative', 'known_bad')
+      AND external_cost_cents = 0
+  `);
+  const costRows = Array.isArray(checkCostRows) ? checkCostRows : (checkCostRows as { rows?: unknown[] })?.rows ?? [];
+  const remainingZero = (costRows[0] as { remaining_zero?: number })?.remaining_zero ?? 0;
+  if (remainingZero > 0) {
+    throw new Error(
+      `0065_pr86_leaky_caps_cleanup post-condition failed: ${remainingZero} website-to-company suites still at external_cost_cents = 0`,
+    );
+  }
+
+  // Post-condition (2): no us-company-data live non-probe suite may
+  // remain with input.company = 'AAPL' after this block.
+  const checkFixtureRows = await tx.execute(sql`
+    SELECT COUNT(*)::int AS remaining_aapl
+    FROM test_suites
+    WHERE capability_slug = 'us-company-data'
+      AND active = true
+      AND test_mode = 'live'
+      AND test_type IN ('known_answer', 'edge_case', 'negative', 'known_bad')
+      AND input->>'company' = 'AAPL'
+  `);
+  const fixtureRows = Array.isArray(checkFixtureRows) ? checkFixtureRows : (checkFixtureRows as { rows?: unknown[] })?.rows ?? [];
+  const remainingAapl = (fixtureRows[0] as { remaining_aapl?: number })?.remaining_aapl ?? 0;
+  if (remainingAapl > 0) {
+    throw new Error(
+      `0065_pr86_leaky_caps_cleanup post-condition failed: ${remainingAapl} us-company-data suites still have input.company = 'AAPL'`,
+    );
+  }
+
+  const total = costBumpCount + fixtureFixCount;
+  return {
+    block: "0065_pr86_leaky_caps_cleanup",
+    outcome:
+      total === 0
+        ? "no rows to update (already classified + fixed)"
+        : `website-to-company cost-bumped=${costBumpCount}, us-company-data fixture-fixed=${fixtureFixCount}`,
+    rows_affected: total,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -436,6 +545,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0062_paidVendorCosts,
   runMigration0063_invoiceExtractCostReclassify,
   runMigration0064_alwaysLlmHaikuCosts,
+  runMigration0065_pr86LeakyCapsCleanup,
 ];
 
 /**

--- a/manifests/norwegian-company-data.yaml
+++ b/manifests/norwegian-company-data.yaml
@@ -81,7 +81,7 @@ test_fixtures:
         operator: not_null
         reliability: guaranteed
   health_check_input:
-    org_number: 556703-7485
+    org_number: "923609016"
 output_field_reliability:
   status: guaranteed
   address: guaranteed

--- a/manifests/us-company-data.yaml
+++ b/manifests/us-company-data.yaml
@@ -66,13 +66,13 @@ geography: us
 test_fixtures:
   known_answer:
     input:
-      company: AAPL
+      company: "320193"
     expected_fields:
       - field: company_name
         operator: not_null
         reliability: guaranteed
   health_check_input:
-    company: AAPL
+    company: "320193"
 output_field_reliability:
   cik: guaranteed
   state: guaranteed


### PR DESCRIPTION
## Summary

Follow-up to audit [PR #86](https://github.com/strale-io/io/pull/86). Closes the 2 LEAKY caps and ships the 3 adjacent doc/hygiene fixes that PR #86 surfaced.

| Cap | Action | Path |
|-----|--------|------|
| `website-to-company` | Promoted to `ALWAYS_LLM_CAPABILITY_COSTS` (1¢). New migration block 0065 bumps prod cost. | Path A (mirror PR #85) |
| `us-company-data` | Fixture `"AAPL"` → `"320193"` (numeric CIK, Apple). Manifest + block 0065 prod UPDATE. Cap stays conditional. | Path C (hybrid) |
| `brazilian-company-data` | `extractCompanyName` + SDK import deleted (dead code, zero callers). Cap drops out of conditional set. | Hygiene |
| `container-track` | Bypass comment rewritten to match actual invalid-format early-return mechanism. | Hygiene |
| `norwegian-company-data` | Manifest `health_check_input.org_number`: `556703-7485` (SE) → `923609016` (Equinor NO). | Hygiene |

## Trace verifications

- `us-company-data` fixture `"320193"` → `findCik` regex `/^\d{1,10}$/` → matches → padded to `"0000320193"` → direct SEC EDGAR API call → no SDK reached. Verified by reading [us-company-data.ts:98](apps/api/src/capabilities/us-company-data.ts#L98).
- `brazilian-company-data` `extractCompanyName` callers: `grep -rn "extractCompanyName" apps/api/src/` matches only the function definition itself. Zero external callers. Safe to delete.
- `website-to-company` already in `ALWAYS_LLM_CAPABILITY_COSTS`; CI gate fails without it (negative-tested).

## Migration 0065 shape

Two UPDATEs in one block (mirroring 0062's two-UPDATE pattern, since both close residual from the same PR #86 finding):

1. `website-to-company` cost: 0 → 1 (idempotency: `external_cost_cents = 0`).
2. `us-company-data` fixture: `input.company = 'AAPL'` → `'320193'` via `jsonb_set` (idempotency: `input->>'company' = 'AAPL'`).

Two post-condition checks: both throw on remaining rows; mirrors PR #85's pattern.

## Test plan

- [x] 28/28 startup-migration + cost-map tests pass (up from 24; 4 new for block 0065).
- [x] Full vitest: 540 passed (+4 vs PR #85) / 1 pre-existing failure (`src/app.classify-error.test.ts` — `strale-mcp/tools` import, unchanged).
- [x] **Negative test:** removing `website-to-company` from `ALWAYS_LLM_CAPABILITY_COSTS` → CI gate fails with actionable message naming the slug. Reverted.
- [ ] **Post-deploy:** `SELECT external_cost_cents FROM test_suites WHERE capability_slug = 'website-to-company' AND test_mode = 'live'` returns rows at 1.
- [ ] **Post-deploy:** `SELECT input->>'company' FROM test_suites WHERE capability_slug = 'us-company-data' AND test_mode = 'live'` returns `'320193'` (no remaining `'AAPL'`).
- [ ] **T+48h (chat/Petter, not a merge gate):** Anthropic Console residual drops by ~35K Haiku tokens/day (the 1.4% PR #86 estimated).

## Structural follow-up

Updating the existing `scheduled_testing_eligible` decoupling To-do with PR #86's chained-LLM-call finding — separate Notion edit, in the closing steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)