### PR TITLE
refactor: scheduled_testing_eligible column + derivation bridge (PR A)

### DIFF
--- a/apps/api/drizzle/0063_decouple_scheduled_testing_eligibility.sql
+++ b/apps/api/drizzle/0063_decouple_scheduled_testing_eligibility.sql
@@ -1,0 +1,43 @@
+-- Decouple scheduled-testing eligibility from external_cost_cents.
+--
+-- Before this PR, the test scheduler's dispatch query filtered on
+-- `test_suites.external_cost_cents = 0` to decide what to run hourly.
+-- That coupled billing data (per-call cost) to a scheduling signal,
+-- which made the May 2026 Haiku token spike (PRs #84/#85/#86/#87)
+-- structurally possible: a compound-PR pattern (cadence flip + deferred
+-- cost-bump) silently turned billing-data lag into a scheduling
+-- regression.
+--
+-- PR A: introduce `test_suites.scheduled_testing_eligible BOOLEAN NOT
+-- NULL DEFAULT FALSE`. The hourly dispatch filters on this column going
+-- forward. `external_cost_cents` is billing-only. Backfill preserves
+-- current behavior exactly: every row with cost = 0 today gets
+-- eligible = TRUE; every row with cost > 0 stays at the default FALSE
+-- (matches DEC-20260503-B doctrine: paid caps have no scheduled
+-- testing). Same cap set tested before and after the migration.
+--
+-- Startup block 0066 (in startup-migrations.ts) re-derives eligibility
+-- from cost at every boot as an interim bridge. PR B will force
+-- explicit declarations at INSERT sites and remove 0066.
+
+-- Add scheduled_testing_eligible column
+ALTER TABLE test_suites
+  ADD COLUMN scheduled_testing_eligible BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Backfill: preserve current behavior exactly
+UPDATE test_suites
+   SET scheduled_testing_eligible = TRUE
+ WHERE external_cost_cents = 0;
+
+-- Post-condition: backfill produced the same set the old dispatch would select
+DO $$
+DECLARE
+  free_count INT;
+  eligible_count INT;
+BEGIN
+  SELECT COUNT(*) INTO free_count FROM test_suites WHERE external_cost_cents = 0;
+  SELECT COUNT(*) INTO eligible_count FROM test_suites WHERE scheduled_testing_eligible = TRUE;
+  IF free_count != eligible_count THEN
+    RAISE EXCEPTION 'Backfill mismatch: % free caps but % eligible (expected equal)', free_count, eligible_count;
+  END IF;
+END $$;

--- a/apps/api/scripts/investigate-singapore.ts
+++ b/apps/api/scripts/investigate-singapore.ts
@@ -125,7 +125,7 @@ async function main() {
       EXTRACT(MINUTE FROM NOW())::int AS current_minute,
       (c.is_active = true
         AND ts.active = true
-        AND ts.external_cost_cents = 0
+        AND ts.scheduled_testing_eligible = TRUE
       )                              AS would_be_picked_if_overdue
     FROM capabilities c
     LEFT JOIN test_suites ts ON ts.capability_slug = c.slug

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -529,6 +529,14 @@ export const testSuites = pgTable(
     // 'live' (real API), 'fixture' (saved data), 'canary' (periodic live check)
     fixtureLastRefreshed: timestamp("fixture_last_refreshed", { withTimezone: true }),
     externalCostCents: integer("external_cost_cents").default(0),
+    // Scheduling eligibility — explicit billing/scheduling decoupling per PR A
+    // of the May 2026 Haiku-leak structural follow-up (see DEC-20260511-?).
+    // The hourly test scheduler reads this column to decide what to dispatch;
+    // `external_cost_cents` is billing-only. Block 0066 reconciles eligibility
+    // from cost at every boot as an interim derivation bridge (PR A).
+    scheduledTestingEligible: boolean("scheduled_testing_eligible")
+      .notNull()
+      .default(false),
     // For auto-generated tests: the capability's updated_at at generation time.
     // If the capability was modified after this timestamp, the ground truth
     // may be contaminated and should be re-verified.

--- a/apps/api/src/jobs/test-scheduler.ts
+++ b/apps/api/src/jobs/test-scheduler.ts
@@ -6,13 +6,14 @@
  * never fire during active development).
  *
  * Per DEC-20260503-B (2026-05-04), the previous tiered cadence (A=6h /
- * B=24h / C=72h) is replaced by a single hourly schedule for free
- * capabilities only. Paid capabilities (test_suites.external_cost_cents > 0)
- * are removed from scheduled testing entirely; quality signals for them
- * come from production observability, piggyback test suites, and any
- * zero-cost auth-less probes the vendor permits. The schedule_tier column
- * stays on test_suites for backwards compatibility but is no longer read
- * by the scheduler.
+ * B=24h / C=72h) is replaced by a single hourly schedule for eligible
+ * capabilities only. Paid / LLM capabilities (test_suites.scheduled_testing_eligible
+ * = FALSE) are removed from scheduled testing entirely; quality signals
+ * for them come from production observability, piggyback test suites,
+ * and any zero-cost auth-less probes the vendor permits. The
+ * schedule_tier column stays on test_suites for backwards compatibility
+ * but is no longer read by the scheduler. Eligibility is an explicit
+ * column per the PR A decoupling (see DEC-20260511-?).
  *
  * Cadence: the scheduler ticks every minute. Each minute M (0–59) it
  * picks free capabilities whose `abs(hashtext(slug)) % 60 = M` and whose
@@ -103,8 +104,8 @@ const FREE_TEST_INTERVAL_HOURS = 1;                 // DEC-20260503-B: hourly fr
 // schedule_tier (A/B/C) is no longer read by the scheduler. The column
 // remains on test_suites for backwards compatibility and downstream
 // consumers (refresh-stale-scores.ts uses it for freshness-decay tier
-// hours). Per DEC-20260503-B, the scheduler dispatches strictly on
-// external_cost_cents = 0 + slug-hash stagger.
+// hours). Per DEC-20260503-B + PR A decoupling, the scheduler dispatches
+// strictly on scheduled_testing_eligible = TRUE + slug-hash stagger.
 
 // Auxiliary task intervals (in ms)
 const HEALTH_CHECK_INTERVAL_MS      = 6 * 60 * 60 * 1000;   // 6h
@@ -238,10 +239,13 @@ export function slugStaggerMinute(slug: string): number {
 /**
  * Find free capabilities due for testing this minute.
  *
- * Per DEC-20260503-B:
- *   - external_cost_cents = 0  (free; paid caps skipped entirely)
+ * Per DEC-20260503-B (refined by the PR A decoupling — see DEC-20260511-?):
+ *   - scheduled_testing_eligible = TRUE  (free/eligible; paid caps skipped)
  *   - last_tested_at older than 1h  (or never tested)
  *   - abs(hashtext(slug)) % 60 = current minute  (slug-hash stagger)
+ *
+ * Eligibility is an explicit column on `test_suites`. `external_cost_cents`
+ * is billing-only and no longer drives dispatch decisions.
  *
  * The status floor (upstream_broken, infra_limited, quarantined) still
  * applies — known-broken suites back off to daily/weekly even on the new
@@ -259,7 +263,7 @@ async function findOverdueCapabilities(): Promise<OverdueCapability[]> {
     INNER JOIN test_suites ts
       ON ts.capability_slug = c.slug AND ts.active = true
     WHERE c.is_active = true
-      AND ts.external_cost_cents = 0
+      AND ts.scheduled_testing_eligible = TRUE
       AND (abs(hashtext(c.slug)) % 60) = EXTRACT(MINUTE FROM NOW())::int
       AND (
         c.last_tested_at IS NULL
@@ -299,7 +303,7 @@ async function countOverdueCapabilities(): Promise<number> {
     INNER JOIN test_suites ts
       ON ts.capability_slug = c.slug AND ts.active = true
     WHERE c.is_active = true
-      AND ts.external_cost_cents = 0
+      AND ts.scheduled_testing_eligible = TRUE
       AND (
         c.last_tested_at IS NULL
         OR c.last_tested_at < NOW() - GREATEST(
@@ -318,9 +322,10 @@ async function countOverdueCapabilities(): Promise<number> {
 }
 
 /**
- * Total count of paid capabilities skipped by the scheduler. Used for
- * end-of-cycle observability so operators can see how many paid caps the
- * scheduler is consciously NOT testing per DEC-20260503-B.
+ * Total count of ineligible capabilities skipped by the scheduler. Used
+ * for end-of-cycle observability so operators can see how many caps the
+ * scheduler is consciously NOT testing per DEC-20260503-B (paid vendors,
+ * LLM caps, anything explicitly flagged scheduled_testing_eligible = FALSE).
  */
 async function countPaidSkipped(): Promise<number> {
   const db = getDb();
@@ -330,7 +335,7 @@ async function countPaidSkipped(): Promise<number> {
     INNER JOIN test_suites ts
       ON ts.capability_slug = c.slug AND ts.active = true
     WHERE c.is_active = true
-      AND ts.external_cost_cents > 0
+      AND ts.scheduled_testing_eligible = FALSE
   `);
   const resultRows = Array.isArray(rows) ? rows : (rows as any)?.rows ?? [];
   return resultRows[0]?.count ?? 0;

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -409,7 +409,7 @@ describe("startup-migrations — block 0065 (PR #86 leaky-cap cleanup)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 8 blocks in historical order", () => {
+  it("exports the expected 9 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -424,6 +424,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0063_invoiceExtractCostReclassify",
       "runMigration0064_alwaysLlmHaikuCosts",
       "runMigration0065_pr86LeakyCapsCleanup",
+      "runMigration0066_reconcileEligibilityFromCost",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -527,6 +527,78 @@ export async function runMigration0065_pr86LeakyCapsCleanup(
   };
 }
 
+// ─── Block 0066: reconcile scheduled_testing_eligible from cost ────────────
+//
+// PR A of the structural decoupling between `external_cost_cents`
+// (billing) and `scheduled_testing_eligible` (scheduling signal). PR A
+// introduces the new column with a backfill that preserves current
+// behavior exactly (eligible = TRUE where cost = 0). This block is the
+// interim derivation bridge: at every boot it re-derives eligibility
+// from cost, catching any INSERT site that ran between PR A and PR B
+// without setting eligibility explicitly.
+//
+// Why it exists: PR A does not touch the 12 INSERT call sites that
+// produce `test_suites` rows. A new free cap inserted between PR A and
+// PR B would land at eligible = FALSE (the column default) and silently
+// drop out of scheduled testing. This block restores the derivation
+// "cost = 0 ⇒ eligible = TRUE" at every boot, so the dispatch sees the
+// correct set regardless of which INSERT path created the row.
+//
+// Ordering: must run AFTER 0064 / 0065 so the cost-bump on LLM caps is
+// applied before eligibility is derived. On a fresh DB the order is:
+// Drizzle 0063 (column + initial backfill) → startup 0062/0063/0064/0065
+// (cost bumps) → startup 0066 (reconcile). On prod the cost-bumps have
+// already run, so 0066 is a no-op verifying the post-Drizzle-backfill
+// state matches.
+//
+// PR B removes this block when INSERT sites are forced explicit and the
+// CI assertion is rewritten to read eligibility instead of cost.
+//
+// Idempotent via the `WHERE` clause: a re-run on a reconciled DB is a
+// no-op (zero rows updated).
+
+export async function runMigration0066_reconcileEligibilityFromCost(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const update = await tx.execute(sql`
+    UPDATE test_suites
+       SET scheduled_testing_eligible = (external_cost_cents = 0),
+           updated_at = NOW()
+     WHERE scheduled_testing_eligible IS DISTINCT FROM (external_cost_cents = 0)
+  `);
+  const updateCount = (update as { count?: number }).count ?? 0;
+
+  // Post-condition: every row's eligibility matches the cost derivation.
+  // If a row remains mismatched, something raced our UPDATE (or the
+  // expression form differs between engines). Fail boot.
+  const checkRows = await tx.execute(sql`
+    SELECT COUNT(*)::int AS mismatched
+      FROM test_suites
+     WHERE scheduled_testing_eligible IS DISTINCT FROM (external_cost_cents = 0)
+  `);
+  const checkResultRows = Array.isArray(checkRows)
+    ? checkRows
+    : (checkRows as { rows?: unknown[] })?.rows ?? [];
+  const mismatched = (checkResultRows[0] as { mismatched?: number })?.mismatched ?? 0;
+  if (mismatched > 0) {
+    throw new Error(
+      `0066_reconcile_eligibility_from_cost post-condition failed: ${mismatched} rows still mismatched after UPDATE`,
+    );
+  }
+
+  return {
+    block: "0066_reconcile_eligibility_from_cost",
+    outcome:
+      updateCount === 0
+        ? "no rows to reconcile (already aligned)"
+        : `reconciled ${updateCount} rows to derived eligibility`,
+    rows_affected: updateCount,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -546,6 +618,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0063_invoiceExtractCostReclassify,
   runMigration0064_alwaysLlmHaikuCosts,
   runMigration0065_pr86LeakyCapsCleanup,
+  runMigration0066_reconcileEligibilityFromCost,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Adds `test_suites.scheduled_testing_eligible BOOLEAN NOT NULL DEFAULT FALSE` and a Drizzle migration that backfills `eligible = TRUE` where `external_cost_cents = 0` (preserves current scheduler behavior exactly).
- Swaps the 3 scheduling readers in `test-scheduler.ts` (dispatch + 2 observability) and 1 diagnostic-script reader (`investigate-singapore.ts`) to filter on the new column. `external_cost_cents` returns to being billing-only.
- Adds startup block `0066_reconcileEligibilityFromCost` as an interim derivation bridge — re-derives eligibility from cost at every boot so any row inserted by the 12 untouched INSERT call sites lands at the correct value.

## Why now

The May 2026 Haiku token spike (PRs #84/#85/#86/#87) was structurally possible because `external_cost_cents = 0` did double duty as billing data and scheduling signal. PR #46's cadence flip (24h → 1h) plus PR #49's deferred Anthropic-Haiku cost-bump silently turned billing-data lag into a scheduling regression for 73 LLM caps for 7 days. PR #85 shipped a CI assertion as the interim guard. This PR decouples the underlying coupling so the assertion is defense in depth, not load-bearing.

## Scope split

PR A (this PR):
- Schema + migration + dispatch swap + observability + script + startup block 0066 + Notion writes.
- INSERT call sites and CI assertion are not touched.

PR B (separately tracked, [Notion To-do](https://www.notion.so/35d67c87082c8102ba48fff997d5fdcf)):
- Force `scheduledTestingEligible: boolean` explicit at all 12 INSERT call sites.
- Remove block 0066.
- Rewrite CI assertion to check `LLM-importer + ALWAYS_LLM_CAPABILITY_COSTS + eligible = FALSE` invariant directly.

## Notion

- New DEC: [DEC-20260511-B — Decouple scheduled_testing_eligible from external_cost_cents (PR A)](https://www.notion.so/35d67c87082c812c864dfeaa2b9afaff). Refines DEC-20260503-B, does not supersede.
- Existing structural-follow-up To-do `35d67c87082c81148ee4fc88f1671776` moved to **In progress** with status note.
- Capability onboarding pipeline page updated with interim-derivation note.

## Verification

- Type-check: pre-existing `routes/mcp.ts` `strale-mcp/tools` errors unchanged; no new errors.
- Vitest: 540 passing / 11 skipped / 1 failing (`app.classify-error.test.ts` is the pre-existing failure noted in the prompt; unrelated to this PR).
- Updated `startup-migrations.test.ts` BLOCKS-list assertion (8 → 9 blocks; new block appended in order).
- Grep confirms no remaining `external_cost_cents = 0 / > 0` scheduling readers in `src/` outside the legitimate billing-data UPDATE blocks (0062–0065) and block 0066's intentional derivation.

## Closing-steps rule walk

- **Rule 4 (source-health integrity):** dispatch swap is the carve-out PR #85 named.
- **Rule 7 (bug-fix framework):** not invoked. Structural prevention, not a bug fix.
- **Rules 8 + 9:** hand-written Drizzle migration + same-commit schema.ts sync, per DEC-20260420-A.
- **Rule 11 (DEC supersession):** does NOT supersede DEC-20260503-B. Refines. No sweep needed.
- **Rule 12 (audit follow-up tests):** dispatch / observability / script swaps covered by backfill parity (same cap set pre/post); block 0066 covered by its post-condition DO block.

## After-deploy plan

```
cd apps/api && npx drizzle-kit migrate
psql $DATABASE_URL -c "\d test_suites" | grep scheduled_testing_eligible
psql $DATABASE_URL -c "SELECT COUNT(*) FROM test_suites WHERE scheduled_testing_eligible = TRUE"
psql $DATABASE_URL -c "SELECT COUNT(*) FROM test_suites WHERE external_cost_cents = 0"
```

Both counts must be equal. Then monitor the next hourly dispatch tick — cap set should match the pre-deploy set exactly.

## Test plan
- [x] Drizzle migration runs locally with the post-condition DO block passing
- [x] Backfill row counts match pre-migration set
- [x] All 3 swapped scheduler queries return identical row sets to the pre-swap version
- [x] Startup-migrations BLOCKS-list test passes with new 9-block expectation
- [x] Full vitest run: 540 passing
- [ ] After Railway deploy: `\d test_suites` shows new column; both `WHERE eligible = TRUE` and `WHERE cost = 0` counts equal
- [ ] After Railway deploy: next hourly dispatch logs same cap set as pre-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)