### PR TITLE
chore: promote 2 handoff notes from 2026-05-11

### DIFF
--- a/handoff/_general/from-code/2026-05-11-decouple-scheduled-testing-eligible-pr-a.md
+++ b/handoff/_general/from-code/2026-05-11-decouple-scheduled-testing-eligible-pr-a.md
@@ -1,0 +1,39 @@
+# Decouple `scheduled_testing_eligible` from `external_cost_cents` (PR A)
+
+**Intent:** Ship PR A of the structural decoupling that retires the implicit billing/scheduling coupling at the root of the May 2026 Haiku token spike (PRs #84/#85/#86/#87). PR #88 merged 2026-05-11.
+
+## Landed
+
+- Schema: `test_suites.scheduled_testing_eligible BOOLEAN NOT NULL DEFAULT FALSE` added in [apps/api/src/db/schema.ts](apps/api/src/db/schema.ts).
+- Migration [apps/api/drizzle/0063_decouple_scheduled_testing_eligibility.sql](apps/api/drizzle/0063_decouple_scheduled_testing_eligibility.sql): adds column + backfills `eligible = TRUE WHERE external_cost_cents = 0` + post-condition DO block asserts parity between the two filters.
+- Scheduler swap (3 readers in [apps/api/src/jobs/test-scheduler.ts](apps/api/src/jobs/test-scheduler.ts)): `findOverdueCapabilities`, `countOverdueCapabilities`, `countPaidSkipped` now filter on `scheduled_testing_eligible`.
+- Script swap: [apps/api/scripts/investigate-singapore.ts:128](apps/api/scripts/investigate-singapore.ts#L128).
+- Startup block `0066_reconcileEligibilityFromCost` added in [apps/api/src/lib/startup-migrations.ts](apps/api/src/lib/startup-migrations.ts), registered in `BLOCKS`. Re-derives eligibility from cost at every boot — interim bridge until PR B forces INSERT sites to declare explicitly.
+- Test: BLOCKS-list assertion in [apps/api/src/lib/startup-migrations.test.ts](apps/api/src/lib/startup-migrations.test.ts) updated 8 → 9 blocks.
+
+## Decisions
+
+- **Migration number 0063** — fills gap. Drizzle migrations and in-startup-blocks are different mechanisms; cross-numbering with startup block 0064/0065/0066 doesn't collide.
+- **PR A deliberately does NOT touch the 12 INSERT call sites** (`capability-persistence.ts`, `capability-onboarding.ts`, all `db/generate-*-tests.ts`, `onboard.ts`, etc.). Deferred to PR B.
+- **Block 0066 added** rather than modifying blocks 0064/0065 — 0066 reconciles every row at boot; modifying 0064/0065 would only cover their specific slugs.
+- New DEC: [DEC-20260511-B](https://www.notion.so/35d67c87082c812c864dfeaa2b9afaff). Refines DEC-20260503-B without superseding.
+
+## Verification
+
+- Type-check: clean (pre-existing `routes/mcp.ts` `strale-mcp/tools` errors unchanged).
+- vitest: 540 passing / 11 skipped. Pre-existing `app.classify-error.test.ts` failure noted in prompt; unrelated.
+- CI on PR #88: green in 54s.
+
+## Follow-ups
+
+- **PR B** ([Notion To-do](https://www.notion.so/35d67c87082c8102ba48fff997d5fdcf)): force `scheduledTestingEligible: boolean` explicit at 12 INSERT sites, remove block 0066, rewrite the CI assertion in `llm-capability-costs.test.ts` to check the eligibility flag directly. P2.
+- **Post-deploy verification** (next Railway deploy): `\d test_suites` shows new column; `SELECT COUNT(*) WHERE eligible = TRUE` must equal `SELECT COUNT(*) WHERE external_cost_cents = 0`; next hourly dispatch logs same cap set as pre-deploy.
+
+## Related
+
+- [DEC-20260511-B](https://www.notion.so/35d67c87082c812c864dfeaa2b9afaff)
+- [PR B Notion To-do](https://www.notion.so/35d67c87082c8102ba48fff997d5fdcf)
+- [Structural follow-up source To-do](https://www.notion.so/35d67c87082c81148ee4fc88f1671776) — moved to In progress
+- PR #88: https://github.com/strale-io/strale/pull/88
+- PR #85 (containment): https://github.com/strale-io/strale/pull/85
+- PR #87 (residual cleanup): https://github.com/strale-io/strale/pull/87

--- a/handoff/_general/from-code/2026-05-11-haiku-cost-leak-audit-contain-cleanup.md
+++ b/handoff/_general/from-code/2026-05-11-haiku-cost-leak-audit-contain-cleanup.md
@@ -1,0 +1,37 @@
+Intent: audit the May 2026 Anthropic Haiku cost ramp (750K → 2.7M tokens/day), contain the leak in startup-migrations, audit the bypass-set's residual surface, and ship the cleanup. Four PRs in one arc: #84 (audit) → #85 (contain + harden) → #86 (audit conditionals) → #87 (cleanup).
+
+## Outcome (merged)
+
+- **PR #85 (`d938abd`):** containment + CI harden. Migration block 0064 bumps `test_suites.external_cost_cents = 1` on 73 always-LLM Haiku capabilities. New `apps/api/src/lib/llm-capability-costs.ts` holds the canonical map; new `llm-capability-costs.test.ts` CI gate fails if any `@anthropic-ai/sdk` importer is unregistered. Phase 3 harden against the compound-PR cost-leak pattern.
+- **PR #87 (`4db4358`):** PR #86 follow-up cleanup. Migration block 0065 closes the two LEAKY caps PR #86 surfaced — `website-to-company` (promoted to ALWAYS_LLM @ 1¢) and `us-company-data` (fixture `AAPL` → `320193` numeric CIK, in-place jsonb_set on prod test_suites). Three doc-hygiene fixes bundled: `brazilian-company-data` dead-code (extractCompanyName + SDK import deleted; cap exits the bypass set entirely), `container-track` bypass comment corrected to match the actual invalid-format early-return, `norwegian-company-data` manifest `health_check_input.org_number` fixed from Swedish format to Norwegian (Equinor 923609016).
+
+## Outcome (audits, not merged)
+
+- **PR #84 (`audit/anthropic-cost-may-2026`):** 95% attribution to PR #46's scheduler cadence flip (24h → 1h, 2026-05-04) intersected with PR #49's explicit deferral of ~80 Haiku-cap cost-bumps. Audit report at `apps/api/handoff/_general/from-code/2026-05-11-anthropic-cost-audit.md`. Awaiting Petter review.
+- **PR #86 (`audit/conditional-llm-bypass-may-2026`):** traced all 11 `CONDITIONAL_LLM_CAPABILITIES` against their `known_answer.input` fixtures. Verdict 9 CLEAN / 2 LEAKY / 0 AMBIGUOUS. Report at `apps/api/handoff/_general/from-code/2026-05-11-conditional-llm-bypass-audit.md`. Awaiting Petter review; PR #87 ships the recommended fixes.
+
+## Token-flow summary
+
+- Pre-PR-#85 baseline: ~2.5M Haiku tokens/day (multiplicative ramp from May 1's 750K).
+- PR #85 expected close: ~2.4M (95% of the leak).
+- PR #87 expected close: ~35K additional (~1.4% — the LEAKY residual).
+- Expected steady-state post-#87: ~50–200K Haiku tokens/day, dominated by `/v1/suggest` Haiku rerank (no prompt caching yet) and paid `/v1/do` + `/x402` customer traffic.
+
+## Open
+
+- **48h Anthropic Console verification** (chat/Petter, not a merge gate): if daily Haiku reads <300K, attribution confirmed. If >500K, `/v1/suggest` prompt caching becomes the next leverage. If >1M, attribution was wrong and a new audit is warranted.
+- **Structural follow-up Notion To-do `35d67c87082c81148ee4fc88f1671776`** (`Decouple scheduled_testing_eligible from external_cost_cents`): P2. Body updated this session with PR #86's chained-LLM-call refinement (three implementation options sketched). The interim CI gate in `llm-capability-costs.test.ts` is the structural guard until this lands.
+- **Pre-existing test failure `src/app.classify-error.test.ts`** (strale-mcp/tools import): present on main before this session, not introduced by any of #84–#87. Not in scope.
+
+## Non-obvious learnings
+
+- **Manifests are not the runtime source of truth for test fixtures.** `onboard.ts` copies `test_fixtures.known_answer.input` into `test_suites.input` at capability-creation time; after that the manifest can drift freely. PR #87's block 0065 had to issue a separate `jsonb_set` UPDATE against the live `test_suites` row to make the `AAPL → 320193` fixture fix effective in prod. Pure manifest-edit fixes are hygiene only.
+- **The compound-PR cost-leak pattern.** Two PRs land on the same day. PR-A changes load/cadence; PR-B is supposed to ship the compensating cost-bump but defers a subset of caps in PR prose. The deferral isn't a hard merge-block on PR-A. Net: cadence change is live with the compensating data half-missing, and the gap leaks silently. The dispatch query coupling billing data (`external_cost_cents`) to scheduling eligibility (`= 0` → schedule hourly) is the structural amplifier. Named pattern + course-correction Journal entry at `35d67c87082c817fac39c445cb7bc1bc`.
+- **Conditional-LLM bypass classification is per-cap-direct, but real call graphs chain.** `website-to-company → norwegian-company-data`: the latter is CLEAN when tested directly (numeric org-number fixture hits direct API), but becomes a leak surface when the former passes an LLM-extracted free-text company name that falls outside `isOrgNumber`'s regex. The CI gate's "is this cap in the bypass set?" check doesn't see chains. The structural follow-up To-do now considers chain edges.
+- **PR #49 (2026-05-04) shipped a UPDATE block in `apply-migrations.ts` that was dead code at the time** — the Dockerfile CMD didn't invoke it, tsconfig rootDir excluded it from build. PR #51/#52 wired `runStartupMigrations()` on the API boot path; PR #49's UPDATEs only took effect after that landed. The chronology matters for ramp attribution: the cost-bump that was supposed to compensate PR #46's cadence flip didn't actually run for ~12 hours after the cadence flip.
+- **The audit's "~50 always-LLM Haiku caps" estimate was a sample, not a total.** The actual count is 73. Audit's pure-LLM table called out "selected examples" — the additional 20 are Browserless+LLM caps (cookie-scan, gdpr-fine-lookup, terms-of-service-extract, etc.) the audit didn't enumerate. Don't read "~N" in audit reports as a precise figure.
+- **Block 0064's IN-list is bind-parameter-driven, not string-concat.** `sql.join` + `sql\`${s}\`` pushes each slug as `$N`. Stable across DBs, no SQL-injection surface, and the test asserts placeholder count ≥ slug count. Pattern for any future bulk-slug UPDATE block.
+
+## Cost
+
+API tokens for this session: not measured directly. The cumulative work shipped four PRs, two Notion entries, two audit reports.


### PR DESCRIPTION
## Summary
Per Rule G (DEC-20260510-A), classify and resolve untracked handoff notes from earlier 2026-05-11 sessions.

**Promoted (this PR):**
- `2026-05-11-decouple-scheduled-testing-eligible-pr-a.md` — PR #88 (PR A) shipped state with landed-list, locked decisions, follow-ups.
- `2026-05-11-haiku-cost-leak-audit-contain-cleanup.md` — 4-PR incident arc (#84/#85/#86/#87) with audit outcomes, decisions.

**Deleted (already rm'd locally, not part of this PR):**
- `2026-05-11-pr88-deploy-recovery-and-phase3-halt.md` — pure session-progress narration; Phase 3 halt resolved by PR #89; content superseded by DEC-20260511-C + PR #89's own handoff note.

## Test plan
- [x] Both files staged with `A` status, no other changes in diff
- [x] No content modifications beyond `git add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)