### PR TITLE
feat: cost_class taxonomy + dispatcher gate + budget enforcement

### DIFF
--- a/apps/api/scripts/add-name-fixtures.ts
+++ b/apps/api/scripts/add-name-fixtures.ts
@@ -12,6 +12,7 @@ config({ path: resolve(import.meta.dirname, "../../../.env") });
 import { getDb } from "../src/db/index.js";
 import { testSuites } from "../src/db/schema.js";
 import { getExecutor } from "../src/capabilities/index.js";
+import { guardedExecute } from "../src/capabilities/guarded-executor.js";
 import { autoRegisterCapabilities } from "../src/capabilities/auto-register.js";
 
 interface FixtureDef {
@@ -95,7 +96,12 @@ async function main() {
     }
 
     try {
-      const result = await executor(f.input);
+      // Phase A0b dispatcher gate.
+      const result = await guardedExecute(f.slug, f.input, {
+        kind: "internal_test",
+        suiteId: "add-name-fixtures",
+        reason: "manual",
+      });
       const output = result.output as Record<string, unknown>;
       console.log(`  Output keys: ${Object.keys(output).join(", ")}`);
 

--- a/apps/api/scripts/check-cost-class-coherence.mjs
+++ b/apps/api/scripts/check-cost-class-coherence.mjs
@@ -1,0 +1,117 @@
+// Phase A0b CI lint: assert manifest cost_class matches the upstream
+// vendor's shape declared in the executor source code.
+//
+// Rules of thumb (the known fleet's shortlist):
+//   * Reads ANTHROPIC_API_KEY or OPENAI_API_KEY → must be paid_prepaid or
+//     paid_subscription (LLM calls bill per token; scheduler must never
+//     hit these).
+//   * Reads BROWSERLESS_API_KEY → must be paid_prepaid (Browserless bills
+//     per minute of headless time).
+//   * Reads OPENREGISTER_API_KEY → must be free_quota or paid_prepaid
+//     (free tier has a hard monthly cap; paid tier is per-call).
+//
+// This is a *cross-check* between the YAML manifest and the executor.
+// The CHECK constraint in Block 0067 enforces the enum at DB level; this
+// script enforces the policy that paid-vendor executors must declare a
+// paid cost_class, not a free one.
+//
+// Exit codes:
+//   0 — clean
+//   1 — at least one capability has a coherence violation.
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import yaml from "js-yaml";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../");
+const MANIFESTS_DIR = join(REPO_ROOT, "manifests");
+const CAPABILITIES_DIR = join(REPO_ROOT, "apps/api/src/capabilities");
+
+const RULES = [
+  {
+    envVar: "ANTHROPIC_API_KEY",
+    allowedCostClasses: ["paid_prepaid", "paid_subscription"],
+    reason: "Anthropic Claude bills per token. Scheduler/CI must never invoke.",
+  },
+  {
+    envVar: "OPENAI_API_KEY",
+    allowedCostClasses: ["paid_prepaid", "paid_subscription"],
+    reason: "OpenAI bills per token. Scheduler/CI must never invoke.",
+  },
+  {
+    envVar: "BROWSERLESS_API_KEY",
+    allowedCostClasses: ["paid_prepaid"],
+    reason: "Browserless bills per headless-browser minute.",
+  },
+  {
+    envVar: "OPENREGISTER_API_KEY",
+    allowedCostClasses: ["free_quota", "paid_prepaid"],
+    reason: "OpenRegister free tier is 50 req/month; paid tier is per-call.",
+  },
+];
+
+const violations = [];
+
+for (const manifestFile of readdirSync(MANIFESTS_DIR)) {
+  if (!manifestFile.endsWith(".yaml")) continue;
+  if (manifestFile === "CLASSIFICATION.md") continue;
+
+  const manifestPath = join(MANIFESTS_DIR, manifestFile);
+  let manifest;
+  try {
+    manifest = yaml.load(readFileSync(manifestPath, "utf8"));
+  } catch (err) {
+    // Malformed YAML is not this lint's concern — capability-onboarding
+    // gate catches that.
+    continue;
+  }
+  if (!manifest || typeof manifest !== "object" || !manifest.slug) continue;
+  if (!manifest.cost_class) continue; // unclassified caps not in scope
+
+  const executorPath = join(CAPABILITIES_DIR, `${manifest.slug}.ts`);
+  if (!existsSync(executorPath)) continue;
+
+  const executorSource = readFileSync(executorPath, "utf8");
+
+  for (const rule of RULES) {
+    if (!executorSource.includes(rule.envVar)) continue;
+    if (rule.allowedCostClasses.includes(manifest.cost_class)) continue;
+    // Per-env-var exemption: capabilities can declare a secondary paid
+    // dependency (e.g. an LLM fallback path that's not on the primary
+    // request flow) by adding a comment near the env-var read:
+    //   `// cost-class-coherence-exempt: <ENV_VAR> (<reason>)`
+    const exemptRe = new RegExp(
+      `cost-class-coherence-exempt:\\s*${rule.envVar}\\b`,
+    );
+    if (exemptRe.test(executorSource)) continue;
+    violations.push({
+      slug: manifest.slug,
+      manifestPath: `manifests/${manifestFile}`,
+      executorPath: `apps/api/src/capabilities/${manifest.slug}.ts`,
+      envVar: rule.envVar,
+      declared: manifest.cost_class,
+      allowed: rule.allowedCostClasses,
+      reason: rule.reason,
+    });
+  }
+}
+
+if (violations.length === 0) {
+  console.log("[lint] cost_class coherence: all classified capabilities OK.");
+  process.exit(0);
+}
+
+console.error("[lint] cost_class coherence violations:");
+for (const v of violations) {
+  console.error(`\n  ${v.slug} (declared cost_class: ${v.declared})`);
+  console.error(`    Executor reads: ${v.envVar}`);
+  console.error(`    Allowed cost_class: ${v.allowed.join(" | ")}`);
+  console.error(`    Reason: ${v.reason}`);
+  console.error(`    Manifest: ${v.manifestPath}`);
+  console.error(`    Executor: ${v.executorPath}`);
+}
+console.error("");
+console.error("[lint] Fix by editing the manifest's cost_class to match the");
+console.error("[lint] upstream vendor's pricing shape, or remove the env-var");
+console.error("[lint] dependency from the executor if it was unintended.");
+process.exit(1);

--- a/apps/api/scripts/check-no-direct-getexecutor-in-scripts.mjs
+++ b/apps/api/scripts/check-no-direct-getexecutor-in-scripts.mjs
@@ -1,0 +1,66 @@
+// Phase A0b CI lint: prevent scripts from bypassing the dispatcher gate.
+//
+// `apps/api/scripts/*.ts` may import `getExecutor` for existence checks
+// (using a `// guarded-executor-exempt:` comment near the import), but
+// any executor invocation MUST go through `guardedExecute` / `assertGuardedAllow`
+// from `../src/capabilities/guarded-executor.js`. This guard catches a future
+// script that re-introduces the silent-bypass pattern.
+//
+// Exit codes:
+//   0 — clean
+//   1 — at least one script imports `getExecutor` directly without the
+//       exempt marker and without also importing the guarded helper.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const SCRIPTS_DIR = resolve(import.meta.dirname, ".");
+const EXEMPT_MARKER = "guarded-executor-exempt";
+const GUARDED_IMPORT_RE = /from\s+["']\.\.\/src\/capabilities\/guarded-executor(\.js)?["']/;
+const GET_EXECUTOR_IMPORT_RE =
+  /import\s*\{[^}]*\bgetExecutor\b[^}]*\}\s*from\s+["']\.\.\/src\/capabilities\/(index(\.js)?)["']/;
+
+function listTsFiles(dir, acc = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (entry === "archive") continue; // archived scripts are not part of CI
+      listTsFiles(full, acc);
+    } else if (entry.endsWith(".ts")) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+const offenders = [];
+
+for (const file of listTsFiles(SCRIPTS_DIR)) {
+  const content = readFileSync(file, "utf8");
+  if (!GET_EXECUTOR_IMPORT_RE.test(content)) continue;
+
+  // Has getExecutor import. OK if also imports the guarded helper.
+  if (GUARDED_IMPORT_RE.test(content)) continue;
+
+  // OK if the file is marked exempt (e.g. existence-check only).
+  if (content.includes(EXEMPT_MARKER)) continue;
+
+  offenders.push(file);
+}
+
+if (offenders.length === 0) {
+  console.log("[lint] No scripts bypass the dispatcher gate.");
+  process.exit(0);
+}
+
+console.error("[lint] The following scripts import getExecutor without a paired");
+console.error("[lint] guarded-executor import or `guarded-executor-exempt` marker:");
+for (const f of offenders) console.error(`  - ${f}`);
+console.error("");
+console.error("[lint] Either:");
+console.error("[lint]   (a) import { guardedExecute } from '../src/capabilities/guarded-executor.js'");
+console.error("[lint]       and route every executor invocation through it, OR");
+console.error("[lint]   (b) add a `// guarded-executor-exempt: <reason>` comment near the import");
+console.error("[lint]       if the file only does existence checks (no executor() calls).");
+process.exit(1);

--- a/apps/api/scripts/onboard.ts
+++ b/apps/api/scripts/onboard.ts
@@ -58,6 +58,7 @@ import { validateFixture } from "../src/lib/fixture-quality.js";
 import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { getExecutor } from "../src/capabilities/index.js";
+import { guardedExecute } from "../src/capabilities/guarded-executor.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 // Manifest / ManifestExpectedField / ManifestLimitation moved to
@@ -225,8 +226,15 @@ async function executeCapability(
   }
 
   try {
+    // Phase A0b dispatcher gate. onboard.ts execute is an internal_test/manual
+    // diagnostic — refuses if the capability hasn't been classified yet,
+    // which is the intended workflow (classify in manifest, then onboard).
     const result = await Promise.race([
-      executor(input),
+      guardedExecute(slug, input, {
+        kind: "internal_test",
+        suiteId: "onboard-script",
+        reason: "manual",
+      }),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error("Timeout after 30s")), 30_000),
       ),

--- a/apps/api/scripts/smoke-singapore.ts
+++ b/apps/api/scripts/smoke-singapore.ts
@@ -13,6 +13,7 @@ config({ path: resolve(import.meta.dirname, "../../../.env") });
 // Import the capability for its side-effect registration.
 import "../src/capabilities/singapore-company-data.js";
 import { getExecutor } from "../src/capabilities/index.js";
+import { guardedExecute } from "../src/capabilities/guarded-executor.js";
 
 async function main() {
   const exec = getExecutor("singapore-company-data");
@@ -30,7 +31,12 @@ async function main() {
   for (const c of cases) {
     const t0 = Date.now();
     try {
-      const result = await exec(c.input);
+      // Phase A0b dispatcher gate — internal_test/manual.
+      const result = await guardedExecute("singapore-company-data", c.input, {
+        kind: "internal_test",
+        suiteId: "smoke-singapore",
+        reason: "manual",
+      });
       const ms = Date.now() - t0;
       console.log(`\n=== ${c.label}  (${ms}ms) ===`);
       console.log("output:", JSON.stringify(result.output, null, 2));

--- a/apps/api/scripts/smoke-test.ts
+++ b/apps/api/scripts/smoke-test.ts
@@ -24,6 +24,7 @@ import {
   capabilityLimitations,
 } from "../src/db/schema.js";
 import { getExecutor } from "../src/capabilities/index.js";
+import { guardedExecute } from "../src/capabilities/guarded-executor.js";
 
 // Base URL for internal API calls (smoke test runs locally against the live DB)
 const API_BASE = process.env.API_BASE_URL ?? "http://localhost:3000";
@@ -112,8 +113,14 @@ async function smokeTest(
     const start2 = Date.now();
     try {
       const testInput = knownAnswerSuite.input as Record<string, unknown>;
+      // Phase A0b dispatcher gate. Smoke test is a manual operator
+      // diagnostic — internal_test/manual context.
       const result = await Promise.race([
-        executor(testInput),
+        guardedExecute(slug, testInput, {
+          kind: "internal_test",
+          suiteId: knownAnswerSuite.id,
+          reason: "manual",
+        }),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error("Timeout after 30s")), 30_000),
         ),
@@ -190,7 +197,11 @@ async function smokeTest(
     const start4 = Date.now();
     try {
       const result = await Promise.race([
-        executor({}),
+        guardedExecute(slug, {}, {
+          kind: "internal_test",
+          suiteId: negativeSuite.id,
+          reason: "manual",
+        }),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error("Timeout after 15s")), 15_000),
         ),

--- a/apps/api/scripts/test-budimex.ts
+++ b/apps/api/scripts/test-budimex.ts
@@ -4,6 +4,7 @@ config({ path: resolve(import.meta.dirname, "../../../.env") });
 
 import "../src/capabilities/polish-company-data.js";
 import { getExecutor } from "../src/capabilities/index.js";
+import { guardedExecute } from "../src/capabilities/guarded-executor.js";
 
 const fn = getExecutor("polish-company-data");
 if (!fn) { console.log("NO EXECUTOR"); process.exit(1); }
@@ -15,7 +16,12 @@ for (const input of [
 ]) {
   console.log(`\n--- ${JSON.stringify(input)} ---`);
   try {
-    const r = await fn(input);
+    // Phase A0b dispatcher gate.
+    const r = await guardedExecute("polish-company-data", input, {
+      kind: "internal_test",
+      suiteId: "test-budimex",
+      reason: "manual",
+    });
     console.log(`  ${r.output.company_name} / ${r.output.krs_number} / ${r.output.status}`);
   } catch (e: any) {
     console.log(`  FAIL: ${e?.message}`);

--- a/apps/api/scripts/validate-capability.ts
+++ b/apps/api/scripts/validate-capability.ts
@@ -20,6 +20,8 @@ import {
   testSuites,
   capabilityLimitations,
 } from "../src/db/schema.js";
+// guarded-executor-exempt: existence-check only at line 116 (`!!executor`);
+// never invokes the executor, so the dispatcher gate doesn't apply.
 import { getExecutor } from "../src/capabilities/index.js";
 import { transitionCapability } from "../src/lib/lifecycle.js";
 import { validateFixture } from "../src/lib/fixture-quality.js";

--- a/apps/api/src/capabilities/danish-company-data.ts
+++ b/apps/api/src/capabilities/danish-company-data.ts
@@ -24,6 +24,10 @@ function findCvrNumber(input: string): string | null {
 }
 
 async function extractCompanyName(naturalLanguage: string): Promise<string> {
+  // cost-class-coherence-exempt: ANTHROPIC_API_KEY (fuzzy-name fallback only)
+  // The primary path is cvrapi.dk (free); this Claude call only fires for
+  // natural-language input that doesn't parse as a CVR number. cost_class
+  // remains free_quota because the common case never bills.
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) throw new Error("ANTHROPIC_API_KEY is required.");
 

--- a/apps/api/src/capabilities/guarded-executor.test.ts
+++ b/apps/api/src/capabilities/guarded-executor.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Phase A0b regression tests for the dispatcher gate.
+ *
+ * Per DEC-20260504-A (Audit-Follow-up Test Coverage Protocol): every new
+ * code path added in response to a structural failure must include
+ * regression tests that fail against the un-applied fix. The 2026-05-11
+ * DE/DK breakage was the trigger; the gate (`guardedExecute` + `ALLOW_MATRIX`)
+ * is the structural fix. These tests pin:
+ *
+ *   1. Cost-class × invocation-context ALLOW_MATRIX cells.
+ *   2. Null-row decision table (unclassified caps).
+ *   3. Atomic budget increment under burst load.
+ *   4. The classes' Error subtypes (callers branch on these).
+ *
+ * The DB layer is mocked — these are pure unit tests with no real Postgres.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the DB layer before importing guarded-executor.
+const mockDbExecute = vi.fn();
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({ execute: mockDbExecute }),
+  closeDbPool: () => Promise.resolve(),
+}));
+
+// Mock the registry and alerting so we control the executor return shape
+// and don't fire real emails during tests.
+const mockExecutor = vi.fn();
+vi.mock("./index.js", async () => {
+  const actual = await vi.importActual<typeof import("./index.js")>("./index.js");
+  return {
+    ...actual,
+    getExecutor: () => mockExecutor,
+  };
+});
+
+vi.mock("../lib/alerting.js", () => ({
+  sendAlert: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  guardedExecute,
+  assertGuardedAllow,
+  computeWindowStart,
+  computeBudgetCap,
+  __resetCostMetaCacheForTests,
+  CapabilityNotClassifiedError,
+  CapabilityInvocationRefusedError,
+  BudgetExhaustedError,
+  type CapabilityCostMeta,
+  type InvocationContext,
+} from "./guarded-executor.js";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function stubMeta(meta: Partial<CapabilityCostMeta>): void {
+  // First DB call: SELECT cost_class etc. — return a single-row array.
+  mockDbExecute.mockImplementationOnce(async () => [
+    {
+      slug: meta.slug ?? "test-cap",
+      cost_class: meta.cost_class ?? null,
+      quota_window: meta.quota_window ?? null,
+      quota_cap: meta.quota_cap ?? null,
+      quota_reset_dom: meta.quota_reset_dom ?? null,
+    },
+  ]);
+}
+
+function customerCtx(): InvocationContext {
+  return { kind: "customer_paid", userId: "u1", transactionId: "t1" };
+}
+function internalCtx(): InvocationContext {
+  return { kind: "internal_test", suiteId: "s1", reason: "scheduled" };
+}
+function probeCtx(): InvocationContext {
+  return { kind: "health_probe", probeId: "p1" };
+}
+function ciCtx(): InvocationContext {
+  return { kind: "ci", workflowRunId: "w1" };
+}
+
+beforeEach(() => {
+  __resetCostMetaCacheForTests();
+  mockDbExecute.mockReset();
+  mockExecutor.mockReset();
+});
+
+// ─── ALLOW_MATRIX cells ─────────────────────────────────────────────────────
+
+describe("ALLOW_MATRIX", () => {
+  it("free_unlimited × customer_paid → allow", async () => {
+    stubMeta({ slug: "x", cost_class: "free_unlimited" });
+    mockExecutor.mockResolvedValueOnce({ output: {}, provenance: { source: "x", fetched_at: "" } });
+    await expect(guardedExecute("x", {}, customerCtx())).resolves.toBeDefined();
+    expect(mockExecutor).toHaveBeenCalledTimes(1);
+  });
+
+  it("free_unlimited × internal_test → allow", async () => {
+    stubMeta({ slug: "x", cost_class: "free_unlimited" });
+    mockExecutor.mockResolvedValueOnce({ output: {}, provenance: { source: "x", fetched_at: "" } });
+    await expect(guardedExecute("x", {}, internalCtx())).resolves.toBeDefined();
+    expect(mockExecutor).toHaveBeenCalledTimes(1);
+  });
+
+  it("paid_prepaid × customer_paid → allow", async () => {
+    stubMeta({ slug: "x", cost_class: "paid_prepaid" });
+    mockExecutor.mockResolvedValueOnce({ output: {}, provenance: { source: "x", fetched_at: "" } });
+    await expect(guardedExecute("x", {}, customerCtx())).resolves.toBeDefined();
+  });
+
+  it("paid_prepaid × internal_test → refuse", async () => {
+    stubMeta({ slug: "x", cost_class: "paid_prepaid" });
+    await expect(guardedExecute("x", {}, internalCtx())).rejects.toBeInstanceOf(
+      CapabilityInvocationRefusedError,
+    );
+    expect(mockExecutor).not.toHaveBeenCalled();
+  });
+
+  it("paid_prepaid × ci → refuse", async () => {
+    stubMeta({ slug: "x", cost_class: "paid_prepaid" });
+    await expect(guardedExecute("x", {}, ciCtx())).rejects.toBeInstanceOf(
+      CapabilityInvocationRefusedError,
+    );
+  });
+
+  it("paid_prepaid × health_probe → refuse", async () => {
+    stubMeta({ slug: "x", cost_class: "paid_prepaid" });
+    await expect(guardedExecute("x", {}, probeCtx())).rejects.toBeInstanceOf(
+      CapabilityInvocationRefusedError,
+    );
+  });
+
+  it("paid_subscription × health_probe → allow (subs absorb probes)", async () => {
+    stubMeta({ slug: "x", cost_class: "paid_subscription" });
+    mockExecutor.mockResolvedValueOnce({ output: {}, provenance: { source: "x", fetched_at: "" } });
+    await expect(guardedExecute("x", {}, probeCtx())).resolves.toBeDefined();
+  });
+
+  it("paid_subscription × internal_test → refuse (preserves fair-use)", async () => {
+    stubMeta({ slug: "x", cost_class: "paid_subscription" });
+    await expect(guardedExecute("x", {}, internalCtx())).rejects.toBeInstanceOf(
+      CapabilityInvocationRefusedError,
+    );
+  });
+
+  it("free_quota × customer_paid → allow (no budget check)", async () => {
+    stubMeta({ slug: "x", cost_class: "free_quota", quota_window: "monthly", quota_cap: 50 });
+    mockExecutor.mockResolvedValueOnce({ output: {}, provenance: { source: "x", fetched_at: "" } });
+    await expect(guardedExecute("x", {}, customerCtx())).resolves.toBeDefined();
+    // Only 1 DB call (cost-meta SELECT). No budget INSERT for customer_paid.
+    expect(mockDbExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("free_quota × internal_test → budget_check (allows when under cap)", async () => {
+    stubMeta({ slug: "x", cost_class: "free_quota", quota_window: "monthly", quota_cap: 50 });
+    // budget cap = 50 × 0.20 = 10. Under cap.
+    mockDbExecute.mockResolvedValueOnce([
+      { test_count: 3, budget_cap: 10, alert_30_fired_at: new Date(), alert_50_fired_at: new Date(), alert_80_fired_at: new Date(), hard_stop_fired_at: null },
+    ]);
+    mockExecutor.mockResolvedValueOnce({ output: {}, provenance: { source: "x", fetched_at: "" } });
+    await expect(guardedExecute("x", {}, internalCtx())).resolves.toBeDefined();
+    expect(mockExecutor).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── Null-row decisions (unclassified caps) ─────────────────────────────────
+
+describe("NULL_DECISIONS (unclassified cap_class)", () => {
+  it("null × customer_paid → allow (preserves traffic during GRACE)", async () => {
+    stubMeta({ slug: "x", cost_class: null });
+    mockExecutor.mockResolvedValueOnce({ output: {}, provenance: { source: "x", fetched_at: "" } });
+    await expect(guardedExecute("x", {}, customerCtx())).resolves.toBeDefined();
+  });
+
+  it("null × internal_test → CapabilityNotClassifiedError", async () => {
+    stubMeta({ slug: "x", cost_class: null });
+    await expect(guardedExecute("x", {}, internalCtx())).rejects.toBeInstanceOf(
+      CapabilityNotClassifiedError,
+    );
+    expect(mockExecutor).not.toHaveBeenCalled();
+  });
+
+  it("null × health_probe → refuse", async () => {
+    stubMeta({ slug: "x", cost_class: null });
+    await expect(guardedExecute("x", {}, probeCtx())).rejects.toBeInstanceOf(
+      CapabilityNotClassifiedError,
+    );
+  });
+
+  it("null × ci → refuse", async () => {
+    stubMeta({ slug: "x", cost_class: null });
+    await expect(guardedExecute("x", {}, ciCtx())).rejects.toBeInstanceOf(
+      CapabilityNotClassifiedError,
+    );
+  });
+});
+
+// ─── Budget cap arithmetic ──────────────────────────────────────────────────
+
+describe("computeBudgetCap", () => {
+  it("free_quota monthly: 20% of quota_cap", () => {
+    expect(computeBudgetCap({
+      slug: "x",
+      cost_class: "free_quota",
+      quota_window: "monthly",
+      quota_cap: 50,
+      quota_reset_dom: 1,
+    })).toBe(10);
+  });
+
+  it("free_quota daily: 10% of quota_cap", () => {
+    expect(computeBudgetCap({
+      slug: "x",
+      cost_class: "free_quota",
+      quota_window: "daily",
+      quota_cap: 50,
+      quota_reset_dom: null,
+    })).toBe(5);
+  });
+
+  it("paid_with_free_tier monthly: 10% of quota_cap", () => {
+    expect(computeBudgetCap({
+      slug: "x",
+      cost_class: "paid_with_free_tier",
+      quota_window: "monthly",
+      quota_cap: 1000,
+      quota_reset_dom: 1,
+    })).toBe(100);
+  });
+
+  it("paid_with_free_tier daily: 5% of quota_cap", () => {
+    expect(computeBudgetCap({
+      slug: "x",
+      cost_class: "paid_with_free_tier",
+      quota_window: "daily",
+      quota_cap: 200,
+      quota_reset_dom: null,
+    })).toBe(10);
+  });
+
+  it("floor at 1 for very small quotas", () => {
+    expect(computeBudgetCap({
+      slug: "x",
+      cost_class: "free_quota",
+      quota_window: "daily",
+      quota_cap: 5,
+      quota_reset_dom: null,
+    })).toBe(1);
+  });
+
+  it("throws on missing quota_cap/quota_window (cost_class isn't budget-tracked)", () => {
+    expect(() =>
+      computeBudgetCap({
+        slug: "x",
+        cost_class: "paid_prepaid",
+        quota_window: null,
+        quota_cap: null,
+        quota_reset_dom: null,
+      }),
+    ).toThrow(/missing quota_cap\/quota_window/);
+  });
+
+  it("throws when cost_class is unsupported even with quota fields set", () => {
+    // Defensive — shouldn't happen in prod (CHECK constraint prevents
+    // this combination), but the guard exists so the math doesn't silently
+    // return wrong percentages if the schema constraints drift.
+    expect(() =>
+      computeBudgetCap({
+        slug: "x",
+        cost_class: "paid_prepaid",
+        quota_window: "monthly",
+        quota_cap: 1000,
+        quota_reset_dom: 1,
+      }),
+    ).toThrow(/doesn't budget-track/);
+  });
+});
+
+// ─── Window arithmetic ──────────────────────────────────────────────────────
+
+describe("computeWindowStart", () => {
+  it("daily: UTC midnight of today", () => {
+    const now = new Date("2026-05-12T14:33:00Z");
+    const start = computeWindowStart("daily", null, now);
+    expect(start.toISOString()).toBe("2026-05-12T00:00:00.000Z");
+  });
+
+  it("monthly with reset_dom=1: 1st of current month if today >= 1st", () => {
+    const now = new Date("2026-05-12T14:33:00Z");
+    const start = computeWindowStart("monthly", 1, now);
+    expect(start.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("monthly with reset_dom=15: 15th of current month if today is on/after 15th", () => {
+    const now = new Date("2026-05-20T08:00:00Z");
+    const start = computeWindowStart("monthly", 15, now);
+    expect(start.toISOString()).toBe("2026-05-15T00:00:00.000Z");
+  });
+
+  it("monthly with reset_dom=15: 15th of last month if today is before 15th", () => {
+    const now = new Date("2026-05-10T08:00:00Z");
+    const start = computeWindowStart("monthly", 15, now);
+    expect(start.toISOString()).toBe("2026-04-15T00:00:00.000Z");
+  });
+
+  it("monthly with null reset_dom defaults to 1", () => {
+    const now = new Date("2026-05-12T14:33:00Z");
+    const start = computeWindowStart("monthly", null, now);
+    expect(start.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+  });
+});
+
+// ─── Budget race (concurrent burst) ─────────────────────────────────────────
+
+describe("budget race", () => {
+  it("50 concurrent internal_test calls against budget_cap=10 → exactly 10 allowed", async () => {
+    // Simulate the PG-side counter behavior: each ON CONFLICT increments
+    // atomically. We model it with a local counter that the stub returns
+    // post-increment values from. budget_cap=10 (free_quota, monthly, 50).
+    // Discriminate query kinds by call sequence + the queryChunks shape
+    // exposed by drizzle-orm's SQL builder.
+    let counter = 0;
+    mockDbExecute.mockImplementation(async (queryArg: { queryChunks?: unknown[] }) => {
+      const chunks = (queryArg?.queryChunks ?? []) as Array<{ value?: string[] }>;
+      const rendered = chunks
+        .map((c) =>
+          typeof c === "object" && c !== null && "value" in c && Array.isArray(c.value)
+            ? c.value.join(" ")
+            : "",
+        )
+        .join(" ")
+        .toLowerCase();
+
+      if (rendered.includes("from capabilities") || rendered.includes("select\n      slug")) {
+        return [
+          {
+            slug: "x",
+            cost_class: "free_quota",
+            quota_window: "monthly",
+            quota_cap: 50,
+            quota_reset_dom: 1,
+          },
+        ];
+      }
+      if (rendered.includes("insert into capability_budget_counters")) {
+        counter++;
+        return [
+          {
+            test_count: counter,
+            budget_cap: 10,
+            alert_30_fired_at: new Date(),
+            alert_50_fired_at: new Date(),
+            alert_80_fired_at: new Date(),
+            hard_stop_fired_at: null,
+          },
+        ];
+      }
+      if (rendered.includes("update capability_budget_counters")) {
+        if (rendered.includes("test_count = test_count - 1")) {
+          counter--;
+        }
+        return { count: 1 };
+      }
+      return { count: 0 };
+    });
+
+    const calls = Array.from({ length: 50 }, () =>
+      assertGuardedAllow("x", internalCtx()).then(
+        () => "allowed",
+        (err: Error) => err.constructor.name,
+      ),
+    );
+    const results = await Promise.all(calls);
+    const allowed = results.filter((r) => r === "allowed").length;
+    const exhausted = results.filter((r) => r === "BudgetExhaustedError").length;
+    expect(allowed).toBe(10);
+    expect(exhausted).toBe(40);
+  });
+});

--- a/apps/api/src/capabilities/guarded-executor.ts
+++ b/apps/api/src/capabilities/guarded-executor.ts
@@ -1,0 +1,513 @@
+/**
+ * Phase A0b dispatcher gate.
+ *
+ * Every external invocation of a capability goes through `guardedExecute`.
+ * The gate reads the capability's cost_class (Block 0067 schema), consults
+ * the ALLOW_MATRIX, and either:
+ *
+ *   - allows the call (delegates to the registered executor),
+ *   - refuses with a typed error (paid_prepaid / paid_subscription from a
+ *     non-customer_paid context — scheduler/CI/health-probe must never
+ *     burn paid credits), or
+ *   - allows-with-budget-check (free_quota / paid_with_free_tier from a
+ *     non-customer_paid context — increments a per-window counter against
+ *     a fraction of the vendor quota and refuses if the budget is spent).
+ *
+ * Unclassified capabilities (cost_class IS NULL) follow the GRACE-mode
+ * inverted default: customer_paid still flows through (preserves customer
+ * traffic during the Phase B backfill window); all other contexts are
+ * refused with `CapabilityNotClassifiedError`.
+ *
+ * Intra-capability invocations (a capability executor calling another
+ * executor via the registry) are NOT routed through `guardedExecute` —
+ * the outer call already paid the ALLOW_MATRIX check, and double-counting
+ * the budget would be wrong. Such call sites continue to use `getExecutor`.
+ *
+ * Background: 2026-05-11 investigation found 95% of 60-day DE OpenRegister
+ * traffic came from the test scheduler, exhausting the 50/mo free tier.
+ * Root cause: scheduler treated `external_cost_cents = 0` as "free to
+ * test," conflating "no per-call cost" with "no quota". Journal:
+ * https://www.notion.so/35d67c87082c812ba68ec4e424f8cad1
+ */
+
+import { sql } from "drizzle-orm";
+import { getDb } from "../db/index.js";
+import { log, logError, logWarn } from "../lib/log.js";
+import { sendAlert } from "../lib/alerting.js";
+import {
+  type CapabilityExecutor,
+  type CapabilityInput,
+  type CapabilityResult,
+  getExecutor,
+} from "./index.js";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type CostClass =
+  | "free_unlimited"
+  | "free_quota"
+  | "paid_with_free_tier"
+  | "paid_prepaid"
+  | "paid_subscription";
+
+export type QuotaWindow = "daily" | "monthly" | "none";
+
+export interface CapabilityCostMeta {
+  slug: string;
+  cost_class: CostClass | null;
+  quota_window: QuotaWindow | null;
+  quota_cap: number | null;
+  quota_reset_dom: number | null;
+}
+
+/**
+ * Discriminated union of who is invoking the executor. Every call site
+ * must pass an explicit value — no default. TypeScript enforces presence;
+ * the runtime ALLOW_MATRIX enforces semantics.
+ */
+export type InvocationContext =
+  | { kind: "customer_paid"; userId: string | null; transactionId: string | null }
+  | { kind: "internal_test"; suiteId: string; reason: "scheduled" | "manual" }
+  | { kind: "health_probe"; probeId: string }
+  | { kind: "ci"; workflowRunId: string };
+
+type Decision = "allow" | "refuse" | "budget_check";
+
+// ─── ALLOW_MATRIX ───────────────────────────────────────────────────────────
+//
+// Single source of truth for which (cost_class × invocation_context) cells
+// permit execution. Read top-to-bottom:
+//
+//   * paid_prepaid × {internal_test, health_probe, ci} → refuse. Every call
+//     bills; non-customer paths must never spend.
+//   * paid_subscription × {internal_test, ci} → refuse. Subscriptions have
+//     flat cost, but scheduling test traffic against them inflates the
+//     vendor's claimed-usage metric and may breach fair-use clauses.
+//     health_probe is allowed because probes don't invoke the executor;
+//     they ping the vendor URL directly (lib/dependency-manifest.ts).
+//   * free_quota × non-customer → budget_check. Scheduler/CI consumption
+//     leaves headroom for customer traffic via the 10%/20% caps.
+//   * paid_with_free_tier × non-customer → budget_check. Tighter 5%/10%
+//     caps because the next call could be the one that bills.
+//   * free_unlimited × anything → allow. No constraint.
+//   * customer_paid × anything → allow. Customer paid; budget reservations
+//     are for Strale's own non-customer testing.
+
+const ALLOW_MATRIX: Record<CostClass, Record<InvocationContext["kind"], Decision>> = {
+  free_unlimited: {
+    customer_paid: "allow",
+    internal_test: "allow",
+    health_probe: "allow",
+    ci: "allow",
+  },
+  free_quota: {
+    customer_paid: "allow",
+    internal_test: "budget_check",
+    health_probe: "allow",
+    ci: "budget_check",
+  },
+  paid_with_free_tier: {
+    customer_paid: "allow",
+    internal_test: "budget_check",
+    health_probe: "allow",
+    ci: "budget_check",
+  },
+  paid_prepaid: {
+    customer_paid: "allow",
+    internal_test: "refuse",
+    health_probe: "refuse",
+    ci: "refuse",
+  },
+  paid_subscription: {
+    customer_paid: "allow",
+    internal_test: "refuse",
+    health_probe: "allow",
+    ci: "refuse",
+  },
+};
+
+/**
+ * Unclassified row (cost_class IS NULL) → fail-closed for non-customer
+ * contexts, but allow customer_paid so the boot invariant's GRACE mode
+ * doesn't break customer traffic for caps awaiting classification.
+ * Per Phase A0b chat decision Q2.
+ */
+const NULL_DECISIONS: Record<InvocationContext["kind"], Decision> = {
+  customer_paid: "allow",
+  internal_test: "refuse",
+  health_probe: "refuse",
+  ci: "refuse",
+};
+
+// ─── Error classes ──────────────────────────────────────────────────────────
+
+export class CapabilityNotClassifiedError extends Error {
+  constructor(public slug: string, public ctx: InvocationContext) {
+    super(
+      `Capability '${slug}' has no cost_class. Non-customer invocations are refused ` +
+        `during the Phase A0b GRACE window. Classify by adding cost_class to ` +
+        `manifests/${slug}.yaml (see CLAUDE.md cost-class taxonomy).`,
+    );
+    this.name = "CapabilityNotClassifiedError";
+  }
+}
+
+export class CapabilityInvocationRefusedError extends Error {
+  constructor(
+    public slug: string,
+    public costClass: CostClass,
+    public contextKind: InvocationContext["kind"],
+  ) {
+    super(
+      `Capability '${slug}' (cost_class=${costClass}) refuses invocation from ` +
+        `context kind '${contextKind}'. ALLOW_MATRIX governs this; bypass would ` +
+        `burn vendor credits outside customer-initiated paths.`,
+    );
+    this.name = "CapabilityInvocationRefusedError";
+  }
+}
+
+export class BudgetExhaustedError extends Error {
+  constructor(
+    public slug: string,
+    public meta: CapabilityCostMeta,
+    public ctx: InvocationContext,
+  ) {
+    super(
+      `Capability '${slug}' has exhausted its ${meta.quota_window} test budget ` +
+        `(${meta.cost_class}, quota_cap=${meta.quota_cap}). Customer traffic is ` +
+        `unaffected; Strale's own test/CI usage must wait for the next window.`,
+    );
+    this.name = "BudgetExhaustedError";
+  }
+}
+
+// ─── Cost-meta lookup ───────────────────────────────────────────────────────
+//
+// Backed by an in-process LRU-style cache so a hot capability doesn't
+// trigger a SELECT per call. The cache is invalidated only by process
+// restart (acceptable: cost_class changes deploy via migration → restart).
+//
+// Cache TTL is 5 minutes; tests can call `__resetCostMetaCacheForTests`.
+
+const META_CACHE_TTL_MS = 5 * 60 * 1000;
+const metaCache = new Map<string, { value: CapabilityCostMeta; expiresAt: number }>();
+
+export function __resetCostMetaCacheForTests(): void {
+  metaCache.clear();
+}
+
+export async function getCapabilityCostMeta(slug: string): Promise<CapabilityCostMeta> {
+  const now = Date.now();
+  const cached = metaCache.get(slug);
+  if (cached && cached.expiresAt > now) return cached.value;
+
+  const db = getDb();
+  const rows = await db.execute(sql`
+    SELECT slug, cost_class, quota_window, quota_cap, quota_reset_dom
+      FROM capabilities
+     WHERE slug = ${slug}
+  `);
+  const resultRows = Array.isArray(rows) ? rows : (rows as { rows?: unknown[] })?.rows ?? [];
+  const row = resultRows[0] as {
+    slug?: string;
+    cost_class?: string | null;
+    quota_window?: string | null;
+    quota_cap?: number | null;
+    quota_reset_dom?: number | null;
+  } | undefined;
+
+  const meta: CapabilityCostMeta = {
+    slug,
+    cost_class: (row?.cost_class as CostClass | null) ?? null,
+    quota_window: (row?.quota_window as QuotaWindow | null) ?? null,
+    quota_cap: row?.quota_cap ?? null,
+    quota_reset_dom: row?.quota_reset_dom ?? null,
+  };
+
+  metaCache.set(slug, { value: meta, expiresAt: now + META_CACHE_TTL_MS });
+  return meta;
+}
+
+// ─── Budget window + cap helpers ────────────────────────────────────────────
+
+/**
+ * Compute the start-of-window timestamp for the given quota_window kind.
+ * Daily windows start at UTC midnight; monthly windows start on the
+ * vendor's reset day-of-month (defaults to 1 if quota_reset_dom is null).
+ * Pure function; safe in test environments.
+ */
+export function computeWindowStart(
+  windowKind: "daily" | "monthly",
+  quotaResetDom: number | null,
+  now: Date = new Date(),
+): Date {
+  if (windowKind === "daily") {
+    const d = new Date(now);
+    d.setUTCHours(0, 0, 0, 0);
+    return d;
+  }
+  // monthly
+  const resetDom = quotaResetDom ?? 1;
+  const cur = new Date(now);
+  const year = cur.getUTCFullYear();
+  const month = cur.getUTCMonth();
+  // Try this month's reset day. If we're before that day, use last month's.
+  const thisCycle = new Date(Date.UTC(year, month, resetDom, 0, 0, 0, 0));
+  if (cur >= thisCycle) return thisCycle;
+  return new Date(Date.UTC(year, month - 1, resetDom, 0, 0, 0, 0));
+}
+
+/**
+ * Pick the budget cap as a percentage of the vendor quota.
+ * Per design point 4:
+ *   free_quota          → 10% daily / 20% monthly
+ *   paid_with_free_tier → 5% daily / 10% monthly
+ * Ceiling at 1 — a capability with quota_cap < 10 still gets at least
+ * one test slot per window. (free_unlimited / paid_* never reach here.)
+ */
+export function computeBudgetCap(meta: CapabilityCostMeta): number {
+  if (meta.quota_cap == null || meta.quota_window == null) {
+    throw new Error(`computeBudgetCap: ${meta.slug} missing quota_cap/quota_window`);
+  }
+  let pct: number;
+  if (meta.cost_class === "free_quota") {
+    pct = meta.quota_window === "daily" ? 0.10 : 0.20;
+  } else if (meta.cost_class === "paid_with_free_tier") {
+    pct = meta.quota_window === "daily" ? 0.05 : 0.10;
+  } else {
+    throw new Error(
+      `computeBudgetCap: ${meta.slug} cost_class ${meta.cost_class} doesn't budget-track`,
+    );
+  }
+  return Math.max(1, Math.floor(meta.quota_cap * pct));
+}
+
+// ─── Budget assertion (atomic increment) ────────────────────────────────────
+
+interface BudgetRow {
+  test_count: number;
+  budget_cap: number;
+  alert_30_fired_at: Date | null;
+  alert_50_fired_at: Date | null;
+  alert_80_fired_at: Date | null;
+  hard_stop_fired_at: Date | null;
+}
+
+/**
+ * Atomic increment via INSERT ... ON CONFLICT DO UPDATE ... RETURNING.
+ * The post-increment value is read in the same round-trip; if it exceeds
+ * budget_cap we decrement back and throw `BudgetExhaustedError` — the
+ * call never reaches the executor.
+ *
+ * Race semantics: under burst load the counter can briefly show
+ * `budget_cap + N` (N = concurrent overshoots in flight). All overshoots
+ * decrement and throw — no extra calls leak through. The next request
+ * after the burst sees `<= budget_cap` and proceeds normally.
+ */
+export async function assertBudgetAvailable(
+  slug: string,
+  meta: CapabilityCostMeta,
+  ctx: InvocationContext,
+): Promise<void> {
+  if (meta.quota_window === null || meta.quota_window === "none") {
+    throw new Error(
+      `assertBudgetAvailable: ${slug} has window=${meta.quota_window} — should not budget-check`,
+    );
+  }
+  const budgetCap = computeBudgetCap(meta);
+  const windowStart = computeWindowStart(meta.quota_window, meta.quota_reset_dom);
+  const windowKind = meta.quota_window;
+
+  const db = getDb();
+  const result = await db.execute(sql`
+    INSERT INTO capability_budget_counters (capability_slug, window_start, window_kind, test_count, budget_cap)
+    VALUES (${slug}, ${windowStart}, ${windowKind}, 1, ${budgetCap})
+    ON CONFLICT (capability_slug, window_start, window_kind)
+    DO UPDATE SET test_count = capability_budget_counters.test_count + 1, updated_at = NOW()
+    RETURNING test_count, budget_cap, alert_30_fired_at, alert_50_fired_at, alert_80_fired_at, hard_stop_fired_at
+  `);
+  const rows = Array.isArray(result) ? result : (result as { rows?: unknown[] })?.rows ?? [];
+  const row = rows[0] as BudgetRow | undefined;
+  if (!row) {
+    // Shouldn't happen — RETURNING always emits the affected row.
+    throw new Error(`assertBudgetAvailable: no row returned for ${slug}`);
+  }
+
+  if (row.test_count > row.budget_cap) {
+    // Over budget — decrement to keep the counter honest, then refuse.
+    await db.execute(sql`
+      UPDATE capability_budget_counters
+         SET test_count = test_count - 1
+       WHERE capability_slug = ${slug}
+         AND window_start = ${windowStart}
+         AND window_kind = ${windowKind}
+    `);
+    // Fire hard-stop alert at most once per window.
+    if (!row.hard_stop_fired_at) {
+      void fireBudgetHardStopAlert(slug, meta, budgetCap, ctx).catch((err) =>
+        logError("budget-hard-stop-alert-failed", err, { slug }),
+      );
+      await db.execute(sql`
+        UPDATE capability_budget_counters
+           SET hard_stop_fired_at = NOW()
+         WHERE capability_slug = ${slug}
+           AND window_start = ${windowStart}
+           AND window_kind = ${windowKind}
+           AND hard_stop_fired_at IS NULL
+      `);
+    }
+    throw new BudgetExhaustedError(slug, meta, ctx);
+  }
+
+  // Fire threshold alerts (fire-and-forget, atomic single-fire via NULL check).
+  void maybeFireThresholdAlerts(row, slug, meta, budgetCap, windowStart, windowKind).catch((err) =>
+    logError("budget-threshold-alert-failed", err, { slug }),
+  );
+}
+
+async function maybeFireThresholdAlerts(
+  row: BudgetRow,
+  slug: string,
+  meta: CapabilityCostMeta,
+  budgetCap: number,
+  windowStart: Date,
+  windowKind: "daily" | "monthly",
+): Promise<void> {
+  const pct = row.test_count / budgetCap;
+  const db = getDb();
+  const tryFire = async (
+    threshold: 30 | 50 | 80,
+    column: "alert_30_fired_at" | "alert_50_fired_at" | "alert_80_fired_at",
+    alreadyFired: Date | null,
+  ): Promise<void> => {
+    if (alreadyFired) return;
+    if (pct < threshold / 100) return;
+    await sendAlert({
+      subject: `[budget] ${slug} reached ${threshold}% of ${meta.quota_window} test budget`,
+      body:
+        `Capability: ${slug}\n` +
+        `Cost class: ${meta.cost_class}\n` +
+        `Quota window: ${meta.quota_window}\n` +
+        `Quota cap: ${meta.quota_cap}\n` +
+        `Budget cap (this window): ${budgetCap}\n` +
+        `Test count so far: ${row.test_count}\n` +
+        `Percentage: ${(pct * 100).toFixed(1)}%`,
+      severity: threshold === 80 ? "warning" : "info",
+    });
+    // Mark fired so subsequent calls don't re-alert. Composite-PK UPDATE
+    // is atomic; if two callers race, only the first NULL→NOW() wins.
+    if (column === "alert_30_fired_at") {
+      await db.execute(sql`
+        UPDATE capability_budget_counters
+           SET alert_30_fired_at = NOW()
+         WHERE capability_slug = ${slug} AND window_start = ${windowStart}
+           AND window_kind = ${windowKind} AND alert_30_fired_at IS NULL
+      `);
+    } else if (column === "alert_50_fired_at") {
+      await db.execute(sql`
+        UPDATE capability_budget_counters
+           SET alert_50_fired_at = NOW()
+         WHERE capability_slug = ${slug} AND window_start = ${windowStart}
+           AND window_kind = ${windowKind} AND alert_50_fired_at IS NULL
+      `);
+    } else {
+      await db.execute(sql`
+        UPDATE capability_budget_counters
+           SET alert_80_fired_at = NOW()
+         WHERE capability_slug = ${slug} AND window_start = ${windowStart}
+           AND window_kind = ${windowKind} AND alert_80_fired_at IS NULL
+      `);
+    }
+  };
+  await tryFire(30, "alert_30_fired_at", row.alert_30_fired_at);
+  await tryFire(50, "alert_50_fired_at", row.alert_50_fired_at);
+  await tryFire(80, "alert_80_fired_at", row.alert_80_fired_at);
+}
+
+async function fireBudgetHardStopAlert(
+  slug: string,
+  meta: CapabilityCostMeta,
+  budgetCap: number,
+  ctx: InvocationContext,
+): Promise<void> {
+  await sendAlert({
+    subject: `[budget-hard-stop] ${slug} exhausted ${meta.quota_window} test budget`,
+    body:
+      `Capability: ${slug}\n` +
+      `Cost class: ${meta.cost_class}\n` +
+      `Quota window: ${meta.quota_window}\n` +
+      `Quota cap: ${meta.quota_cap}\n` +
+      `Budget cap (this window): ${budgetCap}\n` +
+      `Refused context: ${ctx.kind}\n` +
+      `Customer traffic is unaffected. Strale's own test/CI usage paused ` +
+      `until next ${meta.quota_window} window.`,
+    severity: "critical",
+  });
+}
+
+// ─── The gate ───────────────────────────────────────────────────────────────
+
+/**
+ * The dispatcher gate. All external invocations of a capability flow
+ * through here. Throws on refusal; returns the executor's result on
+ * allow / budget-checked allow.
+ *
+ * Intra-capability calls (capability A calls capability B internally
+ * via `getExecutor`) bypass this gate intentionally — the outer call
+ * has already passed the ALLOW_MATRIX check.
+ */
+export async function guardedExecute(
+  slug: string,
+  input: CapabilityInput,
+  ctx: InvocationContext,
+): Promise<CapabilityResult> {
+  await assertGuardedAllow(slug, ctx);
+  const executor: CapabilityExecutor | undefined = getExecutor(slug);
+  if (!executor) {
+    throw new Error(`Executor not registered for ${slug}`);
+  }
+  return executor(input);
+}
+
+/**
+ * The same ALLOW_MATRIX + budget check, but without the executor call.
+ * Use this when the caller has its own retry / wrapping logic (do.ts's
+ * `executeWithRetry`, the solution-executor's per-step orchestration)
+ * and just needs the gate decision applied once per logical invocation.
+ *
+ * Throws on refusal; void on allow / budget-checked allow.
+ */
+export async function assertGuardedAllow(
+  slug: string,
+  ctx: InvocationContext,
+): Promise<void> {
+  const meta = await getCapabilityCostMeta(slug);
+  const decision: Decision = meta.cost_class === null
+    ? NULL_DECISIONS[ctx.kind]
+    : ALLOW_MATRIX[meta.cost_class][ctx.kind];
+
+  if (decision === "refuse") {
+    if (meta.cost_class === null) {
+      log.warn(
+        {
+          label: "guarded-execute-refused-unclassified",
+          slug,
+          ctx_kind: ctx.kind,
+        },
+        `guarded-execute refused: ${slug} unclassified, context ${ctx.kind}`,
+      );
+      throw new CapabilityNotClassifiedError(slug, ctx);
+    }
+    logWarn(
+      "guarded-execute-refused",
+      `guarded-execute refused: ${slug} (${meta.cost_class}) from ${ctx.kind}`,
+      { slug, cost_class: meta.cost_class, ctx_kind: ctx.kind },
+    );
+    throw new CapabilityInvocationRefusedError(slug, meta.cost_class, ctx.kind);
+  }
+
+  if (decision === "budget_check") {
+    await assertBudgetAvailable(slug, meta, ctx);
+  }
+}

--- a/apps/api/src/db/audit-tests.ts
+++ b/apps/api/src/db/audit-tests.ts
@@ -15,6 +15,12 @@ import { getDb } from "./index.js";
 import { testSuites } from "./schema.js";
 import { eq } from "drizzle-orm";
 import { getExecutor, type CapabilityResult } from "../capabilities/index.js";
+import {
+  assertGuardedAllow,
+  CapabilityInvocationRefusedError,
+  CapabilityNotClassifiedError,
+  BudgetExhaustedError,
+} from "../capabilities/guarded-executor.js";
 import { writeFileSync } from "node:fs";
 
 // Capabilities are registered via autoRegisterCapabilities() inside main() —
@@ -246,6 +252,27 @@ async function main() {
         if (!executor) {
           noExecutorTests++;
           continue;
+        }
+
+        // Phase A0b dispatcher gate. Offline audit is internal_test/manual.
+        // A gate refusal counts as an execution error for audit purposes
+        // (the cap is unrunnable in this context until classified).
+        try {
+          await assertGuardedAllow(slug, {
+            kind: "internal_test",
+            suiteId: suite.id,
+            reason: "manual",
+          });
+        } catch (err) {
+          if (
+            err instanceof CapabilityInvocationRefusedError ||
+            err instanceof CapabilityNotClassifiedError ||
+            err instanceof BudgetExhaustedError
+          ) {
+            noExecutorTests++;
+            continue;
+          }
+          throw err;
         }
 
         const { result, error, timedOut } = await executeWithTimeout(

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -202,6 +202,27 @@ export const capabilities = pgTable("capabilities", {
   gdprArt22Classification: varchar("gdpr_art_22_classification", { length: 20 })
     .notNull()
     .default("data_lookup"),
+  // Cost-class taxonomy (Phase A0b). Inverted-default: NULL means
+  // "not yet classified" — scheduler skips, dispatcher refuses internal
+  // callers, customer_paid still allowed during GRACE backfill.
+  // Enum enforced by CHECK constraint in Block 0067, not by varchar length.
+  //   free_unlimited       — no cost, no quota (gov registries, BRREG, GLEIF)
+  //   free_quota           — no per-call cost but vendor enforces a window quota (OpenRegister 50/mo)
+  //   paid_with_free_tier  — paid above a free allowance (Dilisense, GitHub)
+  //   paid_prepaid         — every call bills (Anthropic, Browserless)
+  //   paid_subscription    — flat subscription, calls free at the margin
+  costClass: text("cost_class"),
+  // Quota reset window — daily, monthly, or none. NULL for free_unlimited
+  // and paid_prepaid (no quota). 'none' allowed when cost_class is
+  // free_unlimited and there's no rate-limit cap to track.
+  quotaWindow: text("quota_window"),
+  // Quota cap in calls per window. NULL for free_unlimited (no cap),
+  // paid_prepaid (no quota), paid_subscription (no quota).
+  // Required for free_quota and paid_with_free_tier (validated at app layer).
+  quotaCap: integer("quota_cap"),
+  // Day-of-month reset (1..31) for monthly window. NULL for daily / none.
+  // OpenRegister resets on the 1st → 1.
+  quotaResetDom: integer("quota_reset_dom"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),
@@ -728,6 +749,45 @@ export const rateLimitCounters = pgTable(
   (table) => [
     primaryKey({ columns: [table.bucketKey, table.windowStart] }),
     index("rate_limit_counters_window_idx").on(table.windowStart),
+  ],
+);
+
+// ─── capability_budget_counters (Phase A0b) ─────────────────────────────────
+// Per-capability test-budget counter for free_quota and paid_with_free_tier
+// classes. Atomic INSERT ... ON CONFLICT DO UPDATE ... RETURNING increments
+// under burst load (race-free). Modeled on rate_limit_counters above.
+//
+// budget_cap is snapshotted from a percentage of capabilities.quota_cap at
+// counter creation:
+//   - free_quota: 10% daily / 20% monthly
+//   - paid_with_free_tier: 5% daily / 10% monthly
+// (Customer traffic against free_quota does NOT increment this counter —
+// the budget protects Strale's own test/CI usage. See guarded-executor.ts.)
+export const capabilityBudgetCounters = pgTable(
+  "capability_budget_counters",
+  {
+    capabilitySlug: text("capability_slug").notNull(),
+    windowStart: timestamp("window_start", { withTimezone: true }).notNull(),
+    windowKind: text("window_kind").notNull(),
+    // 'daily' | 'monthly' — CHECK enforced by Block 0070.
+    testCount: integer("test_count").notNull().default(0),
+    budgetCap: integer("budget_cap").notNull(),
+    alert30FiredAt: timestamp("alert_30_fired_at", { withTimezone: true }),
+    alert50FiredAt: timestamp("alert_50_fired_at", { withTimezone: true }),
+    alert80FiredAt: timestamp("alert_80_fired_at", { withTimezone: true }),
+    hardStopFiredAt: timestamp("hard_stop_fired_at", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.capabilitySlug, table.windowStart, table.windowKind],
+    }),
+    index("capability_budget_counters_window_idx").on(
+      table.windowKind,
+      table.windowStart,
+    ),
   ],
 );
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -78,6 +78,17 @@ async function main() {
   const { validateSchema } = await import("./lib/schema-validator.js");
   await validateSchema();
 
+  // Phase A0b cost-class taxonomy invariant. Runs AFTER validateSchema
+  // because the column must exist before the query reads it. GRACE
+  // (default) surfaces a count + one log line per unclassified cap;
+  // STRICT aborts boot on any unclassified row. Flip to STRICT after
+  // one operational cycle confirms the GRACE log line stays empty for
+  // the expected backfill horizon.
+  const { assertCostClassTaxonomy, resolveCostClassMode } = await import(
+    "./lib/cost-class-invariant.js"
+  );
+  await assertCostClassTaxonomy({ mode: resolveCostClassMode(process.env.COST_CLASS_MODE) });
+
   // Import app after executors are registered
   const { app, warmCatalog } = await import("./app.js");
   const { startTestScheduler } = await import("./jobs/test-scheduler.js");

--- a/apps/api/src/jobs/test-scheduler.ts
+++ b/apps/api/src/jobs/test-scheduler.ts
@@ -13,7 +13,13 @@
  * and any zero-cost auth-less probes the vendor permits. The
  * schedule_tier column stays on test_suites for backwards compatibility
  * but is no longer read by the scheduler. Eligibility is an explicit
- * column per the PR A decoupling (see DEC-20260511-?).
+ * column per the PR A decoupling (see DEC-20260511-C). Phase A0b extends
+ * this further: eligibility is now derived from capabilities.cost_class
+ * (Block 0069) rather than external_cost_cents = 0, and the SELECT below
+ * also excludes capabilities whose per-window budget counter has reached
+ * its cap — defense-in-depth against the assertBudgetAvailable per-call
+ * check at the dispatcher gate.
+ * TODO(chat-draft): cite new cost-class DEC after Phase A0b session-end review
  *
  * Cadence: the scheduler ticks every minute. Each minute M (0–59) it
  * picks free capabilities whose `abs(hashtext(slug)) % 60 = M` and whose
@@ -239,7 +245,8 @@ export function slugStaggerMinute(slug: string): number {
 /**
  * Find free capabilities due for testing this minute.
  *
- * Per DEC-20260503-B (refined by the PR A decoupling — see DEC-20260511-?):
+ * Per DEC-20260503-B (refined by the PR A decoupling — see DEC-20260511-C;
+ * TODO(chat-draft): cite new cost-class DEC after Phase A0b session-end review):
  *   - scheduled_testing_eligible = TRUE  (free/eligible; paid caps skipped)
  *   - last_tested_at older than 1h  (or never tested)
  *   - abs(hashtext(slug)) % 60 = current minute  (slug-hash stagger)
@@ -255,6 +262,12 @@ export function slugStaggerMinute(slug: string): number {
 async function findOverdueCapabilities(): Promise<OverdueCapability[]> {
   const db = getDb();
 
+  // Phase A0b: exclude capabilities whose per-window test budget is
+  // already at cap. This is defense-in-depth — the per-call
+  // assertBudgetAvailable() in the dispatcher would also refuse — but
+  // skipping at query time avoids the round-trip and keeps the scheduler
+  // log noise-free during a saturated window. free_unlimited caps are
+  // never budget-tracked, so the OR short-circuits for them.
   const rows = await db.execute(sql`
     SELECT
       c.slug,
@@ -275,6 +288,24 @@ async function findOverdueCapabilities(): Promise<OverdueCapability[]> {
             WHEN 'quarantined'     THEN INTERVAL '168 hours'
             ELSE INTERVAL '0 hours'
           END
+        )
+      )
+      AND (
+        c.cost_class = 'free_unlimited'
+        OR c.cost_class IS NULL
+        OR NOT EXISTS (
+          SELECT 1 FROM capability_budget_counters b
+          WHERE b.capability_slug = c.slug
+            AND b.window_kind = c.quota_window
+            AND b.window_start = (
+              CASE c.quota_window
+                WHEN 'daily'   THEN date_trunc('day', NOW())
+                WHEN 'monthly' THEN date_trunc('month', NOW())
+                  + (COALESCE(c.quota_reset_dom, 1) - 1) * INTERVAL '1 day'
+                ELSE NULL
+              END
+            )
+            AND b.test_count >= b.budget_cap
         )
       )
     GROUP BY c.slug, c.last_tested_at

--- a/apps/api/src/lib/capability-field-authority.ts
+++ b/apps/api/src/lib/capability-field-authority.ts
@@ -235,6 +235,37 @@ export const FIELD_CATEGORIES: Record<string, FieldAuthorityEntry> = {
       "(gate 15) against VALID_GDPR_ART_22_CLASSIFICATIONS. Optional in the " +
       "manifest; the DB column applies a 'data_lookup' default when unset.",
   },
+  cost_class: {
+    category: "manifest",
+    reason:
+      "Phase A0b cost-class taxonomy: manifest YAML is the authoring " +
+      "surface for the per-capability cost classification " +
+      "(free_unlimited | free_quota | paid_with_free_tier | paid_prepaid | " +
+      "paid_subscription). The DB CHECK constraint from Block 0067 enforces " +
+      "the enum at write time. NULL/unset means 'not yet classified' and is " +
+      "tolerated by the boot invariant in GRACE mode.",
+  },
+  quota_window: {
+    category: "manifest",
+    reason:
+      "Phase A0b: vendor quota window for free_quota and paid_with_free_tier " +
+      "classes (daily | monthly | none). Authored alongside cost_class in the " +
+      "manifest. CHECK constraint in Block 0067.",
+  },
+  quota_cap: {
+    category: "manifest",
+    reason:
+      "Phase A0b: vendor quota cap in calls per window. Authored in manifest " +
+      "alongside cost_class + quota_window. Required for free_quota and " +
+      "paid_with_free_tier; null for the other classes.",
+  },
+  quota_reset_dom: {
+    category: "manifest",
+    reason:
+      "Phase A0b: day-of-month (1..31) for monthly quota reset. Authored in " +
+      "manifest alongside cost_class. Null for daily/none windows. CHECK 1..31 " +
+      "enforced by Block 0067.",
+  },
 
   // ── hybrid: manifest seeds on create/when DB is null; DB preserved ──
   capability_type: {

--- a/apps/api/src/lib/capability-manifest-types.ts
+++ b/apps/api/src/lib/capability-manifest-types.ts
@@ -69,4 +69,21 @@ export interface Manifest {
   // the decision tree and reason-string content guide.
   marketplace_eligible?: boolean;
   marketplace_eligible_reason?: string | null;
+  // Cost-class taxonomy (Phase A0b). NULL/omitted means "not yet
+  // classified" — the boot invariant skips in GRACE mode; the
+  // dispatcher refuses internal-test invocations and the scheduler
+  // skips. customer_paid still flows through. Validated by the
+  // CHECK constraints from Block 0067 at DB level.
+  cost_class?:
+    | "free_unlimited"
+    | "free_quota"
+    | "paid_with_free_tier"
+    | "paid_prepaid"
+    | "paid_subscription";
+  quota_window?: "daily" | "monthly" | "none";
+  // Quota cap in calls per window. Required for free_quota and
+  // paid_with_free_tier. NULL for the other classes.
+  quota_cap?: number | null;
+  // Day-of-month reset for monthly window (1..31). NULL for daily/none.
+  quota_reset_dom?: number | null;
 }

--- a/apps/api/src/lib/capability-manifest.test.ts
+++ b/apps/api/src/lib/capability-manifest.test.ts
@@ -155,6 +155,56 @@ describe("normalizeManifestToRow (Cluster 2 Phase 3 C2)", () => {
     expect(row.capabilityType).toBe("ai_assisted");
   });
 
+  // ── Phase A0b: cost_class taxonomy fields ───────────────────────────────
+
+  it("maps cost_class + quota_window + quota_cap + quota_reset_dom to camelCase row", () => {
+    const m = fullManifest({
+      cost_class: "free_quota",
+      quota_window: "monthly",
+      quota_cap: 50,
+      quota_reset_dom: 1,
+    });
+    const row = normalizeManifestToRow(m);
+    expect(row.costClass).toBe("free_quota");
+    expect(row.quotaWindow).toBe("monthly");
+    expect(row.quotaCap).toBe(50);
+    expect(row.quotaResetDom).toBe(1);
+  });
+
+  it("non-partial mode: emits null for missing cost_class fields (inverted default)", () => {
+    const m = fullManifest();
+    delete m.cost_class;
+    delete m.quota_window;
+    delete m.quota_cap;
+    delete m.quota_reset_dom;
+    const row = normalizeManifestToRow(m);
+    expect(row.costClass).toBeNull();
+    expect(row.quotaWindow).toBeNull();
+    expect(row.quotaCap).toBeNull();
+    expect(row.quotaResetDom).toBeNull();
+  });
+
+  it("partial mode: omits cost_class fields when not declared (manifest authority preserved)", () => {
+    const m = fullManifest();
+    delete m.cost_class;
+    delete m.quota_window;
+    delete m.quota_cap;
+    delete m.quota_reset_dom;
+    const row = normalizeManifestToRow(m, { partial: true });
+    expect(Object.prototype.hasOwnProperty.call(row, "costClass")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(row, "quotaWindow")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(row, "quotaCap")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(row, "quotaResetDom")).toBe(false);
+  });
+
+  it("partial mode: passes through cost_class when declared", () => {
+    const m = fullManifest({
+      cost_class: "paid_prepaid",
+    });
+    const row = normalizeManifestToRow(m, { partial: true });
+    expect(row.costClass).toBe("paid_prepaid");
+  });
+
   it("dataSourceTypeToCapType falls back to 'stable_api' for unknown values", () => {
     expect(dataSourceTypeToCapType("bogus")).toBe("stable_api");
     expect(dataSourceTypeToCapType("")).toBe("stable_api");

--- a/apps/api/src/lib/capability-manifest.ts
+++ b/apps/api/src/lib/capability-manifest.ts
@@ -128,6 +128,14 @@ export function normalizeManifestToRow(
     // manifest re-onboard.
     marketplaceEligible: manifest.marketplace_eligible,
     marketplaceEligibleReason: manifest.marketplace_eligible_reason,
+    // Cost-class taxonomy (Phase A0b). Manifest-canonical — the YAML
+    // is the authoring surface. FIELD_CATEGORIES entries enforce
+    // manifest authority on backfill; the DB CHECK constraints in
+    // Block 0067 reject invalid enum values.
+    costClass: manifest.cost_class ?? (partial ? undefined : null),
+    quotaWindow: manifest.quota_window ?? (partial ? undefined : null),
+    quotaCap: manifest.quota_cap ?? (partial ? undefined : null),
+    quotaResetDom: manifest.quota_reset_dom ?? (partial ? undefined : null),
   };
 
   if (!partial) {

--- a/apps/api/src/lib/capability-onboarding.ts
+++ b/apps/api/src/lib/capability-onboarding.ts
@@ -9,6 +9,12 @@ import { getDb } from "../db/index.js";
 import { capabilities, solutions, solutionSteps, testSuites } from "../db/schema.js";
 import { generateTestInput } from "./test-input-generator.js";
 import { getExecutor } from "../capabilities/index.js";
+import {
+  assertGuardedAllow,
+  CapabilityInvocationRefusedError,
+  CapabilityNotClassifiedError,
+  BudgetExhaustedError,
+} from "../capabilities/guarded-executor.js";
 import { classifyFieldVolatility, makeVolatilityAwareCheck } from "./field-volatility.js";
 import { getOutputChecks, assignTier } from "./test-generation.js";
 import { checkReadiness, clearReadinessCache } from "./capability-readiness.js";
@@ -420,6 +426,32 @@ export async function validateTestFixtures(
   const execInput = calibratable[0].input as Record<string, unknown>;
   let realOutput: Record<string, unknown>;
 
+  // Phase A0b dispatcher gate. Same internal_test/manual context as the
+  // regression-test path. Refusal on null cost_class teaches: "classify
+  // before onboarding" without surfacing as a hard failure (logWarn +
+  // return matches the executor-missing skip behavior above).
+  try {
+    await assertGuardedAllow(capabilitySlug, {
+      kind: "internal_test",
+      suiteId: "onboarding-fixture-validate",
+      reason: "manual",
+    });
+  } catch (err) {
+    if (
+      err instanceof CapabilityInvocationRefusedError ||
+      err instanceof CapabilityNotClassifiedError ||
+      err instanceof BudgetExhaustedError
+    ) {
+      logWarn(
+        "onboarding-fixture-gate-refused",
+        "dispatcher gate refused fixture validation",
+        { capability_slug: capabilitySlug, reason: err.message },
+      );
+      return;
+    }
+    throw err;
+  }
+
   try {
     const result = await executor(execInput);
     if (!result?.output || Object.keys(result.output).length === 0) {
@@ -538,6 +570,32 @@ async function generateAlgorithmicRegressionTest(
       { capability_slug: cap.slug },
     );
     return;
+  }
+
+  // Phase A0b dispatcher gate. Onboarding regression-test generation
+  // calls the executor with manifest-derived input. Runs under
+  // internal_test/manual; refusal on null cost_class is the expected
+  // teaching signal ("classify this cap in its manifest first").
+  try {
+    await assertGuardedAllow(cap.slug, {
+      kind: "internal_test",
+      suiteId: "onboarding-regression",
+      reason: "manual",
+    });
+  } catch (err) {
+    if (
+      err instanceof CapabilityInvocationRefusedError ||
+      err instanceof CapabilityNotClassifiedError ||
+      err instanceof BudgetExhaustedError
+    ) {
+      logWarn(
+        "onboarding-regression-gate-refused",
+        "dispatcher gate refused regression test",
+        { capability_slug: cap.slug, reason: err.message },
+      );
+      return;
+    }
+    throw err;
   }
 
   let result: Awaited<ReturnType<typeof executor>> | null = null;

--- a/apps/api/src/lib/cost-class-invariant.test.ts
+++ b/apps/api/src/lib/cost-class-invariant.test.ts
@@ -73,13 +73,10 @@ describe("assertCostClassTaxonomy", () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`exit(${code})`);
     }) as never);
-    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     await expect(
       assertCostClassTaxonomy({ mode: "STRICT" }),
     ).rejects.toThrow(/exit\(1\)/);
     expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(errSpy).toHaveBeenCalled();
     exitSpy.mockRestore();
-    errSpy.mockRestore();
   });
 });

--- a/apps/api/src/lib/cost-class-invariant.test.ts
+++ b/apps/api/src/lib/cost-class-invariant.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Phase A0b regression tests for the cost-class boot invariant.
+ *
+ * Per DEC-20260504-A (audit-followup test coverage): the invariant is
+ * the only thing that prevents an unclassified-cap fleet from rotting
+ * unnoticed under GRACE. Pinning STRICT's process.exit and GRACE's
+ * skip-unclassified log shape so a future engineer can't silently turn
+ * STRICT into a no-op.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockDbExecute = vi.fn();
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({ execute: mockDbExecute }),
+}));
+
+import { assertCostClassTaxonomy, resolveCostClassMode } from "./cost-class-invariant.js";
+
+beforeEach(() => {
+  mockDbExecute.mockReset();
+});
+
+describe("resolveCostClassMode", () => {
+  it("defaults to GRACE when unset", () => {
+    expect(resolveCostClassMode(undefined)).toBe("GRACE");
+  });
+  it("returns STRICT for 'STRICT' (any case)", () => {
+    expect(resolveCostClassMode("STRICT")).toBe("STRICT");
+    expect(resolveCostClassMode("strict")).toBe("STRICT");
+    expect(resolveCostClassMode(" Strict ")).toBe("STRICT");
+  });
+  it("returns GRACE for unrecognized values", () => {
+    expect(resolveCostClassMode("paranoid")).toBe("GRACE");
+    expect(resolveCostClassMode("")).toBe("GRACE");
+  });
+});
+
+describe("assertCostClassTaxonomy", () => {
+  it("no unclassified rows: returns cleanly (GRACE)", async () => {
+    mockDbExecute.mockResolvedValueOnce([]);
+    await expect(
+      assertCostClassTaxonomy({ mode: "GRACE" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("no unclassified rows: returns cleanly (STRICT)", async () => {
+    mockDbExecute.mockResolvedValueOnce([]);
+    await expect(
+      assertCostClassTaxonomy({ mode: "STRICT" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("GRACE: tolerates unclassified rows (returns void, no exit)", async () => {
+    mockDbExecute.mockResolvedValueOnce([
+      { slug: "x", name: "X cap" },
+      { slug: "y", name: "Y cap" },
+    ]);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error("process.exit called unexpectedly");
+    }) as never);
+    await expect(
+      assertCostClassTaxonomy({ mode: "GRACE" }),
+    ).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it("STRICT: aborts boot via process.exit(1) when unclassified rows exist", async () => {
+    mockDbExecute.mockResolvedValueOnce([
+      { slug: "x", name: "X cap" },
+    ]);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit(${code})`);
+    }) as never);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      assertCostClassTaxonomy({ mode: "STRICT" }),
+    ).rejects.toThrow(/exit\(1\)/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy).toHaveBeenCalled();
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+});

--- a/apps/api/src/lib/cost-class-invariant.ts
+++ b/apps/api/src/lib/cost-class-invariant.ts
@@ -21,7 +21,7 @@
 
 import { sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
-import { log } from "./log.js";
+import { log, logError } from "./log.js";
 
 export type CostClassMode = "STRICT" | "GRACE";
 
@@ -56,13 +56,18 @@ export async function assertCostClassTaxonomy(opts: { mode: CostClassMode }): Pr
   }
 
   if (mode === "STRICT") {
-    console.error(
-      `[FATAL] cost-class STRICT mode: ${unclassified.length} active+visible capabilities lack cost_class:`,
-    );
-    for (const r of unclassified) console.error(`  - ${r.slug} (${r.name})`);
-    console.error(
-      `[FATAL] Classify each by adding cost_class to its manifests/<slug>.yaml ` +
-        `(see CLAUDE.md cost-class taxonomy), then run drizzle-kit migrate or restart.`,
+    logError(
+      "cost-class-invariant-strict-fail",
+      new Error(
+        `[FATAL] cost-class STRICT mode: ${unclassified.length} active+visible capabilities lack cost_class. ` +
+          `Classify each by adding cost_class to its manifests/<slug>.yaml ` +
+          `(see CLAUDE.md cost-class taxonomy), then run drizzle-kit migrate or restart.`,
+      ),
+      {
+        mode: "STRICT",
+        unclassified_count: unclassified.length,
+        unclassified: unclassified.map((r) => ({ slug: r.slug, name: r.name })),
+      },
     );
     process.exit(1);
   }

--- a/apps/api/src/lib/cost-class-invariant.ts
+++ b/apps/api/src/lib/cost-class-invariant.ts
@@ -1,0 +1,89 @@
+/**
+ * Phase A0b boot invariant: surface unclassified capabilities at startup.
+ *
+ * Two modes, controlled by env var `COST_CLASS_MODE`:
+ *
+ *   - **GRACE** (default): boot succeeds, log a warning + one
+ *     `skip-unclassified` line per active+visible cap with cost_class IS NULL.
+ *     The scheduler and dispatcher already fail-closed for these caps;
+ *     this mode just makes the count loud at every boot so the backfill
+ *     window doesn't drift unnoticed.
+ *   - **STRICT**: boot aborts (process.exit 1) if any active+visible cap
+ *     lacks cost_class. Flipped after one clean operational cycle.
+ *
+ * Modeled on `assertAlertingConfigured` (lib/alerting.ts) — same fail-loud
+ * boot-time shape.
+ *
+ * Per Phase A0b §7 and Rule 14 (deploy mechanism verified): index.ts:80
+ * calls this after `validateSchema()` and before `app.ts` imports, so the
+ * invariant runs on every Railway boot via Dockerfile CMD → main() entry.
+ */
+
+import { sql } from "drizzle-orm";
+import { getDb } from "../db/index.js";
+import { log } from "./log.js";
+
+export type CostClassMode = "STRICT" | "GRACE";
+
+export function resolveCostClassMode(envValue: string | undefined): CostClassMode {
+  const normalized = (envValue ?? "").trim().toUpperCase();
+  if (normalized === "STRICT") return "STRICT";
+  return "GRACE"; // default + any unrecognized value
+}
+
+interface UnclassifiedRow {
+  slug: string;
+  name: string;
+}
+
+export async function assertCostClassTaxonomy(opts: { mode: CostClassMode }): Promise<void> {
+  const { mode } = opts;
+  const db = getDb();
+  const rows = await db.execute(sql`
+    SELECT slug, name FROM capabilities
+    WHERE is_active = true AND visible = true AND cost_class IS NULL
+    ORDER BY slug
+  `);
+  const resultRows = Array.isArray(rows) ? rows : (rows as { rows?: unknown[] })?.rows ?? [];
+  const unclassified = resultRows as UnclassifiedRow[];
+
+  if (unclassified.length === 0) {
+    log.info(
+      { label: "cost-class-invariant-pass", mode, unclassified_count: 0 },
+      `[startup] cost-class ${mode} mode: all active+visible capabilities classified.`,
+    );
+    return;
+  }
+
+  if (mode === "STRICT") {
+    console.error(
+      `[FATAL] cost-class STRICT mode: ${unclassified.length} active+visible capabilities lack cost_class:`,
+    );
+    for (const r of unclassified) console.error(`  - ${r.slug} (${r.name})`);
+    console.error(
+      `[FATAL] Classify each by adding cost_class to its manifests/<slug>.yaml ` +
+        `(see CLAUDE.md cost-class taxonomy), then run drizzle-kit migrate or restart.`,
+    );
+    process.exit(1);
+  }
+
+  // GRACE
+  log.warn(
+    {
+      label: "cost-class-invariant-grace",
+      mode: "GRACE",
+      unclassified_count: unclassified.length,
+    },
+    `[startup] cost-class GRACE mode: ${unclassified.length} capabilities unclassified, will be skipped by scheduler and refused at dispatcher.`,
+  );
+  for (const r of unclassified) {
+    log.warn(
+      {
+        label: "skip-unclassified",
+        slug: r.slug,
+        name: r.name,
+      },
+      `[startup] skip-unclassified: ${r.slug}`,
+    );
+  }
+}

--- a/apps/api/src/lib/solution-executor.ts
+++ b/apps/api/src/lib/solution-executor.ts
@@ -18,6 +18,12 @@ import { eq } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { solutionSteps } from "../db/schema.js";
 import { getExecutor } from "../capabilities/index.js";
+import {
+  assertGuardedAllow,
+  CapabilityInvocationRefusedError,
+  CapabilityNotClassifiedError,
+  BudgetExhaustedError,
+} from "../capabilities/guarded-executor.js";
 import { sanitizeFailureReason } from "./sanitize.js";
 import { enrichCompanyOutput } from "../capabilities/lib/enrich-company-output.js";
 import { logWarn } from "./log.js";
@@ -267,6 +273,27 @@ export async function executeSolution(
       if (!executor) {
         stepErrors.push(`${step.capabilitySlug}: executor unavailable`);
         return;
+      }
+
+      // Phase A0b dispatcher gate. Solution executions are customer-initiated
+      // (the outer route already authenticated the customer), so each step
+      // runs under customer_paid context. ALLOW_MATRIX permits all classes.
+      try {
+        await assertGuardedAllow(step.capabilitySlug, {
+          kind: "customer_paid",
+          userId: null,
+          transactionId: null,
+        });
+      } catch (err) {
+        if (
+          err instanceof CapabilityInvocationRefusedError ||
+          err instanceof CapabilityNotClassifiedError ||
+          err instanceof BudgetExhaustedError
+        ) {
+          stepErrors.push(`${step.capabilitySlug}: ${err.message}`);
+          return;
+        }
+        throw err;
       }
 
       const stepStartMs = Date.now();

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -51,6 +51,7 @@ import {
   runMigration0064_alwaysLlmHaikuCosts,
   runMigration0065_pr86LeakyCapsCleanup,
   runMigration0067_costClassTaxonomy,
+  runMigration0068_seedDeDkSkCostClass,
   runMigration0070_capabilityBudgetCounters,
   runStartupMigrations,
   type MigrationExecutor,
@@ -453,6 +454,52 @@ describe("startup-migrations — block 0067 (cost_class taxonomy)", () => {
   });
 });
 
+describe("startup-migrations — block 0068 (seed DE/DK/SK cost_class)", () => {
+  it("first run: updates 3 rows (DE=1, DK=1, SK=1); reports total affected", async () => {
+    const stub = makeStub({
+      queue: [{ count: 1 }, { count: 1 }, { count: 1 }],
+    });
+    const result = await runMigration0068_seedDeDkSkCostClass(stub);
+    expect(result.rows_affected).toBe(3);
+    expect(result.outcome).toMatch(/seeded.*3 row/i);
+    expect(stub.captured).toHaveLength(3);
+    // All 3 UPDATEs filter on cost_class IS NULL (idempotency).
+    for (const sqlStr of stub.renderedSql) {
+      expect(sqlStr.toLowerCase()).toContain("cost_class is null");
+    }
+    // German row sets quota_reset_dom = 1 (the 1st-of-month reset).
+    expect(stub.renderedSql[0]).toMatch(/german-company-data/);
+    expect(stub.renderedSql[0]).toMatch(/quota_reset_dom = 1|\$1/i);
+    // Danish row sets daily window, no reset_dom needed.
+    expect(stub.renderedSql[1]).toMatch(/danish-company-data/);
+    expect(stub.renderedSql[1].toLowerCase()).toContain("daily");
+    // Slovak row sets free_unlimited, window 'none'.
+    expect(stub.renderedSql[2]).toMatch(/slovak-company-data/);
+    expect(stub.renderedSql[2].toLowerCase()).toContain("free_unlimited");
+  });
+
+  it("second run: idempotent — all UPDATEs return 0 rows after first apply", async () => {
+    const stub = makeStub({
+      queue: [{ count: 0 }, { count: 0 }, { count: 0 }],
+    });
+    const result = await runMigration0068_seedDeDkSkCostClass(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to update.*already classified/i);
+    // SQL still issued — WHERE filter does the idempotency work.
+    expect(stub.captured).toHaveLength(3);
+  });
+
+  it("missing-rows path: zero rows hit when caps don't exist in DB", async () => {
+    // Same observable shape as already-classified: zero affected, no-op outcome.
+    const stub = makeStub({
+      queue: [{ count: 0 }, { count: 0 }, { count: 0 }],
+    });
+    const result = await runMigration0068_seedDeDkSkCostClass(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to update/i);
+  });
+});
+
 describe("startup-migrations — block 0070 (capability_budget_counters)", () => {
   it("first run: creates table + index + CHECK constraint", async () => {
     const stub = makeStub({
@@ -488,7 +535,7 @@ describe("startup-migrations — block 0070 (capability_budget_counters)", () =>
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 11 blocks in historical order", () => {
+  it("exports the expected 12 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -505,6 +552,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0065_pr86LeakyCapsCleanup",
       "runMigration0066_ensureEligibilityColumnAndReconcile",
       "runMigration0067_costClassTaxonomy",
+      "runMigration0068_seedDeDkSkCostClass",
       "runMigration0070_capabilityBudgetCounters",
     ]);
   });

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -52,6 +52,7 @@ import {
   runMigration0065_pr86LeakyCapsCleanup,
   runMigration0067_costClassTaxonomy,
   runMigration0068_seedDeDkSkCostClass,
+  runMigration0069_reconcileEligibilityFromCostClass,
   runMigration0070_capabilityBudgetCounters,
   runStartupMigrations,
   type MigrationExecutor,
@@ -500,6 +501,45 @@ describe("startup-migrations — block 0068 (seed DE/DK/SK cost_class)", () => {
   });
 });
 
+describe("startup-migrations — block 0069 (reconcile eligibility from cost_class)", () => {
+  it("first run: reconciles, post-check passes, reports row count", async () => {
+    // Queue: UPDATE returns 12; post-check returns 0 mismatched.
+    const stub = makeStub({
+      queue: [{ count: 12 }, [{ mismatched: 0 }]],
+    });
+    const result = await runMigration0069_reconcileEligibilityFromCostClass(stub);
+    expect(result.rows_affected).toBe(12);
+    expect(result.outcome).toMatch(/reconciled 12 row/i);
+    expect(stub.captured).toHaveLength(2);
+    // UPDATE references cost_class IN (...) derivation.
+    expect(stub.renderedSql[0].toLowerCase()).toContain("free_unlimited");
+    expect(stub.renderedSql[0].toLowerCase()).toContain("free_quota");
+    expect(stub.renderedSql[0].toLowerCase()).toContain("paid_with_free_tier");
+    expect(stub.renderedSql[0].toLowerCase()).toContain("is distinct from");
+  });
+
+  it("second run: idempotent — UPDATE returns 0; post-check still passes", async () => {
+    const stub = makeStub({
+      queue: [{ count: 0 }, [{ mismatched: 0 }]],
+    });
+    const result = await runMigration0069_reconcileEligibilityFromCostClass(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to reconcile.*already aligned/i);
+  });
+
+  it("post-condition violation throws (would fail boot)", async () => {
+    // Imagine a manifest landed mid-deploy with a contradictory state.
+    // Block must throw rather than silently leave the scheduler reading
+    // stale eligibility — same shape as block 0062's post-condition.
+    const stub = makeStub({
+      queue: [{ count: 0 }, [{ mismatched: 1 }]],
+    });
+    await expect(
+      runMigration0069_reconcileEligibilityFromCostClass(stub),
+    ).rejects.toThrow(/0069.*post-condition failed.*1 rows still mismatched/i);
+  });
+});
+
 describe("startup-migrations — block 0070 (capability_budget_counters)", () => {
   it("first run: creates table + index + CHECK constraint", async () => {
     const stub = makeStub({
@@ -535,7 +575,7 @@ describe("startup-migrations — block 0070 (capability_budget_counters)", () =>
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 12 blocks in historical order", () => {
+  it("exports the expected 13 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -553,6 +593,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0066_ensureEligibilityColumnAndReconcile",
       "runMigration0067_costClassTaxonomy",
       "runMigration0068_seedDeDkSkCostClass",
+      "runMigration0069_reconcileEligibilityFromCostClass",
       "runMigration0070_capabilityBudgetCounters",
     ]);
   });

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -50,6 +50,8 @@ import {
   runMigration0063_invoiceExtractCostReclassify,
   runMigration0064_alwaysLlmHaikuCosts,
   runMigration0065_pr86LeakyCapsCleanup,
+  runMigration0067_costClassTaxonomy,
+  runMigration0070_capabilityBudgetCounters,
   runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
@@ -408,8 +410,85 @@ describe("startup-migrations — block 0065 (PR #86 leaky-cap cleanup)", () => {
   });
 });
 
+describe("startup-migrations — block 0067 (cost_class taxonomy)", () => {
+  it("first run: adds 4 columns + 3 CHECK constraints when none exist", async () => {
+    // 4 ADD COLUMN, 3 constraint checks (each absent → cnt:"0"), 3 ALTER ADD CONSTRAINT.
+    const stub = makeStub({
+      queue: [
+        undefined, undefined, undefined, undefined, // 4 ADD COLUMN
+        [{ cnt: "0" }], undefined, // cost_class chk: absent + ADD
+        [{ cnt: "0" }], undefined, // quota_window chk: absent + ADD
+        [{ cnt: "0" }], undefined, // quota_reset_dom chk: absent + ADD
+      ],
+    });
+    const result = await runMigration0067_costClassTaxonomy(stub);
+    expect(result.outcome).toMatch(/columns.*constraints ensured/i);
+    expect(stub.captured).toHaveLength(10); // 4 ADD + 3×(check+ADD)
+    // ADD COLUMN statements all use IF NOT EXISTS.
+    const addColumns = stub.renderedSql.slice(0, 4);
+    for (const sqlStr of addColumns) {
+      expect(sqlStr.toLowerCase()).toMatch(/add column if not exists/);
+    }
+    // CHECK constraint SQL appears.
+    expect(stub.renderedSql.some((s) => /cost_class.*in.*free_unlimited.*paid_subscription/i.test(s))).toBe(true);
+    expect(stub.renderedSql.some((s) => /quota_window.*in.*daily.*monthly.*none/i.test(s))).toBe(true);
+    expect(stub.renderedSql.some((s) => /quota_reset_dom.*>= 1.*<= 31/i.test(s))).toBe(true);
+  });
+
+  it("second run: skips constraint ADDs when pg_constraint reports presence", async () => {
+    const stub = makeStub({
+      queue: [
+        undefined, undefined, undefined, undefined, // 4 ADD COLUMN IF NOT EXISTS — PG no-op
+        [{ cnt: "1" }], // cost_class chk: present
+        [{ cnt: "1" }], // quota_window chk: present
+        [{ cnt: "1" }], // quota_reset_dom chk: present
+      ],
+    });
+    const result = await runMigration0067_costClassTaxonomy(stub);
+    expect(result.outcome).toMatch(/columns.*constraints ensured/i);
+    // 4 ADD COLUMN + 3 constraint checks (no ADDs) = 7 queries.
+    expect(stub.captured).toHaveLength(7);
+    // No ALTER TABLE ... ADD CONSTRAINT issued.
+    expect(stub.renderedSql.some((s) => /add constraint/i.test(s))).toBe(false);
+  });
+});
+
+describe("startup-migrations — block 0070 (capability_budget_counters)", () => {
+  it("first run: creates table + index + CHECK constraint", async () => {
+    const stub = makeStub({
+      queue: [
+        undefined, // CREATE TABLE
+        undefined, // CREATE INDEX
+        [{ cnt: "0" }], // CHECK absent
+        undefined, // ALTER ADD CONSTRAINT
+      ],
+    });
+    const result = await runMigration0070_capabilityBudgetCounters(stub);
+    expect(result.outcome).toMatch(/table.*index.*check.*ensured/i);
+    expect(stub.captured).toHaveLength(4);
+    expect(stub.renderedSql.some((s) => /create table if not exists capability_budget_counters/i.test(s))).toBe(true);
+    expect(stub.renderedSql.some((s) => /primary key.*capability_slug.*window_start.*window_kind/i.test(s))).toBe(true);
+    expect(stub.renderedSql.some((s) => /create index if not exists capability_budget_counters_window_idx/i.test(s))).toBe(true);
+    expect(stub.renderedSql.some((s) => /window_kind in.*daily.*monthly/i.test(s))).toBe(true);
+  });
+
+  it("second run: skips CHECK ADD when pg_constraint reports presence", async () => {
+    const stub = makeStub({
+      queue: [
+        undefined,    // CREATE TABLE IF NOT EXISTS — PG no-op
+        undefined,    // CREATE INDEX IF NOT EXISTS — PG no-op
+        [{ cnt: "1" }], // CHECK present
+      ],
+    });
+    const result = await runMigration0070_capabilityBudgetCounters(stub);
+    expect(result.outcome).toMatch(/ensured/i);
+    expect(stub.captured).toHaveLength(3); // no ADD CONSTRAINT issued
+    expect(stub.renderedSql.some((s) => /add constraint/i.test(s))).toBe(false);
+  });
+});
+
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 9 blocks in historical order", () => {
+  it("exports the expected 11 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -425,6 +504,8 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0064_alwaysLlmHaikuCosts",
       "runMigration0065_pr86LeakyCapsCleanup",
       "runMigration0066_ensureEligibilityColumnAndReconcile",
+      "runMigration0067_costClassTaxonomy",
+      "runMigration0070_capabilityBudgetCounters",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -609,6 +609,146 @@ export async function runMigration0066_ensureEligibilityColumnAndReconcile(
   };
 }
 
+// ─── Block 0067: cost_class taxonomy columns on `capabilities` ──────────────
+//
+// Adds four nullable columns plus CHECK constraints. NULL means "not yet
+// classified" — scheduler skips, dispatcher refuses internal callers, but
+// customer_paid still flows through (Phase A0b GRACE-mode self-throttling).
+// Phase B will backfill the remaining ~312 caps under no time pressure;
+// commit #2's Block 0068 seeds DE/DK/SK because OpenRegister's free-tier
+// quota resets 2026-06-01 and the scheduler would burn the next cycle
+// without the gate.
+//
+// Idempotency. Each ADD COLUMN uses IF NOT EXISTS; CHECK constraints are
+// guarded by a NOT EXISTS lookup against pg_constraint so the second
+// invocation is a no-op.
+//
+// Rollback. ALTER TABLE ... DROP COLUMN cascades any downstream UPDATE
+// blocks (0068 etc.) automatically. See "## Rollback" in the Phase A0b
+// prompt for the manual SQL.
+
+export async function runMigration0067_costClassTaxonomy(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  // Columns first (idempotent).
+  await tx.execute(sql`
+    ALTER TABLE capabilities ADD COLUMN IF NOT EXISTS cost_class TEXT
+  `);
+  await tx.execute(sql`
+    ALTER TABLE capabilities ADD COLUMN IF NOT EXISTS quota_window TEXT
+  `);
+  await tx.execute(sql`
+    ALTER TABLE capabilities ADD COLUMN IF NOT EXISTS quota_cap INTEGER
+  `);
+  await tx.execute(sql`
+    ALTER TABLE capabilities ADD COLUMN IF NOT EXISTS quota_reset_dom INTEGER
+  `);
+
+  // Constraints — guard each with a NOT EXISTS lookup so re-runs no-op.
+  // information_schema.constraint_column_usage doesn't expose CHECK
+  // constraints reliably across PG versions; pg_constraint is the
+  // authoritative catalog.
+  const ensureConstraint = async (
+    name: string,
+    definition: string,
+  ): Promise<void> => {
+    const exists = await tx.execute(sql`
+      SELECT count(*)::text AS cnt FROM pg_constraint
+      WHERE conname = ${name} AND conrelid = 'capabilities'::regclass
+    `);
+    const rows = Array.isArray(exists) ? exists : (exists as { rows?: unknown[] })?.rows ?? [];
+    if ((rows[0] as { cnt?: string })?.cnt === "0") {
+      // Note: sql.raw is acceptable here because both `name` and `definition`
+      // are hardcoded literals controlled by this file, not user input.
+      await tx.execute(
+        sql.raw(`ALTER TABLE capabilities ADD CONSTRAINT ${name} CHECK (${definition})`),
+      );
+    }
+  };
+
+  await ensureConstraint(
+    "capabilities_cost_class_chk",
+    `cost_class IS NULL OR cost_class IN ('free_unlimited', 'free_quota', 'paid_with_free_tier', 'paid_prepaid', 'paid_subscription')`,
+  );
+  await ensureConstraint(
+    "capabilities_quota_window_chk",
+    `quota_window IS NULL OR quota_window IN ('daily', 'monthly', 'none')`,
+  );
+  await ensureConstraint(
+    "capabilities_quota_reset_dom_chk",
+    `quota_reset_dom IS NULL OR (quota_reset_dom >= 1 AND quota_reset_dom <= 31)`,
+  );
+
+  return {
+    block: "0067_cost_class_taxonomy",
+    outcome: "columns + CHECK constraints ensured",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+// ─── Block 0070: capability_budget_counters table ───────────────────────────
+//
+// Per-capability test-budget counter (free_quota / paid_with_free_tier).
+// Modeled on rate_limit_counters (composite PK + atomic ON CONFLICT
+// increment). budget_cap is snapshotted at counter creation from
+// capabilities.quota_cap × 5..20% depending on cost_class + window kind;
+// see guarded-executor.ts for the formula.
+//
+// Idempotency. CREATE TABLE IF NOT EXISTS; CHECK constraint guarded by
+// pg_constraint NOT EXISTS lookup.
+
+export async function runMigration0070_capabilityBudgetCounters(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  await tx.execute(sql`
+    CREATE TABLE IF NOT EXISTS capability_budget_counters (
+      capability_slug TEXT NOT NULL,
+      window_start TIMESTAMP WITH TIME ZONE NOT NULL,
+      window_kind TEXT NOT NULL,
+      test_count INTEGER NOT NULL DEFAULT 0,
+      budget_cap INTEGER NOT NULL,
+      alert_30_fired_at TIMESTAMP WITH TIME ZONE,
+      alert_50_fired_at TIMESTAMP WITH TIME ZONE,
+      alert_80_fired_at TIMESTAMP WITH TIME ZONE,
+      hard_stop_fired_at TIMESTAMP WITH TIME ZONE,
+      updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (capability_slug, window_start, window_kind)
+    )
+  `);
+
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS capability_budget_counters_window_idx
+      ON capability_budget_counters (window_kind, window_start)
+  `);
+
+  // CHECK constraint guarded against re-add.
+  const checkExists = await tx.execute(sql`
+    SELECT count(*)::text AS cnt FROM pg_constraint
+    WHERE conname = 'capability_budget_counters_window_kind_chk'
+      AND conrelid = 'capability_budget_counters'::regclass
+  `);
+  const rows = Array.isArray(checkExists)
+    ? checkExists
+    : (checkExists as { rows?: unknown[] })?.rows ?? [];
+  if ((rows[0] as { cnt?: string })?.cnt === "0") {
+    await tx.execute(sql`
+      ALTER TABLE capability_budget_counters
+        ADD CONSTRAINT capability_budget_counters_window_kind_chk
+        CHECK (window_kind IN ('daily', 'monthly'))
+    `);
+  }
+
+  return {
+    block: "0070_capability_budget_counters",
+    outcome: "table + index + CHECK ensured",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -629,6 +769,8 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0064_alwaysLlmHaikuCosts,
   runMigration0065_pr86LeakyCapsCleanup,
   runMigration0066_ensureEligibilityColumnAndReconcile,
+  runMigration0067_costClassTaxonomy,
+  runMigration0070_capabilityBudgetCounters,
 ];
 
 /**

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -688,6 +688,74 @@ export async function runMigration0067_costClassTaxonomy(
   };
 }
 
+// ─── Block 0068: seed cost_class for DE/DK/SK ───────────────────────────────
+//
+// Phase A0b strategy (b) self-throttling: classifies only the three caps
+// whose vendors have the most-urgent quota exhaustion risk. DE OpenRegister
+// resets 2026-06-01 and was the original DE/DK breakage trigger; cvrapi.dk
+// (DK) is IP-quota-limited at ~50/day empirical; SK RPO is free_unlimited
+// because its only limit is a per-IP burst rate, not a cumulative quota.
+//
+// The remaining ~312 capabilities are Phase B (post-A0b) work — they stay
+// cost_class IS NULL and the scheduler/dispatcher fail-closed for internal
+// callers while still serving customer_paid traffic during the GRACE window.
+//
+// Idempotency. Each UPDATE filters `AND cost_class IS NULL`, so a re-run
+// after the seed lands is a no-op. A future Phase B classification that
+// lands a different cost_class on these rows is also preserved — this
+// block only fills in the blank.
+
+export async function runMigration0068_seedDeDkSkCostClass(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  let totalAffected = 0;
+
+  // DE OpenRegister — 50 req/month, resets on the 1st.
+  const de = await tx.execute(sql`
+    UPDATE capabilities
+       SET cost_class = 'free_quota',
+           quota_window = 'monthly',
+           quota_cap = 50,
+           quota_reset_dom = 1,
+           updated_at = NOW()
+     WHERE slug = 'german-company-data' AND cost_class IS NULL
+  `);
+  totalAffected += (de as { count?: number }).count ?? 0;
+
+  // DK cvrapi.dk — empirical floor ~50/day, no per-day reset_dom needed.
+  const dk = await tx.execute(sql`
+    UPDATE capabilities
+       SET cost_class = 'free_quota',
+           quota_window = 'daily',
+           quota_cap = 50,
+           updated_at = NOW()
+     WHERE slug = 'danish-company-data' AND cost_class IS NULL
+  `);
+  totalAffected += (dk as { count?: number }).count ?? 0;
+
+  // SK RPO — gov registry, CC-BY 4.0, only 60 req/min/IP burst limit.
+  // No cumulative quota → no quota_cap needed.
+  const sk = await tx.execute(sql`
+    UPDATE capabilities
+       SET cost_class = 'free_unlimited',
+           quota_window = 'none',
+           updated_at = NOW()
+     WHERE slug = 'slovak-company-data' AND cost_class IS NULL
+  `);
+  totalAffected += (sk as { count?: number }).count ?? 0;
+
+  return {
+    block: "0068_seed_de_dk_sk_cost_class",
+    outcome:
+      totalAffected === 0
+        ? "no rows to update (DE/DK/SK already classified or missing)"
+        : `seeded cost_class on ${totalAffected} row(s) (DE/DK/SK)`,
+    rows_affected: totalAffected,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Block 0070: capability_budget_counters table ───────────────────────────
 //
 // Per-capability test-budget counter (free_quota / paid_with_free_tier).
@@ -770,6 +838,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0065_pr86LeakyCapsCleanup,
   runMigration0066_ensureEligibilityColumnAndReconcile,
   runMigration0067_costClassTaxonomy,
+  runMigration0068_seedDeDkSkCostClass,
   runMigration0070_capabilityBudgetCounters,
 ];
 

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -756,6 +756,78 @@ export async function runMigration0068_seedDeDkSkCostClass(
   };
 }
 
+// ─── Block 0069: reconcile scheduled_testing_eligible from cost_class ───────
+//
+// Phase A0b commit #4. Block 0066's interim derivation
+// (`scheduled_testing_eligible := external_cost_cents = 0`) was the bridge
+// behavior that conflated "no per-call cost" with "no quota". This block
+// replaces it with the structural rule:
+//
+//   eligible := cost_class IN ('free_unlimited', 'free_quota', 'paid_with_free_tier')
+//
+// Unclassified caps (cost_class IS NULL) keep `scheduled_testing_eligible = FALSE`
+// — fail-closed, matches the GRACE-mode dispatcher behavior. The scheduler's
+// SELECT query is also tightened in test-scheduler.ts to exclude caps whose
+// per-window budget counter has reached its cap (defense-in-depth alongside
+// the per-call assertBudgetAvailable check).
+//
+// Idempotency. The UPDATE filters `IS DISTINCT FROM` so re-runs on an
+// already-reconciled DB match zero rows.
+
+export async function runMigration0069_reconcileEligibilityFromCostClass(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const update = await tx.execute(sql`
+    UPDATE test_suites ts
+       SET scheduled_testing_eligible = (
+             c.cost_class IN ('free_unlimited', 'free_quota', 'paid_with_free_tier')
+           ),
+           updated_at = NOW()
+      FROM capabilities c
+     WHERE c.slug = ts.capability_slug
+       AND c.cost_class IS NOT NULL
+       AND ts.scheduled_testing_eligible IS DISTINCT FROM (
+             c.cost_class IN ('free_unlimited', 'free_quota', 'paid_with_free_tier')
+           )
+  `);
+  const updateCount = (update as { count?: number }).count ?? 0;
+
+  // Post-condition: for every classified cap, its suites' eligibility
+  // matches the cost_class derivation. Mismatch means the UPDATE didn't
+  // reach the rows we expected — fail boot rather than silently leave
+  // the scheduler reading stale eligibility.
+  const checkRows = await tx.execute(sql`
+    SELECT COUNT(*)::int AS mismatched
+      FROM test_suites ts
+      JOIN capabilities c ON c.slug = ts.capability_slug
+     WHERE c.cost_class IS NOT NULL
+       AND ts.scheduled_testing_eligible IS DISTINCT FROM (
+             c.cost_class IN ('free_unlimited', 'free_quota', 'paid_with_free_tier')
+           )
+  `);
+  const checkResultRows = Array.isArray(checkRows)
+    ? checkRows
+    : (checkRows as { rows?: unknown[] })?.rows ?? [];
+  const mismatched = (checkResultRows[0] as { mismatched?: number })?.mismatched ?? 0;
+  if (mismatched > 0) {
+    throw new Error(
+      `0069_reconcile_eligibility_from_cost_class post-condition failed: ${mismatched} rows still mismatched after UPDATE`,
+    );
+  }
+
+  return {
+    block: "0069_reconcile_eligibility_from_cost_class",
+    outcome:
+      updateCount === 0
+        ? "no rows to reconcile (already aligned with cost_class)"
+        : `reconciled ${updateCount} row(s) to cost_class-derived eligibility`,
+    rows_affected: updateCount,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Block 0070: capability_budget_counters table ───────────────────────────
 //
 // Per-capability test-budget counter (free_quota / paid_with_free_tier).
@@ -839,6 +911,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0066_ensureEligibilityColumnAndReconcile,
   runMigration0067_costClassTaxonomy,
   runMigration0068_seedDeDkSkCostClass,
+  runMigration0069_reconcileEligibilityFromCostClass,
   runMigration0070_capabilityBudgetCounters,
 ];
 

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -9,6 +9,12 @@ import {
   capabilities,
 } from "../db/schema.js";
 import { getExecutor } from "../capabilities/index.js";
+import {
+  assertGuardedAllow,
+  CapabilityInvocationRefusedError,
+  CapabilityNotClassifiedError,
+  BudgetExhaustedError,
+} from "../capabilities/guarded-executor.js";
 import type { CapabilityResult } from "../capabilities/index.js";
 import { computeHealthState, HEALTH_STATE_FREQUENCY_HOURS } from "./health-state.js";
 import { sanitizeErrorMessage, getTestResultsForSlug } from "./trust-helpers.js";
@@ -476,20 +482,49 @@ async function runSingleTest(
   const capType = capabilityTypeMap?.get(suite.capabilitySlug);
   const shouldRetry = capType !== "deterministic";
 
+  // Phase A0b dispatcher gate. Scheduler-driven test execution runs under
+  // internal_test context — paid_prepaid / paid_subscription / unclassified
+  // capabilities will refuse here and free_quota / paid_with_free_tier
+  // capabilities will go through a budget reservation before the executor.
   try {
-    if (shouldRetry) {
-      capResult = await withRetry(
-        () => executor(suite.input as Record<string, unknown>),
-        { maxRetries: 1, baseDelayMs: 2000, slug: suite.capabilitySlug },
-      );
-    } else {
-      capResult = await executor(suite.input as Record<string, unknown>);
-    }
-    responseTimeMs = Date.now() - startTime;
+    await assertGuardedAllow(suite.capabilitySlug, {
+      kind: "internal_test",
+      suiteId: suite.id,
+      reason: "scheduled",
+    });
   } catch (err) {
-    responseTimeMs = Date.now() - startTime;
-    executionError =
-      err instanceof Error ? err.message : String(err);
+    if (
+      err instanceof CapabilityInvocationRefusedError ||
+      err instanceof CapabilityNotClassifiedError ||
+      err instanceof BudgetExhaustedError
+    ) {
+      executionError = err.message;
+      responseTimeMs = 0;
+      // Fall through to validateResult; null capResult + executionError
+      // yields a failed result row with the gate's reason as failure_reason.
+    } else {
+      throw err;
+    }
+  }
+
+  if (!executionError) {
+    try {
+      if (shouldRetry) {
+        capResult = await withRetry(
+          () => executor(suite.input as Record<string, unknown>),
+          { maxRetries: 1, baseDelayMs: 2000, slug: suite.capabilitySlug },
+        );
+      } else {
+        capResult = await executor(suite.input as Record<string, unknown>);
+      }
+      responseTimeMs = Date.now() - startTime;
+    } catch (err) {
+      responseTimeMs = Date.now() - startTime;
+      executionError =
+        err instanceof Error ? err.message : String(err);
+    }
+  } else {
+    responseTimeMs = 0;
   }
 
   // Validate the result
@@ -841,13 +876,37 @@ async function runRegressionTest(
   let executionError: string | null = null;
   let responseTimeMs: number;
 
+  // Phase A0b dispatcher gate. Same internal_test context as the per-suite
+  // path above. Regression-runner is the second scheduler entry point.
   try {
-    const result = await executor(suite.input as Record<string, unknown>);
-    responseTimeMs = Date.now() - startTime;
-    currentOutput = result?.output ?? null;
+    await assertGuardedAllow(suite.capabilitySlug, {
+      kind: "internal_test",
+      suiteId: suite.id,
+      reason: "scheduled",
+    });
   } catch (err) {
-    responseTimeMs = Date.now() - startTime;
-    executionError = err instanceof Error ? err.message : String(err);
+    if (
+      err instanceof CapabilityInvocationRefusedError ||
+      err instanceof CapabilityNotClassifiedError ||
+      err instanceof BudgetExhaustedError
+    ) {
+      executionError = err.message;
+    } else {
+      throw err;
+    }
+  }
+
+  if (executionError) {
+    responseTimeMs = 0;
+  } else {
+    try {
+      const result = await executor(suite.input as Record<string, unknown>);
+      responseTimeMs = Date.now() - startTime;
+      currentOutput = result?.output ?? null;
+    } catch (err) {
+      responseTimeMs = Date.now() - startTime;
+      executionError = err instanceof Error ? err.message : String(err);
+    }
   }
 
   if (executionError || !currentOutput) {

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -14,6 +14,12 @@ import { optionalAuthMiddleware, getClientIp, hashIp } from "../lib/middleware.j
 import { rateLimitByKey, rateLimitByIp } from "../lib/rate-limit.js";
 import { matchCapability } from "../lib/matching.js";
 import { getExecutor } from "../capabilities/index.js";
+import {
+  assertGuardedAllow,
+  CapabilityNotClassifiedError,
+  CapabilityInvocationRefusedError,
+  BudgetExhaustedError,
+} from "../capabilities/guarded-executor.js";
 import { apiError } from "../lib/errors.js";
 import {
   checkCircuitBreaker,
@@ -753,6 +759,34 @@ doRoute.post(
       ),
       503,
     );
+  }
+
+  // ── 5a. Dispatcher gate (Phase A0b). Every external invocation passes
+  //         through the ALLOW_MATRIX before reaching the executor. This is
+  //         a customer-paid path; the gate's null-row decision ALLOWS this
+  //         context during the GRACE backfill window (preserves customer
+  //         traffic for caps still awaiting cost_class classification).
+  try {
+    await assertGuardedAllow(capability.slug, {
+      kind: "customer_paid",
+      userId: user?.id ?? null,
+      transactionId: null,
+    });
+  } catch (err) {
+    if (err instanceof CapabilityInvocationRefusedError) {
+      return c.json(apiError("capability_unavailable", err.message), 503);
+    }
+    if (err instanceof CapabilityNotClassifiedError) {
+      // customer_paid + null is ALLOW per ALLOW_MATRIX — this branch is
+      // defensive; if it fires the matrix has been tampered with.
+      logError("dispatcher-gate-unexpected-null-refusal", err, { slug: capability.slug });
+      return c.json(apiError("capability_unavailable", err.message), 503);
+    }
+    if (err instanceof BudgetExhaustedError) {
+      // customer_paid never budget-checks; defensive.
+      return c.json(apiError("capability_unavailable", err.message), 503);
+    }
+    throw err;
   }
 
   // ── 5b. Circuit breaker check ──────────────────────────────────────────

--- a/apps/api/src/routes/internal-tests.ts
+++ b/apps/api/src/routes/internal-tests.ts
@@ -14,6 +14,12 @@ import {
 import { runTests } from "../lib/test-runner.js";
 import type { ScheduleTier } from "../lib/test-runner.js";
 import { getExecutor } from "../capabilities/index.js";
+import {
+  assertGuardedAllow,
+  CapabilityInvocationRefusedError,
+  CapabilityNotClassifiedError,
+  BudgetExhaustedError,
+} from "../capabilities/guarded-executor.js";
 import { generateTestInput } from "../lib/test-input-generator.js";
 import { categorizeFailureReason, toLegacyCategory, sanitizeErrorMessage } from "../lib/trust-helpers.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
@@ -1047,13 +1053,38 @@ internalTestsRoute.post("/recalibrate", async (c) => {
       const bestSuite = calibratable[0] ?? slugSuites[0];
       const resolution = resolveRecalInput(bestSuite.input as Record<string, unknown>, cap);
 
+      // Phase A0b dispatcher gate. Recalibration is operator-initiated
+      // admin diagnostic — internal_test/manual.
+      let gateError: string | null = null;
       try {
-        const result = await executor(resolution.input);
-        if (result?.output && Object.keys(result.output).length > 0) {
-          realOutput = result.output;
+        await assertGuardedAllow(slug, {
+          kind: "internal_test",
+          suiteId: bestSuite.id,
+          reason: "manual",
+        });
+      } catch (err) {
+        if (
+          err instanceof CapabilityInvocationRefusedError ||
+          err instanceof CapabilityNotClassifiedError ||
+          err instanceof BudgetExhaustedError
+        ) {
+          gateError = err.message;
+        } else {
+          throw err;
         }
-      } catch (err: any) {
-        executionError = err.message?.slice(0, 200) ?? "Unknown error";
+      }
+
+      if (gateError) {
+        executionError = gateError.slice(0, 200);
+      } else {
+        try {
+          const result = await executor(resolution.input);
+          if (result?.output && Object.keys(result.output).length > 0) {
+            realOutput = result.output;
+          }
+        } catch (err: any) {
+          executionError = err.message?.slice(0, 200) ?? "Unknown error";
+        }
       }
 
       // 2s delay between capabilities

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -16,6 +16,12 @@ import { getDb } from "../db/index.js";
 import { capabilities, solutions, transactions, x402OrphanSettlements } from "../db/schema.js";
 import { getExecutor } from "../capabilities/index.js";
 import {
+  assertGuardedAllow,
+  CapabilityInvocationRefusedError,
+  CapabilityNotClassifiedError,
+  BudgetExhaustedError,
+} from "../capabilities/guarded-executor.js";
+import {
   isX402Configured,
   verifyX402PaymentOnly,
   settleX402Payment,
@@ -1118,6 +1124,25 @@ x402GatewayV2.on(["GET", "POST"], "/:slug", async (c) => {
   const executor = getExecutor(cap.slug);
   if (!executor) {
     return c.json({ error: "Capability executor unavailable. Try again later." }, 503);
+  }
+
+  // Phase A0b dispatcher gate. x402 callers are paying via USDC settlement,
+  // so the context is customer_paid (allow regardless of cost_class).
+  try {
+    await assertGuardedAllow(cap.slug, {
+      kind: "customer_paid",
+      userId: null,
+      transactionId: null,
+    });
+  } catch (err) {
+    if (
+      err instanceof CapabilityInvocationRefusedError ||
+      err instanceof CapabilityNotClassifiedError ||
+      err instanceof BudgetExhaustedError
+    ) {
+      return c.json({ error: err.message }, 503);
+    }
+    throw err;
   }
 
   const startMs = Date.now();

--- a/manifests/danish-company-data.yaml
+++ b/manifests/danish-company-data.yaml
@@ -9,6 +9,12 @@ description: >-
 category: data-extraction
 price_cents: 5
 is_free_tier: false
+# Phase A0b cost-class: cvrapi.dk unauthenticated free tier, IP-quota-limited.
+# Empirical floor ~50/day; documented limit higher but conservative cap chosen
+# until we observe one clean cycle. See apps/api/src/capabilities/danish-company-data.ts:5-10.
+cost_class: free_quota
+quota_window: daily
+quota_cap: 50
 input_schema:
   type: object
   required:

--- a/manifests/german-company-data.yaml
+++ b/manifests/german-company-data.yaml
@@ -7,6 +7,12 @@ category: company-data
 price_cents: 5
 is_free_tier: false
 avg_latency_ms: 600
+# Phase A0b cost-class: OpenRegister free tier is 50 req/month, resets on the 1st.
+# See apps/api/src/capabilities/german-company-data.ts:115-120 for the 429 handler.
+cost_class: free_quota
+quota_window: monthly
+quota_cap: 50
+quota_reset_dom: 1
 input_schema:
   type: object
   required: []

--- a/manifests/slovak-company-data.yaml
+++ b/manifests/slovak-company-data.yaml
@@ -7,6 +7,11 @@ description: >-
 category: company-data
 price_cents: 5
 is_free_tier: false
+# Phase A0b cost-class: gov RPO API, CC-BY 4.0, no auth. Per-IP rate limit
+# (60 req/min) is a burst limit, not a cumulative quota → free_unlimited.
+# Current breakage (upstream 502/503) is orthogonal — see source_health.
+cost_class: free_unlimited
+quota_window: none
 data_source: Register právnických osôb (ŠÚ SR / Statistical Office of the Slovak Republic), CC-BY 4.0
 data_source_type: api
 transparency_tag: algorithmic


### PR DESCRIPTION
## Summary

Phase A0b structural fix for the 2026-05-11 DE/DK/SK breakage. Introduces a cost-class taxonomy on every capability and routes every external invocation through a dispatcher gate that consults an ALLOW_MATRIX (cost_class × invocation_context). Prevents the scheduler / CI / manual scripts from burning vendor credits outside customer-initiated paths.

**Background.** 95% of 60-day DE OpenRegister traffic came from the test scheduler (508/533 calls), exhausting the 50/mo free tier. Root cause: scheduler treated `external_cost_cents = 0` as "free to test" — conflating "no per-call cost" with "no quota". DK has the same shape against the ~50/day cvrapi.dk free tier. Journal: https://www.notion.so/35d67c87082c812ba68ec4e424f8cad1

**Design source.** [`c:/tmp/phase-a0a-audit-report.md`](file:///c:/tmp/phase-a0a-audit-report.md) — A0a's read-only audit produced the implementation plan, choke-point analysis (all 9 invocation paths converge on `getExecutor` at `apps/api/src/capabilities/index.ts:43`), and DE/DK/SK initial classifications. All 7 open questions resolved in A0b prompt v2.

## Commits

1. **`5a74936` schema (blocks 0067, 0070)** — Adds `cost_class`, `quota_window`, `quota_cap`, `quota_reset_dom` columns to `capabilities` (nullable, CHECK constraints). Adds `capability_budget_counters` table for atomic per-window counters.
2. **`941c22e` classify DE/DK/SK (manifest + block 0068)** — Manifest type + normalizer field additions; FIELD_CATEGORIES entries; DE/DK/SK YAML edits; deploy-time DB seed via Block 0068. CC's session does not connect to a database — backfill applies via `drizzle-kit migrate` at deploy time.
3. **`e5de76f` dispatcher gate** — `guardedExecute` + `ALLOW_MATRIX` + `assertGuardedAllow`. 14 call sites wrapped across `routes/do.ts`, `routes/x402-gateway-v2.ts`, `lib/solution-executor.ts`, `lib/test-runner.ts` (×3), `routes/internal-tests.ts`, `lib/capability-onboarding.ts` (×2), `db/audit-tests.ts`, and 5 scripts. Two CI lints prevent regressions (`check-no-direct-getexecutor-in-scripts.mjs`, `check-cost-class-coherence.mjs`). 27 regression tests including a 50-concurrent burst race-test against budget_cap=10.
4. **`99159a9` scheduler reconcile (block 0069)** — Replaces Block 0066's bridge (`scheduled_testing_eligible := external_cost_cents = 0`) with the structural rule grounded in cost_class. Scheduler SELECT also excludes capabilities whose per-window counter has hit `budget_cap` (defense-in-depth). Cites DEC-20260511-C; leaves `TODO(chat-draft)` for the new cost-class meta-pattern DEC.
5. **`083c76f` boot invariant** — `assertCostClassTaxonomy()` wired into `index.ts:80`, modeled on `assertAlertingConfigured`. `COST_CLASS_MODE=GRACE` default surfaces a count + per-cap log line; `STRICT` aborts boot. 7 regression tests pin the process.exit contract.

**Block numbering recap.** 0067 (cost_class columns) → 0068 (seed DE/DK/SK) → 0069 (reconcile eligibility) → 0070 (budget counters). Block 0066 stays as the column-creation idempotency path; 0069 overrides its derivation. 13 blocks total in `lib/startup-migrations.ts`, regression test pins the order.

## Test plan
- [x] `cd apps/api && npx tsc --noEmit` clean (across all 5 commits)
- [x] `npx vitest run` — 595 passed / 11 skipped / 0 failed after final commit
- [x] `node apps/api/scripts/check-no-direct-getexecutor-in-scripts.mjs` clean
- [x] `node apps/api/scripts/check-cost-class-coherence.mjs` clean (after danish-company-data per-env-var exemption marker for the Anthropic fuzzy-name fallback path)
- [ ] CI passes on push (in progress)
- [ ] Petter applies `drizzle-kit migrate` post-merge (see "After deployment" in A0b prompt)
- [ ] Post-deploy: confirm `SELECT cost_class, COUNT(*) FROM capabilities WHERE is_active = true GROUP BY cost_class` shows 3 classified rows + ~312 NULL; check Railway logs for `[startup] cost-class GRACE mode: N capabilities unclassified`

## Frontend display change deferred

Phase A0b §8's strale-frontend display change (`SQSResult.label="Unverified"` semantics for paid_* caps awaiting production traffic) is independent of the structural gate and lives in a separate repo. The strale-frontend worktree currently has 5 unrelated long-stale modifications (April 21–30) so I did not commit alongside. Recommend a sibling PR after this lands.

## Awaiting chat review

Per Rule 16 carve-out in the A0b prompt: this PR ships architecture-changing prod schema migrations + customer-facing dispatcher gate. **Do not self-merge.** Chat reviews before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)