### PR TITLE
feat: expose cost_class + last_customer_call_at on GET /v1/capabilities/:slug

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -70,6 +70,18 @@ export const openApiSpec = {
           search_tags: { type: "array" as const, items: { type: "string" as const }, description: "Searchability tags" },
           freshness_level: { type: "string" as const, description: "Test data freshness", enum: ["fresh", "aging", "stale", "expired", "unverified"] },
           last_tested_at: { type: "string" as const, format: "date-time", nullable: true, description: "When this capability was last tested" },
+          cost_class: {
+            type: "string" as const,
+            nullable: true,
+            enum: ["free_unlimited", "free_quota", "paid_with_free_tier", "paid_prepaid", "paid_subscription"],
+            description: "Per-capability cost classification (Phase A0b, DEC-20260512-A). NULL means the capability has not yet been classified.",
+          },
+          last_customer_call_at: {
+            type: "string" as const,
+            format: "date-time",
+            nullable: true,
+            description: "Timestamp of the most recent customer-initiated completed invocation. Excludes internal test runs. Used by clients to distinguish 'paid capability awaiting first customer call' from 'capability with genuine quality issues.'",
+          },
         },
       },
       Solution: {

--- a/apps/api/src/routes/capabilities.integration.test.ts
+++ b/apps/api/src/routes/capabilities.integration.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Integration tests for GET /v1/capabilities/:slug (Phase A0c.1.v2).
+ *
+ * Phase A0b shipped a cost_class taxonomy on `capabilities` and a
+ * dispatcher gate that refuses internal_test invocations for paid
+ * capabilities (DEC-20260512-A). The frontend's `isSQSUnqualified`
+ * filter currently hides capabilities labelled "Unverified" — which
+ * paid_prepaid / paid_subscription capabilities will become once the
+ * gate denies them test traffic. A0c.1.v2 adds two fields to the
+ * /v1/capabilities/:slug response so the frontend can distinguish
+ * "paid capability awaiting first customer call" from "capability
+ * with genuine quality issues":
+ *
+ *   - cost_class: capabilities.cost_class column (Block 0067).
+ *   - last_customer_call_at: MAX(transactions.created_at) filtered to
+ *     exclude internal test-runner writes (user_id != system user).
+ *
+ * The filter convention matches lib/daily-digest/fetch-platform.ts
+ * (cited at audit time): customer paths set user_id = real_user or
+ * NULL (free-tier); test-runner.ts:1270 writes user_id = system
+ * user, identified by email 'system@strale.internal'. Per
+ * DEC-20260504-A audit-follow-up test coverage, the most important
+ * regression test is "filter ignores system@strale.internal" — a
+ * future refactor that drops the user filter would silently leak
+ * test-runner traffic into the customer-facing surface.
+ *
+ * Pattern follows do.spend-cap.integration.test.ts: gated on
+ * DATABASE_URL_TEST so CI without a Postgres harness skips cleanly;
+ * local dev with a test DB exercises the real query round-trip.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { capabilitiesRoute } from "./capabilities.js";
+import { transactions, users, capabilities } from "../db/schema.js";
+
+const DATABASE_URL_TEST = process.env.DATABASE_URL_TEST;
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+describeMaybe("GET /v1/capabilities/:slug — cost_class + last_customer_call_at", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let systemUserId: string;
+  // Track every row we create so afterEach can purge precisely. Slug + id
+  // pairs let us delete the dependent transactions before the capability
+  // row's FK constraint blocks the parent delete.
+  const createdCapabilityIds: string[] = [];
+  const createdUserIds: string[] = [];
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 2 });
+    db = drizzle(client);
+
+    // Ensure the system user exists. test-runner.ts:1383 creates this
+    // row on demand; in a fresh test DB it may not exist yet. Idempotent
+    // insert keeps repeated test runs stable.
+    const sys = await client`
+      INSERT INTO users (id, email, api_key_hash, key_prefix)
+      VALUES (gen_random_uuid(), 'system@strale.internal', ${`test-system-${randomUUID()}`}, ${`sys_${randomUUID().slice(0, 8)}`})
+      ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email
+      RETURNING id
+    `;
+    systemUserId = sys[0].id;
+  });
+
+  afterAll(async () => {
+    await client.end({ timeout: 2 });
+  });
+
+  afterEach(async () => {
+    if (createdCapabilityIds.length > 0) {
+      await client`DELETE FROM transactions WHERE capability_id IN ${client(createdCapabilityIds)}`;
+      await client`DELETE FROM capabilities WHERE id IN ${client(createdCapabilityIds)}`;
+      createdCapabilityIds.length = 0;
+    }
+    if (createdUserIds.length > 0) {
+      await client`DELETE FROM users WHERE id IN ${client(createdUserIds)}`;
+      createdUserIds.length = 0;
+    }
+  });
+
+  async function seedCap(opts: { costClass: string | null }): Promise<{ id: string; slug: string }> {
+    const slug = `test-cost-class-${randomUUID().slice(0, 8)}`;
+    const id = randomUUID();
+    await db.insert(capabilities).values({
+      id,
+      slug,
+      name: `Test ${slug}`,
+      description: "Integration test capability for Phase A0c.1.v2 regression coverage. Should not appear in production.",
+      category: "validation",
+      inputSchema: { type: "object", properties: {} },
+      outputSchema: { type: "object", properties: {} },
+      priceCents: 0,
+      isActive: true,
+      marketplaceEligible: true,
+      lifecycleState: "active",
+      visible: true,
+      costClass: opts.costClass,
+    });
+    createdCapabilityIds.push(id);
+    return { id, slug };
+  }
+
+  async function seedCustomerUser(): Promise<string> {
+    const id = randomUUID();
+    await db.insert(users).values({
+      id,
+      email: `customer-${randomUUID().slice(0, 8)}@example.com`,
+      apiKeyHash: `test-key-${randomUUID()}`,
+      keyPrefix: `cust_${randomUUID().slice(0, 8)}`,
+    });
+    createdUserIds.push(id);
+    return id;
+  }
+
+  async function seedTransaction(opts: {
+    capabilityId: string;
+    userId: string | null;
+    status?: "completed" | "failed" | "pending";
+    createdAt: Date;
+  }): Promise<void> {
+    await db.insert(transactions).values({
+      capabilityId: opts.capabilityId,
+      userId: opts.userId,
+      status: opts.status ?? "completed",
+      input: {},
+      priceCents: 0,
+      completedAt: opts.createdAt,
+      createdAt: opts.createdAt,
+    });
+  }
+
+  async function fetchCap(slug: string): Promise<Record<string, unknown>> {
+    const res = await capabilitiesRoute.request(`/${slug}`);
+    expect(res.status, `expected 200 for /${slug}, got ${res.status}`).toBe(200);
+    return (await res.json()) as Record<string, unknown>;
+  }
+
+  // ── 1. cost_class field appears in response when classified ─────────────
+  it("returns cost_class when the capability is classified", async () => {
+    const { slug } = await seedCap({ costClass: "free_quota" });
+    const body = await fetchCap(slug);
+    expect(body.cost_class).toBe("free_quota");
+  });
+
+  // ── 2. cost_class is null for unclassified caps (inverted default) ──────
+  it("returns cost_class: null for unclassified caps (not omitted)", async () => {
+    const { slug } = await seedCap({ costClass: null });
+    const body = await fetchCap(slug);
+    expect(body).toHaveProperty("cost_class");
+    expect(body.cost_class).toBeNull();
+  });
+
+  // ── 3. last_customer_call_at reflects the latest customer txn ───────────
+  it("returns the most recent customer-initiated completed timestamp", async () => {
+    const { id, slug } = await seedCap({ costClass: "free_unlimited" });
+    const customerId = await seedCustomerUser();
+    const recent = new Date("2026-05-12T08:00:00Z");
+    const older = new Date("2026-05-10T08:00:00Z");
+    await seedTransaction({ capabilityId: id, userId: customerId, createdAt: older });
+    await seedTransaction({ capabilityId: id, userId: customerId, createdAt: recent });
+    const body = await fetchCap(slug);
+    expect(body.last_customer_call_at).not.toBeNull();
+    expect(new Date(body.last_customer_call_at as string).toISOString()).toBe(recent.toISOString());
+  });
+
+  // ── 4. last_customer_call_at is null when no customer txn exists ────────
+  it("returns last_customer_call_at: null when only system-user txns exist", async () => {
+    const { id, slug } = await seedCap({ costClass: "paid_prepaid" });
+    // Seed an internal test-runner transaction only.
+    await seedTransaction({
+      capabilityId: id,
+      userId: systemUserId,
+      createdAt: new Date("2026-05-12T09:00:00Z"),
+    });
+    const body = await fetchCap(slug);
+    expect(body).toHaveProperty("last_customer_call_at");
+    expect(body.last_customer_call_at).toBeNull();
+  });
+
+  // ── 5. CORE regression: filter ignores system@strale.internal ───────────
+  // Per DEC-20260504-A: this test must fail against an un-applied fix.
+  // A future refactor that drops the system-user exclusion from the
+  // subquery would let the (more recent) test-runner timestamp leak
+  // through here, breaking the frontend's "awaiting customer traffic"
+  // signal for paid caps.
+  it("ignores system@strale.internal transactions even when more recent than customer ones", async () => {
+    const { id, slug } = await seedCap({ costClass: "free_quota" });
+    const customerId = await seedCustomerUser();
+    const customerTimestamp = new Date("2026-05-11T10:00:00Z");
+    const internalTimestamp = new Date("2026-05-12T10:00:00Z"); // newer
+    await seedTransaction({ capabilityId: id, userId: customerId, createdAt: customerTimestamp });
+    await seedTransaction({ capabilityId: id, userId: systemUserId, createdAt: internalTimestamp });
+    const body = await fetchCap(slug);
+    expect(new Date(body.last_customer_call_at as string).toISOString()).toBe(
+      customerTimestamp.toISOString(),
+    );
+  });
+});

--- a/apps/api/src/routes/capabilities.ts
+++ b/apps/api/src/routes/capabilities.ts
@@ -83,6 +83,16 @@ capabilitiesRoute.get("/:slug", async (c) => {
   const slug = c.req.param("slug");
   const db = getDb();
 
+  // Phase A0c.1 (DEC-20260512-A): expose cost_class so the frontend can
+  // distinguish paid_prepaid / paid_subscription caps awaiting customer
+  // traffic from caps that are genuinely unverified for other reasons.
+  // last_customer_call_at uses the daily-digest filter convention
+  // (lib/daily-digest/fetch-platform.ts:20-24, 56, 63, 70, 78, 92):
+  // exclude transactions whose user_id is the system test user
+  // ('system@strale.internal'); customer paths set a real user_id or
+  // NULL (free-tier), test-runner writes user_id = getSystemUserId().
+  // The MAX() runs against an indexed (capability_id, status) pair —
+  // one row per capability fetch is O(1) for this single-cap handler.
   const [cap] = await db
     .select({
       slug: capabilities.slug,
@@ -96,6 +106,16 @@ capabilitiesRoute.get("/:slug", async (c) => {
       geography: capabilities.geography,
       data_source: capabilities.dataSource,
       is_free_tier: capabilities.isFreeTier,
+      cost_class: capabilities.costClass,
+      last_customer_call_at: sql<string | null>`(
+        SELECT MAX(t.created_at)
+          FROM transactions t
+         WHERE t.capability_id = ${capabilities.id}
+           AND t.status = 'completed'
+           AND (t.user_id IS NULL OR t.user_id != (
+             SELECT id FROM users WHERE email = 'system@strale.internal' LIMIT 1
+           ))
+      )`,
     })
     .from(capabilities)
     .where(


### PR DESCRIPTION
## Summary

Phase A0c.1.v2. Extends the live catalog endpoint with two backward-compatible fields needed by A0c.2's frontend display change.

**v1 → v2 reframe.** v1 of this prompt premised an existing `/v1/public/ops/trust/capabilities/:slug` to extend. CC's audit found that route was retired with the SQS engine (DEC-20260503-B) and the frontend's calls at `strale-frontend/src/lib/api.ts:533` have been 404'ing in production since. v2 targets the live `GET /v1/capabilities/:slug` instead and lets A0c.2 drop the dead trust fetches as a side benefit.

## Fields added

- **`cost_class`** — read from `capabilities.cost_class` (Block 0067, Phase A0b). NULL for unclassified caps. Lets A0c.2 distinguish paid_prepaid / paid_subscription caps that should display "Awaiting production traffic" from caps that are genuinely unverified.
- **`last_customer_call_at`** — `MAX(transactions.created_at)` for the capability, filtered to exclude internal test-runner writes. Follows the daily-digest filter convention (`lib/daily-digest/fetch-platform.ts:20-24` and use-sites at 56/63/70/78/92): system user is `email='system@strale.internal'`; customer paths set `user_id = real_user` or `NULL` (free-tier); `test-runner.ts:1270` writes `user_id = getSystemUserId()`. The subquery runs once per capability fetch — O(1) on indexed `(capability_id, status)`.

## OpenAPI

`Capability` schema in `openapi.ts` extended with both fields (nullable; `cost_class` documented as an enum).

## Tests

Five integration tests in `apps/api/src/routes/capabilities.integration.test.ts`, gated on `DATABASE_URL_TEST` (matches `do.spend-cap.integration.test.ts` pattern). CI skips cleanly without the env var; local dev with a test DB exercises the real query round-trip.

Per DEC-20260504-A audit-follow-up test coverage, the **core regression test** seeds a customer txn at T1 and a system-user txn at T2 > T1 and asserts `last_customer_call_at == T1`. A future refactor that drops the system-user filter would let the more recent test-runner timestamp leak through and break the frontend's "awaiting customer traffic" signal.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 595 passed / 16 skipped (5 new integration tests skip without DATABASE_URL_TEST, matching precedent)
- [x] Live-DB read-only sanity check confirmed the subquery shape:
  - DE: `cost_class=free_quota`, last customer 2026-04-12
  - DK: `cost_class=free_quota`, last customer 2026-02-26
  - SK: `cost_class=free_unlimited`, last customer null (no real RPO traffic)
  - iban-validate: `cost_class=null`, last customer 2026-05-07 (free-tier null user_id correctly counted)
- [ ] CI green (in progress)
- [ ] Post-merge: 3 production curls confirm the new fields appear

## Backward compatibility

Existing fields unchanged. New fields are additive. Frontend's `mergeTrustResponse` and any third-party catalog consumer ignore unknown fields safely. Frontend wiring lands in A0c.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)