### PR TITLE
feat: classify free_quota high-conf + free_unlimited medium-conf (Phase B.2)

### DIFF
--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -55,6 +55,8 @@ import {
   runMigration0069_reconcileEligibilityFromCostClass,
   runMigration0070_capabilityBudgetCounters,
   runMigration0071_bulkClassifyFreeUnlimited,
+  runMigration0072_classifyFreeQuotaHighConfidence,
+  runMigration0073_classifyFreeUnlimitedMediumConfidence,
   runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
@@ -641,8 +643,126 @@ describe("startup-migrations — phase-b1-free-unlimited-slugs list", () => {
   });
 });
 
+describe("startup-migrations — block 0072 (classify free_quota high-confidence)", () => {
+  it("first run: UPDATEs the 8 free_quota slugs with per-cap quota params", async () => {
+    const stub = makeStub({ queue: [{ count: 8 }] });
+    const result = await runMigration0072_classifyFreeQuotaHighConfidence(stub);
+    expect(result.rows_affected).toBe(8);
+    expect(result.outcome).toMatch(/classified 8 cap/i);
+    expect(stub.captured).toHaveLength(1);
+
+    const sqlText = stub.renderedSql[0].toLowerCase();
+    expect(sqlText).toContain("update capabilities");
+    expect(sqlText).toContain("cost_class = 'free_quota'");
+    // Per-cap params: VALUES clause must include each (slug, window, cap, reset_dom) tuple.
+    expect(sqlText).toContain("'au-company-data'");
+    expect(sqlText).toContain("'beneficial-ownership-lookup'");
+    expect(sqlText).toContain("'flight-status'");
+    expect(sqlText).toContain("'job-board-search'");
+    // Daily caps with reset_dom=NULL.
+    expect(sqlText).toMatch(/'au-company-data',\s*'daily',\s*1000,\s*null/);
+    // Monthly caps with reset_dom=1.
+    expect(sqlText).toMatch(/'flight-status',\s*'monthly',\s*100,\s*1/);
+    expect(sqlText).toMatch(/'job-board-search',\s*'monthly',\s*1000,\s*1/);
+    // Idempotency clause.
+    expect(sqlText).toContain("c.cost_class is null");
+  });
+
+  it("second run: idempotent — count=0; outcome reports already-classified", async () => {
+    const stub = makeStub({ queue: [{ count: 0 }] });
+    const result = await runMigration0072_classifyFreeQuotaHighConfidence(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to classify.*already have cost_class/i);
+  });
+
+  it("does not touch already-classified rows (cost_class IS NULL safety filter)", async () => {
+    // Pins the safety clause so a future refactor that drops it would
+    // silently overwrite paid_prepaid / free_quota classifications from
+    // Phase B.3+ batches. Block 0072 must only fill blanks.
+    const stub = makeStub({ queue: [{ count: 0 }] });
+    await runMigration0072_classifyFreeQuotaHighConfidence(stub);
+    const sqlText = stub.renderedSql[0].toLowerCase();
+    expect(sqlText).toMatch(/where[\s\S]*c\.cost_class\s+is\s+null/);
+  });
+});
+
+describe("startup-migrations — block 0073 (classify free_unlimited medium-conf)", () => {
+  it("first run: UPDATEs the 5 medium-conf scraping slugs", async () => {
+    const stub = makeStub({ queue: [{ count: 5 }] });
+    const result = await runMigration0073_classifyFreeUnlimitedMediumConfidence(stub);
+    expect(result.rows_affected).toBe(5);
+    expect(result.outcome).toMatch(/classified 5 cap/i);
+
+    const sqlText = stub.renderedSql[0].toLowerCase();
+    expect(sqlText).toContain("cost_class = 'free_unlimited'");
+    expect(sqlText).toContain("quota_window = 'none'");
+    expect(sqlText).toContain("quota_cap = null");
+    // All 5 scraping caps in the IN-list.
+    expect(sqlText).toContain("'canadian-company-data'");
+    expect(sqlText).toContain("'japanese-company-data'");
+    expect(sqlText).toContain("'polish-company-data'");
+    expect(sqlText).toContain("'seo-audit'");
+    expect(sqlText).toContain("'tech-stack-detect'");
+    // Idempotency clause.
+    expect(sqlText).toContain("cost_class is null");
+  });
+
+  it("second run: idempotent — count=0; outcome reports already-classified", async () => {
+    const stub = makeStub({ queue: [{ count: 0 }] });
+    const result = await runMigration0073_classifyFreeUnlimitedMediumConfidence(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to classify/i);
+  });
+});
+
+describe("startup-migrations — phase-b2 slug lists (audit-trail invariants)", () => {
+  it("PHASE_B2_FREE_QUOTA_HIGH_CONF has 8 entries", async () => {
+    const { PHASE_B2_FREE_QUOTA_HIGH_CONF } = await import("./startup-migrations.js");
+    expect(PHASE_B2_FREE_QUOTA_HIGH_CONF.length).toBe(8);
+  });
+
+  it("PHASE_B2_FREE_QUOTA_HIGH_CONF entries have valid quota shapes", async () => {
+    const { PHASE_B2_FREE_QUOTA_HIGH_CONF } = await import("./startup-migrations.js");
+    for (const cap of PHASE_B2_FREE_QUOTA_HIGH_CONF) {
+      expect(cap.slug).toMatch(/^[a-z][a-z0-9-]+$/);
+      expect(["daily", "monthly"]).toContain(cap.quotaWindow);
+      expect(cap.quotaCap).toBeGreaterThan(0);
+      // reset_dom NULL only valid for daily windows.
+      if (cap.quotaWindow === "monthly") {
+        expect(cap.quotaResetDom).toBeGreaterThanOrEqual(1);
+        expect(cap.quotaResetDom).toBeLessThanOrEqual(31);
+      } else {
+        expect(cap.quotaResetDom).toBeNull();
+      }
+    }
+  });
+
+  it("PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF has 5 entries (audit-pinned count)", async () => {
+    const { PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF } = await import("./startup-migrations.js");
+    expect(PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF.length).toBe(5);
+  });
+
+  it("PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF has no duplicates", async () => {
+    const { PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF } = await import("./startup-migrations.js");
+    const unique = new Set(PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF);
+    expect(unique.size).toBe(PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF.length);
+  });
+
+  it("B.2 slug lists do not overlap with B.1 free_unlimited", async () => {
+    const { PHASE_B2_FREE_QUOTA_HIGH_CONF, PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF } = await import("./startup-migrations.js");
+    const { PHASE_B1_FREE_UNLIMITED_SLUGS } = await import("./phase-b1-free-unlimited-slugs.js");
+    const b1Set = new Set(PHASE_B1_FREE_UNLIMITED_SLUGS);
+    for (const cap of PHASE_B2_FREE_QUOTA_HIGH_CONF) {
+      expect(b1Set.has(cap.slug), `${cap.slug} appears in BOTH B.1 and B.2 free_quota`).toBe(false);
+    }
+    for (const slug of PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF) {
+      expect(b1Set.has(slug), `${slug} appears in BOTH B.1 and B.2 free_unlimited`).toBe(false);
+    }
+  });
+});
+
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 14 blocks in historical order", () => {
+  it("exports the expected 16 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -663,6 +783,8 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0069_reconcileEligibilityFromCostClass",
       "runMigration0070_capabilityBudgetCounters",
       "runMigration0071_bulkClassifyFreeUnlimited",
+      "runMigration0072_classifyFreeQuotaHighConfidence",
+      "runMigration0073_classifyFreeUnlimitedMediumConfidence",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -942,6 +942,130 @@ export async function runMigration0071_bulkClassifyFreeUnlimited(
   };
 }
 
+// ─── Block 0072: classify 8 high-confidence free_quota capabilities ─────────
+//
+// Phase B.2 of DEC-20260512-A. Sets cost_class='free_quota' plus per-cap
+// quota_window / quota_cap / quota_reset_dom on 8 capabilities flagged
+// by the Phase B.0 audit (2026-05-12) as high-confidence free_quota.
+//
+// All 8 caps use audit-shortlist env vars (ABN_LOOKUP_GUID, ADZUNA_APP_ID,
+// AVIATIONSTACK_API_KEY, COMPANIES_HOUSE_API_KEY); the chat-supplied
+// vendor override table for Phase B.2 did not affect any of these (none
+// matched the 7 patterns CBEAPI_KEY / SUDREG_* / GITHUB_TOKEN /
+// GEMI_API_KEY / PAGESPEED_API_KEY / BOLAGSVERKET_* / COURTLISTENER_API_TOKEN).
+// No Bolagsverket exclusions needed.
+//
+// Per-cap values are inlined into a VALUES clause rather than a slug list
+// because each cap has different quota params (unlike Block 0071's uniform
+// free_unlimited). Idempotency: WHERE cost_class IS NULL gates the UPDATE.
+
+interface FreeQuotaCapValues {
+  slug: string;
+  quotaWindow: "daily" | "monthly";
+  quotaCap: number;
+  quotaResetDom: number | null;
+}
+
+export const PHASE_B2_FREE_QUOTA_HIGH_CONF: ReadonlyArray<FreeQuotaCapValues> = [
+  { slug: "au-company-data",             quotaWindow: "daily",   quotaCap: 1000, quotaResetDom: null },
+  { slug: "beneficial-ownership-lookup", quotaWindow: "daily",   quotaCap: 600,  quotaResetDom: null },
+  { slug: "flight-status",               quotaWindow: "monthly", quotaCap: 100,  quotaResetDom: 1 },
+  { slug: "insolvency-check",            quotaWindow: "daily",   quotaCap: 600,  quotaResetDom: null },
+  { slug: "job-board-search",            quotaWindow: "monthly", quotaCap: 1000, quotaResetDom: 1 },
+  { slug: "officer-search",              quotaWindow: "daily",   quotaCap: 600,  quotaResetDom: null },
+  { slug: "uk-companies-house-officers", quotaWindow: "daily",   quotaCap: 600,  quotaResetDom: null },
+  { slug: "uk-filing-events",            quotaWindow: "daily",   quotaCap: 600,  quotaResetDom: null },
+];
+
+export async function runMigration0072_classifyFreeQuotaHighConfidence(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  // Build a VALUES-based UPDATE so per-cap quota params survive a single
+  // statement. Each row: slug, quota_window, quota_cap, quota_reset_dom.
+  // The CTE form makes the SQL diff-readable for chat review without
+  // resorting to 8 separate UPDATE statements.
+  const valuesRows = PHASE_B2_FREE_QUOTA_HIGH_CONF.map((c) => {
+    const slug = c.slug.replace(/'/g, "''");
+    const qd = c.quotaResetDom === null ? "NULL" : String(c.quotaResetDom);
+    return `('${slug}', '${c.quotaWindow}', ${c.quotaCap}, ${qd})`;
+  }).join(",\n      ");
+
+  const result = await tx.execute(sql.raw(`
+    UPDATE capabilities AS c
+       SET cost_class = 'free_quota',
+           quota_window = v.quota_window,
+           quota_cap = v.quota_cap,
+           quota_reset_dom = v.quota_reset_dom,
+           updated_at = NOW()
+      FROM (VALUES
+      ${valuesRows}
+      ) AS v(slug, quota_window, quota_cap, quota_reset_dom)
+     WHERE c.slug = v.slug
+       AND c.cost_class IS NULL
+  `));
+  const updateCount = (result as { count?: number }).count ?? 0;
+
+  return {
+    block: "0072_classify_free_quota_high_confidence",
+    outcome:
+      updateCount === 0
+        ? `no rows to classify (all ${PHASE_B2_FREE_QUOTA_HIGH_CONF.length} slugs already have cost_class set)`
+        : `classified ${updateCount} cap(s) as free_quota (of ${PHASE_B2_FREE_QUOTA_HIGH_CONF.length} target slugs)`,
+    rows_affected: updateCount,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+// ─── Block 0073: 5 medium-confidence free_unlimited scraping caps ───────────
+//
+// Phase B.2 sibling of Block 0072. The 5 scraping caps below have
+// data_source_type=scrape, no BROWSERLESS_* env var (raw fetch + cheerio),
+// no vendor cost. Heuristic confidence flagged as medium because the
+// vendor identity is the scrape target (gov registry pages) rather than
+// an API contract — slightly higher operational fragility but no
+// classification ambiguity.
+//
+// Same idempotency shape as Block 0071: ANY-list UPDATE filtered on
+// cost_class IS NULL.
+
+export const PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF: ReadonlyArray<string> = [
+  "canadian-company-data",
+  "japanese-company-data",
+  "polish-company-data",
+  "seo-audit",
+  "tech-stack-detect",
+];
+
+export async function runMigration0073_classifyFreeUnlimitedMediumConfidence(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const result = await tx.execute(sql`
+    UPDATE capabilities
+       SET cost_class = 'free_unlimited',
+           quota_window = 'none',
+           quota_cap = NULL,
+           quota_reset_dom = NULL,
+           updated_at = NOW()
+     WHERE slug IN ${sql.raw("(" + PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF.map((s) => `'${s.replace(/'/g, "''")}'`).join(",") + ")")}
+       AND cost_class IS NULL
+  `);
+  const updateCount = (result as { count?: number }).count ?? 0;
+
+  return {
+    block: "0073_classify_free_unlimited_medium_confidence",
+    outcome:
+      updateCount === 0
+        ? `no rows to classify (all ${PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF.length} slugs already have cost_class set)`
+        : `classified ${updateCount} cap(s) as free_unlimited (of ${PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF.length} target slugs)`,
+    rows_affected: updateCount,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -967,6 +1091,8 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0069_reconcileEligibilityFromCostClass,
   runMigration0070_capabilityBudgetCounters,
   runMigration0071_bulkClassifyFreeUnlimited,
+  runMigration0072_classifyFreeQuotaHighConfidence,
+  runMigration0073_classifyFreeUnlimitedMediumConfidence,
 ];
 
 /**

--- a/manifests/au-company-data.yaml
+++ b/manifests/au-company-data.yaml
@@ -4,6 +4,9 @@ description: >-
   Look up Australian company data from the Australian Business Register (ABR). Accepts an ABN (11 digits). Returns
   entity name, status, type, GST registration, and address details. Free government API — fast and reliable.
 category: company-data
+cost_class: free_quota
+quota_window: daily
+quota_cap: 1000
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/beneficial-ownership-lookup.yaml
+++ b/manifests/beneficial-ownership-lookup.yaml
@@ -6,6 +6,9 @@ description: >-
   chain. Uses Companies House Persons of Significant Control. UK-only — non-GB inputs
   return a clear coverage notice rather than a fabricated result.
 category: compliance
+cost_class: free_quota
+quota_window: daily
+quota_cap: 600
 price_cents: 25
 is_free_tier: false
 input_schema:

--- a/manifests/canadian-company-data.yaml
+++ b/manifests/canadian-company-data.yaml
@@ -5,6 +5,8 @@ slug: canadian-company-data
 name: Canadian Company Data
 description: Look up Canadian company data from Corporations Canada. Accepts corporation number or fuzzy company name.
 category: data-extraction
+cost_class: free_unlimited
+quota_window: none
 price_cents: 80
 is_free_tier: false
 input_schema:

--- a/manifests/flight-status.yaml
+++ b/manifests/flight-status.yaml
@@ -7,6 +7,10 @@ description: >-
   Look up flight status by flight number (e.g. LH400, BA117). Returns departure/arrival times, delays, gates. Requires
   AVIATIONSTACK_API_KEY for live data.
 category: data-extraction
+cost_class: free_quota
+quota_window: monthly
+quota_cap: 100
+quota_reset_dom: 1
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/insolvency-check.yaml
+++ b/manifests/insolvency-check.yaml
@@ -4,6 +4,9 @@ description: >-
   Check if a company has any insolvency, bankruptcy, or winding-up proceedings. Currently
   covers UK (via Companies House). Returns status and key dates.
 category: compliance
+cost_class: free_quota
+quota_window: daily
+quota_cap: 600
 price_cents: 2
 is_free_tier: false
 input_schema:

--- a/manifests/japanese-company-data.yaml
+++ b/manifests/japanese-company-data.yaml
@@ -7,6 +7,8 @@ description: >-
   Look up Japanese company data from the National Tax Agency corporate number system. Accepts 13-digit corporate number
   or fuzzy company name.
 category: data-extraction
+cost_class: free_unlimited
+quota_window: none
 price_cents: 80
 is_free_tier: false
 input_schema:

--- a/manifests/job-board-search.yaml
+++ b/manifests/job-board-search.yaml
@@ -5,6 +5,10 @@ slug: job-board-search
 name: Job Board Search
 description: Search job listings on Arbetsformedlingen (Swedish) and Adzuna (multi-country). Returns title, company, salary, URL.
 category: data-extraction
+cost_class: free_quota
+quota_window: monthly
+quota_cap: 1000
+quota_reset_dom: 1
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/officer-search.yaml
+++ b/manifests/officer-search.yaml
@@ -2,6 +2,9 @@ slug: officer-search
 name: Officer Search
 description: Find company directors and officers from official public registries. Covers UK (Companies House) and US (SEC EDGAR). Returns officer names, roles, appointment dates.
 category: company-data
+cost_class: free_quota
+quota_window: daily
+quota_cap: 600
 price_cents: 10
 input_schema:
   type: object

--- a/manifests/polish-company-data.yaml
+++ b/manifests/polish-company-data.yaml
@@ -7,6 +7,8 @@ description: >-
   Look up Polish company data from KRS (Krajowy Rejestr Sądowy). Accepts KRS number (10 digits) or fuzzy company name.
   Returns company name, legal form, address, registration date.
 category: data-extraction
+cost_class: free_unlimited
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/seo-audit.yaml
+++ b/manifests/seo-audit.yaml
@@ -7,6 +7,8 @@ description: >-
   Comprehensive SEO audit of a URL. Checks title, meta description, h1 structure, image alt tags, canonical, robots.txt,
   sitemap, Open Graph, schema.org, link ratio.
 category: competitive-intelligence
+cost_class: free_unlimited
+quota_window: none
 price_cents: 30
 is_free_tier: false
 input_schema:

--- a/manifests/tech-stack-detect.yaml
+++ b/manifests/tech-stack-detect.yaml
@@ -7,6 +7,8 @@ description: >-
   Detect the technology stack of a website. Identifies frontend framework, CSS framework, CMS, analytics, hosting, CDN,
   and other technologies.
 category: web-intelligence
+cost_class: free_unlimited
+quota_window: none
 price_cents: 3
 is_free_tier: false
 input_schema:

--- a/manifests/uk-companies-house-officers.yaml
+++ b/manifests/uk-companies-house-officers.yaml
@@ -7,6 +7,9 @@ description: >-
   Look up officers (directors, secretaries) of a UK company via Companies House API. Returns active and resigned
   officers with appointment dates.
 category: data-extraction
+cost_class: free_quota
+quota_window: daily
+quota_cap: 600
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/uk-filing-events.yaml
+++ b/manifests/uk-filing-events.yaml
@@ -2,6 +2,9 @@ slug: "uk-filing-events"
 name: "UK Filing Events"
 description: "Get recent filing history for a UK company from Companies House. Returns accounts, officer changes, confirmation statements, charges, and other corporate filings."
 category: "company-data"
+cost_class: free_quota
+quota_window: daily
+quota_cap: 600
 price_cents: 5
 data_source: "UK Companies House"
 data_source_type: "api"


### PR DESCRIPTION
## Summary

Implements **Phase B.2** of DEC-20260512-A — two small batches in one PR.

## Block 0072 — 8 high-confidence free_quota capabilities

All 8 caps use audit-shortlist env vars (\`ABN_LOOKUP_GUID\`, \`ADZUNA_APP_ID\`, \`AVIATIONSTACK_API_KEY\`, \`COMPANIES_HOUSE_API_KEY\`). **The chat-supplied vendor-override table did not affect any cap in this batch** — none matched the 7 patterns (\`CBEAPI_KEY\` / \`SUDREG_*\` / \`GITHUB_TOKEN\` / \`GEMI_API_KEY\` / \`PAGESPEED_API_KEY\` / \`BOLAGSVERKET_*\` / \`COURTLISTENER_API_TOKEN\`). **No Bolagsverket exclusions applied** (Bolagsverket pattern didn't appear in the high-conf free_quota set).

| slug | env var | quota_window | quota_cap | quota_reset_dom |
|---|---|---|---|---|
| \`au-company-data\` | ABN_LOOKUP_GUID | daily | 1000 | NULL |
| \`beneficial-ownership-lookup\` | COMPANIES_HOUSE_API_KEY | daily | 600 | NULL |
| \`flight-status\` | AVIATIONSTACK_API_KEY | monthly | 100 | 1 |
| \`insolvency-check\` | COMPANIES_HOUSE_API_KEY | daily | 600 | NULL |
| \`job-board-search\` | ADZUNA_APP_ID | monthly | 1000 | 1 |
| \`officer-search\` | COMPANIES_HOUSE_API_KEY | daily | 600 | NULL |
| \`uk-companies-house-officers\` | COMPANIES_HOUSE_API_KEY | daily | 600 | NULL |
| \`uk-filing-events\` | COMPANIES_HOUSE_API_KEY | daily | 600 | NULL |

SQL form: \`UPDATE capabilities ... FROM (VALUES ...) AS v WHERE c.slug = v.slug AND c.cost_class IS NULL\` — single statement, per-cap quota params via the VALUES clause. Idempotency: \`AND c.cost_class IS NULL\` filter.

## Block 0073 — 5 medium-confidence free_unlimited scraping caps

Scraping caps with \`data_source_type=scrape\`, no \`BROWSERLESS_*\` env var (raw fetch + cheerio), no vendor cost.

\`canadian-company-data\`, \`japanese-company-data\`, \`polish-company-data\`, \`seo-audit\`, \`tech-stack-detect\`

Same shape as Block 0071's uniform \`free_unlimited\` / \`none\` UPDATE.

## Behavior changes after deploy

- **Boot invariant:** \`unclassified_count\` drops 110 → ~97.
- **Scheduler:** 8 free_quota caps gain \`scheduled_testing_eligible=TRUE\` and budget_check semantics (10%/20% reservation per Phase A0b spec). 5 free_unlimited caps gain unconstrained eligibility.
- **Dispatcher gate:** Internal_test invocations against these 13 caps resume (had been "refuse" under GRACE-NULL).
- **Frontend display:** No impact — neither cost class triggers Awaiting-traffic badge.

## Tests

\`npx tsc --noEmit\`: clean.
\`npx vitest run\`: **611 passed / 16 skipped / 0 failed**.

10 new test cases in \`startup-migrations.test.ts\`:
- Block 0072 first-run UPDATE shape (VALUES clause + per-cap params + safety filter).
- Block 0072 idempotent re-run.
- Block 0072 cost_class IS NULL safety pin.
- Block 0073 first-run UPDATE shape.
- Block 0073 idempotent re-run.
- B.2 slug lists: counts pinned to 8 + 5, shape invariants (window enum, cap > 0, reset_dom valid for monthly), no duplicates, no overlap with B.1.

## Excluded — still pending Phase B work

- **\`BOLAGSVERKET_*\` caps** (Bolagsverket access-model verification pending) — hold NULL.
- **8 low-confidence free_quota** (vendor docs lookups pending) — separate batch.
- **95 paid_prepaid** (chat-batched by env_var, budget-burn risk) — separate batches.

## Verification

Post-merge Railway logs expected:
- \`0072_classify_free_quota_high_confidence outcome="classified 8 cap(s) as free_quota (of 8 target slugs)" rows_affected=8\`
- \`0073_classify_free_unlimited_medium_confidence outcome="classified 5 cap(s) as free_unlimited (of 5 target slugs)" rows_affected=5\`

Spot-check via the live catalog endpoint:
\`\`\`
curl -s https://api.strale.io/v1/capabilities/au-company-data | jq '{cost_class}'
# expected: {"cost_class":"free_quota"}
curl -s https://api.strale.io/v1/capabilities/canadian-company-data | jq '{cost_class}'
# expected: {"cost_class":"free_unlimited"}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)