### PR TITLE
feat: classify 83 ANTHROPIC_API_KEY caps as paid_prepaid (Phase B.3)

### DIFF
--- a/apps/api/src/lib/phase-b3-anthropic-paid-prepaid-slugs.ts
+++ b/apps/api/src/lib/phase-b3-anthropic-paid-prepaid-slugs.ts
@@ -1,0 +1,107 @@
+/**
+ * Phase B.3 (DEC-20260512-A): 78 capabilities reading ANTHROPIC_API_KEY,
+ * classified as paid_prepaid (every call bills per-token on Anthropic).
+ *
+ * Source: c:/tmp/phase-b-audit-report.csv (filter:
+ * proposed_cost_class=paid_prepaid AND confidence=high AND
+ * env_var=ANTHROPIC_API_KEY). The cost-class-coherence CI lint
+ * (apps/api/scripts/check-cost-class-coherence.mjs) already enforces
+ * that reading ANTHROPIC_API_KEY requires paid_prepaid or
+ * paid_subscription; this list ships the classification to DB.
+ *
+ * Why this list lives separately: same rationale as
+ * PHASE_B1_FREE_UNLIMITED_SLUGS and BLOCK_0064_SLUGS — keeps the
+ * 90-line literal out of startup-migrations.ts and lets a dedicated
+ * regression test pin the size + content.
+ *
+ * Semantics: paid_prepaid × any-internal-context = refuse via
+ * ALLOW_MATRIX. customer_paid is allowed unchanged. Scheduler
+ * eligibility stays FALSE (was already FALSE via Block 0066's bridge
+ * derivation from external_cost_cents > 0; now structurally derived
+ * from cost_class per Block 0069).
+ */
+export const PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS: ReadonlyArray<string> = [
+  "address-parse",
+  "agent-trace-analyze",
+  "api-docs-generate",
+  "api-mock-response",
+  "blog-post-outline",
+  "brand-mention-search",
+  "changelog-generate",
+  "classify-text",
+  "code-convert",
+  "code-review",
+  "commit-message-generate",
+  "company-enrich",
+  "company-industry-classify",
+  "company-tech-stack",
+  "competitor-compare",
+  "container-track",
+  "context-window-optimize",
+  "contract-extract",
+  "cookie-scan",
+  "crontab-generate",
+  "curl-to-code",
+  "customs-duty-lookup",
+  "cz-company-data",
+  "diff-review",
+  "dockerfile-generate",
+  "docstring-generate",
+  "email-draft",
+  "env-template-generate",
+  "error-explain",
+  "estonian-company-data",
+  "eu-regulation-search",
+  "eu-trademark-search",
+  "fake-data-generate",
+  "finnish-company-data",
+  "french-company-data",
+  "gdpr-fine-lookup",
+  "github-actions-generate",
+  "github-repo-analyze",
+  "hs-code-lookup",
+  "image-to-text",
+  "invoice-extract",
+  "job-posting-analyze",
+  "jsdoc-generate",
+  "landing-page-roast",
+  "meeting-notes-extract",
+  "nginx-config-generate",
+  "norwegian-company-data",
+  "openapi-generate",
+  "pdf-extract",
+  "pii-redact",
+  "pr-description-generate",
+  "price-compare",
+  "pricing-page-extract",
+  "privacy-policy-analyze",
+  "product-reviews-extract",
+  "product-search",
+  "prompt-compress",
+  "prompt-optimize",
+  "readme-generate",
+  "receipt-categorize",
+  "regex-explain",
+  "regex-generate",
+  "release-notes-generate",
+  "resume-parse",
+  "return-policy-extract",
+  "risk-narrative-generate",
+  "schema-migration-generate",
+  "sentiment-analyze",
+  "social-post-generate",
+  "sql-explain",
+  "sql-generate",
+  "sql-optimize",
+  "structured-scrape",
+  "summarize",
+  "terms-of-service-extract",
+  "test-case-generate",
+  "translate",
+  "uk-company-data",
+  "us-company-data",
+  "web-extract",
+  "webhook-test-payload",
+  "website-to-company",
+  "youtube-summarize",
+];

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -57,6 +57,7 @@ import {
   runMigration0071_bulkClassifyFreeUnlimited,
   runMigration0072_classifyFreeQuotaHighConfidence,
   runMigration0073_classifyFreeUnlimitedMediumConfidence,
+  runMigration0074_classifyAnthropicPaidPrepaid,
   runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
@@ -761,8 +762,90 @@ describe("startup-migrations — phase-b2 slug lists (audit-trail invariants)", 
   });
 });
 
+describe("startup-migrations — block 0074 (classify ANTHROPIC paid_prepaid)", () => {
+  it("first run: UPDATEs the 83 ANTHROPIC slugs to paid_prepaid", async () => {
+    const stub = makeStub({ queue: [{ count: 83 }] });
+    const result = await runMigration0074_classifyAnthropicPaidPrepaid(stub);
+    expect(result.rows_affected).toBe(83);
+    expect(result.outcome).toMatch(/classified 83 cap/i);
+
+    const sqlText = stub.renderedSql[0].toLowerCase();
+    expect(sqlText).toContain("update capabilities");
+    expect(sqlText).toContain("cost_class = 'paid_prepaid'");
+    expect(sqlText).toContain("quota_window = 'none'");
+    expect(sqlText).toContain("quota_cap = null");
+    // Sample slugs from the audit-derived list — assert presence to
+    // confirm the slug-list module was actually serialized into the SQL.
+    expect(sqlText).toContain("'agent-trace-analyze'");
+    expect(sqlText).toContain("'classify-text'");
+    expect(sqlText).toContain("'invoice-extract'");
+    expect(sqlText).toContain("'pii-redact'");
+    expect(sqlText).toContain("'translate'");
+    // Idempotency clause.
+    expect(sqlText).toContain("cost_class is null");
+  });
+
+  it("second run: idempotent — count=0; outcome reports already-classified", async () => {
+    const stub = makeStub({ queue: [{ count: 0 }] });
+    const result = await runMigration0074_classifyAnthropicPaidPrepaid(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to classify.*already have cost_class/i);
+  });
+
+  it("does not overwrite already-classified rows (safety filter pin)", async () => {
+    // A future refactor that drops `AND cost_class IS NULL` would
+    // silently overwrite free_* / paid_subscription classifications
+    // from Phase B.1/B.2/B.4+ batches. Pin the safety filter shape.
+    const stub = makeStub({ queue: [{ count: 0 }] });
+    await runMigration0074_classifyAnthropicPaidPrepaid(stub);
+    const sqlText = stub.renderedSql[0].toLowerCase();
+    expect(sqlText).toMatch(/where[\s\S]*and\s+cost_class\s+is\s+null/);
+  });
+});
+
+describe("startup-migrations — phase-b3 ANTHROPIC slug list (audit invariants)", () => {
+  it("list size is within the audit-bounded range", async () => {
+    // Loose bounds: the audit found 83 caps reading ANTHROPIC_API_KEY
+    // at high confidence on 2026-05-12. Anthropic-dominance in the
+    // LLM-backed fleet means this number is naturally ~80; a future
+    // audit refresh might add or remove a few. Bounds match the chat-
+    // approved 50-100 range from Phase B.3 prompt.
+    const { PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS } = await import("./phase-b3-anthropic-paid-prepaid-slugs.js");
+    expect(PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS.length).toBeGreaterThan(50);
+    expect(PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS.length).toBeLessThan(100);
+  });
+
+  it("list is alphabetically sorted (audit-trail discipline)", async () => {
+    const { PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS } = await import("./phase-b3-anthropic-paid-prepaid-slugs.js");
+    const sorted = [...PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS].sort();
+    expect(PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS).toEqual(sorted);
+  });
+
+  it("list has no duplicates", async () => {
+    const { PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS } = await import("./phase-b3-anthropic-paid-prepaid-slugs.js");
+    const unique = new Set(PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS);
+    expect(unique.size).toBe(PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS.length);
+  });
+
+  it("does not overlap with B.1 free_unlimited or B.2 free_quota/free_unlimited", async () => {
+    const { PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS } = await import("./phase-b3-anthropic-paid-prepaid-slugs.js");
+    const { PHASE_B1_FREE_UNLIMITED_SLUGS } = await import("./phase-b1-free-unlimited-slugs.js");
+    const { PHASE_B2_FREE_QUOTA_HIGH_CONF, PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF } = await import("./startup-migrations.js");
+
+    const b1 = new Set(PHASE_B1_FREE_UNLIMITED_SLUGS);
+    const b2a = new Set(PHASE_B2_FREE_QUOTA_HIGH_CONF.map((c: { slug: string }) => c.slug));
+    const b2b = new Set(PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF);
+
+    for (const slug of PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS) {
+      expect(b1.has(slug), `${slug} also in B.1 free_unlimited`).toBe(false);
+      expect(b2a.has(slug), `${slug} also in B.2 free_quota`).toBe(false);
+      expect(b2b.has(slug), `${slug} also in B.2 free_unlimited`).toBe(false);
+    }
+  });
+});
+
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 16 blocks in historical order", () => {
+  it("exports the expected 17 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -785,6 +868,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0071_bulkClassifyFreeUnlimited",
       "runMigration0072_classifyFreeQuotaHighConfidence",
       "runMigration0073_classifyFreeUnlimitedMediumConfidence",
+      "runMigration0074_classifyAnthropicPaidPrepaid",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -41,6 +41,7 @@ import { getDb } from "../db/index.js";
 import { log } from "./log.js";
 import { BLOCK_0064_SLUGS, BLOCK_0065_SLUGS } from "./llm-capability-costs.js";
 import { PHASE_B1_FREE_UNLIMITED_SLUGS } from "./phase-b1-free-unlimited-slugs.js";
+import { PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS } from "./phase-b3-anthropic-paid-prepaid-slugs.js";
 
 /**
  * Minimal executor surface — matches what `getDb().execute()` returns
@@ -1066,6 +1067,59 @@ export async function runMigration0073_classifyFreeUnlimitedMediumConfidence(
   };
 }
 
+// ─── Block 0074: classify 83 ANTHROPIC_API_KEY caps as paid_prepaid ─────────
+//
+// Phase B.3 of DEC-20260512-A. Every capability that reads
+// process.env.ANTHROPIC_API_KEY classifies as paid_prepaid — Anthropic's
+// API has no free tier, no quota, bills per token on every call.
+// Mechanical batch; no per-cap variation.
+//
+// Zero behavior change vs current state per DEC-20260503-B: these 83
+// caps already had scheduled_testing_eligible=FALSE via Block 0066's
+// bridge derivation from external_cost_cents > 0. After B.3 the
+// scheduler eligibility result stays FALSE but its source flips from
+// external_cost_cents to cost_class (Block 0069 reconcile). No test
+// signal lost. Dispatcher gate's NULL × internal_test = refuse already
+// blocked test-runner invocations; paid_prepaid × internal_test =
+// refuse keeps the same outcome.
+//
+// Side effect: first paid_prepaid classifications in production
+// activate A0c.2b's "Awaiting production traffic" frontend display
+// for any cap with stale last_customer_call_at. Validates the A0c
+// arc end-to-end.
+//
+// Idempotency: WHERE cost_class IS NULL. Slug list lives separately
+// in phase-b3-anthropic-paid-prepaid-slugs.ts (same pattern as
+// PHASE_B1_FREE_UNLIMITED_SLUGS).
+
+export async function runMigration0074_classifyAnthropicPaidPrepaid(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const result = await tx.execute(sql`
+    UPDATE capabilities
+       SET cost_class = 'paid_prepaid',
+           quota_window = 'none',
+           quota_cap = NULL,
+           quota_reset_dom = NULL,
+           updated_at = NOW()
+     WHERE slug IN ${sql.raw("(" + PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS.map((s) => `'${s.replace(/'/g, "''")}'`).join(",") + ")")}
+       AND cost_class IS NULL
+  `);
+  const updateCount = (result as { count?: number }).count ?? 0;
+
+  return {
+    block: "0074_classify_anthropic_paid_prepaid",
+    outcome:
+      updateCount === 0
+        ? `no rows to classify (all ${PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS.length} slugs already have cost_class set)`
+        : `classified ${updateCount} cap(s) as paid_prepaid (of ${PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS.length} target slugs)`,
+    rows_affected: updateCount,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -1093,6 +1147,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0071_bulkClassifyFreeUnlimited,
   runMigration0072_classifyFreeQuotaHighConfidence,
   runMigration0073_classifyFreeUnlimitedMediumConfidence,
+  runMigration0074_classifyAnthropicPaidPrepaid,
 ];
 
 /**

--- a/manifests/address-parse.yaml
+++ b/manifests/address-parse.yaml
@@ -7,6 +7,8 @@ description: >-
   Parse a free-text address into structured components. Returns street, city, postal code, state/province, country.
   Works with addresses worldwide.
 category: data-processing
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/agent-trace-analyze.yaml
+++ b/manifests/agent-trace-analyze.yaml
@@ -7,6 +7,8 @@ description: >-
   Analyze AI agent execution traces (LangChain/CrewAI/AutoGen). Identifies failure points, root causes, token waste, and
   suggests fixes.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/api-docs-generate.yaml
+++ b/manifests/api-docs-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate markdown API documentation from an OpenAPI spec or natural language description. Returns documentation with
   parameters, examples, error codes.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/api-mock-response.yaml
+++ b/manifests/api-mock-response.yaml
@@ -5,6 +5,8 @@ slug: api-mock-response
 name: API Mock Response
 description: Generate a realistic mock API response with proper headers, status codes, and schema-matching body data.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/blog-post-outline.yaml
+++ b/manifests/blog-post-outline.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate a structured blog post outline. Returns title options, sections with subsections and key points, estimated
   word count, SEO keywords. JSON, not prose.
 category: content-writing
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/brand-mention-search.yaml
+++ b/manifests/brand-mention-search.yaml
@@ -7,6 +7,8 @@ description: >-
   Search Google for brand mentions. Returns URLs, titles, snippets, sentiment, and source type. Every result is a
   clickable, verifiable URL.
 category: competitive-intelligence
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 30
 is_free_tier: false
 input_schema:

--- a/manifests/changelog-generate.yaml
+++ b/manifests/changelog-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate a user-facing changelog from git commits. Groups by type, writes human-readable descriptions. Supports Keep a
   Changelog, semantic, and bullet formats.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 3
 is_free_tier: false
 input_schema:

--- a/manifests/classify-text.yaml
+++ b/manifests/classify-text.yaml
@@ -7,6 +7,8 @@ description: >-
   Classify text into categories. Optionally provide custom categories. Returns primary category, confidence scores,
   topic keywords, and summary.
 category: text-processing
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/code-convert.yaml
+++ b/manifests/code-convert.yaml
@@ -7,6 +7,8 @@ description: >-
   Convert code between programming languages. Uses idiomatic patterns for the target language. Supports all major
   languages.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/code-review.yaml
+++ b/manifests/code-review.yaml
@@ -7,6 +7,8 @@ description: >-
   AI code review. Returns issues with severity, line numbers, fix suggestions. Focus on security, performance,
   readability, or bugs.
 category: agent-tooling
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/commit-message-generate.yaml
+++ b/manifests/commit-message-generate.yaml
@@ -5,6 +5,8 @@ slug: commit-message-generate
 name: Commit Message Generate
 description: Generate conventional commit messages from git diffs or change descriptions. Returns subject, body, type, scope.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/company-enrich.yaml
+++ b/manifests/company-enrich.yaml
@@ -7,6 +7,8 @@ description: >-
   Enrich company data from a domain, email, or company name. Scrapes the company website to extract: industry, employee
   estimate, HQ location, description, social links, tech stack.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 50
 is_free_tier: false
 input_schema:

--- a/manifests/company-industry-classify.yaml
+++ b/manifests/company-industry-classify.yaml
@@ -4,6 +4,8 @@ description: >-
   Classify a company's industry using standard codes. Given a company name, description, or
   website URL, returns SIC, NAICS, and NACE codes with confidence levels.
 category: data-processing
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/company-tech-stack.yaml
+++ b/manifests/company-tech-stack.yaml
@@ -7,6 +7,8 @@ description: >-
   Deep tech stack analysis of any domain. Analyzes HTTP headers, HTML source, JS libraries, DNS records, meta tags.
   Returns frontend, analytics, CDN, hosting, CMS, and more.
 category: competitive-intelligence
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 30
 is_free_tier: false
 input_schema:

--- a/manifests/competitor-compare.yaml
+++ b/manifests/competitor-compare.yaml
@@ -7,6 +7,8 @@ description: >-
   Compare two company websites. Analyzes positioning, pricing model, features, target audience, trust signals, content
   strategy. Returns structured comparison + strategic analysis.
 category: competitive-intelligence
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 100
 is_free_tier: false
 input_schema:

--- a/manifests/container-track.yaml
+++ b/manifests/container-track.yaml
@@ -5,6 +5,8 @@ slug: container-track
 name: Container Track
 description: Track shipping containers by ISO 6346 number. Validates format, detects carrier, provides tracking status.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/context-window-optimize.yaml
+++ b/manifests/context-window-optimize.yaml
@@ -7,6 +7,8 @@ description: >-
   Rank and select document chunks by relevance to fit within a token budget. Returns selected/excluded chunks with
   scores.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 3
 is_free_tier: false
 input_schema:

--- a/manifests/contract-extract.yaml
+++ b/manifests/contract-extract.yaml
@@ -7,6 +7,8 @@ description: >-
   Extract key terms from a contract/legal document. Returns parties, dates, obligations, payment terms, liability caps,
   termination clauses. Not legal advice.
 category: document-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 50
 is_free_tier: false
 input_schema:

--- a/manifests/cookie-scan.yaml
+++ b/manifests/cookie-scan.yaml
@@ -7,6 +7,8 @@ description: >-
   Scan a website for cookies, tracking scripts, and consent banners. Categorizes cookies as
   necessary/analytics/marketing.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 15
 is_free_tier: false
 input_schema:

--- a/manifests/crontab-generate.yaml
+++ b/manifests/crontab-generate.yaml
@@ -5,6 +5,8 @@ slug: crontab-generate
 name: Crontab Generate
 description: Convert natural language schedule to cron expression, or explain an existing cron expression. Returns next run times.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/curl-to-code.yaml
+++ b/manifests/curl-to-code.yaml
@@ -5,6 +5,8 @@ slug: curl-to-code
 name: cURL to Code
 description: Convert a curl command to equivalent code in TypeScript, Python, Go, Rust, Java, or PHP.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/customs-duty-lookup.yaml
+++ b/manifests/customs-duty-lookup.yaml
@@ -7,6 +7,8 @@ description: >-
   Look up EU customs duty rates by HS code and origin country. Returns duty rate, preferential rates, anti-dumping
   status.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/cz-company-data.yaml
+++ b/manifests/cz-company-data.yaml
@@ -4,6 +4,8 @@ description: >-
   Look up Czech company data from ARES (Czech Ministry of Finance registry). Accepts IČO (8-digit identifier) or fuzzy
   company name via LLM name-resolution.
 category: company-data
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 data_source: ARES (Czech Ministry of Finance)

--- a/manifests/diff-review.yaml
+++ b/manifests/diff-review.yaml
@@ -5,6 +5,8 @@ description: >-
   quality. Returns structured findings with severity, file paths, and an approval recommendation. Built for CI/CD
   pre-merge checks.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 10
 is_free_tier: false
 maintenance_class: commercial-stable-api

--- a/manifests/dockerfile-generate.yaml
+++ b/manifests/dockerfile-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate optimized, production-ready Dockerfiles. Multi-stage builds, Alpine base, non-root user, layer caching.
   Supports Node, Python, Go, Rust, Java.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/docstring-generate.yaml
+++ b/manifests/docstring-generate.yaml
@@ -5,6 +5,8 @@ slug: docstring-generate
 name: Docstring Generate
 description: Add Python docstrings to functions and classes. Supports Google, NumPy, and Sphinx styles.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/email-draft.yaml
+++ b/manifests/email-draft.yaml
@@ -7,6 +7,8 @@ description: >-
   Draft a professional email. Specify context, intent (cold outreach/follow-up/apology/etc), and tone. Returns subject
   line options, body, and key phrases.
 category: content-writing
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/env-template-generate.yaml
+++ b/manifests/env-template-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Scan source code for environment variable references (process.env, os.environ, etc.) and generate a .env template with
   descriptions and example values.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/error-explain.yaml
+++ b/manifests/error-explain.yaml
@@ -5,6 +5,8 @@ slug: error-explain
 name: Error Explain
 description: Explain an error message or stack trace in plain English. Identifies root cause, suggests fixes with code examples.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/estonian-company-data.yaml
+++ b/manifests/estonian-company-data.yaml
@@ -2,6 +2,8 @@ slug: estonian-company-data
 name: Estonian Company Data
 description: Look up Estonian company data from the e-Business Register. Accepts registry code (8 digits) or fuzzy company name.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/eu-regulation-search.yaml
+++ b/manifests/eu-regulation-search.yaml
@@ -7,6 +7,8 @@ description: >-
   Search EU regulations, directives, and decisions on EUR-Lex. Returns matching legislation with titles, CELEX numbers,
   dates, and summaries.
 category: compliance
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 30
 is_free_tier: false
 input_schema:

--- a/manifests/eu-trademark-search.yaml
+++ b/manifests/eu-trademark-search.yaml
@@ -7,6 +7,8 @@ description: >-
   Search the EUIPO trademark database for registered and pending EU trademarks. Returns trademark names, numbers,
   status, owners.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 50
 is_free_tier: false
 input_schema:

--- a/manifests/fake-data-generate.yaml
+++ b/manifests/fake-data-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate realistic fake data matching a schema. Locale-aware: Swedish names for 'sv', Japanese for 'ja'. Up to 1000
   records.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/finnish-company-data.yaml
+++ b/manifests/finnish-company-data.yaml
@@ -7,6 +7,8 @@ description: >-
   Look up Finnish company data from PRH (Patent and Registration Office). Accepts Business ID (e.g. 0112038-9) or fuzzy
   company name.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/french-company-data.yaml
+++ b/manifests/french-company-data.yaml
@@ -7,6 +7,8 @@ description: >-
   Look up French company data from the SIRENE registry. Accepts SIREN (9 digits), SIRET (14 digits), or fuzzy company
   name. Returns company name, address, activity code, directors.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/gdpr-fine-lookup.yaml
+++ b/manifests/gdpr-fine-lookup.yaml
@@ -5,6 +5,8 @@ slug: gdpr-fine-lookup
 name: GDPR Fine Lookup
 description: Look up GDPR enforcement fines by company name or country. Returns fine amounts, authorities, articles violated.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/github-actions-generate.yaml
+++ b/manifests/github-actions-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate CI/CD workflow YAML for GitHub Actions. Supports multiple languages, frameworks, and deploy targets (Railway,
   Vercel, Fly).
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 15
 is_free_tier: false
 input_schema:

--- a/manifests/github-repo-analyze.yaml
+++ b/manifests/github-repo-analyze.yaml
@@ -7,6 +7,8 @@ description: >-
   Analyze a public GitHub repository. Returns tech stack, documentation quality, activity level, bus factor, maintenance
   health score. Uses GitHub API + AI analysis.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/hs-code-lookup.yaml
+++ b/manifests/hs-code-lookup.yaml
@@ -7,6 +7,8 @@ description: >-
   Classify a product into Harmonized System (HS) commodity codes. Returns primary HS code, chapter, section, and
   alternative classifications with confidence levels.
 category: trade
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 3
 is_free_tier: false
 input_schema:

--- a/manifests/image-to-text.yaml
+++ b/manifests/image-to-text.yaml
@@ -7,6 +7,8 @@ description: >-
   OCR on any image via Claude vision. Works on screenshots, photos of documents, handwritten notes. Returns text with
   confidence.
 category: file-conversion
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/invoice-extract.yaml
+++ b/manifests/invoice-extract.yaml
@@ -7,6 +7,8 @@ description: >-
   Extract structured data from an invoice or receipt image/PDF. Returns line items, totals, dates, vendor info, VAT
   amounts.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 50
 is_free_tier: false
 input_schema:

--- a/manifests/job-posting-analyze.yaml
+++ b/manifests/job-posting-analyze.yaml
@@ -7,6 +7,8 @@ description: >-
   Analyze a job posting. Extracts title, skills, salary range, remote policy, benefits, red flags, culture signals.
   Accepts URL or text.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/jsdoc-generate.yaml
+++ b/manifests/jsdoc-generate.yaml
@@ -5,6 +5,8 @@ slug: jsdoc-generate
 name: JSDoc Generate
 description: Add JSDoc comments to JavaScript/TypeScript functions and classes. Infers param types, return types, and throws.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/landing-page-roast.yaml
+++ b/manifests/landing-page-roast.yaml
@@ -7,6 +7,8 @@ description: >-
   AI conversion expert analyzes any landing page. Returns overall score, headline effectiveness, CTA clarity, value
   proposition, trust signals, issues, and suggestions.
 category: competitive-intelligence
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 50
 is_free_tier: false
 input_schema:

--- a/manifests/meeting-notes-extract.yaml
+++ b/manifests/meeting-notes-extract.yaml
@@ -7,6 +7,8 @@ description: >-
   Extract structured meeting notes from a transcript. Returns summary, decisions, action items with owners, key
   discussion points, follow-ups.
 category: document-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/nginx-config-generate.yaml
+++ b/manifests/nginx-config-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate production nginx server blocks with SSL, proxy_pass, WebSocket support, security headers, gzip, rate
   limiting.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/norwegian-company-data.yaml
+++ b/manifests/norwegian-company-data.yaml
@@ -7,6 +7,8 @@ description: >-
   Look up Norwegian company data from the Brønnøysund Register Centre. Accepts org number (9 digits) or fuzzy company
   name.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/openapi-generate.yaml
+++ b/manifests/openapi-generate.yaml
@@ -5,6 +5,8 @@ slug: openapi-generate
 name: OpenAPI Generate
 description: Generate a complete OpenAPI 3.1 specification from a natural language API description.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 15
 is_free_tier: false
 input_schema:

--- a/manifests/pdf-extract.yaml
+++ b/manifests/pdf-extract.yaml
@@ -7,6 +7,8 @@ description: >-
   Extract structured data from any PDF document. Accepts a URL or base64-encoded PDF. Works on contracts, reports, forms
   — any document type. Returns JSON based on your extraction instructions.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 30
 is_free_tier: false
 input_schema:

--- a/manifests/pii-redact.yaml
+++ b/manifests/pii-redact.yaml
@@ -7,6 +7,8 @@ description: >-
   Detect and redact personally identifiable information (PII) from text. Identifies names, emails, phone numbers,
   national ID numbers (Swedish personnummer, Finnish henkilötunnus, etc.), addresses, and more.
 category: data-processing
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 3
 is_free_tier: false
 input_schema:

--- a/manifests/pr-description-generate.yaml
+++ b/manifests/pr-description-generate.yaml
@@ -5,6 +5,8 @@ slug: pr-description-generate
 name: PR Description Generate
 description: Generate pull request descriptions from diffs or commit logs. Returns title, summary, changes list, testing steps.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/price-compare.yaml
+++ b/manifests/price-compare.yaml
@@ -5,6 +5,8 @@ slug: price-compare
 name: Price Compare
 description: Compare prices across merchants via PriceRunner (Nordic) and Google Shopping. Returns lowest/highest/average prices.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/pricing-page-extract.yaml
+++ b/manifests/pricing-page-extract.yaml
@@ -7,6 +7,8 @@ description: >-
   Extract structured pricing data from any SaaS pricing page. Returns plan names, prices, features per plan, billing
   periods, trial/guarantee info.
 category: competitive-intelligence
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 30
 is_free_tier: false
 input_schema:

--- a/manifests/privacy-policy-analyze.yaml
+++ b/manifests/privacy-policy-analyze.yaml
@@ -7,6 +7,8 @@ description: >-
   Analyze a company's privacy policy. Extracts data collected, purposes, third parties, user rights, GDPR/CCPA
   compliance signals.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 30
 is_free_tier: false
 input_schema:

--- a/manifests/product-reviews-extract.yaml
+++ b/manifests/product-reviews-extract.yaml
@@ -7,6 +7,8 @@ description: >-
   Extract product reviews from Amazon, Trustpilot, or any review page. Returns rating distribution, pros/cons,
   sentiment.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 25
 is_free_tier: false
 input_schema:

--- a/manifests/product-search.yaml
+++ b/manifests/product-search.yaml
@@ -5,6 +5,8 @@ slug: product-search
 name: Product Search
 description: Search products on Google Shopping. Returns product listings with title, price, merchant, rating.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 15
 is_free_tier: false
 input_schema:

--- a/manifests/prompt-compress.yaml
+++ b/manifests/prompt-compress.yaml
@@ -5,6 +5,8 @@ slug: prompt-compress
 name: Prompt Compress
 description: Compress a prompt to be shorter while preserving semantic meaning. Specify target reduction percentage (10-70%).
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 3
 is_free_tier: false
 input_schema:

--- a/manifests/prompt-optimize.yaml
+++ b/manifests/prompt-optimize.yaml
@@ -7,6 +7,8 @@ description: >-
   Analyze and improve a prompt. Returns improved version with changes and reasoning, clarity score comparison, and
   techniques applied.
 category: agent-tooling
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 15
 is_free_tier: false
 input_schema:

--- a/manifests/readme-generate.yaml
+++ b/manifests/readme-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate comprehensive README.md from project description. Includes installation, usage, API docs, contributing
   sections.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/receipt-categorize.yaml
+++ b/manifests/receipt-categorize.yaml
@@ -7,6 +7,8 @@ description: >-
   Extract and categorize receipt data. Returns vendor, date, amount, tax, currency, expense category, line items. Ready
   for expense reports.
 category: document-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/regex-explain.yaml
+++ b/manifests/regex-explain.yaml
@@ -5,6 +5,8 @@ slug: regex-explain
 name: Regex Explain
 description: Explain a regular expression in plain English with token-by-token breakdown. Optionally test against sample strings.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/regex-generate.yaml
+++ b/manifests/regex-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Describe what you want to match in natural language, get a tested regex back. Optionally provide test strings for
   validation.
 category: validation
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/release-notes-generate.yaml
+++ b/manifests/release-notes-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate release notes from commit log or changelog. Keep a Changelog format with Added/Changed/Fixed/Removed
   sections.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 3
 is_free_tier: false
 input_schema:

--- a/manifests/resume-parse.yaml
+++ b/manifests/resume-parse.yaml
@@ -7,6 +7,8 @@ description: >-
   Extract structured data from a CV/resume. Accepts PDF URL, base64, or text. Returns name, contact, experience,
   education, skills, certifications.
 category: document-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 30
 is_free_tier: false
 input_schema:

--- a/manifests/return-policy-extract.yaml
+++ b/manifests/return-policy-extract.yaml
@@ -5,6 +5,8 @@ slug: return-policy-extract
 name: Return Policy Extract
 description: Extract return/refund policy from a retailer website. Returns window, conditions, exclusions, process steps.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/risk-narrative-generate.yaml
+++ b/manifests/risk-narrative-generate.yaml
@@ -4,6 +4,8 @@ description: >-
   Generates a plain-language risk narrative from structured check results. Designed for non-technical users reviewing AI
   agent output. Supports KYB and invoice fraud contexts.
 category: agent-tooling
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/schema-migration-generate.yaml
+++ b/manifests/schema-migration-generate.yaml
@@ -5,6 +5,8 @@ slug: schema-migration-generate
 name: Schema Migration Generate
 description: Generate database migration code from current→desired schema description. Supports Drizzle, Prisma, Knex, and raw SQL.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/sentiment-analyze.yaml
+++ b/manifests/sentiment-analyze.yaml
@@ -7,6 +7,8 @@ description: >-
   Analyze the sentiment of text. Returns overall sentiment (positive/negative/neutral/mixed), confidence scores, and
   aspect-level sentiment.
 category: text-processing
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/social-post-generate.yaml
+++ b/manifests/social-post-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate platform-optimized social media posts. Supports Twitter, LinkedIn, Instagram. Returns post text, hashtags,
   thread version for Twitter.
 category: content-writing
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/sql-explain.yaml
+++ b/manifests/sql-explain.yaml
@@ -7,6 +7,8 @@ description: >-
   Explain a SQL query in plain language. Identifies tables, joins, filters, aggregations, and potential performance
   issues.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/sql-generate.yaml
+++ b/manifests/sql-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate SQL queries from natural language descriptions. Provide table schema for best results. Supports PostgreSQL,
   MySQL, SQLite, MSSQL.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/sql-optimize.yaml
+++ b/manifests/sql-optimize.yaml
@@ -7,6 +7,8 @@ description: >-
   Analyze and optimize a SQL query for performance. Returns rewritten query, index recommendations, and explanation of
   improvements.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/structured-scrape.yaml
+++ b/manifests/structured-scrape.yaml
@@ -7,6 +7,8 @@ description: >-
   Extract structured data from any URL using a caller-defined JSON schema. Browserless renders the page, AI maps content
   to your schema.
 category: web-scraping
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/summarize.yaml
+++ b/manifests/summarize.yaml
@@ -7,6 +7,8 @@ description: >-
   Summarize text into a concise format. Supports paragraph, bullet points, or one-sentence styles. Configurable max
   length.
 category: text-processing
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/terms-of-service-extract.yaml
+++ b/manifests/terms-of-service-extract.yaml
@@ -5,6 +5,8 @@ slug: terms-of-service-extract
 name: Terms of Service Extract
 description: "Extract key clauses from a company's Terms of Service: governing law, arbitration, termination, liability limitations."
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 30
 is_free_tier: false
 input_schema:

--- a/manifests/test-case-generate.yaml
+++ b/manifests/test-case-generate.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate test cases from a function description or signature. Includes happy path, edge cases, boundary tests, and
   error cases.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 15
 is_free_tier: false
 input_schema:

--- a/manifests/translate.yaml
+++ b/manifests/translate.yaml
@@ -7,6 +7,8 @@ description: >-
   Translate text between languages. Auto-detects source language. Supports all major languages. Returns translated text
   with confidence.
 category: text-processing
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/uk-company-data.yaml
+++ b/manifests/uk-company-data.yaml
@@ -7,6 +7,8 @@ description: >-
   Look up UK company data from Companies House. Accepts company number (8 digits) or fuzzy company name. Returns company
   name, status, incorporation date, SIC codes, registered address.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/us-company-data.yaml
+++ b/manifests/us-company-data.yaml
@@ -7,6 +7,8 @@ description: >-
   Look up US company data from SEC EDGAR. Accepts CIK number, ticker symbol, or fuzzy company name. Returns company
   name, CIK, SIC code, state, filings summary.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/web-extract.yaml
+++ b/manifests/web-extract.yaml
@@ -7,6 +7,8 @@ description: >-
   Extract structured data from any web page with full JavaScript rendering. Handles SPAs, dynamic content, and pages
   that require JS to load.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 15
 is_free_tier: false
 input_schema:

--- a/manifests/webhook-test-payload.yaml
+++ b/manifests/webhook-test-payload.yaml
@@ -7,6 +7,8 @@ description: >-
   Generate realistic test webhook payloads for Stripe, GitHub, Slack, Twilio, SendGrid, Shopify. Includes proper headers
   and schema-accurate data.
 category: developer-tools
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/website-to-company.yaml
+++ b/manifests/website-to-company.yaml
@@ -6,6 +6,8 @@ description: >-
   appropriate national registry. Returns registry data for 24 supported
   countries.
 category: company-data
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 80
 is_free_tier: false
 input_schema:

--- a/manifests/youtube-summarize.yaml
+++ b/manifests/youtube-summarize.yaml
@@ -4,6 +4,8 @@ description: >-
   Summarize a YouTube video from its auto-generated transcript. Returns summary,
   key points, topics, timestamps of interest, and sentiment classification.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 maintenance_class: scraping-fragile-target


### PR DESCRIPTION
## Summary

Implements **Phase B.3** of DEC-20260512-A — the largest single paid_prepaid cluster. Every capability reading \`process.env.ANTHROPIC_API_KEY\` classifies as \`paid_prepaid\`. Anthropic has no free tier, no quota, bills per token. Mechanical batch.

## Count: 83 caps

Audit filter (Python \`csv.DictReader\`): \`ANTHROPIC_API_KEY\` × \`paid_prepaid\` × \`confidence=high\`. The earlier bash awk shortcut returned 78 (CSV-parser limitation on quoted vendor fields with embedded commas); the correct count is 83. Within the chat-approved 50-100 range.

## Schema CHECK resolution

\`capabilities_quota_window_chk\` (from Block 0067): \`quota_window IS NULL OR IN ('daily', 'monthly', 'none')\`. No cross-column constraint on (cost_class, quota_window). **Chose \`quota_window = 'none'\`** for paid_prepaid for consistency with the free_unlimited convention (Block 0068 SK seed + Block 0071 + Block 0073). Semantic: "no quota window because the cap has no quota."

## Zero behavior change vs current state

Per DEC-20260503-B, these 83 caps already had \`scheduled_testing_eligible=FALSE\` via Block 0066's bridge derivation from \`external_cost_cents > 0\`. After B.3 the result stays FALSE; the source flips from \`external_cost_cents\` to \`cost_class\` via Block 0069's reconcile. No test signal lost. Dispatcher gate already refused \`internal_test\` via the \`NULL × internal_test = refuse\` (GRACE) rule; \`paid_prepaid × internal_test = refuse\` keeps the same outcome. Customer_paid: \`NULL × customer_paid = allow\` → \`paid_prepaid × customer_paid = allow\`. Customer traffic unaffected.

## Side effect: A0c.2b activates

First paid_prepaid classifications in production activate the **"Awaiting production traffic"** frontend badge for any cap with stale \`last_customer_call_at\`. Validates the entire A0c arc end-to-end against real fleet state.

## What this ships

- 83 manifest YAMLs (\`manifests/<slug>.yaml\`) get \`cost_class: paid_prepaid\` + \`quota_window: none\`.
- New \`apps/api/src/lib/phase-b3-anthropic-paid-prepaid-slugs.ts\` (slug list, same pattern as \`PHASE_B1_FREE_UNLIMITED_SLUGS\`).
- **Block 0074** in \`startup-migrations.ts\`: idempotent UPDATE via \`AND cost_class IS NULL\` safety filter.
- BLOCKS array + 7 new regression tests in \`startup-migrations.test.ts\`.

## CI lints

- **\`cost-class-coherence.mjs\`** (from Phase A0b commit #3): **clean.** Asserts every cap reading \`ANTHROPIC_API_KEY\` is classified as \`paid_prepaid\` or \`paid_subscription\`. The 83 new classifications validate.

## Tests

\`npx tsc --noEmit\`: clean.
\`npx vitest run\`: **618 passed / 16 skipped / 0 failed**.

New cases:
- Block 0074 first-run UPDATE shape (sample slugs serialized, SQL shape, safety filter present).
- Block 0074 idempotent re-run.
- Slug list invariants: 50-100 size, alphabetically sorted, no duplicates.
- **Cross-batch hygiene:** B.3 slug list does not overlap with B.1 / B.2 lists.

## Verification

Post-merge Railway log expected: \`0074_classify_anthropic_paid_prepaid outcome="classified 83 cap(s) as paid_prepaid (of 83 target slugs)" rows_affected=83\`.

Boot invariant expected: \`unclassified_count: 98 → ~15\` (delta 83).

**A0c.2b spot-check (operator action):**
- One classified cap with no recent customer traffic — open \`https://strale.dev/capabilities/<slug>\` in browser, expect "Awaiting production traffic" sub-label visible.
- One with recent customer traffic — same URL, expect normal display, no badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)