### PR TITLE
feat: classify 8 low-confidence free_quota caps (Phase B.4)

### DIFF
--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -58,6 +58,7 @@ import {
   runMigration0072_classifyFreeQuotaHighConfidence,
   runMigration0073_classifyFreeUnlimitedMediumConfidence,
   runMigration0074_classifyAnthropicPaidPrepaid,
+  runMigration0075_classifyFreeQuotaLowConfidence,
   runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
@@ -844,8 +845,115 @@ describe("startup-migrations — phase-b3 ANTHROPIC slug list (audit invariants)
   });
 });
 
+describe("startup-migrations — block 0075 (classify free_quota low-confidence)", () => {
+  it("first run: issues 8 per-cap UPDATEs with chat-supplied quota_cap values", async () => {
+    // Block 0075 runs 8 atomic UPDATEs (one per cap), each returning count=1.
+    const stub = makeStub({
+      queue: Array(8).fill({ count: 1 }),
+    });
+    const result = await runMigration0075_classifyFreeQuotaLowConfidence(stub);
+    expect(result.rows_affected).toBe(8);
+    expect(result.outcome).toMatch(/classified 8 cap/i);
+    expect(stub.captured).toHaveLength(8);
+
+    // Each UPDATE has the same shape: cost_class='free_quota', daily, per-cap cap.
+    const allSql = stub.renderedSql.join("\n").toLowerCase();
+    expect(allSql).toContain("cost_class = 'free_quota'");
+    expect(allSql).toContain("quota_window = 'daily'");
+    expect(allSql).toContain("quota_reset_dom = null");
+    // Idempotency clause on every UPDATE.
+    expect(stub.renderedSql.every((s) => /cost_class\s+is\s+null/i.test(s))).toBe(true);
+    // Per-cap quota_cap values surface in the rendered SQL (drizzle binds
+    // them; the rendered string includes $1-style placeholders, but the
+    // slug also surfaces as $2).
+    expect(stub.renderedSql.every((s) => /quota_cap\s*=\s*\$\d+/i.test(s))).toBe(true);
+  });
+
+  it("second run: all 8 UPDATEs return 0 rows; outcome reports already-classified", async () => {
+    const stub = makeStub({ queue: Array(8).fill({ count: 0 }) });
+    const result = await runMigration0075_classifyFreeQuotaLowConfidence(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to classify.*already have cost_class/i);
+    // SQL still issued (8 statements) — WHERE filter does the idempotency.
+    expect(stub.captured).toHaveLength(8);
+  });
+
+  it("safety filter pin — every UPDATE includes AND cost_class IS NULL", async () => {
+    const stub = makeStub({ queue: Array(8).fill({ count: 0 }) });
+    await runMigration0075_classifyFreeQuotaLowConfidence(stub);
+    for (const sqlText of stub.renderedSql) {
+      expect(sqlText.toLowerCase()).toMatch(/and\s+cost_class\s+is\s+null/);
+    }
+  });
+});
+
+describe("startup-migrations — phase-b4 low-conf free_quota cap list (invariants)", () => {
+  it("has exactly 8 entries (audit-pinned count)", async () => {
+    const { PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS } = await import("./startup-migrations.js");
+    expect(PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS.length).toBe(8);
+  });
+
+  it("every entry has valid shape (slug + quota_cap > 0)", async () => {
+    const { PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS } = await import("./startup-migrations.js");
+    for (const cap of PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS) {
+      expect(cap.slug).toMatch(/^[a-z][a-z0-9-]+$/);
+      expect(cap.quotaCap).toBeGreaterThan(0);
+    }
+  });
+
+  it("contains the 8 chat-supplied slugs", async () => {
+    const { PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS } = await import("./startup-migrations.js");
+    const slugs = PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS.map((c: { slug: string }) => c.slug).sort();
+    expect(slugs).toEqual([
+      "belgian-company-data",
+      "croatian-company-data",
+      "github-repo-compare",
+      "github-user-profile",
+      "greek-company-data",
+      "page-speed-test",
+      "swedish-company-data",
+      "us-court-search",
+    ]);
+  });
+
+  it("pins per-cap quota_cap values (chat-supplied authoritative table)", async () => {
+    const { PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS } = await import("./startup-migrations.js");
+    const byslug = Object.fromEntries(
+      PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS.map((c: { slug: string; quotaCap: number }) => [c.slug, c.quotaCap]),
+    );
+    // Pin the chat-researched quota caps so a future refactor that
+    // re-loads "audit defaults" can't silently regress these values.
+    expect(byslug["belgian-company-data"]).toBe(2500);
+    expect(byslug["croatian-company-data"]).toBe(500);
+    expect(byslug["github-repo-compare"]).toBe(1000);
+    expect(byslug["github-user-profile"]).toBe(1000);
+    expect(byslug["greek-company-data"]).toBe(500);
+    expect(byslug["page-speed-test"]).toBe(25000);
+    expect(byslug["swedish-company-data"]).toBe(1000);
+    expect(byslug["us-court-search"]).toBe(5000);
+  });
+
+  it("does not overlap with B.1 / B.2 / B.3 slug lists", async () => {
+    const { PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS, PHASE_B2_FREE_QUOTA_HIGH_CONF, PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF } = await import("./startup-migrations.js");
+    const { PHASE_B1_FREE_UNLIMITED_SLUGS } = await import("./phase-b1-free-unlimited-slugs.js");
+    const { PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS } = await import("./phase-b3-anthropic-paid-prepaid-slugs.js");
+
+    const b1 = new Set(PHASE_B1_FREE_UNLIMITED_SLUGS);
+    const b2a = new Set(PHASE_B2_FREE_QUOTA_HIGH_CONF.map((c: { slug: string }) => c.slug));
+    const b2b = new Set(PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF);
+    const b3 = new Set(PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS);
+
+    for (const cap of PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS) {
+      expect(b1.has(cap.slug), `${cap.slug} also in B.1`).toBe(false);
+      expect(b2a.has(cap.slug), `${cap.slug} also in B.2 free_quota`).toBe(false);
+      expect(b2b.has(cap.slug), `${cap.slug} also in B.2 free_unlimited`).toBe(false);
+      expect(b3.has(cap.slug), `${cap.slug} also in B.3 paid_prepaid`).toBe(false);
+    }
+  });
+});
+
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 17 blocks in historical order", () => {
+  it("exports the expected 18 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -869,6 +977,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0072_classifyFreeQuotaHighConfidence",
       "runMigration0073_classifyFreeUnlimitedMediumConfidence",
       "runMigration0074_classifyAnthropicPaidPrepaid",
+      "runMigration0075_classifyFreeQuotaLowConfidence",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1120,6 +1120,78 @@ export async function runMigration0074_classifyAnthropicPaidPrepaid(
   };
 }
 
+// ─── Block 0075: classify 8 low-confidence free_quota caps ──────────────────
+//
+// Phase B.4 of DEC-20260512-A. The Phase B.0 audit (2026-05-12) flagged
+// 8 caps as `free_quota` at low confidence — the heuristic identified
+// vendor-API + auth env var but couldn't pin per-window quota params
+// without vendor-doc research. Chat completed that research during B.1/B.2
+// prep and supplied authoritative override values (see PR body for source
+// rationale per cap).
+//
+// All 8 caps share quota_window='daily' + quota_reset_dom=NULL, so only
+// quota_cap varies. The 7 vendor patterns (CBEAPI, SUDREG, GITHUB,
+// GEMI, PAGESPEED, BOLAGSVERKET, COURTLISTENER) span 6 different vendors —
+// the GITHUB_TOKEN pattern covers 2 caps (github-repo-compare,
+// github-user-profile). swedish-company-data resolves to free_quota via
+// URL-based vendor identification: gw.api.bolagsverket.se is the
+// Värdefulla datamängder open-data API (free, OAuth client credentials,
+// rate-limited), NOT paid B2B (which uses different hostnames).
+//
+// Per-cap UPDATEs (8 atomic statements) because each cap has a different
+// quota_cap. Idempotent via `AND cost_class IS NULL` per cap.
+
+interface FreeQuotaLowConfCap {
+  slug: string;
+  quotaCap: number;
+}
+
+export const PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS: ReadonlyArray<FreeQuotaLowConfCap> = [
+  { slug: "belgian-company-data",  quotaCap: 2500 },   // cbeapi.be free tier
+  { slug: "croatian-company-data", quotaCap: 500 },    // sudreg-api.pravosudje.hr — conservative
+  { slug: "github-repo-compare",   quotaCap: 1000 },   // GitHub 5000/hour → conservative daily
+  { slug: "github-user-profile",   quotaCap: 1000 },   // GitHub 5000/hour → conservative daily
+  { slug: "greek-company-data",    quotaCap: 500 },    // GEMI Open Data — conservative
+  { slug: "page-speed-test",       quotaCap: 25000 },  // Google PSI documented 25k/day
+  { slug: "swedish-company-data",  quotaCap: 1000 },   // Bolagsverket Värdefulla datamängder
+  { slug: "us-court-search",       quotaCap: 5000 },   // CourtListener free tier per SDK docs
+];
+
+export async function runMigration0075_classifyFreeQuotaLowConfidence(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  let totalAffected = 0;
+
+  // Per-cap UPDATEs. Could be consolidated into one VALUES-clause UPDATE
+  // like Block 0072, but the per-cap loop keeps the SQL trivial and the
+  // diff readable for chat review of an 8-row batch with chat-supplied
+  // authoritative values.
+  for (const cap of PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS) {
+    const result = await tx.execute(sql`
+      UPDATE capabilities
+         SET cost_class = 'free_quota',
+             quota_window = 'daily',
+             quota_cap = ${cap.quotaCap},
+             quota_reset_dom = NULL,
+             updated_at = NOW()
+       WHERE slug = ${cap.slug}
+         AND cost_class IS NULL
+    `);
+    totalAffected += (result as { count?: number }).count ?? 0;
+  }
+
+  return {
+    block: "0075_classify_free_quota_low_confidence",
+    outcome:
+      totalAffected === 0
+        ? `no rows to classify (all ${PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS.length} slugs already have cost_class set)`
+        : `classified ${totalAffected} cap(s) as free_quota (of ${PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS.length} target slugs)`,
+    rows_affected: totalAffected,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -1148,6 +1220,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0072_classifyFreeQuotaHighConfidence,
   runMigration0073_classifyFreeUnlimitedMediumConfidence,
   runMigration0074_classifyAnthropicPaidPrepaid,
+  runMigration0075_classifyFreeQuotaLowConfidence,
 ];
 
 /**

--- a/manifests/belgian-company-data.yaml
+++ b/manifests/belgian-company-data.yaml
@@ -5,6 +5,9 @@ description: >-
   enterprise number (10 digits, e.g. 0404.616.494), VAT-prefixed form (BE0404170701), or fuzzy company name. Returns
   name, status, juridical form, address, registration date, establishment count, and derived BE VAT number.
 category: company-data
+cost_class: free_quota
+quota_window: daily
+quota_cap: 2500
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/croatian-company-data.yaml
+++ b/manifests/croatian-company-data.yaml
@@ -4,6 +4,9 @@ description: >-
   Look up Croatian company data from the Sudski registar (Ministry of Justice Court Register). Accepts OIB (11 digits)
   or MBS (court registry number). Returns company name, status, address, legal form, VAT.
 category: data-extraction
+cost_class: free_quota
+quota_window: daily
+quota_cap: 500
 price_cents: 80
 is_free_tier: false
 avg_latency_ms: 500

--- a/manifests/github-repo-compare.yaml
+++ b/manifests/github-repo-compare.yaml
@@ -7,6 +7,9 @@ description: >-
   Compare two GitHub repositories side-by-side: stars, forks, activity, language, topics, license. Returns detailed
   comparison.
 category: data-extraction
+cost_class: free_quota
+quota_window: daily
+quota_cap: 1000
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/github-user-profile.yaml
+++ b/manifests/github-user-profile.yaml
@@ -5,6 +5,9 @@ slug: github-user-profile
 name: GitHub User Profile
 description: Fetch a GitHub user's profile, stats, and recent repositories. Returns followers, repos, bio, and activity.
 category: data-extraction
+cost_class: free_quota
+quota_window: daily
+quota_cap: 1000
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/greek-company-data.yaml
+++ b/manifests/greek-company-data.yaml
@@ -5,6 +5,9 @@ description: >-
   Greek tax ID (AFM, 9 digits). Returns name, legal form, address, status, primary activity, directors, and the derived
   VAT number (EL + AFM).
 category: data-extraction
+cost_class: free_quota
+quota_window: daily
+quota_cap: 500
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/page-speed-test.yaml
+++ b/manifests/page-speed-test.yaml
@@ -7,6 +7,9 @@ description: >-
   Test page speed using Google PageSpeed Insights API. Returns performance score, Core Web Vitals, optimization
   opportunities.
 category: data-extraction
+cost_class: free_quota
+quota_window: daily
+quota_cap: 25000
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/swedish-company-data.yaml
+++ b/manifests/swedish-company-data.yaml
@@ -4,6 +4,9 @@ description: >-
   Look up Swedish company registry data via Bolagsverket's Värdefulla datamängder API. Returns name, legal form, status,
   registered address, SNI industry codes, registration date, and ongoing insolvency/liquidation procedures.
 category: company-data
+cost_class: free_quota
+quota_window: daily
+quota_cap: 1000
 price_cents: 5
 is_free_tier: false
 avg_latency_ms: 400

--- a/manifests/us-court-search.yaml
+++ b/manifests/us-court-search.yaml
@@ -5,6 +5,9 @@ description: >-
   number, and absolute URL. Elevates bankruptcy filings as top-level signals (has_bankruptcy_filing, bankruptcy_count,
   most_recent_bankruptcy) for risk decisioning. Federal district + appellate courts; no state-court coverage.
 category: compliance
+cost_class: free_quota
+quota_window: daily
+quota_cap: 5000
 price_cents: 15
 is_free_tier: false
 avg_latency_ms: 1500


### PR DESCRIPTION
## Summary

Implements **Phase B.4** of DEC-20260512-A — classifies the 8 caps flagged at low confidence in the Phase B.0 audit. Chat researched the 7 underlying vendor patterns and supplied authoritative quota values.

## Chat-supplied override table

| Slug | Env var | cost_class | quota_window | quota_cap | Source rationale |
|---|---|---|---|---|---|
| \`belgian-company-data\` | \`CBEAPI_KEY\` | free_quota | daily | 2500 | cbeapi.be free tier 2500/day; paid above. DEC-20260506-G blocks overage. |
| \`croatian-company-data\` | \`SUDREG_CLIENT_ID\` + \`SUDREG_CLIENT_SECRET\` | free_quota | daily | 500 | sudreg-api.pravosudje.hr — auth-gated free, no published quota. Conservative cap. |
| \`github-repo-compare\` | \`GITHUB_TOKEN\` | free_quota | daily | 1000 | 5000/hour authenticated → daily conservative approximation. |
| \`github-user-profile\` | \`GITHUB_TOKEN\` | free_quota | daily | 1000 | Same. |
| \`greek-company-data\` | \`GEMI_API_KEY\` | free_quota | daily | 500 | opendata-api.businessportal.gr; restricted access. Conservative. |
| \`page-speed-test\` | \`PAGESPEED_API_KEY\` | free_quota | daily | 25000 | Google PSI documented 25k/day. No paid tier exists. |
| \`swedish-company-data\` | \`BOLAGSVERKET_CLIENT_ID\` + \`_CLIENT_SECRET\` | free_quota | daily | 1000 | \`gw.api.bolagsverket.se\` Värdefulla datamängder open-data API. URL-confirmed not paid B2B. |
| \`us-court-search\` | \`COURTLISTENER_API_TOKEN\` | free_quota | daily | 5000 | Rate-limit model changed 2026-05-07; free tier 5000/day per SDK. |

## Bolagsverket resolution

Phase B.2 had explicitly carved out caps using \`BOLAGSVERKET_*\` env vars pending chat verification of access model. URL-based identification resolved: \`gw.api.bolagsverket.se\` is the Värdefulla datamängder open-data API gateway (free, OAuth client credentials, rate-limited), not paid B2B (which uses different hostnames). Safe to classify \`free_quota\`.

## What this ships

- 8 manifest YAMLs get \`cost_class: free_quota\`, \`quota_window: daily\`, \`quota_cap: <value>\`.
- **Block 0075** in \`startup-migrations.ts\`: 8 atomic per-cap UPDATEs (each cap has different \`quota_cap\`). Idempotent via \`AND cost_class IS NULL\`.
- BLOCKS array + 8 new regression tests in \`startup-migrations.test.ts\`.

## Behavior changes after deploy

- **Boot invariant:** \`unclassified_count\` drops 17 → ~9.
- **Scheduler:** All 8 caps gain \`scheduled_testing_eligible=TRUE\` via Block 0069's reconcile on next boot.
- **Dispatcher gate:** Internal_test transitions from "refuse (NULL)" to "budget_check (free_quota)". Scheduler can now test these 8 caps within 10%/20% of the daily quota.
- **Budget tracking activates:** Block 0070's \`capability_budget_counters\` table starts accumulating per-cap counters for these 8 caps.
- **Frontend display:** No impact — free_quota never triggers Awaiting-traffic badge.

## Tests

\`npx tsc --noEmit\`: clean.
\`npx vitest run\`: **626 passed / 16 skipped / 0 failed**.
\`check-cost-class-coherence.mjs\` lint: clean.

8 new test cases:
- Block 0075 first-run: 8 per-cap UPDATEs, correct shape, safety filter on every UPDATE.
- Block 0075 idempotent re-run.
- Block 0075 safety-filter pin.
- Slug-list invariants: exactly 8 entries, valid shapes, slug list match.
- **Per-cap quota_cap values pinned** (chat-supplied authoritative table — regression-resistant).
- No overlap with B.1 / B.2 / B.3 lists.

## Verification

Post-merge Railway log expected: \`0075_classify_free_quota_low_confidence outcome="classified 8 cap(s) as free_quota (of 8 target slugs)" rows_affected=8\`.

Spot-check via the catalog endpoint:
\`\`\`
curl -s https://api.strale.io/v1/capabilities/swedish-company-data | jq '{cost_class}'
curl -s https://api.strale.io/v1/capabilities/page-speed-test       | jq '{cost_class}'
curl -s https://api.strale.io/v1/capabilities/belgian-company-data  | jq '{cost_class}'
# all expected: {"cost_class":"free_quota"}
\`\`\`

## After this PR

Phase B remaining: ~12-14 paid_prepaid singletons (BROWSERLESS, SERPER, DILISENSE, etc.) + ~2 active-but-invisible caps. **One more batch closes Phase B and makes the COST_CLASS_MODE=STRICT flip viable.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)