### PR TITLE
feat: classify final non-Anthropic visible caps — closes Phase B (B.5)

### DIFF
--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -59,6 +59,8 @@ import {
   runMigration0073_classifyFreeUnlimitedMediumConfidence,
   runMigration0074_classifyAnthropicPaidPrepaid,
   runMigration0075_classifyFreeQuotaLowConfidence,
+  runMigration0076_classifyNonAnthropicPaidPrepaid,
+  runMigration0077_classifyFreeQuotaOverrides,
   runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
@@ -952,8 +954,130 @@ describe("startup-migrations — phase-b4 low-conf free_quota cap list (invarian
   });
 });
 
+describe("startup-migrations — block 0076 (classify non-Anthropic paid_prepaid)", () => {
+  it("first run: UPDATEs DB-present slugs to paid_prepaid (orphans skipped by cost_class IS NULL+absent-row filter)", async () => {
+    // 7 DB-present caps update; 3 orphans return 0 rows (slug doesn't exist).
+    // The stub doesn't model the orphan-missing behavior, so we assert
+    // the SQL shape covers all 10 + the safety filter is present.
+    const stub = makeStub({ queue: [{ count: 7 }] });
+    const result = await runMigration0076_classifyNonAnthropicPaidPrepaid(stub);
+    expect(result.rows_affected).toBe(7);
+    expect(result.outcome).toMatch(/classified 7 cap/i);
+
+    const sqlText = stub.renderedSql[0].toLowerCase();
+    expect(sqlText).toContain("cost_class = 'paid_prepaid'");
+    expect(sqlText).toContain("quota_window = 'none'");
+    expect(sqlText).toContain("quota_cap = null");
+    // All 10 slugs (including orphans) in the IN-list.
+    expect(sqlText).toContain("'adverse-media-check'");
+    expect(sqlText).toContain("'sanctions-check'");
+    expect(sqlText).toContain("'google-search'");
+    expect(sqlText).toContain("'uk-cop-check'");
+    expect(sqlText).toContain("'us-company-data-cobalt'");   // orphan
+    expect(sqlText).toContain("'us-ein-match'");              // orphan
+    expect(sqlText).toContain("'us-sec-filings-extended'");   // orphan
+    // Idempotency clause.
+    expect(sqlText).toContain("cost_class is null");
+  });
+
+  it("second run: idempotent — count=0; outcome reports already-classified", async () => {
+    const stub = makeStub({ queue: [{ count: 0 }] });
+    const result = await runMigration0076_classifyNonAnthropicPaidPrepaid(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to classify/i);
+  });
+
+  it("safety filter pin — UPDATE includes AND cost_class IS NULL", async () => {
+    const stub = makeStub({ queue: [{ count: 0 }] });
+    await runMigration0076_classifyNonAnthropicPaidPrepaid(stub);
+    const sqlText = stub.renderedSql[0].toLowerCase();
+    expect(sqlText).toMatch(/and\s+cost_class\s+is\s+null/);
+  });
+});
+
+describe("startup-migrations — block 0077 (free_quota overrides — BAG + EP-Online)", () => {
+  it("first run: per-cap UPDATEs with chat-supplied quota_cap values", async () => {
+    const stub = makeStub({ queue: Array(2).fill({ count: 1 }) });
+    const result = await runMigration0077_classifyFreeQuotaOverrides(stub);
+    expect(result.rows_affected).toBe(2);
+    expect(result.outcome).toMatch(/classified 2 cap/i);
+    expect(stub.captured).toHaveLength(2);
+
+    const allSql = stub.renderedSql.join("\n").toLowerCase();
+    expect(allSql).toContain("cost_class = 'free_quota'");
+    expect(allSql).toContain("quota_window = 'daily'");
+    expect(allSql).toContain("quota_reset_dom = null");
+    expect(stub.renderedSql.every((s) => /cost_class\s+is\s+null/i.test(s))).toBe(true);
+  });
+
+  it("second run: idempotent — both UPDATEs return 0", async () => {
+    const stub = makeStub({ queue: Array(2).fill({ count: 0 }) });
+    const result = await runMigration0077_classifyFreeQuotaOverrides(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no rows to classify/i);
+  });
+});
+
+describe("startup-migrations — phase-b5 slug lists (invariants)", () => {
+  it("PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS has the expected 10 entries", async () => {
+    const { PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS } = await import("./startup-migrations.js");
+    expect(PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS.length).toBeGreaterThanOrEqual(7);
+    expect(PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS.length).toBeLessThanOrEqual(10);
+    // Pin the chat-supplied slug set for regression resistance.
+    const sorted = [...PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS].sort();
+    expect(sorted).toEqual([
+      "adverse-media-check",
+      "backlink-check",
+      "google-search",
+      "pep-check",
+      "sanctions-check",
+      "serp-analyze",
+      "uk-cop-check",
+      "us-company-data-cobalt",
+      "us-ein-match",
+      "us-sec-filings-extended",
+    ]);
+  });
+
+  it("PHASE_B5_FREE_QUOTA_OVERRIDE_CAPS has exactly 2 entries with pinned values", async () => {
+    const { PHASE_B5_FREE_QUOTA_OVERRIDE_CAPS } = await import("./startup-migrations.js");
+    expect(PHASE_B5_FREE_QUOTA_OVERRIDE_CAPS.length).toBe(2);
+    const byslug = Object.fromEntries(
+      PHASE_B5_FREE_QUOTA_OVERRIDE_CAPS.map((c: { slug: string; quotaCap: number }) => [c.slug, c.quotaCap]),
+    );
+    expect(byslug["nl-bag-address"]).toBe(50000);
+    expect(byslug["nl-energy-label"]).toBe(1000);
+  });
+
+  it("B.5 slug lists do not overlap with B.1 / B.2 / B.3 / B.4", async () => {
+    const { PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS, PHASE_B5_FREE_QUOTA_OVERRIDE_CAPS,
+            PHASE_B2_FREE_QUOTA_HIGH_CONF, PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF,
+            PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS } = await import("./startup-migrations.js");
+    const { PHASE_B1_FREE_UNLIMITED_SLUGS } = await import("./phase-b1-free-unlimited-slugs.js");
+    const { PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS } = await import("./phase-b3-anthropic-paid-prepaid-slugs.js");
+
+    const b1 = new Set(PHASE_B1_FREE_UNLIMITED_SLUGS);
+    const b2a = new Set(PHASE_B2_FREE_QUOTA_HIGH_CONF.map((c: { slug: string }) => c.slug));
+    const b2b = new Set(PHASE_B2_FREE_UNLIMITED_MEDIUM_CONF);
+    const b3 = new Set(PHASE_B3_ANTHROPIC_PAID_PREPAID_SLUGS);
+    const b4 = new Set(PHASE_B4_FREE_QUOTA_LOW_CONF_CAPS.map((c: { slug: string }) => c.slug));
+
+    const allB5 = [
+      ...PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS,
+      ...PHASE_B5_FREE_QUOTA_OVERRIDE_CAPS.map((c: { slug: string }) => c.slug),
+    ];
+    for (const slug of allB5) {
+      expect(b1.has(slug), `${slug} also in B.1`).toBe(false);
+      expect(b2a.has(slug), `${slug} also in B.2 free_quota`).toBe(false);
+      expect(b2b.has(slug), `${slug} also in B.2 free_unlimited`).toBe(false);
+      expect(b3.has(slug), `${slug} also in B.3`).toBe(false);
+      expect(b4.has(slug), `${slug} also in B.4`).toBe(false);
+    }
+  });
+});
+
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 18 blocks in historical order", () => {
+  it("exports the expected 20 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -978,6 +1102,8 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0073_classifyFreeUnlimitedMediumConfidence",
       "runMigration0074_classifyAnthropicPaidPrepaid",
       "runMigration0075_classifyFreeQuotaLowConfidence",
+      "runMigration0076_classifyNonAnthropicPaidPrepaid",
+      "runMigration0077_classifyFreeQuotaOverrides",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1192,6 +1192,128 @@ export async function runMigration0075_classifyFreeQuotaLowConfidence(
   };
 }
 
+// ─── Block 0076: classify 10 non-Anthropic paid_prepaid caps ────────────────
+//
+// Phase B.5 of DEC-20260512-A. Final paid_prepaid batch. 7 caps are
+// DB-present (the boot invariant's 9 visible unclassified rows = these
+// 7 + the 2 in Block 0077). 3 caps are code-but-not-DB orphans
+// (us-company-data-cobalt, us-ein-match, us-sec-filings-extended) —
+// they have executor files calling registerCapability AND manifest
+// files BUT no DB rows, suggesting onboard.ts was never run for them.
+// They're included in this slug list so when chat fixes their
+// onboarding the UPDATE classifies them on next boot via idempotency
+// (`AND cost_class IS NULL`).
+//
+// Vendor breakdown:
+//   - Dilisense (3): adverse-media-check, pep-check, sanctions-check
+//   - Serper.dev (3): backlink-check, google-search, serp-analyze
+//   - eSortcode (1): uk-cop-check  (Pay.UK CoP commercial bank verification)
+//   - Cobalt Intelligence (1): us-company-data-cobalt  [orphan]
+//   - Liberty Data EINsearch (1): us-ein-match  [orphan]
+//   - sec-api.io (1): us-sec-filings-extended  [orphan; 100-call trial only]
+//
+// All 10 ship paid_prepaid / quota_window='none' / quota_cap=NULL /
+// quota_reset_dom=NULL (same shape as Block 0074's Anthropic batch).
+
+export const PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS: ReadonlyArray<string> = [
+  "adverse-media-check",
+  "backlink-check",
+  "google-search",
+  "pep-check",
+  "sanctions-check",
+  "serp-analyze",
+  "uk-cop-check",
+  "us-company-data-cobalt",
+  "us-ein-match",
+  "us-sec-filings-extended",
+];
+
+export async function runMigration0076_classifyNonAnthropicPaidPrepaid(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const result = await tx.execute(sql`
+    UPDATE capabilities
+       SET cost_class = 'paid_prepaid',
+           quota_window = 'none',
+           quota_cap = NULL,
+           quota_reset_dom = NULL,
+           updated_at = NOW()
+     WHERE slug IN ${sql.raw("(" + PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS.map((s) => `'${s.replace(/'/g, "''")}'`).join(",") + ")")}
+       AND cost_class IS NULL
+  `);
+  const updateCount = (result as { count?: number }).count ?? 0;
+
+  return {
+    block: "0076_classify_non_anthropic_paid_prepaid",
+    outcome:
+      updateCount === 0
+        ? `no rows to classify (all ${PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS.length} slugs already classified or 3 orphan slugs not in DB)`
+        : `classified ${updateCount} cap(s) as paid_prepaid (of ${PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS.length} target slugs; 3 orphans excluded by DB filter)`,
+    rows_affected: updateCount,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+// ─── Block 0077: classify 2 free_quota caps that override audit's paid heuristic ──
+//
+// Phase B.5 sibling. The Phase B.0 audit's heuristic classified these
+// 2 Dutch gov vendors as paid_prepaid because their maintenance_class
+// is `commercial-stable-api`. Chat research confirmed both are
+// gov-operated free APIs with auth-gated rate-limited access (NOT paid
+// commercial APIs as the heuristic assumed):
+//
+//   - nl-bag-address: Kadaster BAG API Individuele Bevragingen,
+//     documented free at 50k/day. URL api.bag.kadaster.nl matches.
+//   - nl-energy-label: RVO/EP-Online gov free with API-key auth,
+//     no published quota. Conservative cap 1000/day matches the
+//     SUDREG/GEMI posture used in Block 0075.
+//
+// Per-cap UPDATEs (same pattern as Block 0075). Idempotent via
+// `AND cost_class IS NULL`.
+
+interface FreeQuotaOverrideCap {
+  slug: string;
+  quotaCap: number;
+}
+
+export const PHASE_B5_FREE_QUOTA_OVERRIDE_CAPS: ReadonlyArray<FreeQuotaOverrideCap> = [
+  { slug: "nl-bag-address",  quotaCap: 50000 }, // Kadaster BAG documented 50k/day
+  { slug: "nl-energy-label", quotaCap: 1000 },  // EP-Online conservative cap
+];
+
+export async function runMigration0077_classifyFreeQuotaOverrides(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  let totalAffected = 0;
+
+  for (const cap of PHASE_B5_FREE_QUOTA_OVERRIDE_CAPS) {
+    const result = await tx.execute(sql`
+      UPDATE capabilities
+         SET cost_class = 'free_quota',
+             quota_window = 'daily',
+             quota_cap = ${cap.quotaCap},
+             quota_reset_dom = NULL,
+             updated_at = NOW()
+       WHERE slug = ${cap.slug}
+         AND cost_class IS NULL
+    `);
+    totalAffected += (result as { count?: number }).count ?? 0;
+  }
+
+  return {
+    block: "0077_classify_free_quota_overrides",
+    outcome:
+      totalAffected === 0
+        ? `no rows to classify (all ${PHASE_B5_FREE_QUOTA_OVERRIDE_CAPS.length} slugs already classified)`
+        : `classified ${totalAffected} cap(s) as free_quota (of ${PHASE_B5_FREE_QUOTA_OVERRIDE_CAPS.length} target slugs)`,
+    rows_affected: totalAffected,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -1221,6 +1343,8 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0073_classifyFreeUnlimitedMediumConfidence,
   runMigration0074_classifyAnthropicPaidPrepaid,
   runMigration0075_classifyFreeQuotaLowConfidence,
+  runMigration0076_classifyNonAnthropicPaidPrepaid,
+  runMigration0077_classifyFreeQuotaOverrides,
 ];
 
 /**

--- a/manifests/adverse-media-check.yaml
+++ b/manifests/adverse-media-check.yaml
@@ -6,6 +6,8 @@ description: >-
   documented thresholds, FATF-aligned category counts, top article headlines with source URLs and
   dates, and the rule used to classify severe vs non-severe coverage.
 category: compliance
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/backlink-check.yaml
+++ b/manifests/backlink-check.yaml
@@ -7,6 +7,8 @@ description: >-
   Check backlinks for a domain via CommonCrawl and Google search. Returns linking domains, anchor text,
   dofollow/nofollow counts.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 15
 is_free_tier: false
 input_schema:

--- a/manifests/google-search.yaml
+++ b/manifests/google-search.yaml
@@ -5,6 +5,8 @@ slug: google-search
 name: Google Search
 description: Perform a Google search and return structured results. Returns title, URL, snippet, position for each result.
 category: web-scraping
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 10
 is_free_tier: false
 input_schema:

--- a/manifests/nl-bag-address.yaml
+++ b/manifests/nl-bag-address.yaml
@@ -4,6 +4,9 @@ description: >-
   Look up Dutch address and building data from the BAG (Basisregistratie Adressen en Gebouwen) via Kadaster API.
   Returns street, city, construction year, floor area, usage purposes, and RD coordinates (EPSG:28992).
 category: data-extraction
+cost_class: free_quota
+quota_window: daily
+quota_cap: 50000
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/nl-energy-label.yaml
+++ b/manifests/nl-energy-label.yaml
@@ -4,6 +4,9 @@ description: >-
   Look up Dutch energy performance labels (energielabel) from EP-Online REST API v5. Returns energy class (A–G), energy
   index, CO2 emissions, building details, and validity.
 category: data-extraction
+cost_class: free_quota
+quota_window: daily
+quota_cap: 1000
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/pep-check.yaml
+++ b/manifests/pep-check.yaml
@@ -6,6 +6,8 @@ description: >-
   and includes Relatives and Close Associates (RCAs). Returns audit-grade evidence: match results
   with classification, position history, jurisdictions, and named source attribution.
 category: compliance
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 5
 is_free_tier: false
 input_schema:

--- a/manifests/sanctions-check.yaml
+++ b/manifests/sanctions-check.yaml
@@ -5,6 +5,8 @@ description: >-
   Bank, EBRD, ADB + 125 national lists). Uses Dilisense consolidated database. Returns audit-grade
   evidence: match results with named source attribution and country attribution.
 category: compliance
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 20
 is_free_tier: false
 input_schema:

--- a/manifests/serp-analyze.yaml
+++ b/manifests/serp-analyze.yaml
@@ -7,6 +7,8 @@ description: >-
   Analyze Google search results for a keyword. Returns organic results, featured snippet, People Also Ask, SERP
   features.
 category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 15
 is_free_tier: false
 input_schema:

--- a/manifests/uk-cop-check.yaml
+++ b/manifests/uk-cop-check.yaml
@@ -6,6 +6,8 @@ description: >-
   cop_code (14 codes), modulus check, bank name, and the registered name when a close_match is returned. Implementation
   via eSortcode (Pay.UK CoP scheme participant).
 category: compliance
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 25
 is_free_tier: false
 avg_latency_ms: 1500

--- a/manifests/us-company-data-cobalt.yaml
+++ b/manifests/us-company-data-cobalt.yaml
@@ -7,6 +7,8 @@ description: >-
   registered agent, officers, and filings history. Distinct from the SEC-EDGAR-only us-company-data
   capability.
 category: company-data
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 200
 is_free_tier: false
 avg_latency_ms: 3000

--- a/manifests/us-ein-match.yaml
+++ b/manifests/us-ein-match.yaml
@@ -6,6 +6,8 @@ description: >-
   (optionally constrained by state). Returns business name, status, formed state, address, and
   match score for name searches.
 category: compliance
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 75
 is_free_tier: false
 avg_latency_ms: 800

--- a/manifests/us-sec-filings-extended.yaml
+++ b/manifests/us-sec-filings-extended.yaml
@@ -6,6 +6,8 @@ description: >-
   type and date. Supplements the free SEC EDGAR API used by us-company-data with full-text search,
   cross-form aggregation, and filing-event monitoring.
 category: compliance
+cost_class: paid_prepaid
+quota_window: none
 price_cents: 25
 is_free_tier: false
 avg_latency_ms: 1500


### PR DESCRIPTION
## Summary

Implements the **final batch** of DEC-20260512-A's Phase B. Two blocks in one PR; afterwards visible unclassified count = 0 and **the STRICT-mode flip is unblocked**.

## Audit reconciliation

The Phase B.0 audit flagged 12 non-Anthropic paid_prepaid rows. DB visibility check:

| Status | Count | Slugs |
|---|---|---|
| Visible in DB | 9 | adverse-media-check, backlink-check, google-search, nl-bag-address, nl-energy-label, pep-check, sanctions-check, serp-analyze, uk-cop-check |
| Code-but-not-DB orphans | 3 | us-company-data-cobalt, us-ein-match, us-sec-filings-extended |

**Orphans:** executor files call \`registerCapability\` + manifest files exist, but no DB rows. \`onboard.ts\` was never run for them. Included in Block 0076's slug list anyway — when chat fixes their onboarding, the UPDATE classifies them on next boot via idempotency. Block 0076's first apply UPDATEs 7 rows; the 3 orphans are no-ops.

## Block 0076 — 10 paid_prepaid

| slug | env_var | vendor |
|---|---|---|
| \`adverse-media-check\` | DILISENSE_API_KEY | Dilisense Adverse Media |
| \`pep-check\` | DILISENSE_API_KEY | Dilisense PEP |
| \`sanctions-check\` | DILISENSE_API_KEY | Dilisense Sanctions |
| \`backlink-check\` | SERPER_API_KEY | Serper.dev + CommonCrawl |
| \`google-search\` | SERPER_API_KEY | Serper.dev Google Search |
| \`serp-analyze\` | SERPER_API_KEY | Serper.dev SERP analysis |
| \`uk-cop-check\` | ESORTCODE_API_KEY | Pay.UK CoP via eSortcode |
| \`us-company-data-cobalt\` | COBALT_API_KEY | Cobalt Intelligence (orphan) |
| \`us-ein-match\` | EINSEARCH_API_KEY | Liberty Data EINsearch (orphan) |
| \`us-sec-filings-extended\` | SEC_API_IO_TOKEN | sec-api.io (orphan; 100-call trial only) |

All 10 ship paid_prepaid / quota_window='none' / quota_cap=NULL.

## Block 0077 — 2 free_quota overrides (chat-supplied)

| slug | env_var | quota_window | quota_cap | Override rationale |
|---|---|---|---|---|
| \`nl-bag-address\` | BAG_API_KEY | daily | 50000 | Kadaster BAG Individuele Bevragingen documented free at 50k/day. URL \`api.bag.kadaster.nl\` matches the free path (not paid B2B). |
| \`nl-energy-label\` | EP_ONLINE_API_KEY | daily | 1000 | RVO/EP-Online gov free with API-key auth; no published quota. Conservative cap matches SUDREG/GEMI posture. |

Both override the audit's heuristic. The heuristic classified them as paid_prepaid because \`maintenance_class=commercial-stable-api\`, but both are gov-operated free APIs with auth-gated rate-limited access.

## Phase B closing state

| Metric | At A0b cutover | After B.5 |
|---|---|---|
| Visible unclassified | 289 | **0** (100% reduction) |
| Classified | 0 | 297 |
| Active-but-orphan (not in DB) | — | 3 (separate cleanup) |

The STRICT-mode flip (\`COST_CLASS_MODE=GRACE\` → \`STRICT\` in Railway env) is unblocked from the data side. One-prompt configuration change closes the Phase A → Phase B workstream that began with the DE/DK scheduler-quota-burn investigation on 2026-05-11 (Journal entry \`35d67c87082c812ba68ec4e424f8cad1\`).

## Tests

\`npx tsc --noEmit\`: clean.
\`npx vitest run\`: **634 passed / 16 skipped / 0 failed**.
\`check-cost-class-coherence.mjs\` lint: clean.

9 new test cases:
- Block 0076 first-run + sample slugs (incl. orphans) + safety filter + idempotent re-run + safety-filter pin.
- Block 0077 first-run + per-cap UPDATEs + idempotent re-run.
- B.5 slug list pinned by exact set + quotaCap values pinned + non-overlap with B.1/B.2/B.3/B.4.

## Verification

Post-merge Railway logs expected:
- \`0076_classify_non_anthropic_paid_prepaid outcome="classified 7 cap(s) as paid_prepaid (of 10 target slugs; 3 orphans excluded by DB filter)" rows_affected=7\`
- \`0077_classify_free_quota_overrides outcome="classified 2 cap(s) as free_quota (of 2 target slugs)" rows_affected=2\`

Boot invariant expected: \`unclassified_count=0\` (was 9).

Spot-checks:
\`\`\`
curl -s https://api.strale.io/v1/capabilities/nl-bag-address    | jq '{cost_class}'
curl -s https://api.strale.io/v1/capabilities/nl-energy-label   | jq '{cost_class}'
curl -s https://api.strale.io/v1/capabilities/sanctions-check   | jq '{cost_class}'
curl -s https://api.strale.io/v1/capabilities/uk-cop-check      | jq '{cost_class}'
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)