### PR TITLE
fix(a0c-1.v3): include cost_class + last_customer_call_at in list endpoint

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -317,6 +317,15 @@ export const transactions = pgTable(
       .where(sql`idempotency_key IS NOT NULL`),
     index("transactions_user_id_idx").on(table.userId),
     index("transactions_status_idx").on(table.status),
+    // Phase A0c.1.v3 (Block 0078, 2026-05-13): compound index for the
+    // list-endpoint GROUP BY MAX(created_at) per capability_id. The
+    // detail handler's per-cap query (capabilities.ts:136-144) ALSO
+    // benefits — previously seq-scanned the status='completed' filter
+    // set looking for one capability_id.
+    index("transactions_capability_id_created_at_idx").on(
+      table.capabilityId,
+      table.createdAt,
+    ),
     // Cert-audit C9: x402 payment-header dedup. Partial index so wallet
     // rows (NULL) don't compete for slots; uniqueness keeps two distinct
     // requests with the same X-Payment header from each becoming a

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -61,6 +61,7 @@ import {
   runMigration0075_classifyFreeQuotaLowConfidence,
   runMigration0076_classifyNonAnthropicPaidPrepaid,
   runMigration0077_classifyFreeQuotaOverrides,
+  runMigration0078_transactionsCapabilityIdCreatedAtIdx,
   runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
@@ -1077,7 +1078,7 @@ describe("startup-migrations — phase-b5 slug lists (invariants)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 20 blocks in historical order", () => {
+  it("exports the expected 21 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1104,7 +1105,36 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0075_classifyFreeQuotaLowConfidence",
       "runMigration0076_classifyNonAnthropicPaidPrepaid",
       "runMigration0077_classifyFreeQuotaOverrides",
+      "runMigration0078_transactionsCapabilityIdCreatedAtIdx",
     ]);
+  });
+});
+
+describe("startup-migrations — block 0078 (transactions capability_id index)", () => {
+  it("emits CREATE INDEX IF NOT EXISTS for the compound index", async () => {
+    const stub = makeStub({ queue: [undefined] });
+    const result = await runMigration0078_transactionsCapabilityIdCreatedAtIdx(stub);
+    expect(result.outcome).toMatch(/compound index ensured/i);
+    expect(stub.captured).toHaveLength(1);
+
+    const sqlText = stub.renderedSql[0].toLowerCase();
+    expect(sqlText).toContain("create index if not exists");
+    expect(sqlText).toContain("transactions_capability_id_created_at_idx");
+    expect(sqlText).toContain("transactions");
+    expect(sqlText).toContain("capability_id");
+    expect(sqlText).toContain("created_at");
+  });
+
+  it("idempotent re-run: IF NOT EXISTS makes re-runs a Postgres-level no-op", async () => {
+    const stub = makeStub({ queue: [undefined, undefined] });
+    await runMigration0078_transactionsCapabilityIdCreatedAtIdx(stub);
+    const result = await runMigration0078_transactionsCapabilityIdCreatedAtIdx(stub);
+    expect(result.outcome).toMatch(/compound index ensured/i);
+    // Both runs issue the IF NOT EXISTS statement; PG handles the actual no-op.
+    expect(stub.captured).toHaveLength(2);
+    for (const sqlText of stub.renderedSql) {
+      expect(sqlText.toLowerCase()).toContain("create index if not exists");
+    }
   });
 });
 

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1314,6 +1314,39 @@ export async function runMigration0077_classifyFreeQuotaOverrides(
   };
 }
 
+// ─── Block 0078: transactions(capability_id, created_at) compound index ────
+//
+// Phase A0c.1.v3 (2026-05-13). The list-endpoint extension for
+// last_customer_call_at runs `SELECT capability_id, MAX(created_at) FROM
+// transactions WHERE status='completed' AND user filter GROUP BY
+// capability_id`. Without an index on (capability_id, created_at), this
+// degrades from index-only aggregate to status-filter-scan + in-memory
+// hash aggregate. Fine at pre-launch scale (<10k transactions); degrades
+// linearly as the table grows.
+//
+// The detail handler's per-cap query (capabilities.ts:136-144) ALSO
+// benefits — previously it seq-scanned the status='completed' filter set
+// looking for one capability_id; now it can index-seek directly.
+//
+// Idempotency: CREATE INDEX IF NOT EXISTS. Re-runs are no-ops.
+
+export async function runMigration0078_transactionsCapabilityIdCreatedAtIdx(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS transactions_capability_id_created_at_idx
+      ON transactions (capability_id, created_at)
+  `);
+
+  return {
+    block: "0078_transactions_capability_id_created_at_idx",
+    outcome: "compound index ensured on transactions(capability_id, created_at)",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -1345,6 +1378,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0075_classifyFreeQuotaLowConfidence,
   runMigration0076_classifyNonAnthropicPaidPrepaid,
   runMigration0077_classifyFreeQuotaOverrides,
+  runMigration0078_transactionsCapabilityIdCreatedAtIdx,
 ];
 
 /**

--- a/apps/api/src/routes/capabilities.integration.test.ts
+++ b/apps/api/src/routes/capabilities.integration.test.ts
@@ -201,3 +201,163 @@ describeMaybe("GET /v1/capabilities/:slug — cost_class + last_customer_call_at
     );
   });
 });
+
+// ─── Phase A0c.1.v3 (2026-05-13): list-endpoint regression tests ────────────
+//
+// Diagnostic surfaced 2026-05-12 ~22:00 UTC: A0c.1.v2 (PR #96/#97) extended
+// only the detail handler. The frontend's `useCapability(slug)` filters
+// `useCapabilities()` locally, so both detail + list surfaces depended on
+// the list endpoint's shape. Missing `cost_class` + `last_customer_call_at`
+// on the list response → A0c.2b's badge silently failed everywhere.
+//
+// These three tests mirror the canonical production failure mode
+// (paid_prepaid + null) so a future refactor that drops the new fields
+// from the list serializer trips immediately.
+describeMaybe("GET /v1/capabilities (LIST) — cost_class + last_customer_call_at", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let systemUserId: string;
+  const createdCapabilityIds: string[] = [];
+  const createdUserIds: string[] = [];
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 2 });
+    db = drizzle(client);
+    const sys = await client`
+      INSERT INTO users (id, email, api_key_hash, key_prefix)
+      VALUES (gen_random_uuid(), 'system@strale.internal', ${`test-system-${randomUUID()}`}, ${`sys_${randomUUID().slice(0, 8)}`})
+      ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email
+      RETURNING id
+    `;
+    systemUserId = sys[0].id;
+  });
+
+  afterAll(async () => {
+    await client.end({ timeout: 2 });
+  });
+
+  afterEach(async () => {
+    if (createdCapabilityIds.length > 0) {
+      await client`DELETE FROM transactions WHERE capability_id IN ${client(createdCapabilityIds)}`;
+      await client`DELETE FROM capabilities WHERE id IN ${client(createdCapabilityIds)}`;
+      createdCapabilityIds.length = 0;
+    }
+    if (createdUserIds.length > 0) {
+      await client`DELETE FROM users WHERE id IN ${client(createdUserIds)}`;
+      createdUserIds.length = 0;
+    }
+  });
+
+  async function seedListCap(opts: { costClass: string | null }): Promise<{ id: string; slug: string }> {
+    const slug = `test-list-${randomUUID().slice(0, 8)}`;
+    const id = randomUUID();
+    await db.insert(capabilities).values({
+      id,
+      slug,
+      name: `Test ${slug}`,
+      description: "Integration test capability for Phase A0c.1.v3 list-endpoint regression.",
+      category: "validation",
+      inputSchema: { type: "object", properties: {} },
+      outputSchema: { type: "object", properties: {} },
+      priceCents: 0,
+      isActive: true,
+      marketplaceEligible: true,
+      lifecycleState: "active",
+      visible: true,
+      costClass: opts.costClass,
+    });
+    createdCapabilityIds.push(id);
+    return { id, slug };
+  }
+
+  async function seedCustomerUser(): Promise<string> {
+    const id = randomUUID();
+    await db.insert(users).values({
+      id,
+      email: `customer-${randomUUID().slice(0, 8)}@example.com`,
+      apiKeyHash: `test-key-${randomUUID()}`,
+      keyPrefix: `cust_${randomUUID().slice(0, 8)}`,
+    });
+    createdUserIds.push(id);
+    return id;
+  }
+
+  async function seedTxn(opts: {
+    capabilityId: string;
+    userId: string | null;
+    createdAt: Date;
+    status?: "completed" | "failed" | "pending";
+  }): Promise<void> {
+    await db.insert(transactions).values({
+      capabilityId: opts.capabilityId,
+      userId: opts.userId,
+      status: opts.status ?? "completed",
+      input: {},
+      priceCents: 0,
+      completedAt: opts.createdAt,
+      createdAt: opts.createdAt,
+    });
+  }
+
+  async function fetchListBySlug(slug: string): Promise<Record<string, unknown> | undefined> {
+    const res = await capabilitiesRoute.request("/");
+    expect(res.status, `expected 200 for /, got ${res.status}`).toBe(200);
+    const body = (await res.json()) as { capabilities: Array<Record<string, unknown>> };
+    return body.capabilities.find((c) => c.slug === slug);
+  }
+
+  // ── 1. CANONICAL PRODUCTION FAILURE MODE ──────────────────────────────────
+  // paid_prepaid cap with no transactions: list endpoint must emit
+  // cost_class='paid_prepaid' AND last_customer_call_at=null. This is the
+  // exact agent-trace-analyze case that surfaced the bug 2026-05-12 — both
+  // fields had to be present in the LIST response for the frontend's badge
+  // to fire, because useCapability(slug) filters the list locally.
+  it("emits cost_class and last_customer_call_at=null for paid_prepaid cap with no transactions", async () => {
+    const { slug } = await seedListCap({ costClass: "paid_prepaid" });
+    const cap = await fetchListBySlug(slug);
+    expect(cap, `expected cap '${slug}' in list response`).toBeDefined();
+    expect(cap).toHaveProperty("cost_class");
+    expect(cap!.cost_class).toBe("paid_prepaid");
+    expect(cap).toHaveProperty("last_customer_call_at");
+    expect(cap!.last_customer_call_at).toBeNull();
+  });
+
+  // ── 2. paid_prepaid WITH a customer_paid transaction ──────────────────────
+  // The MAX(created_at) GROUP BY aggregation must return the transaction's
+  // created_at on the list endpoint, not null. Mirrors the detail handler's
+  // existing test #3 against the new batched query path.
+  it("returns the customer transaction's created_at for paid_prepaid cap with traffic", async () => {
+    const { id, slug } = await seedListCap({ costClass: "paid_prepaid" });
+    const customerId = await seedCustomerUser();
+    const txnTime = new Date("2026-05-13T08:00:00Z");
+    await seedTxn({ capabilityId: id, userId: customerId, createdAt: txnTime });
+    const cap = await fetchListBySlug(slug);
+    expect(cap).toBeDefined();
+    expect(cap!.cost_class).toBe("paid_prepaid");
+    expect(cap!.last_customer_call_at).not.toBeNull();
+    expect(new Date(cap!.last_customer_call_at as string).toISOString()).toBe(
+      txnTime.toISOString(),
+    );
+  });
+
+  // ── 3. List-endpoint WHERE clause excludes system-user transactions ──────
+  // Same filter discipline as detail handler test #5. A refactor that drops
+  // the system-user exclusion from the GROUP BY query would let test-runner
+  // timestamps leak into the list response, breaking the badge logic for
+  // every paid_prepaid cap with internal-test traffic.
+  it("ignores system@strale.internal transactions in the GROUP BY aggregation", async () => {
+    const { id, slug } = await seedListCap({ costClass: "paid_prepaid" });
+    const customerId = await seedCustomerUser();
+    const customerTime = new Date("2026-05-11T10:00:00Z");
+    const internalTime = new Date("2026-05-13T10:00:00Z"); // newer
+    await seedTxn({ capabilityId: id, userId: customerId, createdAt: customerTime });
+    await seedTxn({ capabilityId: id, userId: systemUserId, createdAt: internalTime });
+    const cap = await fetchListBySlug(slug);
+    expect(cap).toBeDefined();
+    // The list endpoint must return the OLDER customer-paid timestamp,
+    // NOT the newer system-user timestamp.
+    expect(new Date(cap!.last_customer_call_at as string).toISOString()).toBe(
+      customerTime.toISOString(),
+    );
+  });
+});

--- a/apps/api/src/routes/capabilities.ts
+++ b/apps/api/src/routes/capabilities.ts
@@ -15,6 +15,7 @@ capabilitiesRoute.get("/", async (c) => {
   const db = getDb();
   const rows = await db
     .select({
+      id: capabilities.id,
       slug: capabilities.slug,
       name: capabilities.name,
       description: capabilities.description,
@@ -29,6 +30,12 @@ capabilitiesRoute.get("/", async (c) => {
       search_tags: capabilities.searchTags,
       freshness_level: capabilities.freshnessLevel,
       last_tested_at: capabilities.lastTestedAt,
+      // Phase A0c.1.v3 (2026-05-13): cost_class for frontend display logic.
+      // A0c.1.v2 added it to the detail handler only; the frontend reads
+      // from this list endpoint for both /capabilities and /capabilities/:slug
+      // surfaces (via useCapability filtering useCapabilities locally), so
+      // the badge silently failed everywhere until this field landed here.
+      cost_class: capabilities.costClass,
     })
     .from(capabilities)
     .where(
@@ -41,6 +48,36 @@ capabilitiesRoute.get("/", async (c) => {
         inArray(capabilities.lifecycleState, ["active", "degraded"]),
       ),
     );
+
+  // Phase A0c.1.v3: batch-fetch last_customer_call_at per capability via a
+  // single GROUP BY query. Same filter convention as the detail handler
+  // (lib/daily-digest/fetch-platform.ts:20-24): exclude transactions whose
+  // user_id is the system test user. Customer paths set user_id = real_user
+  // or NULL (free-tier); test-runner.ts:1270 writes user_id = system user.
+  //
+  // Performance note: the new compound index
+  // `transactions_capability_id_created_at_idx` (Block 0078, added in this
+  // PR) makes the GROUP BY an index-only aggregate. Without it the query
+  // would seq-scan the status='completed' filtered set, which is fine at
+  // pre-launch scale but degrades as transactions grow.
+  const lccRows = await db.execute(sql`
+    SELECT t.capability_id, MAX(t.created_at) AS last_customer_call_at
+      FROM transactions t
+     WHERE t.status = 'completed'
+       AND (t.user_id IS NULL OR t.user_id != (
+         SELECT id FROM users WHERE email = 'system@strale.internal' LIMIT 1
+       ))
+     GROUP BY t.capability_id
+  `);
+  const lccResultRows = Array.isArray(lccRows)
+    ? lccRows
+    : (lccRows as { rows?: unknown[] })?.rows ?? [];
+  const lccByCapId = new Map<string, Date | string>();
+  for (const row of lccResultRows as Array<{ capability_id?: string; last_customer_call_at?: Date | string | null }>) {
+    if (row.capability_id && row.last_customer_call_at != null) {
+      lccByCapId.set(row.capability_id, row.last_customer_call_at);
+    }
+  }
 
   const capabilitiesList = rows.map((r) => ({
     slug: r.slug,
@@ -57,6 +94,8 @@ capabilitiesRoute.get("/", async (c) => {
     search_tags: r.search_tags ?? [],
     freshness_level: r.freshness_level ?? "fresh",
     last_tested_at: r.last_tested_at?.toISOString() ?? null,
+    cost_class: r.cost_class,
+    last_customer_call_at: lccByCapId.get(r.id) ?? null,
   }));
 
   return c.json({ capabilities: capabilitiesList });


### PR DESCRIPTION
## Why

A0c.1.v2 extended only `GET /v1/capabilities/:slug`. But the strale-frontend's `useCapability(slug)` hook filters `useCapabilities()` locally — it reads the **list** endpoint shape for both the `/capabilities` cards and the `/capabilities/:slug` detail page.

The "Awaiting production traffic" badge (DEC-20260512-A, A0c.2b) only renders when `cost_class ∈ {paid_prepaid, paid_subscription}` AND `last_customer_call_at` is null or > 30 days old. Because the list endpoint never emitted those fields, the badge silently failed on every surface — confirmed in production by `curl https://api.strale.io/v1/capabilities | jq '.capabilities[] | select(.slug=="agent-trace-analyze")'` returning neither field.

## What

1. **`routes/capabilities.ts`** — extend list SELECT with `cost_class` + capability `id` (join key), then batch-fetch `last_customer_call_at` per capability via a single GROUP BY query. Apply the daily-digest filter convention (exclude `system@strale.internal`). Map results back into each row by id before stripping id from the public response.
2. **`db/schema.ts`** — declare compound index `transactions_capability_id_created_at_idx` on `(capability_id, created_at)`. Without it the GROUP BY scans the `status='completed'` filtered set; with it the aggregate is index-only.
3. **`lib/startup-migrations.ts`** — register Block 0078 (`CREATE INDEX IF NOT EXISTS`) so the index is ensured at boot in prod per DEC-20260511-C.
4. **`lib/startup-migrations.test.ts`** — BLOCKS array assertion 20 → 21, two behavioral tests for the new block.
5. **`routes/capabilities.integration.test.ts`** — 3 regression tests mirroring the production failure mode:
   - `paid_prepaid` + no transactions → `last_customer_call_at: null` (canonical bug shape)
   - `paid_prepaid` + customer transaction → matches `created_at`
   - `system@strale.internal` transactions ignored in the MAX aggregation

## Test

- `npx tsc --noEmit` — clean
- `npx vitest run` — 636 passed / 19 skipped
- `node apps/api/scripts/check-cost-class-coherence.mjs` — all classified capabilities OK

## Post-deploy verification

1. `curl https://api.strale.io/v1/capabilities | jq '.capabilities[] | select(.slug=="agent-trace-analyze") | {cost_class, last_customer_call_at}'` — expect `cost_class: "paid_prepaid"`, `last_customer_call_at: null`
2. Browser: strale.dev/capabilities/agent-trace-analyze — expect "Awaiting production traffic" badge
3. Browser: strale.dev/capabilities/translate — expect badge NOT rendered (has fresh customer traffic)