### PR TITLE
chore: remove backend Lovable references

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -180,7 +180,6 @@ const restrictedCors = cors({
     // origin === "null" intentionally rejected — sandboxed iframes should not
     // be able to issue credentialed cross-origin requests to payment endpoints.
     if (ALLOWED_ORIGINS.includes(origin)) return origin;
-    if (origin.endsWith(".lovable.app") || origin.endsWith(".lovable.dev") || origin.endsWith(".lovableproject.com")) return origin;
     return "";
   },
   allowMethods: ["GET", "POST", "OPTIONS"],

--- a/apps/api/src/lib/daily-digest/analyze.ts
+++ b/apps/api/src/lib/daily-digest/analyze.ts
@@ -40,7 +40,7 @@ CONTEXT ABOUT STRALE:
 - ${sb.totalCapabilities} active capabilities, ${sb.totalSolutions} solutions, ~1,500 test suites
 - Key growth levers: LLM recommendation layer (framework PRs), Beacon (supply-side growth engine), direct outreach to Nordic fintech
 - Revenue model: pay-per-call API. Current focus is user acquisition, not monetization.
-- Website: strale.dev (on Lovable). Beacon: scan.strale.io (on Vercel). API: api.strale.io (on Railway).
+- Website: strale.dev (on Cloudflare Pages). Beacon: scan.strale.io (on Vercel). API: api.strale.io (on Railway).
 
 PLATFORM ACTIVITY (last 24h):
 - New signups: ${pa.signups.count} (delta: ${pa.signups.delta})${pa.signups.emails.length > 0 ? ` — ${pa.signups.emails.join(", ")}` : ""}


### PR DESCRIPTION
## Summary

Per the 2026-05-13 cancellation audit at \`handoff/_general/from-code/2026-05-13-lovable-cancellation-audit.md\`, Lovable subscription cancellation is in flight after the audit confirmed zero runtime dependencies. This PR removes the two backend touchpoints.

## What changed

- \`apps/api/src/app.ts:183\` — remove the permissive CORS allowlist branch for \`*.lovable.app\`, \`*.lovable.dev\`, \`*.lovableproject.com\` preview URLs. Dead surface; the explicit \`ALLOWED_ORIGINS\` array (strale.dev, www.strale.dev, \`FRONTEND_URL\`) covers every legitimate authenticated caller.
- \`apps/api/src/lib/daily-digest/analyze.ts:43\` — update LLM prompt fragment: \`strale.dev (on Lovable)\` → \`strale.dev (on Cloudflare Pages)\`. Factual correction in the context block fed to the daily-digest analyzer.

## Verified locally

- \`npm run typecheck\` — clean
- \`npx vitest run\` — 636/636 pass (33 integration-skipped, none CORS-related)
- Grepped \`apps/api/\` for \`lovable.app|lovable.dev|lovableproject\` before the edit: only hit was the line being removed. No test exercised the branch.

## Out of scope

The OG image fixture URLs in \`manifests/meta-extract.yaml\` and \`manifests/og-image-check.yaml\` (filenames containing \`.lovable.app\`) — the files are hosted on operator-owned Cloudflare R2, independent of Lovable's subscription. Filename cleanup is a future chore.

## Companion PR

Frontend-side cleanup (\`.lovable/\` directory, \`lovable-tagger\` devDep, doc rewrite) shipped in strale-frontend PR #9 (merge commit \`6509d924\`).

## Test plan

- [x] Local typecheck + tests pass.
- [ ] CI green on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)