### PR TITLE
chore: promote 5 handoff notes from 2026-05-13

### DIFF
--- a/handoff/_general/from-code/2026-05-13-beacon-hosting-verification.md
+++ b/handoff/_general/from-code/2026-05-13-beacon-hosting-verification.md
@@ -1,0 +1,120 @@
+---
+date: 2026-05-13
+type: verification-report
+session-intent: Verify scan.strale.io hosting platform after Lovable silent-deploy outage exposed unverified memory claims
+worktree: strale-research (read-only)
+---
+
+# Beacon Hosting Verification (`scan.strale.io`)
+
+## Verdict
+
+**Hosting platform: Vercel.** Confidence: **HIGH** (4 independent signals agree, no contradicting evidence).
+
+**No Lovable in the pipeline.** Beacon does NOT carry the same silent-deploy risk profile that produced the 73-day `strale-frontend` outage. Memory #14 is correct.
+
+---
+
+## Evidence
+
+### 1. HTTP response headers (live)
+
+```
+$ curl -sI https://scan.strale.io/
+HTTP/1.1 200 OK
+Server: Vercel
+X-Vercel-Cache: HIT
+X-Vercel-Id: arn1::g2q84-1778653628134-b03da1e5f757
+X-Nextjs-Prerender: 1
+X-Nextjs-Stale-Time: 300
+X-Matched-Path: /
+Strict-Transport-Security: max-age=63072000
+Age: 783467
+Etag: "b2d987267eb39d81ee5369cc7795dfde"
+```
+
+Vercel fingerprints present: `Server: Vercel`, `X-Vercel-Id`, `X-Vercel-Cache`, `X-Nextjs-Prerender`. The `arn1` region tag = Stockholm edge (Vercel's `arn1` PoP, IATA code for Stockholm Arlanda).
+
+Identical headers with custom User-Agent (no UA-based variance).
+
+### 2. DNS resolution
+
+```
+$ nslookup scan.strale.io 8.8.8.8
+Name:    scan.strale.io
+Address: 76.76.21.21
+```
+
+`76.76.21.21` is **Vercel's well-known anycast IP for custom domains**. Not Lovable (which uses `185.158.x.x` or routes through Cloudflare Pages), not Cloudflare Pages (which uses `*.pages.dev` CNAME or 172.66.x.x), not Netlify, not Railway.
+
+### 3. Repo deploy config
+
+`strale-io/strale-beacon` root contents include:
+
+| File | Present | Signal |
+|---|---|---|
+| `vercel.json` | YES | Vercel (canonical) |
+| `next.config.ts` | YES | Next.js (consistent with Vercel) |
+| `wrangler.toml` | no | Cloudflare Pages absent |
+| `netlify.toml` | no | Netlify absent |
+| `railway.toml` | no | Railway absent |
+| `fly.toml` | no | Fly.io absent |
+| `_headers` | no | Lovable/CF Pages absent |
+
+Contents of `vercel.json`:
+
+```json
+{
+  "framework": "nextjs",
+  "regions": ["arn1"],
+  "crons": [
+    { "path": "/api/cron/rescan", "schedule": "0 6 * * *" }
+  ],
+  "headers": [ ... ]
+}
+```
+
+The explicit `"framework": "nextjs"`, `"regions": ["arn1"]`, and Vercel-specific `crons` block are unambiguously Vercel. No other platform reads this config.
+
+### 4. Commit author distribution (last 90 days)
+
+```
+74 petterlindstrom79
+```
+
+100% human-authored. **Zero `lovable-dev[bot]` commits.** No automation pushing into the repo — every commit is Petter via Claude Code. This is the inverse of the `strale-frontend` history that produced the silent-deploy gap.
+
+---
+
+## Silent-deploy risk assessment
+
+**Risk: LOW.**
+
+The `strale-frontend` failure mode required three conditions:
+1. Lovable bot owns deploys (not the repo's git push).
+2. Lovable's CF Pages account is opaque to the operator.
+3. Repo commits never trigger a real deploy.
+
+For Beacon, **none of those conditions hold**:
+- Deploy is git-push → Vercel auto-deploy (`vercel.json` + framework auto-detection).
+- The Vercel project is operator-owned and visible in Petter's Vercel dashboard.
+- Every commit is a real deploy trigger.
+
+The `Age: 783467` header (~9 days) on `/` is a prerendered-page cache hit, expected behavior for static Next.js routes with `Cache-Control: public, max-age=0, must-revalidate` and edge cache. Not a deploy issue. Worth re-verifying after the next intentional deploy to confirm a new ETag appears — but that's hygiene, not a risk flag.
+
+---
+
+## Recommendations
+
+1. **Memory #14 (`scan.strale.io` on Vercel)**: KEEP. Verified accurate.
+2. **Tech stack page Frontend section**: the "unverified" caveat about Beacon can now be **removed/sharpened** to "Beacon (`scan.strale.io`): Vercel, verified 2026-05-13 via response headers + DNS + `vercel.json`."
+3. **No migration warranted.** Beacon's deploy posture is healthy.
+4. **Followup hygiene check (optional, low priority)**: next time a Beacon commit lands, confirm the response `ETag` and `X-Vercel-Id` change to validate the auto-deploy path is actually firing. This is the cheap canary against future silent-deploy drift — adopt the same discipline that would have caught the Lovable outage 73 days earlier.
+
+---
+
+## Worktree / process notes
+
+- Read-only verification, no code changes, no PR.
+- Report saved here and `git add`-ed per Rule G (decision-rationale handoff promoted to tracked).
+- Rule 1 audit-first complied: hypothesized Vercel based on memory, gathered 4 independent signals, all agreed; no edits required.

--- a/handoff/_general/from-code/2026-05-13-drizzle-quirks-verification.md
+++ b/handoff/_general/from-code/2026-05-13-drizzle-quirks-verification.md
@@ -1,0 +1,135 @@
+---
+date: 2026-05-13
+type: verification-report
+session-intent: Verify whether Tech stack page Backend "Known quirks" drizzle-kit lines are stale per DEC-20260511-C
+worktree: strale-research (read-only)
+status: SUPERSEDED — see correction below
+---
+
+# Drizzle "Known quirks" verification (Tech stack page)
+
+## CORRECTION (added 2026-05-13 after session-close audit)
+
+**The Outcome below is WRONG.** Correct outcome is **A — fully executed**.
+
+This report was produced from the `strale` trunk worktree, which is checked out on branch `feat/dec-20260511-e-stuck-validating-sweep` (HEAD `03e3b64`). That branch was created **before PR #89 merged** and was never rebased onto main. As a result the working tree there still has the pre-PR-#89 `apps/api/drizzle/` directory with 65 SQL files, the dead `db:migrate` script in `package.json`, and the `drizzle-kit` devDep — but **none of these exist on main** as of 2026-05-11.
+
+PR #89 (commit `3e60d5d`, merged 2026-05-11) shipped the entire deletion: `apps/api/drizzle/` directory, `apps/api/drizzle.config.ts`, `apps/api/scripts/check-migration-prefixes.mjs`, `apps/api/scripts/verify-migration-rename.ts`, the three `db:*` scripts, the `drizzle-kit` devDep, the CI step, and the wording rewordings in `schema.ts` + `schema-validator.ts`. Verified later this session by checking the strale-work worktree (on main) and reading PR #89's file stat (86 files changed).
+
+DEC-20260511-C is **fully executed**, not partially. The Working rules page header softening that this report triggered (2026-05-13) should revert; the Tech stack page Backend "Known quirks" follow-up that this report triggered should be re-scoped to the small residual cleanups noted in the DEC-20260511-C halt report.
+
+**Lesson for future state-verification reports:** always confirm the worktree HEAD against `origin/main` before producing an "is X currently on main?" verdict. Branch-local working trees can show pre-merge state and produce false negatives.
+
+The original (incorrect) Outcome B analysis follows below for forensic completeness. Do not act on it.
+
+---
+
+## Outcome (SUPERSEDED — see correction above)
+
+**Outcome B — partially executed.** The in-TS startup-migrations mechanism described in the Working rules header is **live and load-bearing** (verified in code). However, the `apps/api/drizzle/` directory has **not** been removed — it still contains 65 historical migration files (0000–0099) and the journal. The Working rules header's claim that the directory is "retired" is aspirational, not yet reality.
+
+Net effect on the two "Known quirks" lines on the Tech stack page:
+
+- Line 1 (`drizzle-kit migrate` is broken; use raw SQL via `postgres`): **stale**. The "broken drizzle-kit" framing is structurally outdated and the prescribed workaround (raw SQL via the `postgres` package, as in `apps/api/scripts/apply-migrations.ts`) is dead — that file was replaced by PR #51 and the convention is now in-TS startup-migration blocks.
+- Line 2 (Railway does not auto-apply migrations; manual step required): **stale**. Railway *does* auto-apply migrations at API boot via `runStartupMigrations()` wired into [apps/api/src/index.ts:73-74](apps/api/src/index.ts#L73-L74). No manual migrate step exists.
+
+DEC-20260511-C itself is not referenced anywhere in the committed repo (no handoff file, journal entry, or commit message contains the literal string `DEC-20260511-C`). The convention it codifies, however, is plainly executed in code via PR #51 (2026-05-04) and reinforced by PR #89 (`refactor: adopt in-ts startup-migrations as schema convention`).
+
+## Evidence
+
+### 1. Current migration mechanism in code
+
+The live mechanism is `runStartupMigrations()` in [apps/api/src/lib/startup-migrations.ts](apps/api/src/lib/startup-migrations.ts).
+
+- Wired into API boot at [apps/api/src/index.ts:73-74](apps/api/src/index.ts#L73-L74):
+
+```ts
+const { runStartupMigrations } = await import("./lib/startup-migrations.js");
+await runStartupMigrations();
+```
+
+- The file's docstring (lines 1-37) explicitly documents:
+  - **Blocking, not fire-and-forget.** A failed migration aborts API startup.
+  - **Runs BEFORE `validateSchema()`** in `index.ts`.
+  - **Runs BEFORE the API listens, BEFORE any scheduler / job boots.**
+  - **Every block is idempotent** — `IF NOT EXISTS` for DDL, `WHERE <filter>` for DML.
+  - **Per-block structured logging** so Railway log-grep can distinguish "ran and changed N rows" from "skipped" from "threw and aborted boot."
+
+- Block roster (current `BLOCKS` array at [startup-migrations.ts:348-355](apps/api/src/lib/startup-migrations.ts#L348-L355)):
+  ```
+  runMigration0029_actualCostCents
+  runMigration0030_complianceColumns
+  runMigration0031_testResultsCompositeIdx
+  runMigration0060_marketplaceEligible
+  runMigration0062_paidVendorCosts
+  runMigration0063_invoiceExtractCostReclassify
+  ```
+
+- The retired-by-replacement file [`apps/api/scripts/apply-migrations.ts`](apps/api/scripts/apply-migrations.ts) is no longer the deploy path. PR #51 (`0b157c2 fix(deploy): wire startup migrations into API boot — replaces dead apply-migrations.ts`) was the structural fix.
+
+### 2. `apps/api/drizzle/` directory state
+
+**Present.** 65 SQL files + `README.md` + `meta/` (drizzle journal). Contents include:
+
+- `0000_damp_mastermind.sql` through `0063_…` continuous, then jumps to `0099_suggest_log.sql` (the renamed-out 0046 collision documented in `drizzle/README.md`).
+- `meta/_journal.json` is the authority for which file runs and in what order under `drizzle-kit`.
+
+The directory is **historical / generator artifact**, not the live migration substrate. Inspection of recent merged PRs (#88, #89, #95, #98–#103) shows new schema work going into `runMigrationXXXX_…` blocks in `startup-migrations.ts` rather than new `apps/api/drizzle/*.sql` files. PR #89's title is the explicit convention shift: `refactor: adopt in-ts startup-migrations as schema convention`.
+
+The Working rules header's claim that the directory is "retired" is therefore **partially true** (new work doesn't go there) but **factually overstated** (the directory still exists and `drizzle-kit generate` would still write into it).
+
+### 3. Railway deploy command
+
+**No `railway.toml` / `railway.json` in the repo.** Railway uses the Dockerfile at the repo root. From [Dockerfile:34](Dockerfile#L34):
+
+```
+CMD ["node", "apps/api/dist/index.js"]
+```
+
+That's the entire deploy command. No separate migrate step. The API entry point calls `runStartupMigrations()` before doing anything else. PR #51's commit message and PR #52's "single source of truth" follow-up confirm this is the design intent.
+
+### 4. `package.json` legacy scripts
+
+[apps/api/package.json:20-22](apps/api/package.json#L20-L22) still has:
+```
+"db:generate": "drizzle-kit generate",
+"db:migrate": "drizzle-kit migrate",
+"db:push": "drizzle-kit push"
+```
+
+These remain because `drizzle-kit generate` is still a useful local tool for snapshotting schema changes into the `drizzle/meta/` journal even when the live mechanism is in-TS blocks. `db:migrate` is no longer the production path and isn't invoked in the Dockerfile or by any CI workflow that I could see.
+
+### 5. Recent PR history confirms the pattern
+
+Last ~20 schema-touching PRs in the branch graph:
+
+```
+1e1636a fix(a0c-1.v3): include cost_class + last_customer_call_at … (#103)
+0455230 feat: classify final non-Anthropic visible caps … (#102)
+… (Phase B classification PRs, #98–#101) …
+4c3573d feat: cost_class taxonomy + dispatcher gate + budget enforcement (#95)
+99159a9 feat: scheduler reads cost_class for eligibility (block 0069)
+941c22e feat: classify DE/DK/SK cost_class (manifest + block 0068)
+5a74936 feat: cost_class taxonomy schema (blocks 0067, 0070)
+3e60d5d refactor: adopt in-ts startup-migrations as schema convention (#89)
+cb4e8c1 refactor: introduce scheduled_testing_eligible column (#88)
+…
+0b157c2 fix(deploy): wire startup migrations into API boot (#51)
+```
+
+The "block 0067/0068/0069/0070" naming in commit messages is the same in-TS startup-migrations convention. (Note: these are *newer* block numbers than the rev `BLOCKS` array currently shows — branch `feat/dec-20260511-e-stuck-validating-sweep` may not yet contain main's most-recent merges of these blocks; the count of registered blocks on prod may differ slightly. The convention, however, is unambiguous.)
+
+## Recommended Notion edit
+
+Replace the two "Known quirks" lines with a single, accurate description plus a pointer to DEC-20260511-C. Suggested replacement text for the Backend → Known quirks section:
+
+> **Schema changes use in-TS startup-migrations blocks (DEC-20260511-C).** Each block is a `runMigrationXXXX_<name>` function in [`apps/api/src/lib/startup-migrations.ts`](https://github.com/strale-io/strale/blob/main/apps/api/src/lib/startup-migrations.ts) registered in the `BLOCKS` array, and uses `IF NOT EXISTS` / `WHERE <filter>` for idempotency. `runStartupMigrations()` runs blocking at API boot **before** `validateSchema()` and **before** the API listens, so Railway deploys auto-apply new schema with no manual step. Don't write new SQL files into `apps/api/drizzle/` — that directory is the historical record + drizzle-kit generator output, not the live migration substrate. The `db:migrate` script (`drizzle-kit migrate`) in `apps/api/package.json` is a local tool only; it's not invoked by the Dockerfile or CI and is not the production deploy path. Pattern reference: PR #51 (the structural fix) and PR #89 (codifies the convention).
+
+If the Working rules header's claim that the `drizzle/` directory is "retired" is intended literally, the followup work is to delete the directory (or move it under a `legacy/` prefix) and remove the `db:migrate` / `db:generate` / `db:push` scripts from `package.json`. As of 2026-05-13, neither has happened, so the Tech stack page should describe what is, not what is planned.
+
+## Worktree / process notes
+
+- Read-only verification, no code changes, no PR.
+- Report saved here and `git add`-ed per Rule G (decision-rationale handoff promoted to tracked).
+- DEC-20260511-C text could not be retrieved from the local repo. If Notion is reachable, fetching the DEC body would let the Tech stack edit quote the exact retirement wording rather than inferring intent from the Working rules header. Flag for the Claude chat editor.
+- Outcome label is **B**, not A — the Working rules header's claim is **factually overstated** on the directory-retired point, even though the mechanism it describes is fully live. Recommend the chat editor either softens the Working rules wording or schedules the cleanup PR that deletes `apps/api/drizzle/` and the dead `db:migrate` script.

--- a/handoff/_general/from-code/2026-05-13-lovable-cancellation-audit.md
+++ b/handoff/_general/from-code/2026-05-13-lovable-cancellation-audit.md
@@ -1,0 +1,162 @@
+---
+date: 2026-05-13
+type: verification-report
+session-intent: Pre-cancellation safety audit — confirm Strale has no runtime dependency on Lovable before canceling the subscription
+worktree: strale-research (read-only)
+---
+
+# Lovable Cancellation Audit
+
+## Verdict
+
+**SAFE TO CANCEL. Zero active runtime dependencies. Inert touchpoints exist and have a clean cleanup path.**
+
+Confidence: HIGH. DNS, headers, webhooks, CI workflows, and recent commit activity all show Lovable is operationally absent. The only Lovable-controlled surface still in the picture is the GitHub App installation (`lovable-dev`, id 113143693) and an npm dev-only package (`lovable-tagger`), neither of which is in any production code path.
+
+---
+
+## Block-by-block findings
+
+### Block A — DNS (clean)
+
+```
+strale.dev      → 188.114.97.1, 188.114.96.1               (Cloudflare anycast 188.114.96.0/24)
+www.strale.dev  → 188.114.97.1, 188.114.96.1
+                + 2a06:98c1:3120::1, 2a06:98c1:3121::1     (Cloudflare IPv6)
+scan.strale.io  → 76.76.21.21                              (Vercel custom-domain anycast)
+api.strale.io   → m1d21ii9.up.railway.app → 66.33.22.240   (Railway)
+```
+
+No record points at Lovable's anycast (`185.158.x.x`) or any `*.lovable.app` / `*.lovable.dev` CNAME target.
+
+### Block B — Response headers (clean)
+
+| Surface | Server | Fingerprint |
+|---|---|---|
+| strale.dev/ | `Server: cloudflare` | `CF-RAY: 9fafe4694d00481e-ARN` (Stockholm CF edge) |
+| www.strale.dev/ | `Server: cloudflare` | `CF-RAY: 9fafe46adcbd0a27-ARN` |
+| scan.strale.io/ | `Server: Vercel` | `X-Vercel-Id`, `X-Nextjs-Prerender: 1` |
+| api.strale.io/health | `Server: railway-edge` | `X-Railway-Edge: railway/europe-west4-drams3a` |
+
+No `Server: lovable*` headers anywhere. No redirect to a `*.lovable.*` URL.
+
+**Cross-check:** The deployed strale.dev bundle at `/assets/index-C48CmodB.js` contains the build marker `STRALE_BUILD:d4fc9b14e284177f4527452960dfbe00203cef24:2026-05-13T06:38:51.688Z`. The SHA matches PR #8's merge commit on the strale-frontend repo (the deploy-health monitor PR from earlier today). This is a CF Pages build from operator's account, not a Lovable cache.
+
+### Block C — strale-frontend Lovable touchpoints (all inert, all in repo)
+
+Findings ranked by criticality:
+
+| Location | Nature | Runtime impact of cancellation |
+|---|---|---|
+| `package.json:86` + `vite.config.ts:5` — `lovable-tagger ^1.1.13` devDep + dev-only import | npm package, dev-mode only (`mode === "development"` gate) | None. The package is on npm; cancelling the subscription doesn't pull it from the registry. Production builds don't load it. |
+| `.lovable/plan.md` — 4189-byte planning doc, last touched 2026-04-17 | Static file, no consumer | None. Safe to delete. |
+| `CLAUDE.md` — entire doc framed around Lovable as co-collaborator (lines 5, 9, 33, 41, 49, 52, 58, 60, 73, 77, 79) | Stale instructions for future Claude sessions | None for prod; affects future agent behavior. Should be rewritten. |
+| `index.html:16` — "Lovable hosting doesn't support custom headers" comment | Stale doc note | None. Now on CF Pages which does support custom headers (HSTS landed earlier today per the 2026-05-13 handoff). |
+| `.claude/RUNBOOK.md:17` — table row "Edit `src/components/ui/` — NEVER — Lovable owns these" | Stale instructions | None. |
+| `AUDIT-security-frontend.md:17` — references "Lovable" as the hosting platform | Stale audit note | None. |
+| `package-lock.json` — many `lovable-tagger/` subtree entries | Will regenerate when devDep removed | None. |
+
+### Block D — GitHub webhooks (clean across all three repos)
+
+`gh api repos/strale-io/{strale,strale-frontend,strale-beacon}/hooks` returned empty arrays for all three repos. Zero webhooks anywhere — none pointing at Lovable, none pointing at Cloudflare Pages either (CF Pages auto-deploys via its GitHub App installation, not a webhook).
+
+### Block E — GitHub App installations on `strale-io` org
+
+```
+{"account":"strale-io","app_slug":"lovable-dev",                 "id":113143693, "created_at":"2026-02-28"}
+{"account":"strale-io","app_slug":"claude",                       "id":113157811}
+{"account":"strale-io","app_slug":"railway-app",                  "id":113486885}
+{"account":"strale-io","app_slug":"vercel",                       "id":118400292}
+{"account":"strale-io","app_slug":"claude-design-import",         "id":124764790}
+{"account":"strale-io","app_slug":"chatgpt-codex-connector",      "id":125024088}
+{"account":"strale-io","app_slug":"cloudflare-workers-and-pages", "id":131828731, "created_at":"2026-05-12"}
+```
+
+**`lovable-dev` is the Lovable GitHub App** (installed at signup 2026-02-28). Post-cancellation, revoke at https://github.com/organizations/strale-io/settings/installations.
+
+All other installations are expected and stay.
+
+### Block F — CI workflows (clean across all three repos)
+
+For each of `strale`, `strale-frontend`, `strale-beacon`, fetched every file under `.github/workflows/` and grepped for `lovable` (case-insensitive). **Zero hits in all three repos.** No CI step references Lovable.
+
+### Block G — Code grep across all three repos
+
+**strale (backend):** non-empty matches, all stale text:
+
+| Location | Nature | Cleanup |
+|---|---|---|
+| `apps/api/src/app.ts:183` — CORS allowlist permits `*.lovable.app`, `*.lovable.dev`, `*.lovableproject.com` origins | Active code path. Permissive: if no request from those origins ever hits the API, the allowlist is dead. Lovable cancellation doesn't break this — it just makes the allowlist forever-dead. | Safe to delete the line as a chore. |
+| `apps/api/src/lib/daily-digest/analyze.ts:43` — prompt fragment: `Website: strale.dev (on Lovable). Beacon: scan.strale.io (on Vercel). API: api.strale.io (on Railway).` | Hardcoded LLM context. Stale string — feeds wrong context to Claude in the daily-digest synthesis. | Update to `(on Cloudflare Pages)`. |
+| `docs/audits/activation-traffic-2026-04-08.md:107,111` | Historical audit row containing two `*.lovable.app` URLs from April traffic | Archival doc, leave alone. |
+| `audit-reports/observability-baseline.md:94,99` | Historical option-A vs option-B comparison mentioning Lovable | Archival, leave alone. |
+| `handoff/_general/from-code/2026-04-{28,30}*.md` | Historical handoff notes mentioning the Lovable era | Archival, leave alone. |
+| `handoff/_general/from-code/2026-05-13-restore-hsts-header-cloudflare-pages.md` | Today's handoff documenting the migration off Lovable | Accurate history, leave alone. |
+| `manifests/meta-extract.yaml:29,63` + `manifests/og-image-check.yaml:28,42` — fixture URL `https://pub-bb2e103a32db4e198524a2e9ed8f35b4.r2.dev/.../...-.lovable.app-1772307174433.png` | URL filename contains `.lovable.app` but the file is hosted on **Cloudflare R2** (`pub-….r2.dev`), independent of Lovable. Verified HTTP 200 from R2 with a 258 KB image. | None. R2 is operator-owned; the fixture survives Lovable cancellation. |
+
+**strale-beacon:** zero matches. Lovable was never associated with Beacon.
+
+### Block H — Recent commit activity on strale-frontend
+
+```
+Last 14 days:  14 commits, 14 by petterlindstrom79, 0 by lovable-dev[bot]
+All time:       1 lovable-dev[bot] commit ever: b331aa1 (2025-01-01, the initial Vite/React/shadcn template scaffold)
+```
+
+**The `lovable-dev[bot]` commit path is operationally dead.** It hasn't been used since the repo's initial scaffold over a year ago — meaning Petter loses no actual workflow by cancelling. The Tech stack page's framing of "occasional AI-edit source via `lovable-dev[bot]` commits" overstates current usage; reality is "the bot did the initial scaffold and has been silent since."
+
+---
+
+## Active dependencies
+
+**None.** No DNS record, response header, webhook, CI workflow, runtime code path, or recent commit activity depends on Lovable's services or subscription being active.
+
+---
+
+## Inert touchpoints to clean up
+
+**Single GitHub-UI step (do this with cancellation):**
+
+1. Revoke the `lovable-dev` GitHub App installation on `strale-io` (id 113143693) — https://github.com/organizations/strale-io/settings/installations
+
+**Single chore PR on `strale-frontend` (bundles 4 deletions + 4 rewrites):**
+
+2. Delete `.lovable/` directory (just `plan.md`).
+3. Remove `lovable-tagger` from `package.json` devDependencies and regenerate `package-lock.json`.
+4. Remove the `import { componentTagger } from "lovable-tagger"` line and the `componentTagger()` plugin invocation from `vite.config.ts`.
+5. Rewrite `CLAUDE.md` — Lovable is no longer a collaborator; the entire "your directories / Lovable's directories" framing is wrong now.
+6. Update `.claude/RUNBOOK.md:17` table row.
+7. Update `index.html:16` comment to reflect Cloudflare Pages.
+8. Update `AUDIT-security-frontend.md:17` — Lovable header limitation no longer applies.
+
+**Single chore PR on `strale` (bundles 2 small edits):**
+
+9. Remove the `*.lovable.{app,dev,project.com}` permissive branch from the CORS allowlist at [apps/api/src/app.ts:183](apps/api/src/app.ts#L183).
+10. Update the daily-digest LLM prompt fragment at [apps/api/src/lib/daily-digest/analyze.ts:43](apps/api/src/lib/daily-digest/analyze.ts#L43) — `(on Lovable)` → `(on Cloudflare Pages)`.
+
+**Archival, leave alone:**
+
+11. `docs/audits/activation-traffic-2026-04-08.md`, `audit-reports/observability-baseline.md`, all `handoff/_general/from-code/2026-04-*.md` Lovable mentions — historical and accurate as of the dates they describe.
+
+---
+
+## Recommended order
+
+1. **Export Lovable chat history first** (manual step in Lovable UI, if Petter wants to keep it for reference). Cancellation may purge it.
+2. **Cancel the Lovable subscription.**
+3. **Revoke the `lovable-dev` GitHub App installation** (id 113143693) via the GitHub UI.
+4. **Ship the strale-frontend chore PR** (items 2–8 above).
+5. **Ship the strale chore PR** (items 9–10 above).
+6. **Notion updates** (Claude chat's job):
+   - Memory #21: remove the "only commits via lovable-dev[bot]" clause; replace with "Lovable subscription canceled `<date>`; GitHub App revoked; no role going forward."
+   - Tech stack page Frontend section: drop the "Lovable's role going forward" paragraph. Reframe as "Strale is fully off Lovable as of `<date>`."
+   - To-do `35567c87-082c-81fd-aa99-e4e41257d06b` ("Rebuild strale.dev frontend off Lovable") — close as done (the rebuild happened 2026-05-13 via the CF Pages migration; the cancellation is the final step).
+
+---
+
+## Worktree / process notes
+
+- Read-only verification; no code changes, no PRs.
+- Report saved here and `git add`-ed per Rule G.
+- Cross-worktree: strale-research (worktree). The strale trunk and strale-work worktrees were used as read sources for Block G code grep; no modifications.
+- GitHub installations enumeration succeeded via the org-level endpoint despite the user-token alternative returning 403 — no manual-check caveat needed.

--- a/handoff/_general/from-code/2026-05-13-lovable-cancellation-cleanup-execution.md
+++ b/handoff/_general/from-code/2026-05-13-lovable-cancellation-cleanup-execution.md
@@ -1,0 +1,42 @@
+Intent: Execute the cleanup work named in this morning's Lovable cancellation audit (`2026-05-13-lovable-cancellation-audit.md`) — strip residual Lovable references from both repos so the subscription cancellation has nothing dangling.
+
+## What shipped
+
+**strale-frontend PR #9** (`chore: remove residual Lovable references`) — merge commit `6509d924`. Deleted `.lovable/plan.md`; removed `lovable-tagger` devDep + regenerated `package-lock.json`; removed `lovable-tagger` import + `componentTagger()` plugin from `vite.config.ts`; rewrote `CLAUDE.md` to drop the two-collaborator framing (Lovable now a one-line historical scaffold note, Claude Code owns the whole frontend); softened `.claude/RUNBOOK.md` authority-boundaries table; updated `index.html:16` comment (CF Pages `public/_headers` authoritative now); added a 2026-05-13 update header + S-04 status revision to `AUDIT-security-frontend.md`; fixed stray "Lovable owns the CSS values" comment in `src/lib/trust-display.ts:267`. Local typecheck + tests (23/23) + build all clean.
+
+**strale PR #105** (`chore: remove backend Lovable references`) — merge commit `470e5f31`. Removed the permissive CORS allowlist branch (`*.lovable.app`, `*.lovable.dev`, `*.lovableproject.com`) at `apps/api/src/app.ts:183`; updated the LLM prompt fragment at `apps/api/src/lib/daily-digest/analyze.ts:43` ("on Lovable" → "on Cloudflare Pages"). 636/636 tests passed; no test exercised the removed allowlist branch.
+
+**strale-frontend PR #10** (`hotfix: delete bun.lockb + bun.lock so CF Pages uses npm`) — merge commit `1dc02adb`. Forced by the deploy-health monitor (see below).
+
+## The interesting hour: deploy-health monitor catches PR #9 silently
+
+PR #9 merged at 07:38:18Z. The deploy-health monitor's GHA fired, waited 300s, then failed: the deployed bundle on `strale.dev` still carried PR #8's marker (`STRALE_BUILD:d4fc9b14...`) instead of `6509d924`. Without the monitor, this would have been a silent multi-day drift — exact same class as the 73-day Lovable outage.
+
+Root cause: the strale-frontend repo had **two** bun lockfiles committed during the Lovable era (`bun.lockb` binary from Feb + the newer text-format `bun.lock` from March). CF Pages auto-detects build tooling and prefers bun when a bun lockfile is present. PR #9's deploy ran `bun install --frozen-lockfile` against the stale `bun.lockb` (which still referenced `lovable-tagger`), failed instantly with "lockfile had changes, but lockfile is frozen", and exited 1. CF Pages never produced a build; the GitHub check went `Cloudflare Pages: failure` 12s after merge.
+
+The cancellation audit didn't anticipate the bun lockfiles because the prompt for the audit only looked at the named Lovable touchpoints. They were lurking pre-existing residue, not added by PR #9 — but PR #9 was the trigger that exposed the inconsistency.
+
+Fix path chosen (deletion over regeneration): nothing in the workflow uses bun; npm is the local tool; dual-lockfile sync would be a recurring drift source forever. PR #10 deleted both. CF Pages auto-detect fell back to npm with `package-lock.json`, `npm ci` + `vite build` succeeded, deploy went out, deploy-health monitor went green in 5m2s. Prod now serves `STRALE_BUILD:1dc02adbb56253f91090d973721e375e09775e4f` — both PR #9's residual cleanup and PR #10's hotfix live together.
+
+## Validated structural backstop
+
+The deploy-health monitor (built today, PR #8) caught a real production-impacting drift within 5 minutes of merge, surfaced the actual error via the CF Pages dashboard check status, enabled a targeted hotfix in one cycle, and verified the fix worked end-to-end. This is the silent-deploy class the monitor was designed for, and it did its job on its first real test. Without it, strale.dev would still be on PR #8's bundle.
+
+## What's open
+
+- **CF Pages cleanup confirmation:** Lovable subscription cancellation + GitHub App revocation (id 113143693 for `lovable-dev` on `strale-io` org) are Petter's UI steps. Per the cancellation audit they're the final cleanup actions; this session shipped the code-side work.
+- **Stale Notion to-do `35567c87-082c-81fd-aa99-e4e41257d06b`** ("Rebuild strale.dev frontend off Lovable") — the rebuild happened 2026-05-13 via the CF Pages migration; the residual cleanup shipped this segment. Close as done or re-scope to "Cancel Lovable subscription + revoke GitHub App."
+- **Memory #21 + Tech stack page Frontend section** — final post-cancellation rewrite is chat's job once Petter completes the UI steps.
+- **OG image filename** in `src/components/SEO.tsx:14` still contains `.lovable.app` in the filename (file is on operator-owned Cloudflare R2, so no runtime impact — flagged as out-of-scope chore in PR #9's body).
+- **strale `manifests/meta-extract.yaml` / `manifests/og-image-check.yaml`** test-fixture URLs same pattern as the SEO file. Same disposition: hosted on operator R2, filename cosmetic, future cleanup.
+
+## Non-obvious learnings
+
+1. **CF Pages auto-detects build tooling by lockfile presence**, and when multiple lockfiles are present, **bun outranks npm** even if the project hasn't used bun in months. Deleting other-tool lockfiles is the cleanest way to pin tooling; a `packageManager` field in `package.json` would be a second mechanism but introduces its own pinning fragility. Worth a feedback memory.
+2. **The deploy-health monitor's diagnostic-branch regex `[0-9T:.\-Z]+` triggers `grep: Invalid range end` on the Ubuntu runner.** The escaped `\-` inside a character class is parsed as a malformed range by some grep builds. Fix: `[0-9TZ:.-]+` (put `-` at end of class, no escape). Pass path is unaffected; only the "Found: STRALE_BUILD:..." diagnostic line crashes before printing, so the monitor still correctly reports the failure (via the prior `::error::` line). Trivial 1-line workflow fix queued.
+3. **`gh run watch --exit-status` doesn't propagate inner-step failures reliably.** Background watcher for the PR #9 deploy-health run exited 0 even though the workflow's verify step exited 2. Worth knowing for any future automation that relies on background watchers — always re-check `gh run view` for ground truth rather than trusting the watcher's return code.
+4. **Sub-string greps for "bun" hit `BUNDLE_PATH` / `BUNDLE_URL` etc.** When auditing for runtime references, use word-boundary or command-shape regexes (`\bbun ` / `bun install` / `bun run` / `@types/bun`), not case-insensitive substring matches.
+
+## Cost
+
+Free. Two background GHA runs (PR #105 CI ~58s; PR #10 deploy-health 5m2s), GitHub free tier. No production downtime (prod served PR #8's bundle continuously through the PR #9 failure window — graceful degradation by accident, but the monitor turned the lurking drift into a 5-minute visible incident instead of multi-day silent staleness).

--- a/handoff/_general/from-code/2026-05-13-structural-backstops-and-readiness-audits.md
+++ b/handoff/_general/from-code/2026-05-13-structural-backstops-and-readiness-audits.md
@@ -1,0 +1,32 @@
+Intent: Close the 2026-05-13 megasession's structural follow-ups (deploy-health monitor + list↔detail contract invariant from DEC-20260513-A), produce four point-verification reports requested by chat, and clear the path for canceling the Lovable subscription.
+
+## What shipped
+
+**strale-frontend PR #8 — deploy-health monitor.** Merged 06:38:33Z, merge commit `d4fc9b14`. Vite `define` injects `STRALE_BUILD:<sha>:<iso-time>` as a single static string in the bundle; GHA on push to main waits 300s for Cloudflare Pages then asserts the deployed bundle contains the merge SHA. End-to-end verified — run `25782837765` completed in 5m3s, both steps green. The deployed bundle at `https://strale.dev/assets/index-C48CmodB.js` now carries `STRALE_BUILD:d4fc9b14...:2026-05-13T06:38:51.688Z` (matches PR #8's merge commit), confirming CF Pages serves the actual current build. Closes the 73-day Lovable silent-deploy class structurally — every merge is now self-verifying.
+
+**strale PR #104 — list↔detail contract invariant.** Merged 06:48:50Z, merge commit `b250a07b`. New `apps/api/src/routes/capabilities-contract.test.ts` iterates `FRONTEND_SHARED_FIELDS` (13 fields including `cost_class` + `last_customer_call_at`) and per-field asserts presence + value equality on both `GET /v1/capabilities` and `GET /v1/capabilities/:slug`. Pattern mirrors PR #103's integration test exactly — gated on `DATABASE_URL_TEST` via `describeMaybe`, skips cleanly in CI. Stop-condition mutation verification deferred per DEC-20260504-A test-harness exemption (no Postgres harness in CI; same precedent as PR #103). 80 pass / 29 skip on the route suite, no regressions. Closes the A0c.1.v3 bug class structurally.
+
+## Verification reports authored this session
+
+Three additional handoff files staged this session (in `handoff/_general/from-code/`), each linked to a chat-side decision:
+
+- `2026-05-13-beacon-hosting-verification.md` — verdict: **Vercel, high confidence.** 4 independent signals agree (`Server: Vercel` headers, `76.76.21.21` DNS, `vercel.json` in repo with explicit `framework: nextjs`, zero `lovable-dev[bot]` commits on strale-beacon). Memory #14 stands. Silent-deploy risk LOW.
+- `2026-05-13-drizzle-quirks-verification.md` — **CORRECTED MID-SESSION.** Original verdict Outcome B was wrong; correct is Outcome A. See the "Course-correction" Journal page `35f67c87-082c-8119-9ab3-fa7a12b30080`. The report file now carries a correction header explaining the mistake. PR #89 fully shipped DEC-20260511-C cleanup on 2026-05-11; the strale trunk worktree was on a pre-#89 branch and that's what I read from. Lesson saved to memory.
+- `2026-05-13-lovable-cancellation-audit.md` — verdict: **SAFE TO CANCEL.** Zero active runtime dependencies confirmed across DNS (CF anycast `188.114.96.0/24`), headers (`Server: cloudflare`), webhooks (empty for all 3 repos), CI workflows (zero `lovable` matches), and commit activity (last 14 days: 14 commits all by Petter; lovable-dev[bot] all-time: 1 scaffold commit from 2025-01-01). Cleanup queue: 1 GitHub-UI step (revoke `lovable-dev` App install id 113143693) + 2 small chore PRs (strale-frontend dev-only deps + docs; strale CORS allowlist + LLM prompt fragment).
+
+## What's open
+
+- **DEC-20260513-A follow-ups: closed** by PRs #8 and #104. Notion DEC entry "Outcome" field may need update (Petter / chat).
+- **Lovable cancellation cleanup chore PRs.** Two small PRs identified in the audit report; sequencing is: cancel subscription → revoke GitHub App → ship the two chore PRs. Backend chore removes the CORS lovable allowlist branch (`apps/api/src/app.ts:183`) and fixes the LLM prompt fragment (`apps/api/src/lib/daily-digest/analyze.ts:43`).
+- **To-do `35567c87-082c-81fd-aa99-e4e41257d06b`** ("Rebuild strale.dev frontend off Lovable") — re-scope to "Cancel Lovable subscription + GitHub App cleanup" or close as done (the rebuild itself happened 2026-05-13 via CF Pages migration).
+- **Working rules page header softening** (added 2026-05-13 after my flawed drizzle report) should revert. Tech stack page "Known quirks" bullet about `apps/api/drizzle/` still existing is also false post-PR-#89 and should be deleted.
+
+## Non-obvious learnings
+
+1. **`define` constants don't fold into template literals through esbuild.** First attempt at the deploy-health marker used `BUILD_MARKER = \`STRALE_BUILD:\${BUILD_SHA}:\${BUILD_TIME}\`` — esbuild left it as a runtime template `STRALE_BUILD:${UT}:${BT}` in the bundle and the grep regex couldn't match. Fix: inject the full marker as a single `define` value, not build it from components.
+2. **Branch-local working trees can produce false "is X on main?" verdicts.** The drizzle verification mistake. Saved as feedback memory.
+3. **Auto-merge is disabled on `strale-io/strale`** (`gh pr merge --auto` returns "Auto merge is not allowed for this repository"). Manual merge after CI green works fine. Not blocking.
+
+## Cost
+
+None. All verification was free (HTTP HEADs + DNS lookups + repo greps + GHA API calls). The two GHA runs (deploy-health on strale-frontend, CI on strale PR #104) ran on GitHub's free tier.


### PR DESCRIPTION
Five from-code handoffs authored during the 2026-05-13 sessions, promoting to tracked per Rule G handoff-promotion pattern.

Contents:
- \`2026-05-13-beacon-hosting-verification.md\` — verifies scan.strale.io is on Vercel, high confidence (4 independent signals)
- \`2026-05-13-drizzle-quirks-verification.md\` — original Outcome B was wrong; correction header added mid-session (PR #89 had fully shipped DEC-20260511-C; the report was reading stale branch state from the strale trunk worktree)
- \`2026-05-13-lovable-cancellation-audit.md\` — verdict SAFE TO CANCEL; zero runtime dependencies across DNS / headers / webhooks / CI / commit activity
- \`2026-05-13-structural-backstops-and-readiness-audits.md\` — session-arc summary covering the deploy-health monitor + capabilities list↔detail contract invariant
- \`2026-05-13-lovable-cancellation-cleanup-execution.md\` — session-arc summary of the cleanup PRs (#9 frontend, #105 backend) + deploy-health monitor catching PR #9's silent CF Pages failure + bun-lockfile hotfix (#10)