### PR TITLE
fix(swiss-company-data): correct known_answer fixture to real ACTIVE UID

### DIFF
--- a/manifests/swiss-company-data.yaml
+++ b/manifests/swiss-company-data.yaml
@@ -2,7 +2,7 @@ slug: swiss-company-data
 name: Swiss Company Data
 description: >-
   Look up Swiss company data from the Zefix PublicREST API (Federal Office of Justice). Accepts UID
-  (e.g. CHE-105.805.977), EHRAID, or fuzzy company name.
+  (e.g. CHE-101.602.521), EHRAID, or fuzzy company name.
 category: data-extraction
 cost_class: free_unlimited
 quota_window: none
@@ -15,7 +15,7 @@ input_schema:
   properties:
     uid:
       type: string
-      description: Swiss UID (e.g. CHE-105.805.977), EHRAID, or company name
+      description: Swiss UID (e.g. CHE-101.602.521), EHRAID, or company name
 output_schema:
   type: object
   example:
@@ -83,7 +83,7 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      uid: CHE-105.805.977
+      uid: CHE-101.602.521
     expected_fields:
       - field: company_name
         operator: not_null
@@ -98,7 +98,7 @@ test_fixtures:
         operator: not_null
         reliability: guaranteed
   health_check_input:
-    uid: CHE-105.805.977
+    uid: CHE-101.602.521
 output_field_reliability:
   company_name: guaranteed
   uid: guaranteed


### PR DESCRIPTION
## Summary

Manifest's `known_answer.input.uid` was `CHE-105.805.977` — not a real Swiss UID. Zefix returns `200 OK []` for it under any endpoint. This caused the scheduler to trip the `swiss-company-data` circuit breaker on every `:41` tick, producing a false-positive "Zefix integration broken" diagnosis that led to an unnecessary 30-day manual breaker pin earlier today.

Replacing with `CHE-101.602.521` (Roche Holding AG, ACTIVE, large-cap, stable). Smoke-equivalent against prod confirms all 7 guaranteed fields populated.

## Verification

- Audit-phase probe (direct curl with prod creds): `GET /api/v1/company/uid/CHE101602521` → 200 + populated ACTIVE Roche Holding AG payload
- Smoke-equivalent (`getExecutor("swiss-company-data")({uid:"CHE-101.602.521"})` via Railway): 462 ms, 16 fields, all 7 guaranteed (`company_name`, `uid`, `ehraid`, `legal_form`, `status`, `data_source`, `data_attribution`) populated
- Reference T11 / T12 from the 2026-05-13 credentials-diagnostic session

## Post-merge actions (operator)

Once CI is green and this merges, the following operational state changes happen via Railway SSH + node script (mirroring the DK 2026-05-06 precedent):

1. Sync `test_suites.input` for `swiss-company-data` known_answer suite from the new manifest fixture.
2. Release the manual circuit breaker:
   ```sql
   UPDATE capability_health
   SET state='closed', opened_at=NULL, next_retry_at=NULL,
       consecutive_failures=0, updated_at=NOW()
   WHERE capability_slug='swiss-company-data';
   ```
3. Verify via `POST /v1/do` with `CHE-101.602.521` and a second real UID (`CHE109815753` Société des Produits Nestlé).

## Phase 2 + Phase 3 follow-ups (per parent CH/SK Phase 1 prompt)

- **Phase 2 (Understand):** course-correction Journal entry on how a bad fixture survived (a) the onboarding pipeline's `--discover` step (which should have errored when known_answer returned `[]`), (b) 16 days of hourly testing under DEC-20260503-B, and (c) the full v1-launch business-registry coverage audit. Causal chain ≥3 steps.
- **Phase 3 (Harden):** two structural gates:
  - (a) canonical-input sentinel test — daily check that every Live capability's `known_answer.input` returns populated data (already named in parent prompt).
  - (b) **new:** pipeline-bypass detector — enforce at commit time that a manifest cannot land with a `known_answer.input` not verified against live output. Likely a CI gate or a pre-commit hook that re-runs `--discover` against the new/modified fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)