### PR TITLE
feat: known_answer sentinel — strict-missing-only on guaranteed fields (Phase 3)

### DIFF
--- a/apps/api/src/lib/guaranteed-fields-sentinel.test.ts
+++ b/apps/api/src/lib/guaranteed-fields-sentinel.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the canonical-input sentinel (Gate 3).
+ *
+ * Phase 3 Harden for DEC-20260513-B + DEC-20260513-C. Per Rule 12
+ * (audit-follow-up test coverage): each new code path is paired with a
+ * regression test. Three positive failure cases + one negative
+ * non-failure case satisfy the rule.
+ */
+
+import { describe, it, expect } from "vitest";
+import { checkGuaranteedFieldsPresent } from "./guaranteed-fields-sentinel.js";
+
+describe("checkGuaranteedFieldsPresent (Gate 3 — strict-missing-only)", () => {
+  it("passes when every guaranteed field is present as a key", () => {
+    // Happy path. Values can be anything — the gate only checks key presence.
+    const result = checkGuaranteedFieldsPresent(
+      {
+        company_name: "Roche Holding AG",
+        uid: "CHE101602521",
+        status: "ACTIVE",
+        data_attribution: "Zefix",
+      },
+      {
+        company_name: "guaranteed",
+        uid: "guaranteed",
+        status: "guaranteed",
+        data_attribution: "guaranteed",
+        canton: "common",
+        purpose: "rare",
+      },
+    );
+    expect(result.passed).toBe(true);
+    expect(result.failureReason).toBeUndefined();
+  });
+
+  it("fails when actual_output is an array (CH bad-fixture root shape)", () => {
+    // The CH 2026-05-13 incident class: Zefix returned 200 OK [] for an
+    // invalid UID; the parser path that handled "no match" yielded an
+    // output value that wasn't a plain object. v1 of the sentinel would
+    // have caught this too, but only via the missing-keys branch. v2's
+    // root-shape branch surfaces the explicit signal.
+    const result = checkGuaranteedFieldsPresent(
+      [],
+      { company_name: "guaranteed", uid: "guaranteed" },
+    );
+    expect(result.passed).toBe(false);
+    expect(result.failureReason).toBe("guaranteed_field_missing:<root-not-object>");
+  });
+
+  it("fails when a declared guaranteed field key is absent (the 4 real-bug class)", () => {
+    // The exact pattern surfaced in v1's backfill check for
+    // charity-lookup-uk.income, japanese-company-data.corporate_number,
+    // llm-output-validate.auto_fixed_output, openapi-validate.stats.
+    // Every other declared field is present; one is missing entirely.
+    const result = checkGuaranteedFieldsPresent(
+      { uid: "CHE-..." },
+      {
+        company_name: "guaranteed",
+        uid: "guaranteed",
+      },
+    );
+    expect(result.passed).toBe(false);
+    expect(result.failureReason).toBe("guaranteed_field_missing:company_name");
+  });
+
+  it("passes when guaranteed fields are present with empty / null values (the validator/scanner semantic)", () => {
+    // Critical non-failure case. v1's "non-empty" rule would have failed
+    // here and flipped 35+ healthy capabilities (security scans,
+    // validators, deduplicators) to degraded. v2 must explicitly pass:
+    // findings=[] means no secrets, severity_counts={} means no findings
+    // bucketed, scanner_version="" is implausible but allowed by this gate
+    // (null/empty governance lives in DEC-20260409-A, not here).
+    const result = checkGuaranteedFieldsPresent(
+      {
+        findings: [],
+        severity_counts: {},
+        scanner_version: null,
+        scan_completed_at: "",
+      },
+      {
+        findings: "guaranteed",
+        severity_counts: "guaranteed",
+        scanner_version: "guaranteed",
+        scan_completed_at: "guaranteed",
+      },
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it("passes when no field is declared guaranteed (no-op on caps without reliability data)", () => {
+    // Defensive: capabilities authored before output_field_reliability
+    // was introduced have no guaranteed entries; the gate must not fire.
+    expect(checkGuaranteedFieldsPresent({}, null).passed).toBe(true);
+    expect(checkGuaranteedFieldsPresent({}, undefined).passed).toBe(true);
+    expect(checkGuaranteedFieldsPresent({}, {}).passed).toBe(true);
+    expect(
+      checkGuaranteedFieldsPresent({}, { foo: "common", bar: "rare" }).passed,
+    ).toBe(true);
+  });
+
+  it("fails when output is null and at least one field is guaranteed", () => {
+    // Defensive: a capability that throws before returning output yields
+    // capResult === null upstream; if test-runner happens to reach this
+    // gate with a null output and guaranteed declarations present, the
+    // root-not-object failure path catches it. Belt-and-braces — the
+    // ahead-of-gate `if (!capResult)` check in test-runner already
+    // prevents this in practice.
+    const result = checkGuaranteedFieldsPresent(null, {
+      company_name: "guaranteed",
+    });
+    expect(result.passed).toBe(false);
+    expect(result.failureReason).toBe("guaranteed_field_missing:<root-not-object>");
+  });
+});

--- a/apps/api/src/lib/guaranteed-fields-sentinel.ts
+++ b/apps/api/src/lib/guaranteed-fields-sentinel.ts
@@ -1,0 +1,66 @@
+/**
+ * Canonical-input sentinel — strict-missing-only assertion on guaranteed fields.
+ *
+ * Phase 3 Harden for DEC-20260513-B + DEC-20260513-C. Companion to the
+ * audit-follow-up test coverage rule (DEC-20260504-A). Catches the class of
+ * bug surfaced 2026-05-13 by the CH swiss-company-data bad-fixture incident:
+ * Zefix returned 200 OK [] for an invalid UID, the parser yielded an
+ * actual_output object that contained none of the declared fields, and the
+ * known_answer suite still passed because the `not_null` checks at the
+ * expected_fields layer found `value == null` for fields that were never set
+ * in the first place and bailed without enforcement.
+ *
+ * Strict-missing-only semantics: only key absence flips the suite to failed.
+ * Field-present-with-null, field-present-with-empty-collection, and
+ * field-present-with-empty-string all pass this gate. Validators, scanners,
+ * and dedupers legitimately return `findings=[]` / `duplicates_found=[]` /
+ * `errors=[]` to mean "no findings / no duplicates / no errors" — those are
+ * successful results, not degraded ones. The 50%-null-ratio gate
+ * (DEC-20260409-A, lib/null-field-ratio.ts) governs the null and
+ * empty-collection signals separately.
+ *
+ * v1 (halted) used a non-empty rule and would have flipped 40 healthy
+ * capabilities to failed at the next scheduler tick. v2 (this module)
+ * flips exactly the 4 capabilities with real missing-key parser bugs
+ * (charity-lookup-uk.income, japanese-company-data.corporate_number,
+ * llm-output-validate.auto_fixed_output, openapi-validate.stats — each
+ * surfaces as a separate per-capability triage prompt).
+ */
+
+export interface SentinelResult {
+  passed: boolean;
+  failureReason?: string;
+}
+
+export function checkGuaranteedFieldsPresent(
+  output: unknown,
+  fieldReliability: Record<string, string> | null | undefined,
+): SentinelResult {
+  if (!fieldReliability) return { passed: true };
+
+  const guaranteedFields = Object.entries(fieldReliability)
+    .filter(([, level]) => level === "guaranteed")
+    .map(([field]) => field);
+
+  if (guaranteedFields.length === 0) return { passed: true };
+
+  // Root must be a plain object. Array, null, or non-object output fails
+  // by definition — there are no named keys to verify against.
+  if (typeof output !== "object" || output === null || Array.isArray(output)) {
+    return {
+      passed: false,
+      failureReason: "guaranteed_field_missing:<root-not-object>",
+    };
+  }
+
+  const outputRecord = output as Record<string, unknown>;
+  for (const field of guaranteedFields) {
+    if (!(field in outputRecord)) {
+      return {
+        passed: false,
+        failureReason: `guaranteed_field_missing:${field}`,
+      };
+    }
+  }
+  return { passed: true };
+}

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -1009,6 +1009,10 @@ async function captureBaseline(
 // Feature flag — defaults to disabled; enable with NULL_RATIO_RULE_ENABLED=true
 const NULL_RATIO_RULE_ENABLED = process.env.NULL_RATIO_RULE_ENABLED === "true";
 
+// Gate 3: Canonical-input sentinel (DEC-20260513-B + DEC-20260513-C).
+// See ./guaranteed-fields-sentinel.ts for the rationale + strict-missing semantics.
+import { checkGuaranteedFieldsPresent } from "./guaranteed-fields-sentinel.js";
+
 function validateResult(
   suite: typeof testSuites.$inferSelect,
   capResult: CapabilityResult | null,
@@ -1091,6 +1095,16 @@ function validateResult(
         // 'guaranteed' or unknown field → enforce the check (fall through to fail)
       }
       return { passed: false, failureReason: checkResult.reason };
+    }
+  }
+
+  // Gate 3: Canonical-input sentinel — strict-missing-only on guaranteed
+  // fields (DEC-20260513-B + DEC-20260513-C, Phase 3 Harden).
+  // Applies only to known_answer. See checkGuaranteedFieldsPresent docs.
+  if (suite.testType === "known_answer") {
+    const sentinel = checkGuaranteedFieldsPresent(capResult?.output, fieldReliability);
+    if (!sentinel.passed) {
+      return { passed: false, failureReason: sentinel.failureReason ?? null };
     }
   }
 


### PR DESCRIPTION
## Summary

Phase 3 Harden gate for the bug-fix cycle initiated by **DEC-20260513-B** (CH `swiss-company-data` bad fixture survived 16+ days of hourly testing because the suite passed on HTTP 200 even when Zefix returned an empty array) and **DEC-20260513-C** (SK scheduler-burst, resolved in PR #108). Phase 1 Contain shipped in PR #107 + PR #108. Phase 2 Understand is filed in [Notion Journal 35f67c8](https://www.notion.so/35f67c87082c81ceab3cdfa08b6391a2). This PR is Phase 3 — Rule 7 carve-out applies.

This is **v2** of the canonical-input sentinel. v1 halted on backfill surprise (40 capabilities would have flipped to failed). v2 refines the assertion shape to strict-missing-only and flips exactly the 4 real missing-key bugs.

## What the gate adds

After the existing `expected_fields` per-check loop in `validateResult`, for `known_answer` suites only:

- If `actual_output` is not a plain object (null, array, primitive) and any field is declared `guaranteed`, fail with `failure_reason="guaranteed_field_missing:<root-not-object>"`.
- If any field in `output_field_reliability.guaranteed` is absent as a key from `actual_output`, fail with `failure_reason="guaranteed_field_missing:<field>"`.

**Strict-missing-only.** Field-present-with-null, field-present-with-empty-collection, and field-present-with-empty-string all PASS this gate. Validators, scanners, and dedupers legitimately return `findings=[]` to mean "no secrets" — that's success, not failure. The 50%-null-ratio gate (DEC-20260409-A, feature-flagged off) governs the null/empty-collection signals separately.

## Backfill check (under threshold)

Simulated v2 semantics against last 24h of passing `known_answer` test_results on healthy capabilities. **Exactly 4 capabilities flagged** (≤5 threshold):

```json
[
  {"slug": "charity-lookup-uk",       "missing": ["income"],            "guaranteed_count": 4},
  {"slug": "japanese-company-data",   "missing": ["corporate_number"],  "guaranteed_count": 4},
  {"slug": "llm-output-validate",     "missing": ["auto_fixed_output"], "guaranteed_count": 5},
  {"slug": "openapi-validate",        "missing": ["stats"],             "guaranteed_count": 4}
]
```

Each is a real parser/manifest drift bug deserving per-capability triage (separate follow-up prompts). Surfaced as signal here; not blocked.

For comparison, v1's "non-empty" rule produced 40 affected capabilities:
- 35 empty-array false-positives (`secret-scan.findings=[]`, `cve-lookup.vulnerabilities=[]`, etc. — all valid)
- 1 empty-object false-positive
- 9 null cases (mixed validity)
- 4 real missing-key bugs (same as above)

v2 catches exactly the 4 real bugs.

## Tests (6 passing)

`apps/api/src/lib/guaranteed-fields-sentinel.test.ts`:

1. **Happy path** — every guaranteed field present as a key; passes (values can be anything).
2. **Root-not-object** — `actual_output = []`; fails with `<root-not-object>` token.
3. **Missing key** — `actual_output = { uid: "..." }` while `company_name` declared guaranteed; fails with `guaranteed_field_missing:company_name`.
4. **Empty/null fields present** (the validator/scanner semantic) — `findings=[]`, `severity_counts={}`, `scanner_version=null` all declared guaranteed; **passes**.
5. **No reliability data** — defensive no-op for caps without `output_field_reliability`.
6. **Null output** — defensive belt-and-braces; fails with `<root-not-object>` if reached.

Per Rule 12: each new code path paired with regression coverage.

## Wiring verification

The gate lives inside `validateResult` at [test-runner.ts:1099-1104](../../tree/feat/known-answer-sentinel-cbb59a5/apps/api/src/lib/test-runner.ts#L1099-L1104), called from the canonical suite-execution path at [test-runner.ts:533](../../tree/feat/known-answer-sentinel-cbb59a5/apps/api/src/lib/test-runner.ts#L533) (the same path the per-suite scheduler poll-tick uses). Not dead code.

**Pre-merge canary skipped** per the 2026-05-06 DK precedent constraint: `postgres.railway.internal` does not resolve from outside Railway egress; local `tsx` + `railway run` cannot reach the prod DB. Wiring is verified by (a) call-site trace, (b) the 6 unit tests, (c) the backfill simulation predicting the 4 capabilities that will fire. Same Railway backend deploy mechanism that shipped PR #107 and PR #108 today — verified working.

## Post-deploy verification (Rule 14)

Within ~1 hour after merge, query against prod:

```sql
SELECT capability_slug, executed_at, failure_reason
FROM test_results
WHERE failure_reason LIKE 'guaranteed_field_missing:%'
  AND executed_at > NOW() - INTERVAL '1 hour'
ORDER BY executed_at DESC;
```

Expected: at least one row from each of the 4 backfill-flagged capabilities as their scheduled minute hits. Confirms the gate is firing in production.

## Out of scope (follow-ups)

- **Per-capability triage prompts** for the 4 missing-key bugs.
- **Pipeline-bypass detector v2** (companion Phase 3 gate, named in v1 + v2 prompts) — separate prompt.
- **PL polish-company-data reliability re-labeling** — `address` + `registration_date` should likely move from `guaranteed` to `common` per the v1 halt finding; separate triage.
- **`non_empty: true` opt-in annotation** for capabilities that DO need empty-as-failure semantics on specific fields — design and ship later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)