### PR TITLE
fix: normalize HR + CH customer prices to EUR 0.05 per DEC-20260513-E

### DIFF
--- a/manifests/croatian-company-data.yaml
+++ b/manifests/croatian-company-data.yaml
@@ -7,7 +7,7 @@ category: data-extraction
 cost_class: free_quota
 quota_window: daily
 quota_cap: 500
-price_cents: 80
+price_cents: 5
 is_free_tier: false
 avg_latency_ms: 500
 input_schema:

--- a/manifests/swiss-company-data.yaml
+++ b/manifests/swiss-company-data.yaml
@@ -6,7 +6,7 @@ description: >-
 category: data-extraction
 cost_class: free_unlimited
 quota_window: none
-price_cents: 80
+price_cents: 5
 is_free_tier: false
 input_schema:
   type: object


### PR DESCRIPTION
## Summary

Per **DEC-20260513-E** (`https://www.notion.so/35f67c87082c81f499a9cbb9ebb39553`): normalize `croatian-company-data` and `swiss-company-data` from EUR 0.80 → EUR 0.05 to match the catalog convention for direct-govt-registry capabilities. Pre-launch hygiene — stranded legacy prices from an earlier scraping-era convention that survived migrations to direct govt REST APIs (Sudreg, Zefix).

## Changes

### Manifest diff (this PR — 2 lines)

- `manifests/croatian-company-data.yaml`: `price_cents: 80 → 5`
- `manifests/swiss-company-data.yaml`: `price_cents: 80 → 5`

### DB UPDATEs already applied (production, pre-PR)

`price_cents` is **db-canonical** per `apps/api/src/lib/capability-field-authority.ts:103-106` — manifest seeds on create only; DB UPDATE was the operational change.

```sql
UPDATE capabilities SET price_cents = 5 WHERE slug = 'croatian-company-data';
UPDATE capabilities SET price_cents = 5, capability_type = 'stable_api' WHERE slug = 'swiss-company-data';
```

Before / after:

| slug | price_cents | capability_type |
|---|---|---|
| `croatian-company-data` | 80 → 5 | stable_api (unchanged) |
| `swiss-company-data` | 80 → 5 | scraping → stable_api |

The CH `capability_type` was also drifted: manifest declared `data_source_type: api` (Zefix REST) but DB carried legacy `scraping` tag. Direct UPDATE required because `capability_type` is **hybrid** per `capability-field-authority.ts:271-274` (DB preserved when set; `onboard.ts --backfill` would not overwrite).

## Smoke probes (post-DB-UPDATE, production)

Both `/v1/do` calls returned `price_cents: 5` and `status: completed`:

- **HR** `croatian-company-data` with `{oib: "81793146560"}` (Hrvatski Telekom d.d.) — transaction `dc19948a-9dab-4932-88fd-3d01645c777f`, 5 cents charged, 1098 ms.
- **CH** `swiss-company-data` with `{uid: "CHE-101.602.521"}` (Roche Holding AG) — transaction `35ff87e3-05d3-4903-97f3-20a553e76c13`, 5 cents charged, 469 ms. Provider `zefix-public-rest`, provider_type `api`, fallback_used=false (Zefix REST path, no scraping).

Billing path confirmed end-to-end; no caching-layer issue.

## Sibling-repo grep — no action needed

`strale-frontend` and `strale-beacon` greped for `swiss-company-data|croatian-company-data`. Three benign hits in `strale-frontend`, none with EUR 0.80 / 80-cent context:

- `public/sitemap.xml`: capability URL entries.
- `src/lib/__fixtures__/trust-vat-validate.json`: workaround text.
- `test-report.md`: HTTP-200 check.

Frontend reads capability prices dynamically from the live API.

## Onboarding pipeline exemption

`onboard.ts --backfill` honors field-authority: `price_cents` (db-canonical) and `capability_type` (hybrid) are not overwritten by manifest values when DB has a value. Direct DB UPDATE is the documented path. Pipeline does not apply to this change.

## Out of scope

- CA + JP EUR 0.80 pricing (kept as scraping-cost-justified, per DEC-20260513-E v1 scope).
- Catalog-wide `capability_type` drift on other slugs (separate cleanup).
- 8 inactive EUR 0.80 capabilities (re-priced on reactivation per DEC-20260513-E).

## Test plan

- [x] `npx tsc --noEmit` green (baseline + post-change)
- [x] `npx vitest run src/lib/capability-manifest.test.ts` green (33/33)
- [x] Smoke probe HR: `price_cents: 5` confirmed
- [x] Smoke probe CH: `price_cents: 5` confirmed; Zefix REST path used
- [x] Sibling-repo grep: no hardcoded EUR 0.80 hits

## Outcome field

Chat to populate DEC-20260513-E Outcome with this PR link post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)