### PR TITLE
feat(ci): static manifest guaranteed-field consistency gate + onboard-time strict-missing (Phase 3b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,15 @@ jobs:
       # Pre-existing offenders are tracked in fetch-timeout-allowlist.txt;
       # --strict fails CI on new offenders.
       - run: node apps/api/scripts/check-fetch-timeout-coverage.mjs --strict
+      # Phase 3b (DEC-20260513-B + DEC-20260513-C): every manifest's
+      # output_field_reliability.guaranteed entries must be enumerated in
+      # output_schema.properties or output_schema.example. Pre-existing
+      # drift tracked in scripts/manifest-consistency-allowlist.txt;
+      # --strict fails CI on new offenders. Pairs with the runtime sentinel
+      # at lib/guaranteed-fields-sentinel.ts which fires at scheduler-tick
+      # time, and with onboard.ts verifyFixtures which fires at manifest
+      # authoring time.
+      - run: node apps/api/scripts/check-manifest-guaranteed-consistency.mjs --strict
       # Cert-audit Layer 2 (generalised 2026-04-30): cross-repo
       # type-shape contracts (currently AuditRecord). Skips cleanly
       # when STRALE_FRONTEND_PATH is not present (CI doesn't check out

--- a/apps/api/scripts/check-manifest-guaranteed-consistency.mjs
+++ b/apps/api/scripts/check-manifest-guaranteed-consistency.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Phase 3b Harden — pipeline-bypass detector (static manifest-consistency).
+ *
+ * Per DEC-20260513-B + DEC-20260513-C, enforces that every field declared
+ * `guaranteed` in a manifest's `output_field_reliability` is also enumerated
+ * in `output_schema.properties` or `output_schema.example`. Catches the
+ * authorship-time drift class where a manifest author adds a guaranteed-tier
+ * field reliability annotation but forgets to declare the field in the
+ * output schema — the runtime sentinel (PR #109) would catch the resulting
+ * runtime divergence within one scheduler tick, but this static gate
+ * shifts detection left to PR review.
+ *
+ * Pattern mirrors check-fetch-timeout-coverage.mjs --strict. Two modes:
+ *   default    — print findings + exit 0 (informational)
+ *   --strict   — exit 1 if any new offenders appear vs the allowlist
+ *
+ * Allowlist: scripts/manifest-consistency-allowlist.txt (one slug per line).
+ * The 22 entries grandfathered as of 2026-05-13 are the pre-existing drift
+ * surfaced when the gate first ran; each gets a separate per-manifest fix.
+ *
+ * Path A re-entry triggers (full PR-time dynamic gate that invokes the live
+ * executor against changed manifests) per DEC-20260513-B/C:
+ *   (a) multiple concurrent contributors merging manifests,
+ *   (b) a CH-class bug recurs that the 1-hour runtime-sentinel window
+ *       allows to damage production, or
+ *   (c) CI infrastructure (DB access + ~30 executor env vars) gets
+ *       provisioned for unrelated reasons.
+ */
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..", "..", "..");
+const manifestsDir = resolve(repoRoot, "manifests");
+const allowlistPath = resolve(__dirname, "manifest-consistency-allowlist.txt");
+const strict = process.argv.includes("--strict");
+
+function loadAllowlist() {
+  if (!existsSync(allowlistPath)) return new Set();
+  return new Set(
+    readFileSync(allowlistPath, "utf8")
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith("#")),
+  );
+}
+
+function scan() {
+  if (!existsSync(manifestsDir)) {
+    console.error(`manifests directory not found: ${manifestsDir}`);
+    process.exit(2);
+  }
+
+  const files = readdirSync(manifestsDir).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+  const violations = [];
+
+  for (const file of files) {
+    let parsed;
+    try {
+      parsed = yaml.load(readFileSync(resolve(manifestsDir, file), "utf8"));
+    } catch (err) {
+      // Malformed YAML is a different gate's problem (validate-capability).
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+    const m = parsed;
+
+    const reliability = m.output_field_reliability;
+    if (!reliability || typeof reliability !== "object") continue;
+
+    const guaranteed = Object.entries(reliability)
+      .filter(([, lvl]) => lvl === "guaranteed")
+      .map(([k]) => k);
+    if (guaranteed.length === 0) continue;
+
+    const schemaProps = m.output_schema?.properties || {};
+    const exampleKeys = m.output_schema?.example && typeof m.output_schema.example === "object"
+      ? Object.keys(m.output_schema.example)
+      : [];
+    const declared = new Set([...Object.keys(schemaProps), ...exampleKeys]);
+
+    const missing = guaranteed.filter((f) => !declared.has(f));
+    if (missing.length > 0) {
+      violations.push({ slug: m.slug ?? file.replace(/\.ya?ml$/, ""), file, missing });
+    }
+  }
+
+  return violations;
+}
+
+const violations = scan();
+const allowed = loadAllowlist();
+const newViolations = violations.filter((v) => !allowed.has(v.slug));
+
+console.log(
+  `manifest guaranteed-field consistency: ${violations.length} total, ${newViolations.length} not in allowlist`,
+);
+
+if (newViolations.length > 0) {
+  console.log("\nNew violations (not in allowlist):");
+  for (const v of newViolations) {
+    console.log(`  ${v.slug} (${v.file}): missing-from-schema=[${v.missing.join(", ")}]`);
+  }
+}
+
+if (strict && newViolations.length > 0) {
+  console.error(
+    "\nManifest declares `guaranteed` field(s) not enumerated in output_schema.properties " +
+      "or output_schema.example. Either add the field to output_schema (preferred) or " +
+      "downgrade the reliability annotation to `common` or `rare`. See DEC-20260513-B.",
+  );
+  process.exit(1);
+}

--- a/apps/api/scripts/manifest-consistency-allowlist.txt
+++ b/apps/api/scripts/manifest-consistency-allowlist.txt
@@ -1,0 +1,42 @@
+# Manifest guaranteed-field consistency allowlist
+#
+# Each line is a capability slug whose `output_field_reliability.guaranteed`
+# contains a field path not enumerated in `output_schema.properties` or
+# `output_schema.example`. These are grandfathered drifts as of 2026-05-13;
+# per DEC-20260513-B and DEC-20260513-C, each gets a Notion To-do filed
+# for individual manifest correction. As fixes land, the entry gets removed.
+#
+# If the allowlist length is ever zero, this file may be deleted.
+# If the allowlist length stays at the current size for >6 months, that's
+# a signal the gate became theatre — revisit the gate's value.
+#
+# Path A re-entry triggers (full PR-time dynamic gate that invokes the live
+# executor against changed manifests) per DEC-20260513-B/C:
+#   (a) multiple concurrent contributors merging manifests,
+#   (b) a CH-class bug recurs that the 1-hour runtime-sentinel window allows
+#       to damage production, or
+#   (c) CI infrastructure (DB + ~30 executor env vars) gets provisioned for
+#       unrelated reasons and the marginal cost of the dynamic gate drops to ~0.
+
+address-geocode
+address-validate
+age-verify
+aml-risk-score
+business-day-check
+company-name-match
+company-news
+credit-score-band
+email-reputation-score
+iban-to-bank
+insolvency-check
+license-compatibility-check
+nl-bag-address
+nl-energy-label
+nl-housing-price-index
+nl-housing-stats
+nl-woz-value
+phone-type-detect
+phone-validate
+sec-filing-events
+timezone-lookup
+uk-filing-events

--- a/apps/api/scripts/onboard.ts
+++ b/apps/api/scripts/onboard.ts
@@ -59,6 +59,10 @@ import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { getExecutor } from "../src/capabilities/index.js";
 import { guardedExecute } from "../src/capabilities/guarded-executor.js";
+// Phase 3a runtime sentinel (PR #109): strict-missing-only assertion on
+// guaranteed fields. Reused here at onboard time so the same gate fires
+// before a manifest can be committed.
+import { checkGuaranteedFieldsPresent } from "../src/lib/guaranteed-fields-sentinel.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 // Manifest / ManifestExpectedField / ManifestLimitation moved to
@@ -508,6 +512,24 @@ async function verifyFixtures(
 
   console.log(`  Output: ${Object.keys(output).length} fields returned`);
 
+  // Phase 3b strict-missing gate (DEC-20260513-B + DEC-20260513-C): every
+  // field declared `guaranteed` in output_field_reliability must appear as
+  // a key in actual_output. Reuses the runtime sentinel from PR #109 so
+  // the same assertion fires at onboard time AND at scheduler-tick time.
+  // Caught fixtures are rejected before manifest commit; this closes the
+  // window between manifest authoring and the runtime sentinel's first tick.
+  const reliability = manifest.output_field_reliability ?? null;
+  const sentinel = checkGuaranteedFieldsPresent(output, reliability as Record<string, string> | null);
+  if (!sentinel.passed) {
+    console.log(`  ✗ Strict-missing gate failed: ${sentinel.failureReason}`);
+    console.log(
+      "  The executor's output is missing a field declared `guaranteed` in " +
+        "output_field_reliability. Either fix the executor to populate the field, " +
+        "or downgrade the reliability annotation to `common` or `rare`.",
+    );
+    return { passed: false, manifest };
+  }
+
   // Check each expected field
   let allPass = true;
   for (const ef of expectedFields) {
@@ -522,7 +544,7 @@ async function verifyFixtures(
   }
 
   if (allPass) {
-    console.log("  ✓ known_answer verified against live output");
+    console.log("  ✓ known_answer verified against live output (strict-missing + expected_fields)");
     return { passed: true, manifest };
   }
 

--- a/apps/api/test/check-manifest-guaranteed-consistency.test.ts
+++ b/apps/api/test/check-manifest-guaranteed-consistency.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the Phase 3b static manifest-consistency check.
+ *
+ * Per Rule 12 (audit-follow-up test coverage): three cases — happy path,
+ * new-violation detection, allowlist-exempt. The script itself is .mjs and
+ * scans the on-disk manifests directory; these tests exercise the smaller
+ * shape-validation logic by mirroring it against fixture YAML data so they
+ * don't depend on the production manifest set.
+ */
+
+import { describe, it, expect } from "vitest";
+import yaml from "js-yaml";
+
+// Mirror of the static-check logic from check-manifest-guaranteed-consistency.mjs.
+// Kept here for unit testing without spawning the script and crawling disk.
+// If the mjs script's logic changes, this mirror must change with it —
+// the live check at CI time uses the script; this test guards the contract.
+function findMissingGuaranteedFields(manifest: unknown): string[] {
+  if (!manifest || typeof manifest !== "object") return [];
+  const m = manifest as Record<string, unknown>;
+  const reliability = m.output_field_reliability;
+  if (!reliability || typeof reliability !== "object") return [];
+
+  const guaranteed = Object.entries(reliability as Record<string, unknown>)
+    .filter(([, lvl]) => lvl === "guaranteed")
+    .map(([k]) => k);
+  if (guaranteed.length === 0) return [];
+
+  const outputSchema = m.output_schema as Record<string, unknown> | undefined;
+  const schemaProps = (outputSchema?.properties as Record<string, unknown>) || {};
+  const example = outputSchema?.example;
+  const exampleKeys =
+    example && typeof example === "object" ? Object.keys(example as Record<string, unknown>) : [];
+  const declared = new Set([...Object.keys(schemaProps), ...exampleKeys]);
+
+  return guaranteed.filter((f) => !declared.has(f));
+}
+
+describe("check-manifest-guaranteed-consistency (Phase 3b static gate)", () => {
+  it("passes a clean manifest where every guaranteed field is in output_schema.properties", () => {
+    const manifest = yaml.load(`
+      slug: clean-cap
+      output_field_reliability:
+        company_name: guaranteed
+        uid: guaranteed
+        status: guaranteed
+        canton: common
+      output_schema:
+        type: object
+        properties:
+          company_name: { type: string }
+          uid: { type: string }
+          status: { type: string }
+          canton: { type: string }
+    `);
+    expect(findMissingGuaranteedFields(manifest)).toEqual([]);
+  });
+
+  it("passes a clean manifest where every guaranteed field is in output_schema.example", () => {
+    // Many manifests rely on the .example shape rather than .properties.
+    const manifest = yaml.load(`
+      slug: example-only-cap
+      output_field_reliability:
+        ico: guaranteed
+        company_name: guaranteed
+      output_schema:
+        type: object
+        example:
+          ico: "12345678"
+          company_name: Example s.r.o.
+    `);
+    expect(findMissingGuaranteedFields(manifest)).toEqual([]);
+  });
+
+  it("detects a new violation when a guaranteed field is not declared in schema", () => {
+    // The regression class this gate catches: manifest author adds a
+    // guaranteed-tier reliability annotation but forgets to declare the
+    // field in output_schema. Runtime sentinel (PR #109) would catch this
+    // within one scheduler tick; this gate shifts detection to PR review.
+    const manifest = yaml.load(`
+      slug: drift-cap
+      output_field_reliability:
+        company_name: guaranteed
+        forgotten_field: guaranteed
+      output_schema:
+        type: object
+        properties:
+          company_name: { type: string }
+    `);
+    expect(findMissingGuaranteedFields(manifest)).toEqual(["forgotten_field"]);
+  });
+
+  it("ignores non-guaranteed reliability tiers (common, rare)", () => {
+    // The gate is strict-missing-only on `guaranteed`. Fields marked common
+    // or rare are allowed to be absent from the schema enumeration.
+    const manifest = yaml.load(`
+      slug: tiered-cap
+      output_field_reliability:
+        always_there: guaranteed
+        sometimes_there: common
+        rarely_there: rare
+      output_schema:
+        type: object
+        properties:
+          always_there: { type: string }
+    `);
+    expect(findMissingGuaranteedFields(manifest)).toEqual([]);
+  });
+
+  it("returns empty for manifests with no output_field_reliability block", () => {
+    // Defensive: capabilities authored before the field-reliability concept
+    // landed don't have the annotation. The gate must no-op on them rather
+    // than producing false positives.
+    expect(findMissingGuaranteedFields(yaml.load("slug: legacy-cap"))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3b Harden for the bug-fix cycle initiated by **DEC-20260513-B** + **DEC-20260513-C**. Phase 1 in PR #107 + PR #108. Phase 2 in [Notion Journal 35f67c8](https://www.notion.so/35f67c87082c81ceab3cdfa08b6391a2). Phase 3a runtime sentinel in PR #109. This PR is Phase 3b — Rule 7 carve-out applies; all four phases of the cycle close here.

This is **v3** of the pipeline-bypass detector. v1/v2 specified a dynamic CI gate requiring DB+executor infrastructure that isn't currently provisioned (out of CC's autonomy). v3 is the **Path B** shipping shape: static manifest-consistency check at PR time + strict-missing assertion at onboard time, with the runtime sentinel from PR #109 closing the loop within ~1 hour of any drift hitting prod.

## Three gates compose

1. **Onboard time** (`apps/api/scripts/onboard.ts verifyFixtures`): imports `checkGuaranteedFieldsPresent` from PR #109. A new bad manifest fails before commit.
2. **PR time** (`apps/api/scripts/check-manifest-guaranteed-consistency.mjs --strict`, wired into [ci.yml](.github/workflows/ci.yml)): static scan asserts every `output_field_reliability.guaranteed` field is enumerated in `output_schema.properties` or `output_schema.example`. No executor invocation; no DB required.
3. **Runtime, hourly** (PR #109): `checkGuaranteedFieldsPresent` fires inside `validateResult` on each known_answer scheduler tick.

## Backfill of 22 grandfathered drifts

All are pre-existing manifest inconsistencies surfaced when the gate first ran (mostly input-echo fields, status flags, or metadata that are runtime-functional but manifest-schema-inconsistent). Each gets a separate per-manifest fix prompt; chat files Notion To-do entries post-merge.

```
address-geocode           input_address, found
address-validate          input_address
age-verify                reference_date
aml-risk-score            entity_type, country_code, inputs_received, scored_at
business-day-check        date, country_code
company-name-match        name_a, name_b
company-news              timespan
credit-score-band         points_to_next, score_range
email-reputation-score    domain, provider_type
iban-to-bank              iban
insolvency-check          query
license-compatibility-check  licenses_analyzed
nl-bag-address            nummeraanduiding_id, total_results
nl-energy-label           is_simplified_label, based_on_reference_building, total_results
nl-housing-price-index    note
nl-housing-stats          note
nl-woz-value              note
phone-type-detect         is_toll_free, is_premium, input
phone-validate            country_name, input
sec-filing-events         total_filings_available
timezone-lookup           query
uk-filing-events          total_filings
```

Allowlist file header includes Path A re-entry triggers (full dynamic CI gate) for the next session that re-scopes:
- (a) multiple concurrent contributors merging manifests, OR
- (b) a CH-class bug recurs that the 1-hour runtime-sentinel window allows to damage production, OR
- (c) CI infrastructure (DB + ~30 executor env vars) gets provisioned for unrelated reasons.

## Verification

- `node apps/api/scripts/check-manifest-guaranteed-consistency.mjs --strict` → exit 0 (22 total, 0 not in allowlist).
- `npx tsc --noEmit -p apps/api` → clean.
- `npx vitest run test/check-manifest-guaranteed-consistency.test.ts src/lib/guaranteed-fields-sentinel.test.ts` → 11 tests pass (5 new + 6 from PR #109).

## Tests (5 cases, Rule 12)

1. **Happy path — properties form:** clean manifest with every guaranteed field in `output_schema.properties` → passes.
2. **Happy path — example form:** clean manifest with every guaranteed field in `output_schema.example` (not properties) → passes.
3. **New violation:** guaranteed field declared in reliability but absent from schema → detected.
4. **Non-guaranteed-tier no-op:** `common`/`rare`-tier fields don't require schema enumeration.
5. **Legacy no-op:** manifests without `output_field_reliability` block are not flagged.

## After deployment (Rule 14)

- CI workflow file shows the new step between `check-fetch-timeout-coverage` and `check-shape-contracts` (after rebase on main 86b04be).
- Next PR touching any manifest exercises the gate naturally.
- A future PR introducing a new `guaranteed` reliability annotation without matching schema declaration will fail this CI check with an explicit error message naming the field path and pointing at DEC-20260513-B.

## Out of scope (follow-ups for chat)

- File 22 Notion To-do entries (one per allowlisted manifest) for individual fixes.
- Populate `Outcome` field on DEC-20260513-B + DEC-20260513-C with PR link + "Phase 3b shipped via Path B; Path A re-entry triggers documented in allowlist header."
- Update [Capability onboarding pipeline page](https://www.notion.so/33c67c87082c81969b1fe32c87095f5a) with `verifyFixtures` strengthening note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)