### PR TITLE
feat: classify guaranteed_field_missing:* as manifest_drift non-tripping

### DIFF
--- a/apps/api/src/lib/circuit-breaker.ts
+++ b/apps/api/src/lib/circuit-breaker.ts
@@ -193,6 +193,19 @@ export async function recordFailure(slug: string, failureReason?: string): Promi
 
   const db = getDb();
   const category = categorizeFailureReason(failureReason ?? null);
+
+  // Skip circuit breaker for manifest_drift (PR #109 sentinel emissions per
+  // DEC-20260513-B + DEC-20260513-C). The capability is still serving valid
+  // data; only the manifest's output_field_reliability declaration is wrong
+  // or incomplete. The failure is recorded in test_results with the
+  // structured `guaranteed_field_missing:*` reason for triage visibility,
+  // but the customer-facing breaker stays closed. Real upstream failures
+  // (HTTP 5xx, exception, timeout) continue to trip via the unchanged
+  // non-retryable / 3-consecutive-retryable branches below.
+  if (category === "manifest_drift") {
+    return;
+  }
+
   const retryable = isRetryableFailure(category);
   const now = new Date();
 

--- a/apps/api/src/lib/trust-helpers.test.ts
+++ b/apps/api/src/lib/trust-helpers.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the failure-reason classifier (DEC-20260513-F-prep).
+ *
+ * Focus: the new `manifest_drift` category for PR #109's sentinel
+ * emissions (`guaranteed_field_missing:*`) introduced as part of the
+ * Phase 3 closure for DEC-20260513-B + DEC-20260513-C. Existing
+ * categories are smoke-checked to ensure the new clause doesn't
+ * regress them.
+ *
+ * Per Rule 12 (audit-follow-up test coverage): the new branch in
+ * categorizeFailureReason is paired with regression tests for both
+ * legitimate suffix shapes the sentinel emits, plus a sanity check
+ * that genuine upstream failures still classify as retryable
+ * external-service errors.
+ */
+
+import { describe, it, expect } from "vitest";
+import { categorizeFailureReason, isRetryableFailure, toLegacyCategory } from "./trust-helpers.js";
+
+describe("categorizeFailureReason — manifest_drift (DEC-20260513-B/C)", () => {
+  it("classifies guaranteed_field_missing:<field-path> as manifest_drift", () => {
+    // The dominant shape emitted by checkGuaranteedFieldsPresent
+    // (lib/guaranteed-fields-sentinel.ts) when a key declared
+    // `guaranteed` in output_field_reliability is absent from
+    // actual_output. The breaker must skip this category — see
+    // circuit-breaker.ts recordFailure.
+    expect(categorizeFailureReason("guaranteed_field_missing:company_name")).toBe("manifest_drift");
+    expect(categorizeFailureReason("guaranteed_field_missing:income")).toBe("manifest_drift");
+    expect(categorizeFailureReason("guaranteed_field_missing:corporate_number")).toBe("manifest_drift");
+  });
+
+  it("classifies guaranteed_field_missing:<root-not-object> as manifest_drift", () => {
+    // The second legitimate suffix shape the sentinel emits, when the
+    // executor's actual_output isn't a plain object at all (the CH
+    // 2026-05-13 bad-fixture root-shape failure mode). Same category;
+    // same breaker-skip path.
+    expect(categorizeFailureReason("guaranteed_field_missing:<root-not-object>")).toBe("manifest_drift");
+  });
+
+  it("genuine upstream failures still classify as their existing categories (no regression)", () => {
+    // Sanity check: the new clause is prefix-anchored, so it doesn't
+    // accidentally catch unrelated failure_reason strings. The breaker
+    // continues to trip on real HTTP 5xx, timeouts, auth failures, etc.
+    expect(categorizeFailureReason("HTTP 502 Bad Gateway")).toBe("transient");
+    expect(categorizeFailureReason("Request timed out after 30000ms")).toBe("transient");
+    expect(categorizeFailureReason("HTTP 401 Unauthorized")).toBe("auth_expired");
+    expect(categorizeFailureReason("HTTP 404 not found")).toBe("endpoint_gone");
+    expect(categorizeFailureReason("TypeError: Cannot read property 'foo' of undefined"))
+      .toBe("internal");
+  });
+
+  it("manifest_drift is not retryable (no point retrying a manifest bug)", () => {
+    // isRetryableFailure returns true only for transient/unknown.
+    // manifest_drift is neither — but the circuit-breaker entry skips
+    // the category entirely (recordFailure returns early), so the
+    // retryable bit is never read for this category in practice.
+    // Asserting it here so the contract stays stable if a future
+    // caller starts consuming isRetryableFailure on manifest_drift.
+    expect(isRetryableFailure("manifest_drift")).toBe(false);
+  });
+
+  it("manifest_drift maps to legacy 'internal' for backward-compat consumers", () => {
+    // toLegacyCategory is used by the 3-value compat layer for older
+    // API consumers. manifest_drift is bucketed as `internal` because
+    // the underlying cause is in Strale's own manifest authorship,
+    // not the upstream service.
+    expect(toLegacyCategory("manifest_drift")).toBe("internal");
+  });
+
+  it("null / empty failure_reason still classifies as unknown", () => {
+    // Defensive: the prefix-match must not false-trigger on null or
+    // empty strings (early-return path).
+    expect(categorizeFailureReason(null)).toBe("unknown");
+    expect(categorizeFailureReason("")).toBe("unknown");
+  });
+});

--- a/apps/api/src/lib/trust-helpers.ts
+++ b/apps/api/src/lib/trust-helpers.ts
@@ -364,12 +364,26 @@ export type FailureCategory =
   | "format_changed"      // 200 response but parsing fails — upstream changed response format
   | "dependency_missing"  // env var not set or not configured
   | "scraping_broken"     // HTML/regex extraction returns no data from a 200 response
+  | "manifest_drift"      // PR #109 sentinel: declared-guaranteed field absent from actual_output
   | "internal"            // Strale code error, not upstream
   | "unknown";            // cannot determine
 
 export function categorizeFailureReason(reason: string | null): FailureCategory {
   if (!reason) return "unknown";
   const lower = reason.toLowerCase();
+
+  // 0. manifest_drift — Phase 3a runtime sentinel (DEC-20260513-B + DEC-20260513-C)
+  //    emits `guaranteed_field_missing:<field-path>` when the executor's
+  //    actual_output omits a key declared `guaranteed` in
+  //    output_field_reliability. This is maintainer signal — the capability
+  //    is still serving valid data, the manifest is just incomplete or wrong
+  //    about what it guarantees. Per the Phase 3 closure decision, this
+  //    category is skipped at the circuit-breaker entry (see
+  //    circuit-breaker.ts recordFailure) so a manifest drift surfaces in
+  //    test_results without tripping the customer-facing breaker. Genuine
+  //    upstream failures (HTTP 5xx, exception, timeout) continue to trip
+  //    via the existing classifications below.
+  if (reason.startsWith("guaranteed_field_missing:")) return "manifest_drift";
 
   // 1. dependency_missing — env var / credential not configured
   if (/not (configured|set)|is required/i.test(reason) && /[A-Z_]{3,}/.test(reason)) return "dependency_missing";
@@ -432,6 +446,7 @@ export function toLegacyCategory(category: FailureCategory): "external_service" 
     case "scraping_broken":
     case "dependency_missing":
       return "external_service";
+    case "manifest_drift":
     case "internal":
       return "internal";
     case "unknown":


### PR DESCRIPTION
## Summary

PR #109's runtime sentinel (Phase 3a) emits `failure_reason` strings of the form `guaranteed_field_missing:<field-path>` (or `<root-not-object>`). Today those classify as `unknown` → retryable → trip the breaker at the third hourly tick. Four currently-Live capabilities would trip ~3 hours after PR #109's deploy without this patch:

- `charity-lookup-uk` (also has 2 real upstream failures — those still trip via unchanged path)
- `japanese-company-data`
- `llm-output-validate`
- `openapi-validate`

## Semantic claim

Manifest drift is **maintainer signal**, not customer-blocking. The capability is still serving valid data; the manifest's `output_field_reliability` declaration is wrong or incomplete. Tripping the breaker on this would:

- Block customer calls to actually-working capabilities.
- Generate false-degraded signal across AVS / source_health / Coverage Matrix surfaces.
- Require manual breaker resets when the per-capability triage prompts land.

## What changes

1. Add `manifest_drift` to the `FailureCategory` union in [trust-helpers.ts](apps/api/src/lib/trust-helpers.ts).
2. `categorizeFailureReason` returns `manifest_drift` for any reason that `startsWith("guaranteed_field_missing:")`.
3. `toLegacyCategory` maps `manifest_drift` → `internal` (root cause is in Strale's own manifest authorship).
4. `circuit-breaker.recordFailure` early-returns on `manifest_drift`, mirroring the existing `isUserInputError` skip pattern.

## What this does NOT change

- Genuine upstream failures (HTTP 5xx, exception, timeout, auth, format, scraping_broken, etc.) **still trip the breaker** via unchanged non-retryable / 3-consecutive-retryable branches.
- The runtime sentinel itself (PR #109) is unchanged.
- The `test_results` row continues to get the structured `failure_reason` for triage visibility — only the `capability_health` write is skipped.

## Rule 4 note

This change is **classification-only** and does NOT modify source_health / per-product routing engines, nor hide real upstream errors. The binary "real upstream error → tripping" path is preserved.

## Retro-cleanup

Unnecessary. Audit at session start confirmed **none of the 4 affected capabilities had tripped yet** — no `capability_health` rows in `open` state for any of them. Step 3 of the prompt skipped.

## Tests (6 cases)

`apps/api/src/lib/trust-helpers.test.ts`:

1. `guaranteed_field_missing:<field-path>` (three sample paths) → `manifest_drift`.
2. `guaranteed_field_missing:<root-not-object>` → `manifest_drift`.
3. Genuine upstream failures (HTTP 502/401/404, timeout, TypeError) still classify to their existing categories — no regression on the binary "real error → trip" path.
4. `isRetryableFailure("manifest_drift")` → `false` (contract pinned for future callers).
5. `toLegacyCategory("manifest_drift")` → `"internal"`.
6. `null` / empty `failure_reason` still classifies as `unknown` (defensive — prefix-match doesn't false-trigger).

All 6 pass locally.

## Path-not-taken

A per-field `non_empty: true` opt-in annotation on `output_field_reliability` entries would give capability authors a way to declare empty-as-failure semantics on specific fields (the right tool for customer-critical guarantees post-launch). Out of scope for this PR; tracked separately as a Phase 3 follow-up.

## Out of scope (chat post-merge)

- Log small DEC-20260513-F (or next-available ID) naming the manifest-drift-as-non-tripping semantic decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)