### PR TITLE
fix(manifests): align reliability to executor output for 4 sentinel-failing caps

### DIFF
--- a/manifests/charity-lookup-uk.yaml
+++ b/manifests/charity-lookup-uk.yaml
@@ -38,7 +38,7 @@ output_schema:
     date_of_registration: "1994-07-01"
     latest_financial_year_end: "2024-12-31"
   properties:
-    income:
+    latest_income:
       type: number
     status:
       type: string
@@ -87,7 +87,7 @@ test_fixtures:
   health_check_input:
     charity_number: "1038963"
 output_field_reliability:
-  income: guaranteed
+  latest_income: guaranteed
   status: guaranteed
   charity_name: guaranteed
   charity_number: guaranteed

--- a/manifests/japanese-company-data.yaml
+++ b/manifests/japanese-company-data.yaml
@@ -37,7 +37,7 @@ output_schema:
       type: string
     business_type:
       type: string
-    corporate_number:
+    registration_number:
       type: string
 data_source: National Tax Agency Corporate Number System (Japan)
 data_source_type: scrape
@@ -76,7 +76,7 @@ output_field_reliability:
   status: guaranteed
   company_name: guaranteed
   business_type: guaranteed
-  corporate_number: guaranteed
+  registration_number: guaranteed
 limitations:
   - title: Japan NTA database provides corporate numbers only — financial data and officer details are not included
     text: Extracted from National Tax Agency corporate number database — financial data and officer details are not included

--- a/manifests/llm-output-validate.yaml
+++ b/manifests/llm-output-validate.yaml
@@ -97,7 +97,12 @@ output_field_reliability:
   errors: guaranteed
   auto_fixed: guaranteed
   parsed_output: guaranteed
-  auto_fixed_output: guaranteed
+  # auto_fixed_output is only populated when auto_fixed=true (parser corrected
+  # an invalid JSON shape). For inputs that parse cleanly on first try the
+  # field is absent. Re-labeled to `common` per PR #109 + PR #112 triage —
+  # the strict-missing sentinel was correctly firing because the key didn't
+  # exist on the happy path; the manifest was wrong to declare it guaranteed.
+  auto_fixed_output: common
 limitations:
   - title: Validates LLM output structure and format only — cannot verify factual correctness of content
     text: Validates output structure and format — cannot verify factual correctness of LLM-generated content

--- a/manifests/openapi-validate.yaml
+++ b/manifests/openapi-validate.yaml
@@ -30,14 +30,22 @@ output_schema:
     endpoint_count: 0
     version_detected: 3.0.0
   properties:
-    stats:
-      type: object
     valid:
       type: boolean
     errors:
       type: array
     warnings:
       type: array
+    error_count:
+      type: integer
+    schema_count:
+      type: integer
+    warning_count:
+      type: integer
+    endpoint_count:
+      type: integer
+    version_detected:
+      type: string
 data_source: Algorithmic (OpenAPI 3.x specification validation)
 data_source_type: computed
 transparency_tag: algorithmic
@@ -75,10 +83,18 @@ test_fixtures:
   health_check_input:
     spec: "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"Test\",\"version\":\"1.0.0\"},\"paths\":{}}"
 output_field_reliability:
-  stats: guaranteed
+  # `stats` was an orphan reliability declaration — the executor never
+  # returned a `stats` wrapper object; the actual statistics (error_count,
+  # schema_count, warning_count, endpoint_count, version_detected) live as
+  # top-level fields on the response. Replaced per PR #109 + PR #112 triage.
   valid: guaranteed
   errors: guaranteed
   warnings: guaranteed
+  error_count: guaranteed
+  warning_count: guaranteed
+  endpoint_count: guaranteed
+  schema_count: guaranteed
+  version_detected: guaranteed
 limitations:
   - title: Validates against OpenAPI 3.0/3.1 specification only — custom vendor extensions are not checked
     text: >-


### PR DESCRIPTION
## Summary

Triage of the 4 capabilities the PR #109 runtime sentinel was firing on hourly (PR #112 was preventing breaker trips). Each fix is a manifest change only — no executor changes needed; the executors were producing consistent outputs and the manifests' `output_field_reliability` declarations had drifted.

| Capability | Field | Fix shape |
|---|---|---|
| `charity-lookup-uk` | `income` → `latest_income` | Manifest rename (executor returns `latest_income`, matches `latest_*` family) |
| `japanese-company-data` | `corporate_number` → `registration_number` | Manifest rename (executor returns `registration_number`, matches EU registry convention) |
| `llm-output-validate` | `auto_fixed_output` | `guaranteed` → `common` (only populated when `auto_fixed=true`) |
| `openapi-validate` | `stats` → 5 top-level stats fields | Orphan `stats` wrapper removed; `error_count`/`warning_count`/`endpoint_count`/`schema_count`/`version_detected` added as guaranteed (executor produces them) |

For each, audit ran:
1. Read manifest YAML
2. Read executor code (where `output` is built)
3. Inspect last 3 failing `test_results` rows + last successful row's `actual_output`
4. Decide parser-fix vs reliability-re-label based on whether the missing field is actually in the upstream response

All 4 came out as reliability re-labels — the executors were correct; the manifests were stale or wrongly-classified.

## Per-capability detail

**charity-lookup-uk**: last successful response (2026-05-13T05:12Z) returned `latest_income: 339366903` (Oxfam test entity). Executor at [charity-lookup-uk.ts:96](apps/api/src/capabilities/charity-lookup-uk.ts#L96) builds `latest_income: d.latestIncome ?? null`. The `latest_*` family (`latest_income`, `latest_spending`, `latest_employees`, `latest_volunteers`, `latest_financial_year_end`) is the executor's consistent naming pattern. Manifest declared `income` which never existed. Aligned manifest to executor.

**japanese-company-data**: failing test_result's `actual_output` contained `registration_number: "1180301018771"` (Toyota's corporate number — matches the test fixture input). Executor's `lookupCompany` builds the output with `registration_number` as the canonical key (matches EU registry conventions used by `czech`, `polish`, etc.). Manifest declared `corporate_number` as output-key which the executor never populates (only as input parameter name). Aligned manifest's output reliability to `registration_number`.

**llm-output-validate**: executor at [llm-output-validate.ts:71](apps/api/src/capabilities/llm-output-validate.ts#L71) conditionally sets `output.auto_fixed_output = JSON.stringify(parsed, null, 2)` ONLY when auto-fix triggers. For valid-on-first-try inputs (the known_answer test fixture), `auto_fixed: false` and `auto_fixed_output` is absent by design. Re-labeled to `common` with an inline comment.

**openapi-validate**: executor returns 8 top-level fields including `error_count`, `schema_count`, `warning_count`, `endpoint_count`, `version_detected` — but no `stats` wrapper object. Manifest's `stats: guaranteed` was an orphan declaration; the corresponding `output_schema.properties.stats` was also orphaned. Removed both, added the 5 real fields as guaranteed (the executor unconditionally produces them on successful validation).

## Verification

- `node apps/api/scripts/check-manifest-guaranteed-consistency.mjs --strict` → exit 0 (22 total in allowlist; no new offenders).
- `git diff --stat` shows only the 4 manifest files; no executor changes.

Post-deploy expected:
- All 4 capabilities' next scheduler-tick known_answer suites produce `passed=true` rows.
- The runtime sentinel's failed-rows accumulation drops to zero for these caps.
- `test_results` query for `failure_reason LIKE 'guaranteed_field_missing:%'` returns 0 rows after ~70 min wall-clock (covering all 4 capabilities' minute-hash slots).

## Out of scope

- Per-capability triage prompts for the 22 PR #111 static-allowlist entries — separate class of fix (output_schema enumeration drift), each its own future prompt.
- Any catalog-wide `capability_type` drift cleanup — separate prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)