### PR TITLE
fix(swiss-company-data): correct legal_form + legal_form_id + canton + municipality JSON paths

### DIFF
--- a/apps/api/src/capabilities/providers/swiss-company-data.test.ts
+++ b/apps/api/src/capabilities/providers/swiss-company-data.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the Zefix parseCompany shape-correctness cleanup.
+ *
+ * PR #107's smoke output exposed four parser bugs:
+ *  - legal_form returned as Zefix's full object instead of a short string
+ *  - legal_form_id read from `company.legalFormId` (doesn't exist)
+ *    instead of `company.legalForm.id`
+ *  - canton read via `legalSeat.canton` (legalSeat is a string, not object)
+ *    instead of top-level `company.canton`
+ *  - municipality read via `legalSeat.municipalityName` (same shape error)
+ *    instead of the value of `legalSeat` itself (which IS the municipality
+ *    name as a string)
+ *
+ * Per Rule 12: parser changes paired with regression tests using a
+ * representative Zefix response fixture (Roche Holding AG, sampled
+ * 2026-05-13 during PR #107 validation).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseCompany,
+  extractLegalFormShort,
+  extractLegalFormId,
+} from "./swiss-company-data.js";
+
+// Trimmed Roche response captured via the actual Zefix REST API.
+// Keeps just the keys parseCompany reads so the fixture is small.
+const ROCHE_FIXTURE: Record<string, unknown> = {
+  name: "Roche Holding AG",
+  uid: "CHE101602521",
+  chid: "CH27030051590",
+  ehraid: 154673,
+  legalSeatId: 2701,
+  legalSeat: "Basel", // STRING (the prior parser tried to treat as object)
+  legalForm: {
+    id: 3,
+    uid: "0106",
+    name: {
+      de: "Aktiengesellschaft",
+      fr: "Société anonyme",
+      it: "Società anonima",
+      en: "Corporation",
+    },
+    shortName: {
+      de: "AG",
+      fr: "SA",
+      it: "SA",
+      en: "Ltd",
+    },
+  },
+  status: "ACTIVE",
+  canton: "BS", // top-level — NOT nested under legalSeat
+  sogcDate: "2026-05-11",
+  deletionDate: null,
+  address: {
+    organisation: "Roche Holding AG",
+    street: "Grenzacherstrasse",
+    houseNumber: "124",
+    swissZipCode: "4070",
+    city: "Basel",
+  },
+};
+
+describe("parseCompany — Zefix response shape correctness", () => {
+  it("legal_form is a string (Swiss-canonical short name), not the Zefix object", () => {
+    const out = parseCompany(ROCHE_FIXTURE);
+    expect(typeof out.legal_form).toBe("string");
+    expect(out.legal_form).toBe("AG");
+  });
+
+  it("legal_form_id reads company.legalForm.id (not the absent company.legalFormId)", () => {
+    const out = parseCompany(ROCHE_FIXTURE);
+    expect(out.legal_form_id).toBe(3);
+  });
+
+  it("canton reads top-level company.canton (the 2-letter cantonal code)", () => {
+    const out = parseCompany(ROCHE_FIXTURE);
+    expect(out.canton).toBe("BS");
+  });
+
+  it("municipality reads the string value of company.legalSeat", () => {
+    const out = parseCompany(ROCHE_FIXTURE);
+    expect(out.municipality).toBe("Basel");
+  });
+
+  it("falls back gracefully when legalForm is missing or malformed", () => {
+    // Defensive: parser must return null rather than crash if Zefix returns
+    // an entity without legalForm (rare but possible for incomplete records).
+    expect(extractLegalFormShort(undefined)).toBeNull();
+    expect(extractLegalFormShort(null)).toBeNull();
+    expect(extractLegalFormShort({})).toBeNull();
+    expect(extractLegalFormShort({ shortName: null })).toBeNull();
+    expect(extractLegalFormId(undefined)).toBeNull();
+    expect(extractLegalFormId({})).toBeNull();
+    expect(extractLegalFormId({ id: "not-a-number" })).toBeNull();
+  });
+
+  it("prefers .de but falls back to .en when .de is absent (non-Swiss-domiciled records)", () => {
+    expect(extractLegalFormShort({ shortName: { en: "Ltd" } })).toBe("Ltd");
+    expect(extractLegalFormShort({ shortName: { de: "AG", en: "Ltd" } })).toBe("AG");
+  });
+
+  it("preserves existing field extractions (company_name, uid, status, etc.)", () => {
+    // Regression guard: the cleanup must not break the fields that were
+    // already correct.
+    const out = parseCompany(ROCHE_FIXTURE);
+    expect(out.company_name).toBe("Roche Holding AG");
+    expect(out.uid).toBe("CHE101602521");
+    expect(out.ehraid).toBe(154673);
+    expect(out.status).toBe("ACTIVE");
+    expect(out.registration_date).toBe("2026-05-11");
+    expect(out.address).toBe("Grenzacherstrasse, 124, 4070 Basel");
+  });
+});

--- a/apps/api/src/capabilities/providers/swiss-company-data.ts
+++ b/apps/api/src/capabilities/providers/swiss-company-data.ts
@@ -35,9 +35,31 @@ function normalizeUid(raw: string): string {
   return raw.replace(/[- .]/g, "").toUpperCase();
 }
 
-function parseCompany(company: Record<string, unknown>): Record<string, unknown> {
-  const legalSeat = company.legalSeat as Record<string, unknown> | undefined;
+// Zefix's `legalForm` is a structured object; the canonical short name
+// used in Swiss company correspondence is the German form ("AG", "GmbH",
+// "Sàrl", "SA"). Prefer .de, then .en as a fallback so non-Swiss callers
+// still get a meaningful string.
+export function extractLegalFormShort(legalForm: unknown): string | null {
+  if (!legalForm || typeof legalForm !== "object") return null;
+  const shortName = (legalForm as { shortName?: Record<string, unknown> }).shortName;
+  if (!shortName || typeof shortName !== "object") return null;
+  return (shortName.de as string) ?? (shortName.en as string) ?? null;
+}
+
+export function extractLegalFormId(legalForm: unknown): number | null {
+  if (!legalForm || typeof legalForm !== "object") return null;
+  const id = (legalForm as { id?: unknown }).id;
+  return typeof id === "number" ? id : null;
+}
+
+export function parseCompany(company: Record<string, unknown>): Record<string, unknown> {
   const address = company.address as Record<string, unknown> | undefined;
+  // Zefix returns `legalSeat` as a STRING (the municipality name, e.g.
+  // "Basel"), NOT as a nested object — the prior parser treated it as an
+  // object and silently produced `null` for canton/municipality. The
+  // canonical canton code (2 letters, e.g. "BS") lives at the company's
+  // top level, not under legalSeat.
+  const legalSeatString = typeof company.legalSeat === "string" ? company.legalSeat : null;
 
   // Build address string
   let addressStr: string | null = null;
@@ -55,15 +77,11 @@ function parseCompany(company: Record<string, unknown>): Record<string, unknown>
     uid: (company.uid as string) ?? null,
     ehraid: (company.ehraid as number) ?? null,
     ch_id: (company.chid as number) ?? (company.chId as number) ?? null,
-    legal_form: (company.legalForm as string) ?? null,
-    legal_form_id: (company.legalFormId as number) ?? null,
+    legal_form: extractLegalFormShort(company.legalForm),
+    legal_form_id: extractLegalFormId(company.legalForm),
     status: (company.status as string) ?? null,
-    canton: legalSeat
-      ? (legalSeat.canton as string) ?? null
-      : (company.canton as string) ?? null,
-    municipality: legalSeat
-      ? (legalSeat.municipalityName as string) ?? null
-      : (company.municipality as string) ?? null,
+    canton: (company.canton as string) ?? null,
+    municipality: legalSeatString,
     address: addressStr,
     purpose: (company.purpose as string) ?? (company.purposeTranslations as any)?.en ?? null,
     registration_date: (company.sogcDate as string) ?? (company.registrationDate as string) ?? null,


### PR DESCRIPTION
## Summary

PR #107's smoke output for Roche surfaced four parser shape bugs in [providers/swiss-company-data.ts](apps/api/src/capabilities/providers/swiss-company-data.ts). PR #109's strict-missing sentinel didn't catch them because the keys were *present* in actual_output — just with wrong shapes/values. Per-field fix:

| Field | Before | After |
|---|---|---|
| `legal_form` | Returned the whole Zefix `legalForm` object (schema declared `string`) | `legalForm.shortName.de` ("AG"/"GmbH"/"Sàrl"), fallback `.en` |
| `legal_form_id` | Read `company.legalFormId` (doesn't exist) → always `null` | Read `company.legalForm.id` |
| `canton` | Read `legalSeat.canton` (legalSeat is a string, not an object) → always `null` | Read top-level `company.canton` ("BS", "ZH", etc.) |
| `municipality` | Read `legalSeat.municipalityName` (same shape error) → always `null` | Read `company.legalSeat` (the string IS the municipality name) |

## Why these slipped through

The original parser used TypeScript casts (`company.legalForm as string`) that lie at runtime. Zefix's actual response shape:

```json
{
  "name": "Roche Holding AG",
  "legalSeat": "Basel",
  "legalForm": {
    "id": 3,
    "shortName": { "de": "AG", "fr": "SA", "it": "SA", "en": "Ltd" }
  },
  "canton": "BS",
  ...
}
```

`legalSeat` being a string (not the nested object the parser assumed) plus `legalFormId` being absent (the id lives under `legalForm.id`) caused two of the four fields to silently return null. The third (`legal_form`) returned the object literal cast as string, which downstream renders as `[object Object]`.

## Tests (7 cases)

`apps/api/src/capabilities/providers/swiss-company-data.test.ts`:
1. `legal_form` is a string ("AG")
2. `legal_form_id` reads from `legalForm.id` (3)
3. `canton` reads top-level (`"BS"`)
4. `municipality` reads from `legalSeat` string (`"Basel"`)
5. Graceful fallback when `legalForm` is missing/malformed (returns null, doesn't crash)
6. `.de` preferred, `.en` fallback for non-Swiss-domiciled records
7. Regression guard for already-correct fields (`company_name`, `uid`, `ehraid`, `status`, `registration_date`, `address`)

All 7 pass locally.

## What this doesn't touch

- No schema or manifest change — the schema already declared the right types; the parser was the only thing wrong.
- No executor logic change — only the response-shape extraction.

Pre-launch cleanup. No real customer callers at risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)