### PR TITLE
chore: promote 5 handoff notes (2026-05-11 + 2026-05-13 batch)

### DIFF
--- a/handoff/_general/from-code/2026-05-11-failure-investigation-de-dk-sk-rootcause.md
+++ b/handoff/_general/from-code/2026-05-11-failure-investigation-de-dk-sk-rootcause.md
@@ -1,0 +1,72 @@
+Intent: Diagnose three production failure modes surfaced by the 2026-05-11 identity-leg output map — DE OpenRegister quota burn (highest priority, with Petter's explicit null hypothesis that *internal research* did not consume the 50/mo budget), DK cvrapi.dk quota state, and SK api.statistics.sk 15 s timeouts. Read-only investigation; fixes deferred.
+
+# What shipped
+
+Three root causes documented. Zero code changes to platform code. One diagnostic script left in the repo (mirrors the `dk-cvr-retry-2026-05-06.ts` precedent for one-off investigation tooling).
+
+## DE — root cause: scheduler-driven internal traffic, not external customers
+
+**Null hypothesis confirmed: Petter's manual research did not burn the quota.** But the broader hypothesis ("something other than internal usage is consuming OpenRegister calls") is **false**. 100 % of the burn comes from Strale's own scheduled-test infrastructure writing transactions as `system@strale.internal`.
+
+- 508 of 533 (95 %) of 60-day `german-company-data` transactions are from the internal system user.
+- Mechanism: [`apps/api/src/lib/test-runner.ts:1208-1222`](apps/api/src/lib/test-runner.ts#L1208-L1222) writes a `transactions` row for each scheduled test execution. The scheduler in [`apps/api/src/jobs/test-scheduler.ts`](apps/api/src/jobs/test-scheduler.ts) dispatches free-cost (`external_cost_cents=0`) tests every hour with slug-hash stagger.
+- The bug: `external_cost_cents=0` cannot distinguish "no per-call charge" from "free tier with hard monthly quota cap." OpenRegister is the second; the scheduler treated it as the first.
+- Burn arithmetic: 5 test fixtures × ~3 OR API calls per burst × ~12 bursts/day = 36–60 calls/day. May's 50-call budget exhausted on/around 2026-05-07 16:29 UTC.
+- Negative findings: no CI burn, no health-probe burn (OpenRegister not in dependency-manifest), no env-key sharing burn, no scraper/bot traffic, no piggyback monitor traffic. One real external customer made one call on 2026-04-09 and never returned.
+
+**Recommended prevention (Petter-decides):** add a `quota_bound` flag on `test_suites` (or `capabilities`) so the scheduler excludes quota-capped free-tier capabilities even with `external_cost_cents=0`. Plus a 30/50 budget-consumption alert. Do NOT default to OpenRegister's paid tier without a customer attached (DEC-20260506-G).
+
+## DK — root cause: daily-reset quota gets immediately re-exhausted; breaker isn't firing
+
+- cvrapi.dk free tier is **daily** (~50/day), not monthly. Resets ~24 h.
+- Strale's test scheduler hits ~96 calls/day (8-call bursts × ~12 bursts). Daily quota exhausts within hours of every reset, so DK has appeared "always exhausted" for most of May.
+- `capability_health` for DK: `state=closed, consecutive_failures=1, total_failures=3, total_successes=0, last_success_at=2026-05-06`. `total_failures=3` is far below the hundreds of actual failures because **`recordFailure` is fire-and-forget at do.ts:1282/1772**, and the test runner fires 8 concurrent calls — calls 2–8 all `checkCircuitBreaker` and see `state=closed, consecutive_failures=0` before call 1's `recordFailure` has committed. None of them trip the breaker. This is a real race in the breaker's interaction with the test-runner burst pattern.
+- The 2026-05-06 manual containment (`UPDATE capability_health SET state='open'`) auto-recovered when the next call hit cvrapi.dk during a brief successful window, then quota hit again.
+
+**Recommended fix shape (two pieces, both small):**
+
+1. DK executor: prefix quota errors with `capability-unavailable:` to match DE's pattern at [`german-company-data.ts:117`](apps/api/src/capabilities/german-company-data.ts#L117). **AND** patch `do.ts:1771-1772` so a `capability-unavailable:`-prefixed error returns HTTP 503 `error_code=capability_unavailable` instead of HTTP 500 `execution_failed`. Without the route-side change, the executor's prefix is decoration.
+2. Fix the breaker race: make test-runner's `recordFailure` awaitable on the test-runner path; keep customer path fire-and-forget. Two-line change, scoped.
+
+**Source-diversification options (listed not recommended):** cvrapi.dk paid tier (exists, pricing not public, email them); datacvr.virk.dk system-to-system direct (free, formal application via `cvrselvbetjening@erst.dk`; the licensed-bulk path per DEC-20260428-A); Bisnode/Dun & Bradstreet DK; CVRHub.dk (unverified).
+
+## SK — root cause: persistent upstream degradation, not entity- or environment-specific
+
+- 6/6 attempts timed out at 15 s budget across 3 cross-source-verified IČOs (Tatry MR 31560636, Slovak Telekom 35763469, VSE Holding 36211222).
+- Independent bare-curl probe to `api.statistics.sk/rpo/v1/` from local egress: timeout >30 s. Host base path responds in 0.4 s with 404; the `/rpo/v1/*` subtree is unresponsive right now.
+- Historic prod: 4 % success rate over last 5 days. Successful SK calls land in 0.8–7.6 s. Today: 0 % success.
+- Not in the SI onboarding-pipeline-missing pattern (SK is in prod DB and being called as `slovak-company-data`, just timing out).
+
+**Recommended fix path:** ship the `upstream_timeout` structured error code first per DEC-19 (cheapest, makes the failure shape honest). Defer timeout expansion (15→25 s + one retry) until customer signal demands it. Don't touch the upstream endpoint set yet — orsr.sk scraping is blocked by DEC-20260428-A Tier 1, finstat.sk is a commercial vendor decision, ORSF is unverified.
+
+# Cost
+
+- €0 from Strale test wallet (SK upstream is free; no wallet debit; prod DB queries read-only via railway ssh).
+- 7 SK upstream calls + 3 curl probes = 10 of 20 cap used. Well under.
+
+# Files produced
+
+- [`c:\tmp\failure-investigation\report.md`](c:/tmp/failure-investigation/report.md) — full consolidated report with mechanical OpenRegister-dashboard cross-check queries Petter can run.
+- [`c:\tmp\failure-investigation\diag-output.json`](c:/tmp/failure-investigation/diag-output.json) — raw prod DB diagnostic dump (4373 lines).
+- [`c:\tmp\failure-investigation\summary.txt`](c:/tmp/failure-investigation/summary.txt) — pretty-printed diagnostic summary (1109 lines).
+- [`c:\tmp\failure-investigation\diag-de-dk-sk.mjs`](c:/tmp/failure-investigation/diag-de-dk-sk.mjs) — read-only diagnostic script (executed once via `railway ssh --service strale` + base64 piping; the `_diag.mjs` file on Railway was removed by the same command via `rm -f` after execution).
+- ~~`apps/api/src/scripts/sk-timeout-investigation-2026-05-11.ts`~~ — SK test script. **Deleted at session close** per Petter's call: the script was purpose-built for this investigation (3 hardcoded IČOs, fixed attempt counts) and didn't generalize like the `audit-live-registries.ts` family. Implicit policy this sets: investigation scripts default to delete; only generalizing diagnostic tooling gets committed. Local copy preserved at `c:\tmp\failure-investigation\sk-test.mjs` (the earlier draft) and the .ts source is reproducible from this handoff's content.
+
+# Non-obvious learnings
+
+- **`recordTestQuality` writes to `transactions`.** [test-runner.ts:1209](apps/api/src/lib/test-runner.ts#L1209) inserts a transactions row for every scheduled test execution, attributed to `getSystemUserId()`. The `system@strale.internal` user (`374b977e-42d9-432a-ac72-fd0893a24a45`) was created 2026-03-03 for this purpose. Daily-digest analytics already excludes this user — but that's just analytics; nothing stops the calls themselves.
+- **`external_cost_cents` is the wrong gate for quota-bound free APIs.** The scheduler uses it as a binary "free vs paid" filter, but OpenRegister is `€0/call + 50/mo cap` — neither "paid" nor "free-unlimited." The schema needs a `quota_bound` semantic.
+- **`capability-unavailable:` prefix is decoration without route-side support.** I noticed DE's executor already uses the prefix on HTTP 429, but do.ts doesn't pattern-match on it — both DE 402s and DK quota errors get serialized as `error_code=execution_failed` with HTTP 500. The prefix is currently a human-readable annotation only; making it load-bearing requires touching do.ts:1771-1772 (the sync-path error mapper).
+- **Methodology Rule 3 (domiciliation) on holding entities is non-trivial.** VSE Holding a.s. (36211222) has Slovak Republic 51 % + E.ON 49 % shareholders; the legal entity itself is registered at Košice court Sa 1203/V (SK-domiciled), so it returns SK registry data. Confirmed via orsr.sk + finstat.sk. The DIČ-vs-IČO trap from the 2026-05-11 prompt for Tatry MR (which used `SK2020428036` — a DIČ — as if it were the IČO) was avoided this run.
+- **Railway SSH base64-piping pattern is the right shape for ad-hoc prod queries.** `B64=$(cat script.b64) && railway ssh --service strale -- "echo '$B64' | base64 -d > /app/_diag.mjs && cd /app && node _diag.mjs && rm -f /app/_diag.mjs"`. The `cd /app` is load-bearing (ESM resolution to `/app/node_modules`); the `rm -f` at the end cleans up. `railway` CLI must be invoked from the project root for the linked-project context to apply.
+
+# What's open (Petter-decides)
+
+1. **OpenRegister dashboard cross-check** — the report has mechanical queries (Strale-side counts + expected OR-side count of ~50 from Railway US-East IP range, exhausted on/before 2026-05-07 16:29 UTC). If OR-side count exceeds 50 for May 1–7, there's a hidden caller; flag for follow-up.
+2. **DE fix-path decision** — `quota_bound` flag (recommended), price-fudge on `external_cost_cents`, or executor-level budget guard.
+3. **DK fix-path decision** — wire `capability-unavailable:` prefix on executor + route-side mapper change in do.ts + breaker race fix on test-runner path. Three small pieces, two small PRs.
+4. **SK fix-path decision** — ship `upstream_timeout` error code first. Defer timeout expansion.
+
+# Non-decisions made
+
+No Decisions DB entries authored. No supersessions. No to-do mutations. No memory writes. All four "open" items above require Petter's call.

--- a/handoff/_general/from-code/2026-05-13-a0c-1-v3-list-endpoint-cost-class.md
+++ b/handoff/_general/from-code/2026-05-13-a0c-1-v3-list-endpoint-cost-class.md
@@ -1,0 +1,37 @@
+Intent: Close the A0c.2b "Awaiting production traffic" badge regression by extending GET /v1/capabilities (list) with `cost_class` + `last_customer_call_at`, matching what A0c.1.v2 added to the detail endpoint.
+
+## Why this was broken
+
+A0c.1.v2 (PR #97) added `cost_class` + `last_customer_call_at` to `GET /v1/capabilities/:slug` only. But strale-frontend's `useCapability(slug)` hook filters `useCapabilities()` locally — the list endpoint is the data source for *both* the `/capabilities` listing and the `/capabilities/:slug` detail page. So the badge silently failed everywhere. Confirmed in prod: `curl https://api.strale.io/v1/capabilities | jq '.capabilities[] | select(.slug=="agent-trace-analyze")'` returned neither field.
+
+## What shipped — PR #103 (merged + deployed)
+
+Branch: `fix/a0c-1-v3-list-endpoint-cost-class` → squash-merged into `main`.
+
+Five files changed (273 insertions, 1 deletion):
+
+1. **`routes/capabilities.ts`** — list handler now selects `id` (join key) and `cost_class`, batch-fetches `last_customer_call_at` per capability via a single GROUP BY query with the daily-digest filter convention (exclude `system@strale.internal`). Maps results back into rows by id, then strips id before the public response.
+2. **`db/schema.ts`** — declares compound index `transactions_capability_id_created_at_idx` on `(capability_id, created_at)`.
+3. **`lib/startup-migrations.ts`** — Block 0078 (`CREATE INDEX IF NOT EXISTS`) added + registered in BLOCKS array. Ensures the index is created at boot in prod per DEC-20260511-C (in-TS-block migration convention).
+4. **`lib/startup-migrations.test.ts`** — BLOCKS array assertion 20 → 21, two behavioral tests for Block 0078.
+5. **`routes/capabilities.integration.test.ts`** — 3 regression tests mirroring the production failure mode: `paid_prepaid` + no transactions → `last_customer_call_at: null` (canonical bug shape); `paid_prepaid` + customer transaction → matches `created_at`; `system@strale.internal` transactions excluded from MAX aggregation.
+
+## Verification
+
+- `npx tsc --noEmit` — clean
+- `npx vitest run` — 636 passed / 19 skipped
+- `node apps/api/scripts/check-cost-class-coherence.mjs` — all classified capabilities OK
+- CI on PR #103 — pass (45s)
+- Post-deploy prod query:
+  - agent-trace-analyze: `cost_class=paid_prepaid`, `last_customer_call_at=null` (canonical case — badge will render)
+  - translate: `cost_class=paid_prepaid`, `last_customer_call_at=2026-04-28` (15d old, ≤ 30d window — badge suppressed)
+  - 292/292 capabilities emit `cost_class` in list endpoint
+
+## Open
+
+- Browser-side visual confirmation on strale.dev/capabilities/agent-trace-analyze that the badge actually renders. Wire-shape is correct; the frontend logic from the prior A0c.2b PR (strale-frontend #6) should pick it up automatically.
+
+## Non-obvious learnings
+
+- The "extend the detail endpoint, frontend reads it" mental model was wrong. The frontend's `useCapability` hook is a *local filter* over `useCapabilities()`, not a separate fetch. Any field the detail UI needs must live on the list payload.
+- The batched GROUP BY pattern in the list handler is shape-equivalent to the detail endpoint's per-cap subquery — same filter, same join semantics, just amortized across N caps. Index `transactions_capability_id_created_at_idx` is what makes it index-only.

--- a/handoff/_general/from-code/2026-05-13-dec-20260513-bc-cycle-closure-plus-followups.md
+++ b/handoff/_general/from-code/2026-05-13-dec-20260513-bc-cycle-closure-plus-followups.md
@@ -1,0 +1,91 @@
+Intent: close out the DEC-20260513-B (CH `swiss-company-data` bad-fixture) and DEC-20260513-C (SK scheduler-burst) bug-fix cycle through all four Bug Fix Framework phases (Contain → Understand → Harden-runtime → Harden-PR-time), then sweep the related drifts surfaced along the way.
+
+# What shipped (8 PRs merged + 1 DB cleanup)
+
+## DEC-20260513-B/C bug-fix cycle (all 4 phases)
+
+- **PR #107 (Phase 1 Contain, CH)** `fix(swiss-company-data): correct known_answer fixture to real ACTIVE UID`. Replaced `CHE-105.805.977` (not a real Swiss UID) with `CHE-101.602.521` (Roche Holding AG, ACTIVE). After merge, synced `test_suites.input` to match and released the 30-day operator pin on CH's breaker. Confirmed post-deploy: `/v1/do swiss-company-data {uid: "CHE-101.602.521"}` returns populated Roche payload (505 ms, €0.05).
+
+- **PR #108 (Phase 1 Contain, SK)** `fix(scheduler): spread per-capability test suites across the hour`. Per-suite hash-stagger (`abs(hashtext(slug || ':' || test_type)) % 60`) replaces per-capability stagger. SK's 5 suites now distribute across 4 minutes (27/27/37/39/51) instead of all firing on minute 41 simultaneously. New SQL uses `LEFT JOIN test_results MAX(executed_at)` per-suite for debounce instead of the capability-level `last_tested_at`. SK breaker auto-recovered post-deploy; `/v1/do slovak-company-data` returned populated SEXES s.r.o. data within 4 minutes of deploy.
+
+- **Phase 2 Understand** — Notion Journal `35f67c87082c81ceab3cdfa08b6391a2` (filed by chat). Covers the trust-in-pipeline blind spot pattern: CH bad fixture survived 16+ days because `verifyFixtures` reported `passed: true` when the executor threw on the bad UID and `--strict` wasn't used; SK rate-limit-burst was misdiagnosed as a structural Zenedge cap when it was really Strale's own scheduler burst at the `:41` tick.
+
+- **PR #109 (Phase 3a Harden, runtime sentinel)** `feat: known_answer suite fails on missing guaranteed fields (strict-missing-only)`. Added Gate 3 inside `validateResult`: for `known_answer` suites only, every field declared `guaranteed` in `output_field_reliability` must appear as a key in `actual_output`. Strict-missing-only — empty arrays, null values, empty objects all pass (validators/scanners legitimately return `findings=[]`). Backfill simulation predicted exactly 4 affected capabilities; v1 of the prompt was halted on 40-cap backfill surprise (the over-aggressive "non-empty" rule); v2 (this PR) flipped exactly those 4. Live-fired in prod at 12:24Z on `japanese-company-data` with `failure_reason="guaranteed_field_missing:corporate_number"` — Rule 14 verified.
+
+- **PR #111 (Phase 3b Harden, PR-time gate)** `feat(ci): static manifest guaranteed-field consistency gate + onboard-time strict-missing`. v3 of the pipeline-bypass detector — Path B per CC's earlier halt (Path A dynamic CI gate needs CI-DB infra Petter would have to provision). Three gates compose: onboard-time (verifyFixtures uses PR #109 helper), PR-time (static check `check-manifest-guaranteed-consistency.mjs --strict` wired into ci.yml, 22 pre-existing drifts allowlisted with header documenting Path A re-entry triggers), runtime (PR #109).
+
+## Sibling cleanups surfaced by the cycle
+
+- **PR #110** `fix(manifests): normalize HR + CH price_cents to 5 per DEC-20260513-E` — landed mid-session by another agent. HR and CH had stranded legacy €0.80 pricing; both are direct govt registries (Sudreg REST, Zefix REST), not scraping-cost-justified. Caused a rebase on my PR #111 branch; clean fast-forward, no conflicts on modify-list.
+
+- **PR #112** `feat: classify guaranteed_field_missing:* as manifest_drift non-tripping in categorizeFailureReason`. Added `manifest_drift` category to FailureCategory enum, prefix-match in `categorizeFailureReason`, early-return in `circuit-breaker.recordFailure` mirroring the `isUserInputError` skip pattern. Prevents PR #109's sentinel emissions from tripping breakers on the 4 affected capabilities at their 3rd consecutive failure (~3 hours after deploy). Genuine upstream failures (HTTP 5xx, exception, timeout) still trip via unchanged paths — test case 3 explicitly verifies this. Post-deploy at 13:16Z: `llm-output-validate` known_answer ran, sentinel fired, `capability_health` row was NOT created — confirms the early-return works on the canonical path.
+
+- **PR #113** `fix(manifests): align reliability declarations to actual executor output for 4 sentinel-failing caps`. Per-capability triage of the 4 affected by PR #109. All 4 turned out to be **manifest fixes** (no executor changes):
+  - `charity-lookup-uk`: `income` → `latest_income` (executor returns `latest_income` consistent with `latest_*` family)
+  - `japanese-company-data`: `corporate_number` → `registration_number` (executor returns `registration_number` matching EU-registry convention)
+  - `llm-output-validate`: `auto_fixed_output` `guaranteed` → `common` (only populated when `auto_fixed=true`)
+  - `openapi-validate`: orphan `stats` wrapper removed; 5 real top-level stats fields added as guaranteed (`error_count`, `warning_count`, `endpoint_count`, `schema_count`, `version_detected`)
+  - Also synced `capabilities.output_field_reliability` from new manifests to prod DB (since the column is manifest-canonical but only the `onboard --backfill` script auto-syncs).
+  - All 4 verified end-to-end via `/v1/do` direct probe — sentinel will pass on their next scheduled tick (debounce blocked this hour's tick from re-running since each was tested <1h ago).
+
+- **PR #114** `fix(swiss-company-data): correct legal_form + legal_form_id + canton + municipality JSON paths`. PR #107's smoke output revealed 4 shape bugs in `providers/swiss-company-data.ts` that PR #109's sentinel didn't catch (keys were present, just with wrong values/types):
+  - `legal_form`: returned the whole Zefix `legalForm` object (schema declared `string`) → now extracts `legalForm.shortName.de` ("AG"), falls back to `.en`
+  - `legal_form_id`: read non-existent `company.legalFormId` (always null) → now reads `legalForm.id` (3 for Roche)
+  - `canton`: read `legalSeat.canton` (legalSeat is a string!) → now reads top-level `company.canton` ("BS")
+  - `municipality`: read `legalSeat.municipalityName` (same shape error) → now reads `company.legalSeat` (the string IS the municipality name, "Basel")
+  - 7 tests cover the corrections + fallbacks + regression-guard for already-correct fields. Post-deploy `/v1/do` confirmed all 4 fields populated with correct types.
+
+## Operational DB cleanup (no PR)
+
+- **`capability_type` DB drift cleanup** — 13 UPDATEs aligning DB `capabilities.capability_type` to manifest `data_source_type` mapping. 5 EU registries migrated from scraping to direct API but DB stale at `scraping` (belgian/irish/latvian/lithuanian/swedish-company-data → `stable_api`). 8 computed/algorithmic caps mis-tagged as `stable_api` → `deterministic` (age-verify, aml-risk-score, business-day-check, language-detect, phone-type-detect, phone-validate, timezone-lookup, website-to-company). 0 reverse-drift. 67 `ai_assisted` rows intentionally left alone per `capability-field-authority.ts:271-274`. Smoke verified 3 caps (1 changed-to-stable_api, 1 changed-to-deterministic, 1 control unchanged). Closes the provenance-classification drift on `do.ts:2442`.
+
+# What's open
+
+## Provider-Coverage systematic sweep — HALTED
+
+The MCP toolset in this environment doesn't expose `query_data_sources` — only `notion-search` (semantic, max 25/call, non-exhaustive). The prompt requires enumerating ALL ~100+ Provider-Coverage rows for the codebase-truth alignment sweep. CC's halt report surfaced four forward paths for chat decision:
+
+- **Path A**: enable `query_data_sources` MCP tool in this environment, then re-run the sweep with full coverage
+- **Path B**: chat exports row list as CSV/structured artifact; CC reads it and computes deltas locally
+- **Path C**: chat narrowly scopes to a specific subset (e.g. all rows with status=Gap, or the 4 CH-related rows)
+- **Path D**: defer — runtime sentinel + static check already cover the most customer-visible drift; Provider-Coverage drift is internal-canonical noise
+
+Recommended Path A or D depending on launch urgency.
+
+## Stuck-validating caps
+
+3 caps in lifecycle_state=validating with last_tested_at NULL (never run):
+- `us-company-data-cobalt`
+- `us-ein-match`
+- `us-sec-filings-extended`
+
+These are US-class caps that appear to have been onboarded but never tested. Worth chat triage — likely missing env vars or executor not registered.
+
+## Notion governance
+
+- **DEC-20260513-F** (manifest-drift-as-non-tripping semantic decision per PR #112): chat needs to log a small DEC matching DEC-20260506-D's shape.
+- **22 Notion To-do entries** for PR #111's static-check allowlist — each is a separate per-manifest triage prompt to shrink the allowlist toward zero.
+- **DEC-20260513-B + DEC-20260513-C Outcome fields**: chat populates with PR links + "all 4 phases shipped".
+- **Capability onboarding pipeline page** (`33c67c87082c81969b1fe32c87095f5a`): chat applies `verifyFixtures` strengthening note from PR #111.
+
+# Non-obvious learnings
+
+- **Manifest fields can have type-cast lies that survive forever.** PR #114's `legal_form` bug was `(company.legalForm as string) ?? null` — TypeScript cast accepted at compile time, but Zefix actually returns an object. The downstream code happily passed the object through as if it were a string for months. Schema declared `string`; reality was `object`. The lesson: schema declarations are aspirational without a runtime gate that verifies them. PR #109's strict-missing sentinel doesn't catch this class (the key was present, just wrong-shape); the right tool is a per-field type-validation gate, but that requires schema → runtime contract testing which is bigger than today's scope.
+
+- **Field-reliability is two competing axes that v1 sentinel conflated.** Empty-as-success (validators/scanners returning `findings=[]`) vs missing-key-bug (executor never populating the field). v1 of PR #109 tried to assert both with one rule and would have tripped 40 healthy capabilities. v2 (the strict-missing-only shape that shipped) catches only the missing-key class. The empty-as-failure axis is opt-in territory — would need a per-field `non_empty: true` manifest annotation, named as future work in PR #109's PR body.
+
+- **Per-suite scheduler spread side effect**: with the old per-capability stagger, all 5 SK suites fired on minute 41 → 5 calls in ~1 second → Zenedge saturation. The same pattern was hiding for every multi-suite capability — SK happened to be the one with the tightest upstream throttle. PR #108 distributes load globally; the upstream-burst pathology is gone for all caps, not just SK.
+
+- **`postgres.railway.internal` doesn't resolve from local network.** Re-confirmed today (would have hit this on PR #109's canary if I hadn't already known from the 2026-05-06 DK precedent). Workaround: `railway ssh` + inline node script using `process.env.DATABASE_URL`. All operational SQL today went through that pattern.
+
+- **Manifest-canonical vs DB-canonical hybrid is more subtle than it looks.** `output_field_reliability` is manifest-canonical (manifest is authoritative; backfill overwrites DB) BUT only `onboard --backfill` auto-syncs. Merging a manifest change doesn't propagate to prod DB without a separate step. PR #113 caught this — I had to manually `UPDATE capabilities SET output_field_reliability = $json` for the 4 fixed caps. Similarly, `capability_type` is hybrid (manifest seeds on create; DB preserved when set) — so today's 13 drift fixes had to go straight to DB UPDATE, not via manifest re-run.
+
+- **`legalSeat` in Zefix is a STRING, not an object.** Tripped me up in PR #114. The parser assumed `legalSeat.municipalityName` and `legalSeat.canton`; in reality, `legalSeat` IS the municipality name (a string like "Basel"), and `canton` lives at the top level. A 30-second response inspection saved 30 minutes of guessing.
+
+# Cost
+
+- Zero deploy cost (8 PRs, all standard Railway backend deploys).
+- 24 live API calls in the v1-launch coverage audit (~€0.75 wallet hit).
+- ~20 live `/v1/do` calls across smoke verifications (~€0.15).
+- ~50 Zefix probe calls in the CH credentials diagnostic (free public REST).
+- 1 hour of /v1/do test-account budget consumed across the day's work.

--- a/handoff/_general/from-code/2026-05-13-hr-ch-price-normalize-dec-20260513-e.md
+++ b/handoff/_general/from-code/2026-05-13-hr-ch-price-normalize-dec-20260513-e.md
@@ -1,0 +1,40 @@
+Intent: ship DEC-20260513-E — normalize HR `croatian-company-data` and CH `swiss-company-data` from €0.80 to €0.05 customer price; fix CH `capability_type` DB drift (scraping → stable_api) in the same pass.
+
+## Outcome — shipped
+
+**PR #110** merged at 2026-05-13T12:58:48Z (squash, merge commit `86b04be`).
+- https://github.com/strale-io/strale/pull/110
+- 2-line manifest diff: `manifests/croatian-company-data.yaml` and `manifests/swiss-company-data.yaml`, `price_cents: 80 → 5`.
+
+**DB UPDATEs applied to Railway production:**
+```sql
+UPDATE capabilities SET price_cents = 5 WHERE slug = 'croatian-company-data';
+UPDATE capabilities SET price_cents = 5, capability_type = 'stable_api' WHERE slug = 'swiss-company-data';
+```
+
+**Smoke probes (post-UPDATE, production):**
+- HR: txn `dc19948a-9dab-4932-88fd-3d01645c777f` — Hrvatski Telekom d.d., 5 cents charged, 1098 ms.
+- CH: txn `35ff87e3-05d3-4903-97f3-20a553e76c13` — Roche Holding AG, 5 cents charged, 469 ms; provider `zefix-public-rest`, `provider_type: api`, fallback_used=false (clean Zefix REST path).
+
+**Sibling-repo grep:** 3 benign hits in `strale-frontend` (sitemap URL, fixture workaround text, test-report HTTP-200 check). No 80-cent hardcoding. `strale-beacon`: zero hits. No follow-up needed.
+
+## Open
+
+- Petter to populate **DEC-20260513-E Outcome field** with PR #110 link: https://www.notion.so/35f67c87082c81f499a9cbb9ebb39553
+- Out of scope per DEC: CA + JP €0.80 (scraping-cost-justified), catalog-wide `capability_type` drift on other slugs, 8 inactive €0.80 caps (re-price on reactivation).
+
+## Non-obvious learnings
+
+1. **`price_cents` is db-canonical, not manifest-canonical** per `apps/api/src/lib/capability-field-authority.ts:103-106`. Manifest seeds on create; DB UPDATE is the operational change. Backfill via `onboard.ts --backfill` would NOT overwrite admin-tuned DB prices. This means the manifest commit is hygiene (drift-prevention for fresh-DB rebuild + human-readable seed), not the operational fix. The DEC's "prevent silent overwrites on backfill" framing reads sideways from the field-authority docstring — both are right; the field-authority module is what enforces the non-overwrite, the manifest commit just keeps the seed file aligned.
+
+2. **`capability_type` is hybrid** per `capability-field-authority.ts:271-274` — DB preserved if set, manifest only fills NULL. CH's stale `scraping` tag would have survived any backfill. Direct UPDATE was the only path.
+
+3. **Manifest data_source_type → DB capability_type mapping** is in `apps/api/src/lib/capability-manifest.ts:41-54` (`dataSourceTypeToCapType`): `api → stable_api`, `scrape → scraping`, `computed → deterministic`, `ai_assisted → ai_assisted`. CH manifest declared `api`; correct DB value was `stable_api`.
+
+4. **`/v1/do` request schema:** body field is `inputs`, not `input`. Took 3 attempts to land the smoke probe. The 400 error message hints at `top-level → inputs` migration only — doesn't catch `input → inputs` (singular vs plural). Worth a future error-message tweak if the same trip hits more agents.
+
+5. **Working-tree state mid-session:** the manifest commit landed on the feature branch, then a separate process (likely a hook or worktree switch) returned HEAD to main, which made it look like the manifest changes had been reverted. They hadn't — the branch still held the commit. Don't trust working-tree state alone as proof of commit state; check `git log <branch>`.
+
+## Cost
+
+Minimal — 2 smoke `/v1/do` calls (€0.10 total at the new prices) + the planning-prompt + go-prompt thread time.

--- a/handoff/_general/from-code/2026-05-13-restore-hsts-header-cloudflare-pages.md
+++ b/handoff/_general/from-code/2026-05-13-restore-hsts-header-cloudflare-pages.md
@@ -1,0 +1,42 @@
+Intent: Restore the `Strict-Transport-Security` header that strale.dev lost during the Lovable → Cloudflare Pages migration.
+
+## Why
+
+Pre-migration (Lovable), strale.dev emitted `Strict-Transport-Security: max-age=31536000; includeSubDomains` on every response. Post-migration (Cloudflare Pages, 2026-05-12), the header was absent. Browsers with the existing HSTS pin would continue enforcing HTTPS for the remaining max-age window, but new visitors after the migration weren't getting a fresh pin. Security regression.
+
+## What shipped — strale-frontend PR #7 (merged + deployed)
+
+Branch: `chore/restore-hsts-header` → squash-merged into `main`.
+
+One file added:
+
+- **`public/_headers`**:
+  ```
+  /*
+    Strict-Transport-Security: max-age=31536000; includeSubDomains
+  ```
+
+Cloudflare Pages convention. Vite copies `public/_headers` → `dist/_headers` at build (verified locally). CF Pages auto-applies on every deploy.
+
+`preload` deliberately omitted — the HSTS preload list submission is operationally hard to reverse and not something to commit to pre-launch.
+
+## Verification (post-deploy)
+
+```
+$ curl -sI https://strale.dev/ | grep -i strict-transport-security
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+
+$ curl -sI https://www.strale.dev/ | grep -i strict-transport-security
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+```
+
+Both apex and `www.` subdomain emit the header. Security parity with pre-migration restored.
+
+## Open
+
+None for HSTS specifically. Adjacent future work that the `_headers` file makes cheap: adding CSP, X-Content-Type-Options, X-Frame-Options, Referrer-Policy under the same `/*` block when there's a reason. Not doing them now — single-purpose PR.
+
+## Non-obvious learnings
+
+- Cloudflare Pages reads `_headers` from the build *output* directory (`dist/`), not the source `public/`. Vite's default `publicDir → outDir` copy is what makes the `public/_headers` placement work. If the project ever changes `publicDir` or pre-processes `public/` differently, the `_headers` file needs to follow.
+- Cloudflare Pages syntax requires the two-space indent on header lines — without it, the parser doesn't associate the header with the path glob.


### PR DESCRIPTION
## Summary

Promotes 5 handoff notes that were sitting untracked across the `strale` and `strale-work` worktrees.

- `2026-05-11-failure-investigation-de-dk-sk-rootcause.md` (was in `strale`)
- `2026-05-13-hr-ch-price-normalize-dec-20260513-e.md` (was in `strale`)
- `2026-05-13-a0c-1-v3-list-endpoint-cost-class.md` (was in `strale-work`)
- `2026-05-13-dec-20260513-bc-cycle-closure-plus-followups.md` (was in `strale-work`)
- `2026-05-13-restore-hsts-header-cloudflare-pages.md` (was in `strale-work`)

Standard chore-promote pattern (PR #106 shape). Unblocks the v1 Identity audit residual prompt which halted on a dirty-tree gate in strale-work.

## Test plan

- [x] git diff shows additions only, 5 files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)