### PR TITLE
chore: end-of-session cleanup 2026-05-14 — handoff + audit-doc promote + uk-company-data orient comment + strale-frontend scan

### DIFF
--- a/apps/api/docs/hmrc-sandbox-test-report-2026-05-13.md
+++ b/apps/api/docs/hmrc-sandbox-test-report-2026-05-13.md
@@ -1,0 +1,240 @@
+# HMRC Check a UK VAT Number API v2.0 — Sandbox Test Report
+
+**Support reference:** 2026-CNS433
+**Date:** 2026-05-13T21:50:28.140Z
+**Application:** Strale (Moonlighter AB)
+**Tested against:** `https://test-api.service.hmrc.gov.uk`
+**Scope:** `read:vat`
+**Accept header:** `application/vnd.hmrc.2.0+json`
+**Sandbox credentials:** `HMRC_SANDBOX_CLIENT_ID` (client_id ado6…xK (len=28) <REDACTED>) / `HMRC_SANDBOX_CLIENT_SECRET` from local `.env`. No production credentials referenced or read.
+
+**Mock VRN source:** HMRC's own published canonical mock-data file at `github.com/hmrc/vat-registered-companies-api/blob/main/public/api/conf/2.0/test-data/vrn.csv` (40 provisioned VRNs).
+
+**VRNs selected for this run:**
+- Target: `553557881` (canonical example from HMRC OAS docs; first entry in the mock-data CSV)
+- Requester: `436189915` (distinct from target; also in the canonical CSV)
+- Regression: `553557817` (prior test VRN; NOT in the canonical CSV — used to show the 404 path is correct behaviour for non-provisioned identifiers)
+
+---
+
+## Test 1 — OAuth2 token request
+
+**Request**
+- Method: `POST`
+- URL: `https://test-api.service.hmrc.gov.uk/oauth/token`
+- Headers:
+  - `Content-Type: application/x-www-form-urlencoded`
+- Body (form-encoded):
+  - `grant_type=client_credentials`
+  - `client_id=<REDACTED>`
+  - `client_secret=<REDACTED>`
+  - `scope=read:vat`
+
+**Response**
+- HTTP status: `200 OK`
+- Wall clock: `537ms`
+- Headers:
+```json
+{
+  "cache-control": "no-cache,no-store,max-age=0",
+  "connection": "keep-alive",
+  "content-length": "111",
+  "content-security-policy": "default-src 'self'",
+  "content-type": "application/json",
+  "date": "Wed, 13 May 2026 21:50:27 GMT",
+  "strict-transport-security": "max-age=31536000;",
+  "via": "1.1 4ded1750dc7e0bef188a5520fb9fef28.cloudfront.net (CloudFront)",
+  "x-amz-cf-id": "yYKmscr2RxRxSAuNQWZDvsPcK5n5yIlh9z_5I8duEre2do98VecdrA==",
+  "x-amz-cf-pop": "ARN56-P1",
+  "x-cache": "Miss from cloudfront",
+  "x-content-type-options": "nosniff",
+  "x-envoy-upstream-service-time": "54",
+  "x-frame-options": "SAMEORIGIN"
+}
+```
+- Body:
+```json
+{
+  "access_token": "<REDACTED>",
+  "scope": "read:vat",
+  "expires_in": 14400,
+  "token_type": "bearer"
+}
+```
+- Granted scope: `read:vat`
+- Token TTL: `14400s`
+
+**Verdict: PASS** — HTTP 200, `read:vat` scope granted.
+
+---
+
+## Test 2 — Unverified check (positive path, 200 expected)
+
+**Source of test VRN:** `github.com/hmrc/vat-registered-companies-api/blob/main/public/api/conf/2.0/test-data/vrn.csv` (entry 1 of 40).
+
+**Request**
+- Method: `GET`
+- URL: `https://test-api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup/553557881`
+- Headers:
+  - `Accept: application/vnd.hmrc.2.0+json`
+  - `Authorization: Bearer <REDACTED>`
+- Time of call (UTC): `2026-05-13T21:50:28.681Z`
+
+**Response**
+- HTTP status: `200 OK`
+- Wall clock: `369ms`
+- Headers:
+```json
+{
+  "cache-control": "no-cache,no-store,max-age=0",
+  "connection": "keep-alive",
+  "content-length": "199",
+  "content-security-policy": "default-src 'self'",
+  "content-type": "application/json",
+  "date": "Wed, 13 May 2026 21:50:27 GMT",
+  "strict-transport-security": "max-age=31536000;",
+  "vary": "Origin",
+  "via": "1.1 30a448a0dbd4a52ea118d2e64f0535c8.cloudfront.net (CloudFront)",
+  "x-amz-cf-id": "gVx4hdK1MrCwxbXL68BoBclbJEK1ZAl13Kua1Grd5Yv_axJK93PyhQ==",
+  "x-amz-cf-pop": "ARN56-P1",
+  "x-cache": "Miss from cloudfront",
+  "x-content-type-options": "nosniff",
+  "x-envoy-upstream-service-time": "19",
+  "x-frame-options": "SAMEORIGIN"
+}
+```
+- Body:
+```json
+{
+  "target": {
+    "name": "Credite Sberger Donal Inc.",
+    "vatNumber": "553557881",
+    "address": {
+      "line1": "131B Barton Hamlet",
+      "postcode": "SW97 5CK",
+      "countryCode": "GB"
+    }
+  },
+  "processingDate": "2026-05-13T22:50:27+01:00"
+}
+```
+
+**Verdict: PASS** — HTTP 200 as expected for unverified lookup of a canonical mock VRN.
+
+---
+
+## Test 3 — Verified check (positive path, 200 expected)
+
+**Source of test VRNs:** both target and requester drawn from `vrn.csv` (entries 1 and 8 respectively; distinct identifiers).
+
+**Request**
+- Method: `GET`
+- URL: `https://test-api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup/553557881/436189915`
+- Headers:
+  - `Accept: application/vnd.hmrc.2.0+json`
+  - `Authorization: Bearer <REDACTED>`
+- Time of call (UTC): `2026-05-13T21:50:29.053Z`
+
+**Response**
+- HTTP status: `200 OK`
+- Wall clock: `258ms`
+- Headers:
+```json
+{
+  "cache-control": "no-cache,no-store,max-age=0",
+  "connection": "keep-alive",
+  "content-length": "258",
+  "content-security-policy": "default-src 'self'",
+  "content-type": "application/json",
+  "date": "Wed, 13 May 2026 21:50:27 GMT",
+  "strict-transport-security": "max-age=31536000;",
+  "vary": "Origin",
+  "via": "1.1 4ded1750dc7e0bef188a5520fb9fef28.cloudfront.net (CloudFront)",
+  "x-amz-cf-id": "BBAO3yqc6GaaYxtFgNWK8JYy4zj2Clrcta3VyUpezmVsuDOkgPiooQ==",
+  "x-amz-cf-pop": "ARN56-P1",
+  "x-cache": "Miss from cloudfront",
+  "x-content-type-options": "nosniff",
+  "x-envoy-upstream-service-time": "20",
+  "x-frame-options": "SAMEORIGIN"
+}
+```
+- Body:
+```json
+{
+  "target": {
+    "name": "Credite Sberger Donal Inc.",
+    "vatNumber": "553557881",
+    "address": {
+      "line1": "131B Barton Hamlet",
+      "postcode": "SW97 5CK",
+      "countryCode": "GB"
+    }
+  },
+  "requester": "436189915",
+  "consultationNumber": "YQD-VNF-WWX",
+  "processingDate": "2026-05-13T22:50:27+01:00"
+}
+```
+
+**Verdict: PASS** — HTTP 200 as expected for verified lookup with target + requester.
+
+---
+
+## Test 4 — Authenticated 404 regression (negative path, 404 expected)
+
+**Test VRN:** `553557817` — the identifier used in the prior 5 May test report. This VRN is **NOT** in the canonical `vrn.csv` mock-data list, so a 404 is the documented correct sandbox behaviour, NOT a configuration issue with Strale's application.
+
+**Request**
+- Method: `GET`
+- URL: `https://test-api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup/553557817`
+- Headers:
+  - `Accept: application/vnd.hmrc.2.0+json`
+  - `Authorization: Bearer <REDACTED>`
+- Time of call (UTC): `2026-05-13T21:50:29.311Z`
+
+**Response**
+- HTTP status: `404 Not Found`
+- Wall clock: `121ms`
+- Headers:
+```json
+{
+  "cache-control": "no-cache",
+  "connection": "keep-alive",
+  "content-length": "78",
+  "content-security-policy": "default-src 'self'",
+  "content-type": "application/json",
+  "date": "Wed, 13 May 2026 21:50:28 GMT",
+  "strict-transport-security": "max-age=31536000;",
+  "vary": "Origin",
+  "via": "1.1 30a448a0dbd4a52ea118d2e64f0535c8.cloudfront.net (CloudFront)",
+  "x-amz-cf-id": "F2GRdfkMP5FCaX87kQh9VmpGawyLnxa8oXrUxOxFBdjTJU2fddRYLA==",
+  "x-amz-cf-pop": "ARN56-P1",
+  "x-cache": "Error from cloudfront",
+  "x-envoy-upstream-service-time": "8"
+}
+```
+- Body:
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "targetVrn does not match a registered company"
+}
+```
+
+**Verdict: PASS** — HTTP 404 as expected for non-provisioned VRN regression.
+
+---
+
+## Summary
+
+| # | Test | Expected | Got | Verdict |
+|---|---|---|---|---|
+| 1 | OAuth2 token (`read:vat`) | 200 | 200 | PASS |
+| 2 | Unverified lookup, canonical VRN `553557881` | 200 | 200 | PASS |
+| 3 | Verified lookup, target `553557881` + requester `436189915` | 200 | 200 | PASS |
+| 4 | Authenticated 404 regression, non-provisioned VRN `553557817` | 404 | 404 | PASS |
+
+**Diagnosis of the prior 5 May report's 404:** the prior test used `553557817`, which is not in HMRC's canonical mock-VRN list. The 404 response was the correct, documented sandbox behaviour for a non-provisioned identifier — not an authentication, scope, or configuration problem with Strale's sandbox application. Tests 2 and 3 above use VRNs from the canonical list and return populated 200 responses with the same client credentials, scope, headers, and code path.
+
+Test started: 2026-05-13T21:50:28.140Z
+Test finished: 2026-05-13T21:50:29.432Z

--- a/apps/api/docs/vies-uk-gb-coverage-verification-2026-05-13.md
+++ b/apps/api/docs/vies-uk-gb-coverage-verification-2026-05-13.md
@@ -1,0 +1,248 @@
+# VIES UK GB-prefix coverage verification (2026-05-13)
+
+**Investigation type:** read-only. No code changes, no commits, no PR.
+**Trigger:** claim in third-party library `valvat` (Ruby gem) that VIES stopped accepting GB-prefix VAT requests in early 2021 post-Brexit. Memory entry + Active Vendor Stack page state "VIES covers EU27 + UK." If the valvat claim is accurate, the canonical-surface text is stale.
+**Worktree:** strale-research @ origin/main SHA `5c22c77`.
+
+---
+
+## Verdict: **REFUTED with no code impact**
+
+The valvat claim is empirically confirmed. VIES rejects GB-prefix VAT queries at the country-code level. **However**, Strale's `vat-validate` capability code is already correctly architected for this reality — GB is routed to HMRC, EU27+XI to VIES. **The drift is in the canonical-surface text (memory + Active Vendor Stack), not in the code.**
+
+This means:
+
+- **No code gap.** Strale's UK VAT validation path is HMRC and has been HMRC since at least the `vat-validate.ts` capability was written.
+- **HMRC support ticket 2026-CNS433 is critical-path, not enrichment.** The framing of the memory entry as "VIES covers EU27 + UK" understates HMRC's importance.
+- **Canonical-surface corrections needed** in: (a) memory entry on VIES coverage; (b) Active Vendor Stack page row for VIES.
+
+---
+
+## Step 2 findings — Strale UK Identity capability behaviour
+
+### `apps/api/src/capabilities/uk-company-data.ts`
+
+UK Identity returns no `vat_number` field at all in its output. The return object (lines 98-109) is:
+
+```typescript
+return {
+  company_name: c.company_name || "",
+  company_number: c.company_number || companyNumber,
+  business_type: c.type || null,
+  jurisdiction: c.jurisdiction || null,
+  address,
+  incorporation_date: c.date_of_creation || null,
+  dissolution_date: c.date_of_cessation || null,
+  status: statusMap[c.company_status] || c.company_status || "unknown",
+  sic_codes: c.sic_codes || [],
+  has_charges: c.has_charges || false,
+};
+```
+
+No VIES call. No HMRC call. No VAT field. The capability is Companies House only.
+
+### `apps/api/src/capabilities/vat-validate.ts`
+
+VAT validation is a separate capability that dispatches by country-code prefix. The header docstring (lines 9-14) already correctly documents post-Brexit reality:
+
+```
+Coverage today:
+  - EU27 + XI (Northern Ireland)  → VIES
+  - NO                            → Brønnøysundregistrene
+  - CH, LI                        → Swiss UID register (public services)
+  - GB                            → HMRC v2 (active when credentials are set)
+```
+
+`PROVIDER_BY_PREFIX` map (lines 88-93) routes each parsed country code to its provider. The unsupported-country error message (line 177) names the same routing.
+
+### `apps/api/src/capabilities/lib/vat-providers/vies.ts`
+
+The VIES provider's prefix list (lines 16-21):
+
+```typescript
+const EU27_PREFIXES = [
+  "AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "EL", "ES",
+  "FI", "FR", "HR", "HU", "IE", "IT", "LT", "LU", "LV", "MT",
+  "NL", "PL", "PT", "RO", "SE", "SI", "SK",
+  "XI", // Northern Ireland (post-Brexit protocol — VIES handles XI)
+] as const;
+```
+
+GB is **not** in the list. XI is. The comment on line 20 explicitly cites the post-Brexit protocol — whoever wrote `vat-validate.ts` knew about the change.
+
+### `apps/api/src/capabilities/lib/vat-providers/hmrc.ts`
+
+HMRC provider:
+
+```typescript
+name: "hmrc",
+source: "api.service.hmrc.gov.uk (Check a UK VAT Number v2)",
+prefixes: ["GB"],
+```
+
+GB is exclusively routed to HMRC.
+
+**Conclusion of Step 2:** Strale's UK Identity capability does not return VAT data at all (out of scope for that capability). The `vat-validate` capability — the surface that actually does VAT validation — correctly routes GB to HMRC, not VIES. Code is sound.
+
+---
+
+## Step 3 — UK Identity capability execution
+
+Not run. Step 2 established that `uk-company-data.ts` does not call VIES or any VAT-checking surface for the UK — VAT is simply not part of the response shape. A live execution would not produce VIES-related signal; it would just confirm the response omits VAT.
+
+---
+
+## Step 4 findings — direct VIES REST calls
+
+**Endpoint:** `https://ec.europa.eu/taxation_customs/vies/rest-api/check-vat-number` (POST, JSON body).
+
+### Test A — GB-prefix (Tesco PLC VAT `220430231`)
+
+**Request body:** `{"countryCode":"GB","vatNumber":"220430231"}`
+
+**Response:** HTTP 200, body:
+
+```json
+{
+  "actionSucceed" : false,
+  "errorWrappers" : [ {
+    "error" : "INVALID_INPUT"
+  } ]
+}
+```
+
+VIES rejects GB at the country-code level. The rejection is independent of which GB VAT number is submitted — the error fires before VIES validates the number itself. This is structural: VIES does not accept GB as a valid country code post-Brexit.
+
+### Test B — XI-prefix (Northern Ireland VAT `174918964`)
+
+**Request body:** `{"countryCode":"XI","vatNumber":"174918964"}`
+
+**Response:** HTTP 200, body (truncated):
+
+```json
+{
+  "countryCode" : "XI",
+  "vatNumber" : "174918964",
+  "requestDate" : "2026-05-13T21:55:59.516Z",
+  "valid" : false,
+  "name" : "",
+  "address" : "",
+  ...
+}
+```
+
+VIES accepts XI as a valid country code and processes the request normally. The specific VAT number returned `valid: false` (test VRN may have been inaccurate), but the request *shape* was accepted — VIES did not throw `INVALID_INPUT` on the XI prefix. **XI is in VIES.** Matches the post-Brexit Northern Ireland Protocol per the `vies.ts:20` comment.
+
+### Test C — DE-prefix control (Siemens VAT `129273398`)
+
+**Request body:** `{"countryCode":"DE","vatNumber":"129273398"}`
+
+**Response:** HTTP 200, body:
+
+```json
+{
+  "actionSucceed" : false,
+  "errorWrappers" : [ {
+    "error" : "MS_UNAVAILABLE"
+  } ]
+}
+```
+
+Note: `MS_UNAVAILABLE` means the German member-state service was transiently down at audit time. The call shape was accepted (no `INVALID_INPUT`). This is a known per-MS availability quirk of VIES and is orthogonal to GB coverage.
+
+### Test D — FR-prefix control (L'Oréal VAT `79632012100`)
+
+Re-ran the control with France to escape the DE outage.
+
+**Request body:** `{"countryCode":"FR","vatNumber":"79632012100"}`
+
+**Response:** HTTP 200, body (truncated):
+
+```json
+{
+  "countryCode" : "FR",
+  "vatNumber" : "79632012100",
+  "requestDate" : "2026-05-13T21:56:18.425Z",
+  "valid" : false,
+  "name" : "---",
+  "address" : "---",
+  ...
+}
+```
+
+VIES accepts FR, processes the call, returns a structured response. `valid: false` for the specific number (test fixture stale) but the request shape was accepted — confirms VIES is up and CC's call shape is correct. **Control passes.**
+
+### Test E — HMRC production API (Tesco VAT `220430231`)
+
+Out of investigation scope per prompt; sanity check only.
+
+**Request:** `GET https://api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup/220430231` with `Accept: application/vnd.hmrc.2.0+json`, no auth header.
+
+**Response:** HTTP 401, body:
+
+```json
+{"code": "MISSING_CREDENTIALS", "message": "Authentication information is not provided"}
+```
+
+Confirms the HMRC production API is reachable and exists; authentication is required (which is what HMRC support ticket 2026-CNS433 is requesting).
+
+---
+
+## Step 5 — reconciliation
+
+| Surface | Claim | Reality |
+|---|---|---|
+| Strale code (`vat-validate.ts` + `vies.ts` + `hmrc.ts`) | EU27+XI → VIES; GB → HMRC | ✅ Matches reality |
+| Memory entry on VIES coverage | "VAT (EU27): free — EU27 + UK" | ❌ "UK" should be "+XI"; GB is not in VIES |
+| Active Vendor Stack page row for VIES | "VAT (EU27) | VIES | … EU27 + UK (DE/ES suppress name/address)" | ❌ "UK" should be "XI"; GB needs its own row pointing at HMRC |
+| Empirical VIES behaviour | n/a | GB → `INVALID_INPUT`; XI → processed normally |
+
+**Verdict per the prompt's options: REFUTED.** VIES does not work for GB-prefix VAT. Memory and Active Vendor Stack canonical text are stale.
+
+The only saving grace is that the **code** has been correct all along — whoever wrote `vat-validate.ts` understood the post-Brexit reality and structured the providers accordingly. The drift is purely in the human-readable canonical surfaces that summarise the stack.
+
+---
+
+## Recommended canonical updates (NOT done in this prompt — chat-driven)
+
+### Memory entry (chat-side)
+
+Current text (memory bullet on VAT coverage, approximate wording from the Active Vendor Stack page mirror):
+> "VAT (EU27): VIES — free — EU27 + UK (DE/ES suppress name/address)"
+
+Replace with:
+> "VAT (EU27+XI via VIES, GB via HMRC): VIES (free) for EU27 + Northern Ireland (XI prefix); HMRC Check a UK VAT Number API v2 (free, OAuth required, sandbox ✓ production credentials pending support ref 2026-CNS433) for GB prefix. Post-Brexit reality — VIES rejects GB with `INVALID_INPUT` at country-code level. Strale's `vat-validate.ts` routes correctly. DE/ES suppress name/address in VIES responses."
+
+### Active Vendor Stack page (Notion `35367c87082c812e88d1dc6bdbfbd4f5`)
+
+The "v1 stack — global legs" table has a single VAT row crediting VIES with "EU27 + UK." Recommended: split into two rows, one for VIES (EU27+XI) and one for HMRC (GB). Cite this verification doc + the existing `vat-validate.ts` architecture as the rationale.
+
+Alternative single-row phrasing if a table split is heavyweight: `VAT validation | VIES (EU27 + XI, free) + HMRC Check a UK VAT Number v2 (GB, free, OAuth) | free | none | n/a | EU27 + XI via VIES; GB via HMRC (post-Brexit; VIES rejects GB with INVALID_INPUT). DE/ES suppress name/address in VIES.`
+
+### HMRC support ticket 2026-CNS433 framing
+
+The memory's "VIES covers UK" wording understates HMRC's importance. Petter's email to HMRC should frame HMRC API as the **sole programmatic path** for UK VAT validation post-Brexit, not an enrichment over VIES. The HMRC sandbox retest report (`apps/api/docs/hmrc-sandbox-test-report-2026-05-13.md`, this session) demonstrates Strale's sandbox integration is functioning end-to-end; the production credential request is the remaining blocker for shipping UK VAT validation as a customer-callable surface.
+
+---
+
+## Follow-ups (named, not executed in this prompt)
+
+1. **Memory edit (chat-driven)** — update the VAT coverage entry per the wording above.
+2. **Active Vendor Stack page edit (chat-driven)** — split or rephrase the VAT row.
+3. **No code follow-up needed.** `vat-validate.ts` is already correct. If a future audit finds a separate surface (e.g. a marketing page, a public docs page, an OpenAPI description) that claims "VIES covers UK," that's where the next sweep would target.
+4. **(Optional)** Add a brief comment to `uk-company-data.ts` noting that VAT enrichment for UK is handled separately by `vat-validate.ts` via HMRC, not via Companies House — orientation for future readers. Trivial, non-load-bearing.
+
+---
+
+## Test details (for reproducibility)
+
+- VIES REST endpoint: `https://ec.europa.eu/taxation_customs/vies/rest-api/check-vat-number`
+- Method: POST, Content-Type: application/json
+- HMRC production endpoint (auth required): `https://api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup/{vrn}`
+- All tests run from the Strale workstation, 2026-05-13 ~21:55–21:56 UTC.
+- No authentication used for VIES (it's unauthenticated by design).
+- No credentials read from any .env for this investigation. Tests A–D were direct cURL against the public VIES endpoint; Test E was an unauthenticated probe of the HMRC production API to confirm reachability.
+
+---
+
+*This document is the artifact. Memory + Active Vendor Stack edits happen in a follow-up chat-driven step.*

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -1,6 +1,11 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { registerCapability, type CapabilityInput } from "./index.js";
 
+// UK VAT validation is handled by vat-validate.ts (which routes GB → HMRC v2),
+// not by this Identity capability. Companies House (the source for this
+// capability) does not return VAT data. See DEC-20260513-F + the Active Vendor
+// Stack page row split (2026-05-13) for the post-Brexit routing rationale.
+
 // UK Companies House API — free but requires API key
 // Register at https://developer.company-information.service.gov.uk/
 const API = "https://api.company-information.service.gov.uk";

--- a/handoff/_general/from-code/2026-05-14-v1-identity-closeout-phase3-sentinel-vies-corrections.md
+++ b/handoff/_general/from-code/2026-05-14-v1-identity-closeout-phase3-sentinel-vies-corrections.md
@@ -1,0 +1,104 @@
+Intent: close out the DEC-20260513-B/C/D bug-fix arc + v1 Identity audit residuals, ship the Phase 3 Harden gate (a) sentinel test, and correct canonical-surface drift on VIES UK-GB coverage. Session ran across strale-research (read-only audit work + Notion updates) and strale-work (3 PRs shipped + merged).
+
+## What shipped
+
+### PR #115 — chore: promote 5 handoff notes (2026-05-11 + 2026-05-13 batch)
+Cleared the dirty-tree gate that the audit-residual prompt halted on. Two pre-existing untracked files in the `strale` worktree (`2026-05-11-failure-investigation-de-dk-sk-rootcause.md`, `2026-05-13-hr-ch-price-normalize-dec-20260513-e.md`) + three from `strale-work` (`2026-05-13-a0c-1-v3-list-endpoint-cost-class.md`, `2026-05-13-dec-20260513-bc-cycle-closure-plus-followups.md`, `2026-05-13-restore-hsts-header-cloudflare-pages.md`) promoted to tracked.
+
+### PR #116 — fix(gr-identity): swap manifest fixture from branch entity to parent SA + close v1 audit residuals (merge `4553b75`)
+Closed three residuals from the 2026-05-13 v1 Identity coverage audit:
+- **GR fixture swap**: `manifests/greek-company-data.yaml` `known_answer.input.gemi_number` changed from `000237954001` (Lamia branch of NBG, `is_branch=true`, empty directors/NACE) to `296601000` (HELLENiQ ENERGY Holdings SA, parent, `is_branch=false`, 11 directors, NACE 19200000). Expected_fields rewritten to match HELLENiQ's response shape; added `industry_code not_null` assertion that the prior branch fixture couldn't sustain.
+- **DK + DE quota residuals**: verified operationally healthy via direct query of `test_results` over the trailing 24h. Both 6/6 green = 100% (most recent 20:27 UTC / 20:17 UTC). Met the prompt's ≥95% threshold cleanly. Audit-time `quota_exceeded` errors were correct DEC-20260512-A cost-class gate behaviour, not failures.
+- **Audit doc**: copied + extended `apps/api/docs/v1-identity-coverage-matrix-2026-05-13.md` with §10 closeout evidence chain. Table B GR row flipped directors ❌→✅ and NACE ❌→✅. Headline 17 → 20 of 20 v1-ready.
+
+### DEC-20260513-F logged + canonical-surface propagation
+Logged in Decisions DB at `35f67c87-082c-81c0-9fbf-c2253cf4e24c`. Title: "v1 Identity coverage verdict — 20 of 20 audited capabilities v1-ready." Scope global, confidence high, supersedes nothing (verdict-documentation DEC). Source PR #116.
+
+Propagated to:
+- **Active Vendor Stack page** (`35367c87082c812e88d1dc6bdbfbd4f5`): new chronological update line citing DEC-20260513-F + PR #116, counts unchanged at 20+4+1+5+1.
+- **Capability × Country Coverage Matrix page** (`35767c87082c8184ba34e116f673a1d6`): short reference line added.
+
+### PR #117 — feat(test): canonical-input sentinel test for identity capabilities (DEC-20260513-D Phase 3 Harden gate (a))
+Three commits stacked on `feat/identity-fixture-shape-sentinel`:
+1. `e5b5ac9` — observation mode (script + allowlist + CI invocation without `--strict`)
+2. `a129d48` — `fix(french-company-data): add company_name not_null assertion` (Step 4 surfaced FR's missing name-field assertion; one-line manifest fix, no fixture entity change)
+3. `2a669f4` — enforcement mode (`--strict` added)
+
+Static manifest-introspection node script at `apps/api/scripts/check-identity-fixture-shape.mjs`. Pattern mirrors sibling gate (b) `check-manifest-guaranteed-consistency.mjs` (already shipped PR #111). Allowlist file at `apps/api/scripts/identity-fixture-shape-allowlist.txt` (empty at v1 ship). CI invocation at `.github/workflows/ci.yml:76` runs `--strict`; exit 0 on clean tree, exit 1 on new violations.
+
+v1 criteria (kept tight per prompt scope):
+1. `is_branch` equals-assertion must NOT be `true` (catches GR original-fixture bug shape).
+2. `status` equals-assertion must be in per-country active set (SI exempt via `PER_SLUG_EXEMPTIONS` with DEC-20260513-F reference).
+3. `expected_fields` must include at least one assertion on a recognised name field.
+4. `known_answer.input` must contain at least one identifier matching country's canonical regex.
+
+All three runtime + static gates from the DEC-20260513-B/C/D arc are now live:
+- Runtime: `guaranteed-fields-sentinel.ts` (PR #109)
+- Static gate (a): this PR #117
+- Static gate (b): `check-manifest-guaranteed-consistency.mjs` (PR #111, earlier)
+
+### Phase 2 (Understand) journal entry — halted, already existed
+Pre-check found existing chat-authored entry: "Course correction: trust-in-pipeline blind spot (CH bad-fixture cascade + SK burst-misdiagnosis + DK silent auto-recovery)" at `35f67c87-082c-81ce-ab3c-dfa08b6391a2`. Authored 2026-05-13 18:57 UTC by claude-chat. Substantively more thorough than the prompt's proposed body — covers all three causal chains in 6/4/3 steps respectively, names "trust-in-pipeline blind spot" as 1st-occurrence pattern, includes three additional named patterns + a chat-side analog addendum. Stop condition fired correctly; no duplicate written.
+
+Pre-existing entry's only gap: cites the in-flight PRs (#117, #111) as "running in CC at time of writing" — the merge SHAs and PR #116 (which post-dated this entry) aren't cited. Cosmetic; doesn't affect substance. Petter can append a one-line supplementary entry if desired, or leave as-is.
+
+### HMRC sandbox retest — support ref 2026-CNS433
+Report at `apps/api/docs/hmrc-sandbox-test-report-2026-05-13.md` (in `strale-research` worktree). All 4 tests PASS: OAuth token (200), unverified lookup `553557881` Credite Sberger Donal Inc. (200), verified lookup with requester `436189915` returning `consultationNumber: "YQD-VNF-WWX"` (200), authenticated 404 regression on prior-test VRN `553557817` returning documented `NOT_FOUND` body (404). VRN selection sourced from HMRC's canonical mock-data CSV at `github.com/hmrc/vat-registered-companies-api/blob/main/public/api/conf/2.0/test-data/vrn.csv`. Diagnosis: the prior 5 May report's 404 was correct behaviour for a non-provisioned identifier, not a configuration issue. Production credentials remain in flight via HMRC support ticket.
+
+### VIES UK-GB coverage verification + canonical-surface corrections
+Findings doc at `apps/api/docs/vies-uk-gb-coverage-verification-2026-05-13.md` (in `strale-research`). **Verdict: REFUTED with no code impact.**
+
+Empirical:
+- VIES REST rejects GB at country-code level: `{"actionSucceed":false,"errorWrappers":[{"error":"INVALID_INPUT"}]}`. Rejection is structural, independent of VAT number.
+- XI is in VIES (XI calls accepted normally).
+- DE/FR controls work (FR call shape passed; DE had transient `MS_UNAVAILABLE`).
+- HMRC production API confirmed reachable, requires auth (401 without credentials).
+
+Code-side: **Strale's `vat-validate.ts` already handles this correctly.** Header docstring (lines 9-14) explicitly documents `EU27+XI → VIES`, `GB → HMRC v2`. `vies.ts:16-21` `EU27_PREFIXES` lists 26 EU codes + `"XI"` (with explicit post-Brexit-protocol comment); GB is not in the list. `hmrc.ts:prefixes: ["GB"]`. Whoever wrote the capability understood post-Brexit reality from day one.
+
+Drift was canonical-surface only:
+- **Active Vendor Stack page**: "v1 stack — global legs" table VAT row corrected. Was: `VAT (EU27) | VIES | … | EU27 + UK (DE/ES suppress name/address)`. Now: two rows — `VAT (EU27 + XI) | VIES | …` and `VAT (GB) | HMRC Check a UK VAT Number API v2.0 | …`. Plus chronological update line citing the findings doc.
+- **Capability × Country Coverage Matrix**: "Vendor → coverage summary" table VIES row corrected from "All EU + UK" → "EU27 + XI (Northern Ireland)"; HMRC row added. Plus chronological update line.
+
+### Closing prompt: Active Vendor Stack page VAT row split (2026-05-14 morning)
+First update attempt used pipe-table markdown syntax (`| col | col |`) which didn't match Notion's stored format — table cells are stored in `<td>` form per the enhanced markdown spec. Retry with `<td>` syntax succeeded on both pages. Both pages now show split correctly post-verify-fetch.
+
+## Cost
+
+- ~€1.00 wallet spend on test account (v1 Identity audit's 19+1 prod `/v1/do` calls × €0.05).
+- ~€0 on VIES (unauthenticated public API).
+- ~€0 on HMRC sandbox (free).
+- ~€0 on Notion writes.
+
+## Non-obvious learnings
+
+- **Notion `update_content` table-row edits require `<tr>/<td>` syntax**, not pipe-table form. Chronological flat-prose edits work with flat text. Same call, different anchor strategies. Worth a line in any future Notion-update-pattern doc.
+- **Notion `update_content` operations within a single call are independent on match failure** — the chronological-line edit succeeded while the table-row edit silently failed (no match found). The retry pattern: fetch back → verify which ops landed → retry the failed ones with corrected syntax. No data-loss risk; only extra round-trip.
+- **The cost-class gate (DEC-20260512-A) is doing exactly what it should at audit time.** DK and DE returning structured `quota_exceeded` errors instead of consuming wallet was correct, designed behaviour. The audit's verdict "DK and DE quota-exhausted at audit time" was accurate; the closeout via canary signal showed the broader operational picture via the substrate that already records it.
+- **`strale-research` lacks `node_modules`.** Scripts that import `dotenv` / `postgres` / etc. can't run from there. Workaround: copy the script to `strale-work/apps/api/scripts/_tmp-*.ts` and run from there with the trunk `.env` as inline DATABASE_URL source. Used twice this session (canary query for DK/DE, HMRC sandbox retest).
+- **The valvat claim about VIES post-Brexit was correct.** VIES rejects GB at country-code level (`INVALID_INPUT`), structurally, not number-by-number. Strale's `vat-validate.ts` author knew this. The drift was purely in human-readable canonical-surface text that summarised the stack with a stale "EU27 + UK" framing.
+
+## Open / queued follow-ups (no PRs in this session)
+
+1. **Cosmetic NO + UK manifest example-fixture drifts** (audit Findings §5): NO's `output_schema.example` shows Equinor but fixture is DNB; UK's example shows fake-name co but fixture is Tesco. Neither blocks v1. Queued.
+2. **HMRC production credentials**: support ref 2026-CNS433 reply pending. Sandbox integration verified; production blocker is HMRC-side, not Strale-side.
+3. **Manual-pin lifecycle vs auto-pin lifecycle conflation** (DK-pattern from Phase 2 journal): the circuit-breaker half-open probe doesn't distinguish auto-pin from manual-pin lifecycles. No Phase 3 commitment yet; structural options in the Phase 2 entry.
+4. **OpenAPI / MCP description copy for `vat-validate`**: would benefit from clearer per-country provenance copy (EU27+XI vs GB). Separate content prompt.
+5. **strale.dev coverage page**: may have similar "VIES covers EU27 + UK" stale claim. Sweep recommended via a future content prompt that goes through Brand & voice.
+6. **v1.1 sentinel extensions** for gate (a): directors-must-be-asserted check, live-call mode, non-Identity capability coverage. Watch for value vs false-positive ratio.
+
+## Uncommitted artifacts in `strale-research`
+
+Four audit/research doc files in `apps/api/docs/`:
+- `hmrc-sandbox-test-report-2026-05-13.md` (HMRC support ref 2026-CNS433 evidence)
+- `v1-identity-coverage-matrix-2026-05-13.md` (audit doc; also lives committed in `strale-work` main at `4553b75` via PR #116, so this strale-research copy is now redundant)
+- `v1-launch-audit-2026-05-13.md` (pre-existing from earlier session)
+- `vies-uk-gb-coverage-verification-2026-05-13.md` (this session's verification findings)
+
+Recommendation: the matrix file is fully captured by PR #116's committed copy and the Notion mirror — can be deleted from strale-research. The HMRC + VIES docs are genuinely strale-research-only artifacts; Petter can either promote them via a chore PR (matching the PR #115 pattern) or leave them as worktree-local research notes.
+
+## State at close
+
+- strale-research: detached HEAD `5c22c77`, working tree has the four audit-doc untracked files. Behind `origin/main` by 4 commits but that's expected for strale-research's role.
+- strale-work: on `main` at `dd9a082` (PR #117 merge), tree clean.
+- strale: HEAD at `f6188708` (older, pre-PR-#115). Two untracked handoff files there have already been promoted via PR #115 — next `git pull --ff-only` in strale will make those tracked. No action required.


### PR DESCRIPTION
## Summary

Bundled cleanup of small loose ends from the 2026-05-13 v1 Identity work. Four trivial items + one diagnostic scan. No new substantive code; orientation comment in `uk-company-data.ts` is the only code change (4-line file-header comment, no behaviour change).

## Items 1–3 (in this PR)

### 1. Handoff promote
- `handoff/_general/from-code/2026-05-14-v1-identity-closeout-phase3-sentinel-vies-corrections.md` — session-arc summary spanning PR #115/#116/#117, DEC-20260513-F, VIES UK-GB verification + canonical-surface corrections, HMRC sandbox retest, Phase 2 journal halt.

### 2. Audit-doc tidying
Promotes 2 docs from `strale-research/apps/api/docs/` to main:
- `hmrc-sandbox-test-report-2026-05-13.md` — HMRC support ref 2026-CNS433 evidence (4/4 PASS: OAuth, unverified lookup, verified lookup, authenticated-404 regression). Secrets verified redacted as `<REDACTED>`.
- `vies-uk-gb-coverage-verification-2026-05-13.md` — empirical evidence behind the Active Vendor Stack VAT row split. Findings doc is referenced by name in the AVS chronological update line; without it tracked, the citation would dangle.

Deletes the obsolete strale-research copy of `v1-identity-coverage-matrix-2026-05-13.md` (was the pre-closeout snapshot; the authoritative version with §10 closeout extensions is already on main via PR #116. Verified every unique line in the predecessor is a superseded variant of content that's preserved in main's authoritative version with explicit historical framing).

### 3. Orienting comment in `uk-company-data.ts`
4-line file-header comment:
```
// UK VAT validation is handled by vat-validate.ts (which routes GB → HMRC v2),
// not by this Identity capability. Companies House (the source for this
// capability) does not return VAT data. See DEC-20260513-F + the Active Vendor
// Stack page row split (2026-05-13) for the post-Brexit routing rationale.
```
No behaviour change.

## Item 6 — strale-frontend stale-claim scan (discovery-only)

**Findings: 3 stale claims. Fixes deferred to a separate content prompt that runs through Rule 10 (brand voice).**

| # | File:line | Stale text | Why it's stale |
|---|---|---|---|
| 1 | `public/llms.txt:100` | `Financial validation: IBAN validation, VAT verification (VIES), BIC/SWIFT lookup, exchange rates, invoice validation` | Frames VIES as the sole VAT path. Post-Brexit, GB routes via HMRC. Should reference both VIES (EU27+XI) and HMRC (GB) — or use a broader framing like "VAT verification". |
| 2 | `src/data/learnGuides.ts:181-206` | Entire learnGuide centered on VIES as the EU VAT path. TLDR: *"Use the Strale SDK to check VAT numbers against the EU VIES database in real time."* howItWorks: *"Strale's VAT validation … queries the EU VIES (VAT Information Exchange System) database in real time."* | The guide title is "validate EU VAT numbers" so VIES is correct for EU27+XI. But the framing misses HMRC for GB. A GB-VAT-numbers reader following this guide would get rejected by VIES. Worth either splitting (EU + GB guides) or adding a "what about GB?" note. |
| 3 | `src/lib/__fixtures__/trust-vat-validate.json:3, 107-108, 125, 140` | `"data_source": "VIES (EU VAT Information Exchange System, European Commission)"` (and 3 other VIES-as-sole-source mentions in fallback context) | Trust-page fixture frames VIES as the sole data source. Backend `vat-validate.ts` actually routes VIES (EU27+XI) / HMRC (GB) / Brreg (NO) / Swiss UID (CH+LI). May need re-capture against current prod response shape per the api.contract.test pattern. |

Scope-confined per prompt instructions: this is discovery-only. Any fixes will go through a separate content prompt because they touch customer-facing copy.

## Items 4 + 5 (NOT in this PR)

- **Item 4** (Notion table-edit pattern note in cc-prompts skill): cc-prompts skill canonically lives in `tilja-io/tilja` (not strale). Separate Tilja PR opened in parallel.
- **Item 5** (Phase 2 journal supplement on Notion page `35f67c87-082c-81ce-ab3c-dfa08b6391a2`): Notion-only, no PR. Done in the same session.

## Test plan

- [x] Secrets grep clean on promoted docs (`grep -iE "BEGIN PRIVATE KEY|client_secret=[^<]|password=|api[_-]?key[= :]"` returns empty)
- [x] Matrix predecessor's unique lines verified as superseded-in-main (every one is a pre-closeout variant)
- [x] `uk-company-data.ts` comment placement non-disruptive (top-of-file, before existing comment block)
- [x] strale-frontend scan returns 3 named findings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)