### PR TITLE
fix: raise FR directors cap from 3 to 50

### DIFF
--- a/apps/api/src/capabilities/french-company-data.ts
+++ b/apps/api/src/capabilities/french-company-data.ts
@@ -9,6 +9,13 @@ const API = "https://recherche-entreprises.api.gouv.fr";
 const SIREN_RE = /^\d{9}$/;
 const SIRET_RE = /^\d{14}$/;
 
+// Cap directors at 50. Typical major French entities have 15-20 directors;
+// the prior cap of 3 was empirically too aggressive (audit:
+// apps/api/docs/fr-directors-truncation-2026-05-15.md). 50 covers the long
+// tail without pathological payload growth, preserving directors_truncated /
+// total_directors honesty for state entities, mutuelles, etc.
+const DIRECTORS_CAP = 50;
+
 function findSiren(input: string): string | null {
   const cleaned = input.replace(/[\s.-]/g, "");
   if (SIREN_RE.test(cleaned)) return cleaned;
@@ -50,10 +57,10 @@ async function searchCompany(query: string): Promise<Record<string, unknown>> {
   // company_name and siren: null instead of "" when missing — empty string
   // implies "we got a value, it was empty" rather than "the source omitted
   // the field" (DEC-20260428-B).
-  // Directors: keep the slice(0, 3) but expose truncation transparency via
-  // companion fields so consumers know more directors exist beyond the slice.
+  // Directors: cap at DIRECTORS_CAP (50). directors_truncated / total_directors
+  // preserve honest disclosure for the rare 50+ case.
   const allDirectors = Array.isArray(c.dirigeants) ? c.dirigeants : [];
-  const directors = allDirectors.slice(0, 3).map((d: any) =>
+  const directors = allDirectors.slice(0, DIRECTORS_CAP).map((d: any) =>
     `${d.prenoms || ""} ${d.nom || ""}`.trim() + (d.qualite ? ` (${d.qualite})` : ""),
   );
 
@@ -71,7 +78,7 @@ async function searchCompany(query: string): Promise<Record<string, unknown>> {
     status: c.etat_administratif === "A" ? "active" : c.etat_administratif === "C" ? "closed" : c.etat_administratif || "unknown",
     vat_number: c.siren ? deriveVatFR(c.siren) : null,
     directors,
-    directors_truncated: allDirectors.length > 3,
+    directors_truncated: allDirectors.length > DIRECTORS_CAP,
     total_directors: allDirectors.length,
   };
 }

--- a/manifests/french-company-data.yaml
+++ b/manifests/french-company-data.yaml
@@ -51,9 +51,11 @@ output_schema:
     directors:
       type: array
       description: >-
-        Up to 3 directors from the registry (slice cap for payload). When
-        the registry lists more than 3, `directors_truncated` is true and
-        `total_directors` carries the full count.
+        Up to 50 directors from the registry (slice cap for payload). When
+        the registry lists more than 50, `directors_truncated` is true and
+        `total_directors` carries the full count. Typical major French
+        entities have 15-20 directors; the cap protects against pathological
+        state-entity / mutuelle payloads.
     directors_truncated:
       type: boolean
     total_directors:


### PR DESCRIPTION
## Summary

Empirical follow-up to the 2026-05-15 identity field-coverage audit Batch 2. The `french-company-data` handler's `.slice(0, 3)` on the upstream `dirigeants` array truncates typical major French companies (15-20 directors) to 3 entries.

- **Verdict** (from `apps/api/docs/fr-directors-truncation-2026-05-15.md` on branch `docs/identity-field-coverage-2026-05-15`, commit `042589b`): Strale-side cap, one-line fix, zero breaking-change risk.
- **Supersedes** the 2026-05-09 doctrine sweep verdict (commit `c523485`) which kept the slice as "defensible payload management" but never benchmarked. The Batch 2 audit produced the benchmark.

## Change

- Introduce `DIRECTORS_CAP = 50` constant in `apps/api/src/capabilities/french-company-data.ts`.
- Replace `.slice(0, 3)` with `.slice(0, DIRECTORS_CAP)`.
- Update `directors_truncated` comparison to use `DIRECTORS_CAP`.
- Update manifest description to reflect the new cap.

Payload growth: ~240 B → ~1-2 KB per FR call. Trivial.

Consumers reading `directors`: get more entries, same shape. `directors_truncated` flips `true → false` for typical entities (still honestly `true` for the rare 50+ case). `total_directors` semantics unchanged.

## Test plan

- [x] Typecheck: `npx tsc --noEmit` passes.
- [x] Vitest: 665 tests pass, 33 skipped (unrelated DB-integration tests).
- [x] Stale-reference grep: no other `slice(0, 3)` patterns in FR scope; manifest description was the only "Up to 3 directors" string.
- [ ] Post-deploy verification: hit `/v1/do` with FR fixture SIREN `542051180` (TotalEnergies SE). Expect `directors` length > 3 and `directors_truncated: false` (true count is 15 per Batch 2 audit).

## Follow-ups for chat (not in this PR)

- Capability × Country Coverage Matrix (Notion): FR row may need updating to "yes (capped at 50)" for directors coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)