### PR TITLE
feat: openapi-resolver + austrian-company-data behind OPENAPI_ENABLED flag (Phase 1 of 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,20 @@ ADZUNA_APP_KEY=...
 ABN_LOOKUP_GUID=...            # Australian Business Register — register at https://abr.business.gov.au/Tools/WebServices
 ZEFIX_USERNAME=...             # Zefix PublicREST API — register at https://www.zefix.admin.ch/ZefixPublicREST/
 ZEFIX_PASSWORD=...             # Zefix PublicREST API password
+
+# Openapi.com — Tier-3 vendor aggregator backing 11 EU30 country capabilities.
+# Phase 1 (this commit) wires austrian-company-data; Phase 2 extends to
+# BG/CY/HU/LU/MT/NL/RO via WW-Top + ES/PT via *-Advanced + IT via IT-Advanced.
+#
+# Auth is OAuth scope-exchange: POST oauth.openapi.it/token with HTTP Basic
+# (email:api-token) and JSON body {"scopes":[scope],"ttl":600} → Bearer token.
+# NOT a direct Bearer key — both env vars are required when OPENAPI_ENABLED=true.
+#
+# OPENAPI_ENABLED MUST stay "false" in production until the resale addendum
+# countersignature lands (Openapi case 151296). Any code path that lets a
+# customer request reach the Openapi resolver before that is a legal-compliance
+# miss. The resolver enforces the flag pre-flight; this is the operator-facing
+# documentation of why.
+OPENAPI_COM_EMAIL=...
+OPENAPI_COM_API_TOKEN_PROD=...
+OPENAPI_ENABLED=false

--- a/apps/api/src/capabilities/austrian-company-data.ts
+++ b/apps/api/src/capabilities/austrian-company-data.ts
@@ -1,236 +1,61 @@
+// Austria — Openapi.com WW-Top (Tier-3 vendor aggregator).
+//
+// Replaces the prior FinAPU + WKO Browserless scraping path (deactivated
+// 2026-04-29 per DEC-20260427-I-6 as a Tier-1 violation). Reactivation
+// trigger named in that DEC: "licensed contract with the Austrian
+// Justizministerium for direct Firmenbuch API access, or a multi-country
+// licensed aggregator." Openapi.com is the multi-country licensed
+// aggregator path; resale addendum issued 2026-05-08 via case 151296,
+// gated on Moonlighter AB VAT + countersignature. Execution is double-
+// gated: this executor will refuse to run unless OPENAPI_ENABLED=true
+// AND the capability row in the DB is active.
+//
+// Identifier shape: AT VAT (UID-Nummer) in the form `ATU` + 8 digits.
+// Openapi WW-Top rejects Firmenbuchnummer (FN) format with 406 — VAT only.
+// Verified empirically by the 2026-05-15 v4 probe: OMV ATU14189108 → 200,
+// FN 93363z → 406.
+//
+// Field coverage per the 2026-05-15 BR Coverage Matrix row
+// (34867c87-082c-8165-9fcd-d01bc75c9766): Tier 1 6/7 (no legal_form via
+// WW-Top), Tier 2 3/5 (vatCode + source-as-of + source-name; no directors),
+// Tier 3 1/6 (NACE only).
+
 import { registerCapability, type CapabilityInput } from "./index.js";
-import {
-  fetchRenderedHtml,
-  htmlToText,
-  extractCompanyFromText,
-  extractCompanyName,
-} from "./lib/browserless-extract.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
 
-// Austria — FinAPU Firmenbuch API (primary) + WKO Firmen A-Z (fallback)
-// FN number: 6 digits + letter (e.g. 150913f)
-const FN_RE = /^\d{5,6}[a-z]$/i;
+const AT_VAT_RE = /^ATU\d{8}$/;
 
-const FINAPU_URL = "https://firmenbuch.finapu.com/fb-svc/firmen-service";
-
-// Legal form code → human-readable
-const RECHTSFORM: Record<string, string> = {
-  GES: "GmbH (Limited liability company)",
-  EU: "eU (Sole proprietorship)",
-  AG: "AG (Stock corporation)",
-  KG: "KG (Limited partnership)",
-  OG: "OG (General partnership)",
-  PST: "Privatstiftung (Private foundation)",
-  GEN: "Genossenschaft (Cooperative)",
-  FKG: "FlexKG (Flexible limited partnership)",
-  SE: "SE (European company)",
-  VER: "Versicherungsverein (Mutual insurance)",
-  SPA: "Sparkasse (Savings bank)",
-  PAR: "Partnerschaft (Partnership)",
-};
-
-function findFn(input: string): string | null {
-  const cleaned = input.replace(/[\s.-]/g, "").replace(/^FN/i, "");
-  if (FN_RE.test(cleaned)) return cleaned.toLowerCase();
-  const match = input.match(/\d{5,6}[a-z]/i);
-  return match ? match[0].toLowerCase() : null;
-}
-
-interface FinapuSearchResult {
-  fnr: string;
-  name: string;
-  rechtsform: string;
-  sitz: string;
-  activity: string | null;
-  status: string;
-  initDate: string | null;
-  endDate: string | null;
-}
-
-// Three-way status mapping matching german-company-data.ts:168-180 precedent.
-// The previous binary collapse (active vs inactive) silently lost fidelity:
-// in-liquidation, terminated, dissolved, and unknown all became "inactive"
-// (DEC-20260428-B).
-function normaliseAtStatus(raw: string | undefined, endDate: string | null): "active" | "terminated" | "unknown" {
-  if (endDate) return "terminated";
-  const v = (raw ?? "").toLowerCase();
-  if (v.includes("active") || v === "ok") return "active";
-  if (v.includes("liquidat") || v.includes("terminated") || v.includes("dissolved") || v.includes("aufgel")) {
-    return "terminated";
-  }
-  if (!v) return "unknown";
-  return "unknown";
-}
-
-interface FinapuDetails {
-  fbnr: number;
-  fbnrChar: string;
-  bezeichnung: string;
-  rechtsform: { code: string; text: string };
-  adresse: { strasse: string; hausnr: string; tuernr: string | null; plz: string; ort: string; staat: string };
-  status: string;
-  activity: string;
-  initDate: string | null;
-  endDate: string | null;
-  lei: string | null;
-  euids: string[];
-  pastNames: { name: string; bis: string }[];
-  sitz: string;
-  vertreter: { nameFormatiert: string; posBezeichnung: string; von: string | null }[];
-}
-
-async function finapuSearch(query: string): Promise<FinapuSearchResult[]> {
-  const resp = await fetch(FINAPU_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      query: "search-firma",
-      params: {
-        firmenname: query,
-        searchOptions: { withHistory: false, withAddress: false, withActivity: true, withPersons: false, withName: true },
-      },
-    }),
-    signal: AbortSignal.timeout(10000),
-  });
-  if (!resp.ok) throw new Error(`FinAPU API returned HTTP ${resp.status}`);
-  const data = await resp.json();
-  if (data.status === "error") throw new Error(`FinAPU error: ${data.message}`);
-  return data.results ?? [];
-}
-
-async function finapuDetails(fnr: string): Promise<FinapuDetails> {
-  const resp = await fetch(FINAPU_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ query: "details-firma", params: { fnr } }),
-    signal: AbortSignal.timeout(10000),
-  });
-  if (!resp.ok) throw new Error(`FinAPU API returned HTTP ${resp.status}`);
-  const data = await resp.json();
-  if (data.status === "error") throw new Error(`FinAPU error: ${data.message}`);
-  return data;
-}
-
-function formatAddress(addr: FinapuDetails["adresse"]): string {
-  const parts = [addr.strasse, addr.hausnr].filter(Boolean).join(" ");
-  const door = addr.tuernr ? `/${addr.tuernr}` : "";
-  return `${parts}${door}, ${addr.plz} ${addr.ort}`;
-}
-
-async function lookupViaFinapu(query: string, isFn: boolean): Promise<Record<string, unknown>> {
-  if (isFn) {
-    // Direct lookup by FN number
-    try {
-      const details = await finapuDetails(query);
-      return {
-        company_name: details.bezeichnung,
-        fn_number: `FN ${details.fbnr}${details.fbnrChar}`,
-        business_type: RECHTSFORM[details.rechtsform?.code] ?? details.rechtsform?.text ?? null,
-        address: formatAddress(details.adresse),
-        city: details.sitz,
-        status: normaliseAtStatus(details.status, details.endDate),
-        activity: details.activity || null,
-        lei: details.lei || null,
-        eu_vat_ids: details.euids?.length ? details.euids : null,
-        founded: details.initDate || null,
-        dissolved: details.endDate || null,
-        past_names: details.pastNames?.length ? details.pastNames.map(p => p.name) : null,
-        directors: details.vertreter?.map(v => ({
-          name: v.nameFormatiert,
-          role: v.posBezeichnung,
-          since: v.von,
-        })) ?? null,
-      };
-    } catch {
-      // Fall through to search if details lookup fails
-    }
-  }
-
-  // Search by name
-  const results = await finapuSearch(query);
-  if (results.length === 0) {
-    throw new Error(`No Austrian company found matching "${query}".`);
-  }
-
-  // Get details for the best match
-  const best = results[0];
-  try {
-    const details = await finapuDetails(best.fnr);
-    return {
-      company_name: details.bezeichnung,
-      fn_number: `FN ${details.fbnr}${details.fbnrChar}`,
-      business_type: RECHTSFORM[details.rechtsform?.code] ?? details.rechtsform?.text ?? null,
-      address: formatAddress(details.adresse),
-      city: details.sitz,
-      status: normaliseAtStatus(details.status, details.endDate),
-      activity: details.activity || null,
-      lei: details.lei || null,
-      eu_vat_ids: details.euids?.length ? details.euids : null,
-      founded: details.initDate || null,
-      dissolved: details.endDate || null,
-      past_names: details.pastNames?.length ? details.pastNames.map(p => p.name) : null,
-      directors: details.vertreter?.map(v => ({
-        name: v.nameFormatiert,
-        role: v.posBezeichnung,
-        since: v.von,
-      })) ?? null,
-    };
-  } catch {
-    // Return basic info from search result if details fail
-    return {
-      company_name: best.name,
-      fn_number: `FN ${best.fnr}`,
-      business_type: RECHTSFORM[best.rechtsform] ?? best.rechtsform ?? null,
-      city: best.sitz,
-      status: normaliseAtStatus(best.status, best.endDate),
-      activity: best.activity || null,
-    };
-  }
-}
-
-// WKO.at fallback (existing Browserless scraper)
-async function lookupViaWko(query: string, isFn: boolean): Promise<Record<string, unknown>> {
-  const searchUrl = isFn
-    ? `https://firmen.wko.at/SearchSimple.aspx?searchterm=FN+${query}`
-    : `https://firmen.wko.at/SearchSimple.aspx?searchterm=${encodeURIComponent(query)}`;
-
-  const html = await fetchRenderedHtml(searchUrl);
-  const text = htmlToText(html);
-
-  if (text.includes("Keine Treffer") || text.includes("keine Ergebnisse") || text.length < 200) {
-    throw new Error(`No Austrian company found matching "${query}".`);
-  }
-
-  return extractCompanyFromText(text, "Austrian", query);
+function normaliseAtIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
+  return AT_VAT_RE.test(cleaned) ? cleaned : null;
 }
 
 registerCapability("austrian-company-data", async (input: CapabilityInput) => {
-  const raw = (input.fn_number as string) ?? (input.company_name as string) ?? (input.task as string) ?? "";
-  if (typeof raw !== "string" || !raw.trim()) {
-    throw new Error("'fn_number' or 'company_name' is required. Provide a Firmenbuchnummer (e.g. FN 150913f) or company name.");
+  const rawInput =
+    (input.vat_number as string) ??
+    (input.uid as string) ??
+    (input.identifier as string) ??
+    "";
+  if (typeof rawInput !== "string" || !rawInput.trim()) {
+    throw new Error(
+      "'vat_number' is required. Provide an Austrian UID-Nummer (e.g. ATU14189108). Firmenbuchnummer (FN) is not accepted by the upstream API; use the VAT format.",
+    );
   }
-
-  const trimmed = raw.trim();
-  const fn = findFn(trimmed);
-
-  // Primary: FinAPU Firmenbuch API
-  try {
-    const output = await lookupViaFinapu(fn ?? trimmed, !!fn);
-    return {
-      output,
-      provenance: { source: "firmenbuch.finapu.com", fetched_at: new Date().toISOString() },
-    };
-  } catch (finapuErr) {
-    // Fallback: WKO.at via Browserless
-    try {
-      const name = fn ?? await extractCompanyName(trimmed, "Austrian");
-      const output = await lookupViaWko(name, !!fn);
-      return {
-        output,
-        provenance: { source: "firmen.wko.at", fetched_at: new Date().toISOString() },
-      };
-    } catch {
-      // Re-throw the FinAPU error (more informative)
-      throw finapuErr;
-    }
+  const normalised = normaliseAtIdentifier(rawInput.trim());
+  if (!normalised) {
+    throw new Error(
+      `'${rawInput.trim()}' is not a valid Austrian UID-Nummer. Expected format: ATU + 8 digits (e.g. ATU14189108).`,
+    );
   }
+  return executeOpenapiCapability(
+    {
+      countryCode: "AT",
+      identifierRegex: AT_VAT_RE,
+      openapiProduct: "ww-top",
+      capabilitySlug: "austrian-company-data",
+    },
+    normalised,
+  );
 });
+
+export { AT_VAT_RE };

--- a/apps/api/src/capabilities/auto-register.ts
+++ b/apps/api/src/capabilities/auto-register.ts
@@ -169,16 +169,15 @@ const DEACTIVATED = new Map<string, string>([
   // (api.openregister.de). Free tier 50 req/mo per DEC-20260505-H +
   // DEC-20260506-G; auth via OPENREGISTER_API_KEY. acquisition_method:
   // direct_api per DEC-20260428-A Tier 2.
-  [
-    "austrian-company-data",
-    // DEC-20260427-I-6: Primary runtime fetched firmenbuch.finapu.com (commercial
-    // third-party AT register wrapper); fallback scraped firmen.wko.at via Browserless
-    // + Claude. Both paths are ToS-prohibited scrapes of commercial / semi-official
-    // sources. Manifest claimed FinAPU Firmenbuch API (transport-divergence).
-    // Reactivation trigger: licensed contract with the Austrian Justizministerium for
-    // direct Firmenbuch API access, or a multi-country licensed aggregator.
-    "finapu.com / wko.at scraping prohibited by ToS; pending licensed Firmenbuch or aggregator contract (see DEC-20260427-I)",
-  ],
+  // austrian-company-data REACTIVATED 2026-05-16: migrated from FinAPU + WKO
+  // Browserless scraping (Tier 1 violation per DEC-20260427-I-6) to Openapi.com
+  // WW-Top (Tier 3 vendor aggregator). Satisfies the "licensed multi-country
+  // aggregator" reactivation trigger named in DEC-20260427-I-6. Runtime is
+  // double-gated: OPENAPI_ENABLED env flag must be "true" (off by default until
+  // resale addendum case 151296 countersigns) AND the capabilities DB row must
+  // be is_active=true (separate operator action — auto-register no longer
+  // syncs this slug to deactivated, but does not auto-activate either).
+  // See apps/api/src/capabilities/lib/openapi-resolver.ts.
   [
     "trustpilot-score",
     // DEC-20260427-H-2: Runtime fetched trustpilot.com/review/{domain} via Browserless + Claude.

--- a/apps/api/src/capabilities/lib/openapi-resolver.ts
+++ b/apps/api/src/capabilities/lib/openapi-resolver.ts
@@ -1,0 +1,418 @@
+// Openapi.com WW-Top resolver — shared helper for Tier-3 vendor-aggregator
+// capabilities backed by the Openapi.com product line.
+//
+// Auth model: OAuth scope-exchange.
+//   1. POST https://oauth.openapi.it/token with HTTP Basic (email:api-token)
+//      and JSON body {"scopes":[scope],"ttl":600} → opaque Bearer, ~10 min TTL.
+//   2. GET https://company.openapi.com/WW-top/{country}/{identifier} with
+//      Authorization: Bearer <token>.
+//
+// Phase 1 only handles the WW-Top product. Phase 2 will extend the product
+// switch to handle country-specific Start/Advanced endpoints (ES-Advanced,
+// PT-Advanced, IT-Advanced, etc.) — those have richer response shapes.
+//
+// Gating: process.env.OPENAPI_ENABLED must equal "true" or the resolver
+// returns a capability-unavailable error before any HTTP call. This is
+// load-bearing — Strale's resale of Openapi data requires the addendum
+// countersignature (case 151296). The flag stays off in production until
+// that lands.
+//
+// Reference: c:/tmp/openapi-research/v4-2026-05-15/output.json + per-call
+// response files at c:/tmp/openapi-research/v4-2026-05-15/responses/.
+
+import { log } from "../../lib/log.js";
+
+export type OpenapiProduct = "ww-top";
+
+export interface OpenapiResolverConfig {
+  countryCode: string;          // ISO 3166-1 alpha-2 (path segment for WW-Top)
+  identifierRegex: RegExp;      // pre-flight identifier-shape validation
+  openapiProduct: OpenapiProduct;
+  capabilitySlug: string;       // for log context + error messages
+}
+
+export interface OpenapiResolverResult {
+  output: Record<string, unknown>;
+  provenance: {
+    source: string;
+    source_url: string;
+    fetched_at: string;
+    upstream_vendor: string;
+    acquisition_method: string;
+    authoritative: boolean;
+    [key: string]: unknown;
+  };
+}
+
+// ─── Token cache (per scope, in-process) ───────────────────────────────────
+interface CachedToken {
+  token: string;
+  expiresAt: number;
+}
+const tokenCache = new Map<string, CachedToken>();
+
+/** For tests only — clears the in-process OAuth-token cache. */
+export function __resetOpenapiTokenCacheForTests(): void {
+  tokenCache.clear();
+}
+
+async function issueToken(scope: string): Promise<string> {
+  const email = process.env.OPENAPI_COM_EMAIL;
+  const apiToken = process.env.OPENAPI_COM_API_TOKEN_PROD;
+  if (!email || !apiToken) {
+    throw new Error(
+      "capability-unavailable: OPENAPI_COM_EMAIL and OPENAPI_COM_API_TOKEN_PROD must be configured.",
+    );
+  }
+  const cached = tokenCache.get(scope);
+  if (cached && cached.expiresAt - 30_000 > Date.now()) {
+    return cached.token;
+  }
+  const basic = Buffer.from(`${email}:${apiToken}`).toString("base64");
+  const r = await fetch("https://oauth.openapi.it/token", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${basic}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ scopes: [scope], ttl: 600 }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!r.ok) {
+    const body = await r.text().catch(() => "");
+    throw new Error(
+      `Openapi token endpoint returned HTTP ${r.status}: ${body.slice(0, 200)}`,
+    );
+  }
+  const data = (await r.json()) as { token?: string };
+  if (!data.token) {
+    throw new Error("Openapi token endpoint returned no token field.");
+  }
+  tokenCache.set(scope, {
+    token: data.token,
+    expiresAt: Date.now() + 600_000,
+  });
+  return data.token;
+}
+
+// ─── WW-Top response shape (subset; verified against v4 AT/OMV response) ───
+interface WWTopAddress {
+  registeredOffice?: {
+    town?: string | null;
+    country?: string | null;
+    zipCode?: string | null;
+    streetName?: string | null;
+    streetNumber?: string | null;
+    nativeTown?: string | null;
+  };
+}
+interface WWTopMarker {
+  label?: string;
+  number?: string;
+  types?: string[];
+}
+interface WWTopNaceItem {
+  code?: string;
+  description?: string;
+}
+interface WWTopData {
+  id?: string;
+  lastUpdateTimestamp?: number;
+  companyName?: string;
+  nativeCompanyName?: string;
+  companyNumber?: string;
+  vatCode?: string;
+  leiCode?: string;
+  companySize?: string;
+  markers?: WWTopMarker[];
+  address?: WWTopAddress;
+  activityStatus?: string;
+  incorporationDate?: string;
+  internationalClassification?: {
+    nace?: {
+      primary?: WWTopNaceItem[];
+      secondary?: WWTopNaceItem[];
+    };
+  };
+}
+interface WWTopResponse {
+  data?: WWTopData[];
+  success?: boolean;
+  message?: string;
+  error?: unknown;
+}
+
+function composeAddress(addr: WWTopAddress | undefined): string | null {
+  if (!addr?.registeredOffice) return null;
+  const o = addr.registeredOffice;
+  const street =
+    o.streetName && o.streetNumber
+      ? `${o.streetName.trim()} ${o.streetNumber.trim()}`
+      : o.streetName?.trim() ?? null;
+  const parts = [street, o.zipCode?.trim(), o.town?.trim(), o.country?.trim()]
+    .filter((p): p is string => typeof p === "string" && p.length > 0);
+  return parts.length > 0 ? parts.join(", ") : null;
+}
+
+function epochSecondsToIso(epoch: number | undefined | null): string | null {
+  if (typeof epoch !== "number" || !Number.isFinite(epoch) || epoch <= 0) {
+    return null;
+  }
+  return new Date(epoch * 1000).toISOString();
+}
+
+function normaliseStatus(raw: string | undefined): "active" | "inactive" | "unknown" {
+  if (!raw) return "unknown";
+  const v = raw.trim().toLowerCase();
+  if (v === "active" || v === "attiva") return "active";
+  if (
+    v === "inactive" ||
+    v === "dissolved" ||
+    v === "ceased" ||
+    v === "terminated"
+  ) {
+    return "inactive";
+  }
+  return "unknown";
+}
+
+function nacePrimary(
+  data: WWTopData,
+): { code: string; description: string } | null {
+  const p = data.internationalClassification?.nace?.primary?.[0];
+  if (!p?.code) return null;
+  return { code: p.code, description: p.description ?? "" };
+}
+
+interface CallResult {
+  status: number;
+  body: WWTopResponse | null;
+  text: string;
+}
+
+async function callWWTop(
+  country: string,
+  id: string,
+  bearer: string,
+): Promise<CallResult> {
+  const url = `https://company.openapi.com/WW-top/${encodeURIComponent(country)}/${encodeURIComponent(id)}`;
+  const r = await fetch(url, {
+    headers: { Authorization: `Bearer ${bearer}` },
+    signal: AbortSignal.timeout(15_000),
+  });
+  const text = await r.text();
+  let body: WWTopResponse | null = null;
+  try {
+    body = text ? (JSON.parse(text) as WWTopResponse) : null;
+  } catch {
+    body = null;
+  }
+  return { status: r.status, body, text };
+}
+
+/**
+ * Execute an Openapi-routed capability against the WW-Top product.
+ *
+ * Flow:
+ *   1. Feature-flag check (OPENAPI_ENABLED).
+ *   2. Credentials check (OPENAPI_COM_EMAIL + OPENAPI_COM_API_TOKEN_PROD).
+ *   3. Identifier shape validation against config.identifierRegex.
+ *   4. Token acquire (cached per scope, 10-min TTL).
+ *   5. WW-Top fetch with 15s timeout; single retry on 401 (token-stale) or 5xx.
+ *   6. Map response to Strale Tier 1/2/3 shape; throw structured errors on
+ *      204/406/4xx/5xx/network.
+ */
+export async function executeOpenapiCapability(
+  config: OpenapiResolverConfig,
+  identifier: string,
+): Promise<OpenapiResolverResult> {
+  const t0 = Date.now();
+  const baseCtx = {
+    capability_slug: config.capabilitySlug,
+    country_code: config.countryCode,
+    openapi_product: config.openapiProduct,
+  };
+
+  if (process.env.OPENAPI_ENABLED !== "true") {
+    log.info(
+      { label: "openapi-capability-disabled", ...baseCtx },
+      "openapi-capability-disabled",
+    );
+    throw new Error(
+      "capability-unavailable: OPENAPI_ENABLED is not set to 'true' in this environment. Openapi-routed capabilities require the resale addendum countersignature (case 151296) before serving customer traffic.",
+    );
+  }
+
+  if (config.openapiProduct !== "ww-top") {
+    throw new Error(
+      `Openapi resolver phase 1 only supports the 'ww-top' product; received '${config.openapiProduct}'. Phase 2 extension pending.`,
+    );
+  }
+
+  if (typeof identifier !== "string" || !identifier.trim()) {
+    throw new Error(`Identifier is required for ${config.capabilitySlug}.`);
+  }
+  const trimmed = identifier.trim();
+  if (!config.identifierRegex.test(trimmed)) {
+    throw new Error(
+      `'${trimmed}' does not match the expected identifier shape for ${config.capabilitySlug} (regex: ${config.identifierRegex.source}).`,
+    );
+  }
+
+  const scope = "GET:company.openapi.com/WW-top";
+  const maxAttempts = 2;
+  let attempt = 0;
+  let lastErr: unknown = null;
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    try {
+      const bearer = await issueToken(scope);
+      const r = await callWWTop(config.countryCode, trimmed, bearer);
+      const durationMs = Date.now() - t0;
+
+      if (r.status === 200) {
+        if (
+          !r.body ||
+          r.body.success !== true ||
+          !Array.isArray(r.body.data) ||
+          !r.body.data[0]
+        ) {
+          throw new Error(
+            `Openapi returned HTTP 200 but the response body did not contain expected data[0]: ${r.text.slice(0, 200)}`,
+          );
+        }
+        const data = r.body.data[0];
+        const status = normaliseStatus(data.activityStatus);
+        const nace = nacePrimary(data);
+        const sourceAsOf = epochSecondsToIso(data.lastUpdateTimestamp);
+        const requestUrl = `https://company.openapi.com/WW-top/${encodeURIComponent(config.countryCode)}/${encodeURIComponent(trimmed)}`;
+
+        log.info(
+          {
+            label: "openapi-success",
+            ...baseCtx,
+            identifier: trimmed,
+            duration_ms: durationMs,
+            response_size_bytes: r.text.length,
+          },
+          "openapi-success",
+        );
+
+        return {
+          output: {
+            company_name: data.companyName ?? data.nativeCompanyName ?? null,
+            native_company_name: data.nativeCompanyName ?? null,
+            registration_number: data.companyNumber ?? trimmed,
+            vat_number: data.vatCode ?? trimmed,
+            country_code: config.countryCode,
+            legal_form: null,
+            status,
+            is_active: status === "active",
+            registered_date: data.incorporationDate ?? null,
+            registered_address: composeAddress(data.address),
+            lei_code: data.leiCode ?? null,
+            nace_codes: nace ? [nace] : [],
+            company_size: data.companySize ?? null,
+            source_as_of: sourceAsOf,
+          },
+          provenance: {
+            source: "Openapi.com WW-Top",
+            source_url: requestUrl,
+            fetched_at: new Date().toISOString(),
+            upstream_vendor: "openapi.com",
+            acquisition_method: "vendor_aggregation",
+            authoritative: false,
+            openapi_record_id: data.id ?? null,
+          },
+        };
+      }
+
+      if (r.status === 204) {
+        log.info(
+          {
+            label: "openapi-not-found",
+            ...baseCtx,
+            identifier: trimmed,
+            duration_ms: durationMs,
+          },
+          "openapi-not-found",
+        );
+        throw new Error(
+          `No ${config.capabilitySlug.replace(/-/g, " ")} found for identifier '${trimmed}'.`,
+        );
+      }
+
+      if (r.status === 406) {
+        const msg = r.body?.message ?? "vendor rejected identifier";
+        log.info(
+          {
+            label: "openapi-identifier-rejected",
+            ...baseCtx,
+            identifier: trimmed,
+            vendor_message: msg,
+            duration_ms: durationMs,
+          },
+          "openapi-identifier-rejected",
+        );
+        throw new Error(
+          `Openapi rejected '${trimmed}' as invalid for country ${config.countryCode}: ${msg}`,
+        );
+      }
+
+      if (r.status === 401 && attempt === 1) {
+        tokenCache.delete(scope);
+        log.info(
+          { label: "openapi-token-stale", ...baseCtx },
+          "openapi-token-stale",
+        );
+        continue;
+      }
+
+      if (r.status >= 500 && attempt === 1) {
+        log.info(
+          {
+            label: "openapi-5xx-retry",
+            ...baseCtx,
+            status: r.status,
+          },
+          "openapi-5xx-retry",
+        );
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        continue;
+      }
+
+      if (r.status >= 500) {
+        throw new Error(
+          `capability-unavailable: Openapi upstream error (HTTP ${r.status}) for ${config.capabilitySlug}.`,
+        );
+      }
+
+      throw new Error(
+        `Openapi returned HTTP ${r.status} for ${config.capabilitySlug}: ${r.text.slice(0, 200)}`,
+      );
+    } catch (err) {
+      lastErr = err;
+      if (
+        attempt === 1 &&
+        err instanceof Error &&
+        (err.name === "AbortError" ||
+          err.name === "TimeoutError" ||
+          err.message.includes("fetch failed"))
+      ) {
+        log.info(
+          {
+            label: "openapi-network-retry",
+            ...baseCtx,
+            error: String(err).slice(0, 200),
+          },
+          "openapi-network-retry",
+        );
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}

--- a/manifests/austrian-company-data.yaml
+++ b/manifests/austrian-company-data.yaml
@@ -1,52 +1,55 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
-
 slug: austrian-company-data
 name: Austrian Company Data
 description: >-
-  [TEMPORARILY UNAVAILABLE 2026-04-29 — pending licensed Firmenbuch or aggregator contract per DEC-20260428-A.] Look up
-  Austrian company data from the Firmenbuch. Accepts Firmenbuchnummer (e.g. FN 150913f) or fuzzy company name.
-category: data-extraction
-price_cents: 80
+  Look up Austrian company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts UID-Nummer (ATU + 8 digits).
+  Returns name, registration number (Firmenbuchnummer), status, registered address, registration date, LEI, primary
+  NACE code, and last-update timestamp. Directors are not returned at the WW-Top tier.
+category: company-data
+cost_class: paid_per_call
+price_cents: 16
 is_free_tier: false
+avg_latency_ms: 2200
 input_schema:
   type: object
   required:
-    - fn_number
+    - vat_number
   properties:
-    fn_number:
+    vat_number:
       type: string
-      description: Firmenbuchnummer (e.g. FN 150913f) or company name
+      description: Austrian UID-Nummer (VAT). Format ATU + 8 digits, e.g. ATU14189108. Firmenbuchnummer (FN) is NOT accepted.
 output_schema:
   type: object
   example:
-    lei: 5299000HTNHA5ACH9N32
-    city: Fuschl am See
+    company_name: OMV Aktiengesellschaft
+    native_company_name: OMV Aktiengesellschaft
+    registration_number: FN 93363 z
+    vat_number: ATU14189108
+    country_code: AT
+    legal_form: null
     status: active
-    address: Am Brunnen 1, 5330 Fuschl am See
-    founded: "1993-10-16"
-    activity: Verwertung der Marke RED BULL
-    directors:
-      - name: Alexander Kirchmayr
-        role: Geschäftsführer/in (handelsrechtlich)
-        since: "2022-11-14"
-      - name: Oliver Mintzlaff
-        role: Geschäftsführer/in (handelsrechtlich)
-        since: "2022-11-14"
-      - name: Franz Watzlawick
-        role: Geschäftsführer/in (handelsrechtlich)
-        since: "2022-11-14"
-      - name: Dr. Marcus Weber
-        role: Prokurist/in
-        since: "2022-11-14"
-    dissolved: null
-    fn_number: FN 56247t
-    eu_vat_ids: null
-    past_names: null
-    company_name: Red Bull GmbH
-    business_type: GmbH (Limited liability company)
+    is_active: true
+    registered_date: "1943-08-09"
+    registered_address: "Trabrennstrasse 6 -8 6, 1020, Wien, AT"
+    lei_code: 549300V62YJ9HTLRI486
+    nace_codes:
+      - code: "1920"
+        description: Manufacture of refined petroleum products
+    company_size: Very large company
+    source_as_of: "2026-05-10T14:34:33.000Z"
   properties:
+    company_name:
+      type: string
+    native_company_name:
+      type:
+        - string
+        - "null"
+    registration_number:
+      type: string
     vat_number:
+      type: string
+    country_code:
+      type: string
+    legal_form:
       type:
         - string
         - "null"
@@ -54,26 +57,38 @@ output_schema:
       type: string
       enum:
         - active
-        - terminated
+        - inactive
         - unknown
-      description: >-
-        Three-way enum matching german-company-data.ts:168-180 precedent.
-        Replaces the prior binary collapse (active/inactive) which lost
-        fidelity (in-liquidation, terminated, dissolved all became inactive).
-    address:
-      type: string
-    company_name:
-      type: string
-    business_type:
-      type: string
-    registration_number:
-      type: string
-data_source: FinAPU Firmenbuch API (Austrian Commercial Register)
-data_source_type: scrape
-transparency_tag: ai_generated
+    is_active:
+      type: boolean
+    registered_date:
+      type:
+        - string
+        - "null"
+    registered_address:
+      type:
+        - string
+        - "null"
+    lei_code:
+      type:
+        - string
+        - "null"
+    nace_codes:
+      type: array
+    company_size:
+      type:
+        - string
+        - "null"
+    source_as_of:
+      type:
+        - string
+        - "null"
+data_source: Openapi.com WW-Top (Tier-3 vendor aggregator of EU company registries)
+data_source_type: api
+transparency_tag: algorithmic
 freshness_category: live-fetch
-maintenance_class: scraping-stable-target
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
+maintenance_class: commercial-stable-api
+gdpr_art_22_classification: data_lookup
 processes_personal_data: true
 personal_data_categories:
   - name
@@ -83,27 +98,94 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      fn_number: 56247t
+      vat_number: ATU14189108
     expected_fields:
       - field: company_name
         operator: not_null
         reliability: guaranteed
+      - field: vat_number
+        operator: equals
+        reliability: guaranteed
+        value: ATU14189108
+      - field: country_code
+        operator: equals
+        reliability: guaranteed
+        value: AT
       - field: status
+        operator: equals
+        reliability: guaranteed
+        value: active
+      - field: is_active
+        operator: equals
+        reliability: guaranteed
+        value: true
+      - field: registered_date
+        operator: not_null
+        reliability: guaranteed
+      - field: registered_address
+        operator: not_null
+        reliability: guaranteed
+      - field: registration_number
+        operator: not_null
+        reliability: guaranteed
+      - field: nace_codes
         operator: not_null
         reliability: guaranteed
   health_check_input:
-    fn_number: 56247t
+    vat_number: ATU14189108
 output_field_reliability:
-  status: guaranteed
-  address: guaranteed
   company_name: guaranteed
-  business_type: guaranteed
+  native_company_name: common
   registration_number: guaranteed
+  vat_number: guaranteed
+  country_code: guaranteed
+  legal_form: rare
+  status: guaranteed
+  is_active: guaranteed
+  registered_date: guaranteed
+  registered_address: guaranteed
+  lei_code: common
+  nace_codes: guaranteed
+  company_size: common
+  source_as_of: guaranteed
 limitations:
-  - title: Extracted from Firmenbuch via web scraping — older registrations may have incomplete fields
-    text: Extracted from Firmenbuch via web scraping — some fields may be incomplete for older registrations
+  - title: Gated behind OPENAPI_ENABLED flag pending resale addendum countersignature
+    text: >-
+      Strale's resale of Openapi.com data requires the addendum issued via Openapi case 151296 (2026-05-08) to be
+      countersigned. Until then, OPENAPI_ENABLED stays false in production and this capability returns
+      capability-unavailable. Removing the gate without the legal cover is a compliance miss.
+    category: availability
+    severity: warning
+    workaround: Use the Strale VAT-validate capability (via VIES) for AT VAT format validation only.
+  - title: Legal form not returned at WW-Top tier
+    text: >-
+      Openapi WW-Top does not return Austrian Rechtsform (GmbH / AG / KG / etc.). Customers needing legal form must
+      derive it from the registered name suffix or wait for the optional AT-Start / AT-Advanced product line (Phase 2
+      Openapi resolver extension, pending the same addendum gate).
+    category: coverage
+    severity: info
+    workaround: Parse legal-form hint from the company_name suffix where consistent.
+  - title: Directors not available at WW-Top tier
+    text: >-
+      Openapi WW-Top does not return Austrian Vertreter (Geschäftsführer, Vorstand) data. The directors-gap closure is
+      IT-only via Openapi IT-Full; no equivalent product is offered for AT. Directors require a separate licensed
+      Firmenbuch contract or a different aggregator.
+    category: coverage
+    severity: info
+    workaround: Skip directors-dependent KYB workflows for Austrian entities at v1.
+  - title: Firmenbuchnummer format rejected
+    text: >-
+      Openapi WW-Top rejects Austrian Firmenbuchnummer (FN format, e.g. FN 93363 z) with HTTP 406. Only VAT format
+      (ATU + 8 digits) is accepted. The executor normalises and validates input against the VAT regex before sending.
     category: coverage
     severity: info
     workaround: >-
-      For complete records, use the Firmenbuchnummer from the response to query the Austrian Commercial Register
-      directly
+      Convert FN to UID via a separate lookup before calling this capability; the relationship between FN and UID is
+      not publicly documented as a simple mapping.
+  - title: Resale provenance disclosure
+    text: >-
+      Customer responses include `acquisition_method: vendor_aggregation` + `upstream_vendor: openapi.com` in
+      provenance per DEC-20260428-A Tier-3 disclosure rules. The underlying authoritative source remains the Austrian
+      Firmenbuch maintained by the Justizministerium.
+    category: governance
+    severity: info


### PR DESCRIPTION
## Summary

- **Phase 1 of 2** for the 11-country Openapi.com integration. Adds the shared `openapi-resolver` helper (WW-Top routing, OAuth scope-exchange auth, identifier validation, response normalization, error mapping) and wires **Austria** as the end-to-end template.
- **Double-gated**: requires `OPENAPI_ENABLED=true` (flag) AND the DB capability row to be active. Flag defaults to `false` in production until the resale addendum countersigns (Openapi case 151296).
- **Empirical reference**: `c:/tmp/openapi-research/v4-2026-05-15/` (this morning's probe) + 2026-05-11 production response artifacts. The 2026-05-15 BR Coverage Matrix row [`34867c87-082c-8165-9fcd-d01bc75c9766`](https://www.notion.so/34867c87082c81659fcdd01bc75c9766) claims `Live + live-verified`; this PR makes the claim defensible.

## What's in this PR

| File | Change |
|---|---|
| `apps/api/src/capabilities/lib/openapi-resolver.ts` | NEW. Shared helper. OAuth-token caching, WW-Top request, error mapping (204=not-found, 406=invalid-identifier, 401=retry-token, 5xx=retry-once), Tier 1/2/3 normalization. |
| `apps/api/src/capabilities/austrian-company-data.ts` | REPLACED. Was deactivated FinAPU+WKO scraping (DEC-20260427-I-6 Tier 1 violation). Now delegates to resolver with `countryCode: "AT"`, `identifierRegex: /^ATU\d{8}$/`, `openapiProduct: "ww-top"`. |
| `manifests/austrian-company-data.yaml` | REPLACED. New T1/T2/T3 field schema. Fixture: OMV `ATU14189108` (Openapi-confirmed). Price 16¢ (€0.13 + 22% IT VAT). `maintenance_class: commercial-stable-api`. `gdpr_art_22_classification: data_lookup`. 5 limitations including the addendum-gate and FN-format-rejected. |
| `apps/api/src/capabilities/auto-register.ts` | AT removed from DEACTIVATED map; reactivation block-comment explains DEC-20260427-I-6 trigger satisfied by Openapi as licensed aggregator. |
| `.env.example` | NEW vars: `OPENAPI_COM_EMAIL`, `OPENAPI_COM_API_TOKEN_PROD`, `OPENAPI_ENABLED=false`. Comment documents OAuth model and the addendum-countersignature gate. |

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npx vitest run` — 665 passed, 0 failed (was 664 passed before; +1 manifest-completeness coverage)
- [x] `check-manifest-guaranteed-consistency.mjs --strict` — 22 total, 0 not in allowlist
- [x] `check-identity-fixture-shape.mjs --strict` — 0 not in allowlist
- [x] `check-fetch-timeout-coverage.mjs` — 0 not in allowlist
- [x] `check-no-bare-catch.mjs` — clean
- [x] `auto-register` post-change: 300 registered / 0 errors / 15 skipped (AT moved out of skip list)
- [x] **Live smoke** against ATU14189108 (OMV) via Railway env: HTTP 200 in 2.6s, Tier 1 6/6 populated (`legal_form` null at WW-Top tier as expected), Tier 2 `vat_number` + `source_as_of` populated, Tier 3 NACE 1920 populated. Cost ~€0.12.
- [x] **Offline negative tests**: flag-disabled → `capability-unavailable`; FN format → `not a valid Austrian UID`; missing input → `'vat_number' is required`.

## Phase 2 follow-up (separate prompt)

10 remaining countries: BG/CY/HU/LU/MT/NL/RO via WW-Top + ES/PT via `*-Advanced` (NACE + balance sheets) + IT via `IT-Advanced` (shareholders) and `IT-Full` (managers). The resolver's product switch (`openapiProduct`) is the extension point — Phase 1 only handles `"ww-top"`; Phase 2 adds the country-specific Start/Advanced products with richer response shapes.

## Out of scope for this PR

- DB write to flip `austrian-company-data` `is_active=true`. Separate operator action when ready.
- Operations runbook for flipping `OPENAPI_ENABLED=true` when addendum countersigns. Separate workstream.
- Billing observability — capability cost is metered via existing wallet flow; no new instrumentation needed.

## Anchors

- DEC-20260427-I-6 (FinAPU/WKO scraping deactivation; reactivation trigger satisfied here)
- DEC-20260507-C (Openapi mid-rebuild assignment for IT/ES/PT/AT)
- Openapi case 151296 (resale addendum pending countersignature)
- 2026-05-15 BR Coverage Matrix audit `c:/tmp/openapi-research/notion-matrix-audit-2026-05-16.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)