### PR TITLE
feat: openapi-resolver phase 2a — 7 WW-Top countries (BG/CY/HU/LU/MT/NL/RO) + committed regression smoke

### DIFF
--- a/apps/api/scripts/smoke-openapi-resolver.ts
+++ b/apps/api/scripts/smoke-openapi-resolver.ts
@@ -1,0 +1,180 @@
+/**
+ * Committed regression smoke for the openapi-resolver chain across all 8
+ * WW-Top countries (AT + Phase 2a BG/CY/HU/LU/MT/NL/RO).
+ *
+ * Modes:
+ *   --offline-only (default): runs negative tests only. Free.
+ *   --live: additionally exercises each country with its probe-verified
+ *           fixture against Openapi prod credentials. Cost ~€1.28 per
+ *           full sweep (€0.16 × 8 countries).
+ *
+ * Negative tests (run per country in both modes):
+ *   1. OPENAPI_ENABLED=false → capability-unavailable
+ *   2. invalid identifier shape → invalid-identifier error
+ *   3. missing input → missing-input error
+ *
+ * Live test (only in --live):
+ *   4. Fixture identifier → HTTP 200 with T1=6/7 (legal_form null OK),
+ *      T2 vat+source_as_of populated, T3 NACE populated.
+ *
+ * Exit code: 0 on all-pass, 1 on any-fail.
+ *
+ * Usage:
+ *   npx tsx apps/api/scripts/smoke-openapi-resolver.ts --offline-only
+ *   railway run -- npx tsx apps/api/scripts/smoke-openapi-resolver.ts --live
+ */
+
+import { config } from "dotenv";
+import { resolve } from "node:path";
+config({ path: resolve(import.meta.dirname, "../../../.env") });
+
+const args = process.argv.slice(2);
+const LIVE = args.includes("--live");
+const OFFLINE_ONLY = !LIVE;
+
+interface CountryConfig {
+  country: string;
+  slug: string;
+  validFixture: Record<string, string>;
+  invalidShape: Record<string, string>; // pre-flight regex reject
+  expectedCompanyName: string;          // for live verify (loose match)
+}
+
+const COUNTRIES: CountryConfig[] = [
+  { country: "AT", slug: "austrian-company-data", validFixture: { vat_number: "ATU14189108" }, invalidShape: { vat_number: "FN93363z" }, expectedCompanyName: "OMV" },
+  { country: "BG", slug: "bulgarian-company-data", validFixture: { vat_number: "831902088" }, invalidShape: { vat_number: "ABC" }, expectedCompanyName: "Sopharma" },
+  { country: "CY", slug: "cypriot-company-data", validFixture: { vat_number: "C165" }, invalidShape: { vat_number: "INVALID" }, expectedCompanyName: "Bank of Cyprus" },
+  { country: "HU", slug: "hungarian-company-data", validFixture: { vat_number: "HU10537914" }, invalidShape: { vat_number: "01-10-041585" }, expectedCompanyName: "OTP" },
+  { country: "LU", slug: "luxembourgish-company-data", validFixture: { vat_number: "LU18513414" }, invalidShape: { vat_number: "B10807" }, expectedCompanyName: "RTL" },
+  { country: "MT", slug: "maltese-company-data", validFixture: { vat_number: "MT12826209" }, invalidShape: { vat_number: "C 2833" }, expectedCompanyName: "GO" },
+  { country: "NL", slug: "dutch-company-data", validFixture: { vat_number: "NL803441526B01" }, invalidShape: { vat_number: "17085815" }, expectedCompanyName: "ASML" },
+  { country: "RO", slug: "romanian-company-data", validFixture: { vat_number: "RO13267213" }, invalidShape: { vat_number: "INVALID" }, expectedCompanyName: "Hidroelectrica" },
+];
+
+// Disable DB sync in auto-register — smoke runs locally without prod DB access.
+const savedDbUrl = process.env.DATABASE_URL;
+process.env.DATABASE_URL = "";
+
+const { autoRegisterCapabilities } = await import("../src/capabilities/auto-register.js");
+const { getExecutor } = await import("../src/capabilities/index.js");
+await autoRegisterCapabilities();
+process.env.DATABASE_URL = savedDbUrl ?? "";
+
+interface TestResult {
+  country: string;
+  test: string;
+  passed: boolean;
+  detail?: string;
+}
+const results: TestResult[] = [];
+
+function record(country: string, test: string, passed: boolean, detail?: string) {
+  results.push({ country, test, passed, detail });
+  const prefix = passed ? "  ✓" : "  ✗";
+  console.error(`${prefix} ${country} ${test}${detail ? ": " + detail.slice(0, 100) : ""}`);
+}
+
+async function expectError(fn: () => Promise<unknown>, matcher: string): Promise<{ ok: boolean; msg: string }> {
+  try {
+    await fn();
+    return { ok: false, msg: "no error thrown" };
+  } catch (err) {
+    const msg = String(err);
+    return { ok: msg.includes(matcher), msg };
+  }
+}
+
+async function runOfflineTests(cfg: CountryConfig) {
+  console.error(`\n--- ${cfg.country} (${cfg.slug}) offline ---`);
+  const executor = getExecutor(cfg.slug);
+  if (!executor) {
+    record(cfg.country, "executor registered", false, "no executor for slug");
+    return;
+  }
+  record(cfg.country, "executor registered", true);
+
+  // Test 1: flag disabled
+  const savedFlag = process.env.OPENAPI_ENABLED;
+  process.env.OPENAPI_ENABLED = "false";
+  const t1 = await expectError(() => executor(cfg.validFixture), "capability-unavailable");
+  record(cfg.country, "flag-disabled → capability-unavailable", t1.ok, t1.msg);
+
+  // Test 2: invalid shape (flag enabled so we reach the validator)
+  process.env.OPENAPI_ENABLED = "true";
+  const t2 = await expectError(() => executor(cfg.invalidShape), "not a valid");
+  record(cfg.country, "invalid-shape → rejected", t2.ok, t2.msg);
+
+  // Test 3: missing input
+  const t3 = await expectError(() => executor({}), "required");
+  record(cfg.country, "missing-input → required-error", t3.ok, t3.msg);
+
+  process.env.OPENAPI_ENABLED = savedFlag;
+}
+
+async function runLiveTest(cfg: CountryConfig) {
+  console.error(`\n--- ${cfg.country} (${cfg.slug}) LIVE ---`);
+  process.env.OPENAPI_ENABLED = "true";
+  const executor = getExecutor(cfg.slug);
+  if (!executor) {
+    record(cfg.country, "live executor", false, "no executor");
+    return;
+  }
+  try {
+    const t0 = Date.now();
+    const result = await executor(cfg.validFixture);
+    const ms = Date.now() - t0;
+    const output = result.output as Record<string, unknown>;
+    const provenance = result.provenance as Record<string, unknown>;
+
+    const companyName = String(output.company_name ?? "");
+    const nameMatch = companyName.toLowerCase().includes(cfg.expectedCompanyName.toLowerCase());
+    record(cfg.country, `live HTTP 200 in ${ms}ms`, true);
+    record(cfg.country, `company_name contains '${cfg.expectedCompanyName}'`, nameMatch, `got: ${companyName.slice(0, 80)}`);
+
+    // Tier 1 (6/7 — legal_form null OK at WW-Top)
+    const t1Fields = ["company_name", "registration_number", "country_code", "status", "registered_date", "registered_address"];
+    const t1Populated = t1Fields.filter((f) => output[f] !== null && output[f] !== undefined && output[f] !== "");
+    record(cfg.country, `T1 6/7 (legal_form null at WW-Top)`, t1Populated.length === 6, `${t1Populated.length}/6 (legal_form=${output.legal_form === null ? "null✓" : output.legal_form})`);
+
+    // Tier 2 output fields (vat_number, source_as_of)
+    const t2OutputFields = ["vat_number", "source_as_of"];
+    const t2OutputPopulated = t2OutputFields.filter((f) => output[f] !== null && output[f] !== undefined);
+    record(cfg.country, `T2 output 2/2 (vat + source_as_of)`, t2OutputPopulated.length === 2, `${t2OutputPopulated.length}/2`);
+
+    // Tier 2 provenance fields (source_register_name, authoritative)
+    const provSourceOk = provenance.source === "Openapi.com WW-Top";
+    const provAuthOk = provenance.authoritative === false;
+    record(cfg.country, "T2 provenance source-name + authoritative=false", provSourceOk && provAuthOk, `source=${provenance.source} authoritative=${provenance.authoritative}`);
+
+    // Tier 3 (NACE)
+    const nace = output.nace_codes;
+    const naceOk = Array.isArray(nace) && nace.length > 0;
+    record(cfg.country, "T3 NACE populated", naceOk);
+  } catch (err) {
+    record(cfg.country, "live HTTP call", false, String(err).slice(0, 200));
+  }
+}
+
+console.error(`smoke-openapi-resolver: ${LIVE ? "LIVE mode (cost ~€1.28)" : "OFFLINE-ONLY mode"}`);
+
+for (const cfg of COUNTRIES) {
+  await runOfflineTests(cfg);
+}
+
+if (LIVE) {
+  for (const cfg of COUNTRIES) {
+    await runLiveTest(cfg);
+  }
+}
+
+const passed = results.filter((r) => r.passed).length;
+const failed = results.filter((r) => !r.passed).length;
+console.error(`\n=== RESULT: ${passed} passed, ${failed} failed (${results.length} total) ===`);
+if (failed > 0) {
+  console.error("Failures:");
+  for (const r of results.filter((x) => !x.passed)) {
+    console.error(`  ${r.country} | ${r.test}${r.detail ? " | " + r.detail.slice(0, 150) : ""}`);
+  }
+  process.exit(1);
+}
+process.exit(0);

--- a/apps/api/src/capabilities/auto-register.ts
+++ b/apps/api/src/capabilities/auto-register.ts
@@ -132,17 +132,13 @@ const DEACTIVATED = new Map<string, string>([
     // Reactivation trigger: migrate to EPO OPS / USPTO PEDS / Lens.org.
     "Google Patents scraping prohibited by Google ToS (see DEC-20260420-H)",
   ],
-  [
-    "dutch-company-data",
-    // DEC-20260427-I-1: Runtime fetched northdata.com (Bavarian commercial KYB aggregator)
-    // and extracted JSON-LD profile data for Dutch (KVK) company lookups. Manifest claimed
-    // KVK / Kamer van Koophandel as the data source — full divergence. northdata.com's
-    // ToS forbids automated access; using it undermines Strale's compliance positioning.
-    // Reactivation trigger: licensed contract with KVK directly (their Handelsregister API
-    // requires Dutch business registration), or with a licensed multi-country aggregator
-    // (Creditsafe, Bisnode/Dun & Bradstreet, Experian).
-    "northdata.com scraping prohibited by ToS; pending licensed KVK or aggregator contract (see DEC-20260427-I)",
-  ],
+  // dutch-company-data REACTIVATED 2026-05-16 (Phase 2a): migrated from
+  // northdata.com Browserless scrape (Tier 1 violation per DEC-20260427-I-1)
+  // to Openapi.com WW-Top (Tier 3 vendor aggregator). KVK Option B closed
+  // 2026-05-12 (DEC-20260512-A: Mirjam Boele confirmed KVK partner status
+  // is closed to foreign EU entities); Openapi is the licensed-aggregator
+  // path per DEC-20260507-B. Double-gated: OPENAPI_ENABLED env flag +
+  // capabilities DB row is_active. Same pattern as Phase 1 AT (PR #121).
   [
     "portuguese-company-data",
     // DEC-20260427-I-2: Same as dutch-company-data — runtime fetched northdata.com,

--- a/apps/api/src/capabilities/bulgarian-company-data.ts
+++ b/apps/api/src/capabilities/bulgarian-company-data.ts
@@ -1,0 +1,60 @@
+// Bulgaria — Openapi.com WW-Top (Tier-3 vendor aggregator).
+//
+// Phase 2a of the Openapi resolver replication (PR #121 was Phase 1 AT
+// template). Strale's reactivation trigger for BG was "licensed
+// aggregator" — Openapi.com is that aggregator. Resale addendum
+// (Openapi case 151296) pending Moonlighter AB VAT confirmation +
+// countersignature; double-gated until both land (OPENAPI_ENABLED env
+// flag + DB is_active row).
+//
+// Identifier shape: BG UIC/EIK (Единен идентификационен код) is 9 bare
+// digits. Openapi WW-Top accepts the bare form; the BG-prefix VAT
+// (BGNNNNNNNNN) maps to the same upstream record but the canonical
+// input is bare digits. Capability normalizes by stripping BG prefix.
+//
+// Field coverage (Matrix row 34867c87-082c-819b-afdb-dafdeca4f369):
+// Tier 1 6/7 (no legal_form via WW-Top), Tier 2 4/5 (no directors),
+// Tier 3 1/6 (NACE only).
+
+import { registerCapability, type CapabilityInput } from "./index.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
+
+const BG_INPUT_RE = /^(BG)?\d{9}$/;
+const BG_CANONICAL_RE = /^\d{9}$/;
+
+function normaliseBgIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
+  if (!BG_INPUT_RE.test(cleaned)) return null;
+  return cleaned.replace(/^BG/, "");
+}
+
+registerCapability("bulgarian-company-data", async (input: CapabilityInput) => {
+  const rawInput =
+    (input.vat_number as string) ??
+    (input.eik as string) ??
+    (input.uic as string) ??
+    (input.identifier as string) ??
+    "";
+  if (typeof rawInput !== "string" || !rawInput.trim()) {
+    throw new Error(
+      "'vat_number' is required. Provide a Bulgarian UIC/EIK (9 digits, optionally BG-prefixed; e.g. 831902088 or BG831902088).",
+    );
+  }
+  const normalised = normaliseBgIdentifier(rawInput.trim());
+  if (!normalised) {
+    throw new Error(
+      `'${rawInput.trim()}' is not a valid Bulgarian UIC/EIK. Expected format: 9 digits, optionally with BG prefix (e.g. 831902088).`,
+    );
+  }
+  return executeOpenapiCapability(
+    {
+      countryCode: "BG",
+      identifierRegex: BG_CANONICAL_RE,
+      openapiProduct: "ww-top",
+      capabilitySlug: "bulgarian-company-data",
+    },
+    normalised,
+  );
+});
+
+export { BG_INPUT_RE, BG_CANONICAL_RE };

--- a/apps/api/src/capabilities/cypriot-company-data.ts
+++ b/apps/api/src/capabilities/cypriot-company-data.ts
@@ -1,0 +1,57 @@
+// Cyprus — Openapi.com WW-Top (Tier-3 vendor aggregator).
+//
+// Phase 2a Openapi resolver replication. PARTIAL coverage: Openapi
+// catalog has some CY entities (Bank of Cyprus on C-format `C165`
+// confirmed 200 by 2026-05-11 probe) but returned 204 for Wargaming
+// (CY99000230P) on 2026-05-15 v4 — anomaly bundled on Openapi case
+// 151296. The capability accepts the shape; vendor returns not-found
+// for some entities.
+//
+// Identifier shape: Openapi WW-Top accepts THREE regex variants for
+// CY: ^CY\d{8}[A-Z]$ (CY-prefix VAT), ^\d{8}[A-Z]$ (bare VAT, no
+// prefix), or ^C\d+$ (CRO company number, e.g. C165). The capability
+// validates against the union shape and passes through to Openapi.
+//
+// Field coverage (Matrix row 34867c87-082c-8115-8442-e152ede99b8c):
+// Tier 1 6/7 (no legal_form via WW-Top), Tier 2 4/5 (no directors),
+// Tier 3 1/6 (NACE only).
+
+import { registerCapability, type CapabilityInput } from "./index.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
+
+const CY_RE = /^(CY\d{8}[A-Z]|\d{8}[A-Z]|C\d+)$/;
+
+function normaliseCyIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/\s/g, "").toUpperCase();
+  return CY_RE.test(cleaned) ? cleaned : null;
+}
+
+registerCapability("cypriot-company-data", async (input: CapabilityInput) => {
+  const rawInput =
+    (input.vat_number as string) ??
+    (input.identifier as string) ??
+    (input.company_number as string) ??
+    "";
+  if (typeof rawInput !== "string" || !rawInput.trim()) {
+    throw new Error(
+      "'vat_number' or 'identifier' is required. Provide a Cypriot VAT (CY-prefix or bare 8-digit-plus-letter) or company number (C-prefix, e.g. C165).",
+    );
+  }
+  const normalised = normaliseCyIdentifier(rawInput.trim());
+  if (!normalised) {
+    throw new Error(
+      `'${rawInput.trim()}' is not a valid Cypriot identifier. Expected: CY + 8 digits + 1 letter (VAT), 8 digits + 1 letter (bare VAT), or C + digits (company number).`,
+    );
+  }
+  return executeOpenapiCapability(
+    {
+      countryCode: "CY",
+      identifierRegex: CY_RE,
+      openapiProduct: "ww-top",
+      capabilitySlug: "cypriot-company-data",
+    },
+    normalised,
+  );
+});
+
+export { CY_RE };

--- a/apps/api/src/capabilities/dutch-company-data.ts
+++ b/apps/api/src/capabilities/dutch-company-data.ts
@@ -1,29 +1,55 @@
-import { registerCapability, type CapabilityInput } from "./index.js";
-import { searchNorthdata } from "./lib/northdata.js";
+// Netherlands — Openapi.com WW-Top (Tier-3 vendor aggregator).
+//
+// Phase 2a Openapi resolver replication. REPLACES the prior northdata.com
+// scraping path (Tier 1 violation per DEC-20260427-I-1, deactivated
+// 2026-04-29). KVK Option B closed 2026-05-12 (DEC-20260512-A: Mirjam
+// Boele confirmed KVK partner status is closed to foreign EU entities).
+// Openapi is the licensed-aggregator path per DEC-20260507-B.
+//
+// Identifier shape: NL VAT (omzetbelasting) is NL + 9 digits + B + 2
+// digits (e.g. NL803441526B01). KvK 8-digit registration numbers
+// rejected by Openapi WW-Top — VAT is the canonical input. No NL-*
+// country-specific Openapi product exists (scope rejected).
+//
+// Field coverage (Matrix row 34867c87-082c-81f7-bb3b-f242c2d6edb2):
+// Tier 1 6/7 (no legal_form via WW-Top), Tier 2 4/5 (no directors),
+// Tier 3 1/6 (NACE only).
 
-/**
- * Dutch Company Data — northdata.com JSON-LD extraction
- *
- * northdata.com has comprehensive coverage of Dutch companies via KVK
- * (Kamer van Koophandel) data. Replaces the previous Browserless+LLM
- * scraper that was failing to extract data from kvk.nl.
- */
+import { registerCapability, type CapabilityInput } from "./index.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
+
+const NL_VAT_RE = /^NL\d{9}B\d{2}$/;
+
+function normaliseNlIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
+  return NL_VAT_RE.test(cleaned) ? cleaned : null;
+}
 
 registerCapability("dutch-company-data", async (input: CapabilityInput) => {
-  const raw = (input.kvk_number as string) ?? (input.company_name as string) ?? (input.task as string) ?? "";
-  if (typeof raw !== "string" || !raw.trim()) {
-    throw new Error("'kvk_number' or 'company_name' is required. Provide a KVK number (8 digits) or company name.");
+  const rawInput =
+    (input.vat_number as string) ??
+    (input.identifier as string) ??
+    "";
+  if (typeof rawInput !== "string" || !rawInput.trim()) {
+    throw new Error(
+      "'vat_number' is required. Provide a Dutch VAT/BTW number (NL + 9 digits + B + 2 digits, e.g. NL803441526B01). KvK numbers are not accepted by the upstream API.",
+    );
   }
-
-  const companyName = (input.company_name as string) ?? null;
-  const kvkNumber = (input.kvk_number as string) ?? null;
-  const output = await searchNorthdata(raw.trim(), "Netherlands", { company_name: companyName, registration_number: kvkNumber }) as unknown as Record<string, unknown>;
-
-  return {
-    output,
-    provenance: {
-      source: "northdata.com (KVK data)",
-      fetched_at: new Date().toISOString(),
+  const normalised = normaliseNlIdentifier(rawInput.trim());
+  if (!normalised) {
+    throw new Error(
+      `'${rawInput.trim()}' is not a valid Dutch VAT/BTW number. Expected format: NL + 9 digits + B + 2 digits (e.g. NL803441526B01).`,
+    );
+  }
+  return executeOpenapiCapability(
+    {
+      countryCode: "NL",
+      identifierRegex: NL_VAT_RE,
+      openapiProduct: "ww-top",
+      capabilitySlug: "dutch-company-data",
     },
-  };
+    normalised,
+  );
 });
+
+export { NL_VAT_RE };

--- a/apps/api/src/capabilities/hungarian-company-data.ts
+++ b/apps/api/src/capabilities/hungarian-company-data.ts
@@ -1,0 +1,54 @@
+// Hungary — Openapi.com WW-Top (Tier-3 vendor aggregator).
+//
+// Phase 2a Openapi resolver replication. v2 probe (2026-05-15) initially
+// reported HU as "format-rejected" because v2 used bare 8-digit
+// Cégjegyzékszám (returns 406). v3 probe (same day) resolved this:
+// Openapi WW-Top accepts HU-prefix VAT (^HU\d{8}$) and returns the
+// underlying entity. OTP/MOL/Richter Gedeon all 200 via v3.
+//
+// Identifier shape: HU + 8 digits (Hungarian "általános forgalmi adó"
+// VAT prefix). Cégjegyzékszám (10-digit hyphenated) NOT accepted by
+// Openapi WW-Top — capability rejects pre-flight.
+//
+// Field coverage (Matrix row 34867c87-082c-810f-a5a9-ef73291fc0f3):
+// Tier 1 6/7 (no legal_form via WW-Top), Tier 2 4/5 (no directors),
+// Tier 3 1/6 (NACE only).
+
+import { registerCapability, type CapabilityInput } from "./index.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
+
+const HU_VAT_RE = /^HU\d{8}$/;
+
+function normaliseHuIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
+  return HU_VAT_RE.test(cleaned) ? cleaned : null;
+}
+
+registerCapability("hungarian-company-data", async (input: CapabilityInput) => {
+  const rawInput =
+    (input.vat_number as string) ??
+    (input.identifier as string) ??
+    "";
+  if (typeof rawInput !== "string" || !rawInput.trim()) {
+    throw new Error(
+      "'vat_number' is required. Provide a Hungarian VAT (HU + 8 digits, e.g. HU10537914). Cégjegyzékszám is not accepted by the upstream API.",
+    );
+  }
+  const normalised = normaliseHuIdentifier(rawInput.trim());
+  if (!normalised) {
+    throw new Error(
+      `'${rawInput.trim()}' is not a valid Hungarian VAT. Expected format: HU + 8 digits (e.g. HU10537914).`,
+    );
+  }
+  return executeOpenapiCapability(
+    {
+      countryCode: "HU",
+      identifierRegex: HU_VAT_RE,
+      openapiProduct: "ww-top",
+      capabilitySlug: "hungarian-company-data",
+    },
+    normalised,
+  );
+});
+
+export { HU_VAT_RE };

--- a/apps/api/src/capabilities/luxembourgish-company-data.ts
+++ b/apps/api/src/capabilities/luxembourgish-company-data.ts
@@ -1,0 +1,56 @@
+// Luxembourg — Openapi.com WW-Top (Tier-3 vendor aggregator).
+//
+// Phase 2a Openapi resolver replication. Strong empirical coverage:
+// 2026-05-11 LU-followup probe confirmed 5 entities (Aperam, BGL BNP
+// Paribas, Cargolux, RTL Group, BCEE) + SES via gap-country-verify, all
+// 200 via WW-Top with LU-prefix VAT. B-prefix RCS company numbers
+// rejected with 406 — VAT is the canonical input.
+//
+// Note: no LU-* country-specific Openapi product exists (token scope
+// rejected on v3 probe). WW-Top is the only path.
+//
+// Field coverage (Matrix row 34867c87-082c-81c8-a809-f2673f0e7ff3):
+// Tier 1 6/7 (no legal_form via WW-Top), Tier 2 4/5 (no directors),
+// Tier 3 1/6 (NACE only).
+
+import { registerCapability, type CapabilityInput } from "./index.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
+
+const LU_VAT_RE = /^LU\d{8}$/;
+
+function normaliseLuIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
+  return LU_VAT_RE.test(cleaned) ? cleaned : null;
+}
+
+registerCapability(
+  "luxembourgish-company-data",
+  async (input: CapabilityInput) => {
+    const rawInput =
+      (input.vat_number as string) ??
+      (input.identifier as string) ??
+      "";
+    if (typeof rawInput !== "string" || !rawInput.trim()) {
+      throw new Error(
+        "'vat_number' is required. Provide a Luxembourgish VAT (LU + 8 digits, e.g. LU18513414). RCS B-prefix company numbers are not accepted by the upstream API.",
+      );
+    }
+    const normalised = normaliseLuIdentifier(rawInput.trim());
+    if (!normalised) {
+      throw new Error(
+        `'${rawInput.trim()}' is not a valid Luxembourgish VAT. Expected format: LU + 8 digits (e.g. LU18513414).`,
+      );
+    }
+    return executeOpenapiCapability(
+      {
+        countryCode: "LU",
+        identifierRegex: LU_VAT_RE,
+        openapiProduct: "ww-top",
+        capabilitySlug: "luxembourgish-company-data",
+      },
+      normalised,
+    );
+  },
+);
+
+export { LU_VAT_RE };

--- a/apps/api/src/capabilities/maltese-company-data.ts
+++ b/apps/api/src/capabilities/maltese-company-data.ts
@@ -1,0 +1,54 @@
+// Malta — Openapi.com WW-Top (Tier-3 vendor aggregator).
+//
+// Phase 2a Openapi resolver replication. PARTIAL coverage: GO P.L.C.
+// (MT12826209) confirmed 200 via WW-Top by both 2026-05-11 + v4 probes,
+// but Bank of Valletta and HSBC Malta returned 204 in v3 probes.
+// Openapi catalog is thin for MT relative to other countries — some
+// entities present, others not.
+//
+// Identifier shape: STRICT MT + 8 digits regex (single accepted format).
+// MFSA C-prefix company numbers (e.g. C 2833) rejected with 406. No
+// MT-* country-specific Openapi product exists (scope rejected).
+//
+// Field coverage (Matrix row 34867c87-082c-81b4-8d8a-ddc827ad6f96):
+// Tier 1 6/7 (no legal_form via WW-Top), Tier 2 4/5 (no directors),
+// Tier 3 1/6 (NACE only).
+
+import { registerCapability, type CapabilityInput } from "./index.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
+
+const MT_VAT_RE = /^MT\d{8}$/;
+
+function normaliseMtIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
+  return MT_VAT_RE.test(cleaned) ? cleaned : null;
+}
+
+registerCapability("maltese-company-data", async (input: CapabilityInput) => {
+  const rawInput =
+    (input.vat_number as string) ??
+    (input.identifier as string) ??
+    "";
+  if (typeof rawInput !== "string" || !rawInput.trim()) {
+    throw new Error(
+      "'vat_number' is required. Provide a Maltese VAT (MT + 8 digits, e.g. MT12826209). MFSA C-prefix company numbers are not accepted by the upstream API.",
+    );
+  }
+  const normalised = normaliseMtIdentifier(rawInput.trim());
+  if (!normalised) {
+    throw new Error(
+      `'${rawInput.trim()}' is not a valid Maltese VAT. Expected format: MT + 8 digits (e.g. MT12826209).`,
+    );
+  }
+  return executeOpenapiCapability(
+    {
+      countryCode: "MT",
+      identifierRegex: MT_VAT_RE,
+      openapiProduct: "ww-top",
+      capabilitySlug: "maltese-company-data",
+    },
+    normalised,
+  );
+});
+
+export { MT_VAT_RE };

--- a/apps/api/src/capabilities/romanian-company-data.ts
+++ b/apps/api/src/capabilities/romanian-company-data.ts
@@ -1,0 +1,56 @@
+// Romania — Openapi.com WW-Top (Tier-3 vendor aggregator).
+//
+// Phase 2a Openapi resolver replication. PARTIAL coverage with a
+// structural caveat: Openapi WW-Top regex requires ^RO\d{8}$ |
+// ^\d{13}$ | ^\d{8}$. Entities with 7-digit CUI (Banca Transilvania
+// RO5022670, OMV Petrom RO1590082) structurally rejected with 406 —
+// confirmed across 4 probe attempts (2026-05-11 + v3 + v4 WW-Top + v4
+// WW-start with padding). 8-digit-CUI entities (Hidroelectrica
+// RO13267213) work fine. Anomaly bundled on Openapi case 151296.
+//
+// Identifier shape: union of RO + 8 digits | 13 digits | 8 digits.
+// Capability validates the union shape; vendor 406s 7-digit-CUI inputs.
+//
+// Field coverage (Matrix row 34867c87-082c-81dd-b802-e5397b801133):
+// Tier 1 6/7 (no legal_form via WW-Top), Tier 2 4/5 (no directors),
+// Tier 3 1/6 (NACE only).
+
+import { registerCapability, type CapabilityInput } from "./index.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
+
+const RO_RE = /^(RO\d{8}|\d{13}|\d{8})$/;
+
+function normaliseRoIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
+  return RO_RE.test(cleaned) ? cleaned : null;
+}
+
+registerCapability("romanian-company-data", async (input: CapabilityInput) => {
+  const rawInput =
+    (input.vat_number as string) ??
+    (input.cui as string) ??
+    (input.identifier as string) ??
+    "";
+  if (typeof rawInput !== "string" || !rawInput.trim()) {
+    throw new Error(
+      "'vat_number' or 'cui' is required. Provide a Romanian VAT (RO + 8 digits, e.g. RO13267213) or CUI (8 or 13 digits). 7-digit CUI entities are not in the upstream catalog.",
+    );
+  }
+  const normalised = normaliseRoIdentifier(rawInput.trim());
+  if (!normalised) {
+    throw new Error(
+      `'${rawInput.trim()}' is not a valid Romanian identifier. Expected: RO + 8 digits (VAT), 13 digits (full CUI), or 8 digits (CUI). 7-digit CUI entities (legacy banks, older corporations) are not reachable.`,
+    );
+  }
+  return executeOpenapiCapability(
+    {
+      countryCode: "RO",
+      identifierRegex: RO_RE,
+      openapiProduct: "ww-top",
+      capabilitySlug: "romanian-company-data",
+    },
+    normalised,
+  );
+});
+
+export { RO_RE };

--- a/manifests/bulgarian-company-data.yaml
+++ b/manifests/bulgarian-company-data.yaml
@@ -1,10 +1,9 @@
-slug: dutch-company-data
-name: Dutch Company Data
+slug: bulgarian-company-data
+name: Bulgarian Company Data
 description: >-
-  Look up Dutch company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts Dutch VAT/BTW number
-  (NL + 9 digits + B + 2 digits). Returns name, registration number, status, registered address, registration
-  date, LEI, primary NACE code, and last-update timestamp. KvK 8-digit registration numbers are NOT accepted by
-  the upstream API.
+  Look up Bulgarian company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts UIC/EIK (9 digits,
+  optionally BG-prefixed). Returns name, registration number, status, registered address, registration date, LEI,
+  primary NACE code, and last-update timestamp. Directors are not returned at the WW-Top tier.
 category: company-data
 cost_class: paid_per_call
 price_cents: 16
@@ -17,24 +16,24 @@ input_schema:
   properties:
     vat_number:
       type: string
-      description: Dutch VAT/BTW number (NL + 9 digits + B + 2 digits, e.g. NL803441526B01). KvK numbers are NOT accepted.
+      description: Bulgarian UIC/EIK (9 digits, optionally BG-prefixed; e.g. 831902088 or BG831902088).
 output_schema:
   type: object
   example:
-    company_name: ASML Holding N.V.
-    native_company_name: ASML Holding N.V.
-    registration_number: "17085815"
-    vat_number: NL803441526B01
-    country_code: NL
+    company_name: Sopharma
+    native_company_name: Софарма
+    registration_number: "831902088"
+    vat_number: BG831902088
+    country_code: BG
     legal_form: null
     status: active
     is_active: true
-    registered_date: "1994-10-04"
-    registered_address: "De Run 6501, 6501, 5504 DR, Veldhoven, NL"
-    lei_code: 724500Y6DUVHQD6OXN27
+    registered_date: "1991-04-18"
+    registered_address: "Iliensko Shose, 16, Sofia, BG"
+    lei_code: 097900BGGW0000048796
     nace_codes:
-      - code: "2611"
-        description: Manufacture of electronic components
+      - code: "2120"
+        description: Manufacture of pharmaceutical preparations
     company_size: Very large company
     source_as_of: "2026-04-30T12:00:00.000Z"
   properties:
@@ -67,17 +66,17 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      vat_number: NL803441526B01
+      vat_number: "831902088"
     expected_fields:
       - { field: company_name, operator: not_null, reliability: guaranteed }
-      - { field: vat_number, operator: equals, reliability: guaranteed, value: NL803441526B01 }
-      - { field: country_code, operator: equals, reliability: guaranteed, value: NL }
+      - { field: country_code, operator: equals, reliability: guaranteed, value: BG }
       - { field: status, operator: equals, reliability: guaranteed, value: active }
       - { field: is_active, operator: equals, reliability: guaranteed, value: true }
       - { field: registered_address, operator: not_null, reliability: guaranteed }
       - { field: registration_number, operator: not_null, reliability: guaranteed }
+      - { field: nace_codes, operator: not_null, reliability: guaranteed }
   health_check_input:
-    vat_number: NL803441526B01
+    vat_number: "831902088"
 output_field_reliability:
   company_name: guaranteed
   native_company_name: common
@@ -101,12 +100,8 @@ limitations:
       capability-unavailable.
     category: availability
     severity: warning
-  - title: KvK numbers rejected
-    text: Openapi WW-Top accepts only NL-prefix VAT format. KvK 8-digit registration numbers return 406.
-    category: coverage
-    severity: info
   - title: Legal form not returned at WW-Top tier
-    text: Openapi WW-Top does not return Dutch legal form.
+    text: Openapi WW-Top does not return Bulgarian legal form. Customers needing legal form must derive it from the registered name suffix.
     category: coverage
     severity: info
   - title: Directors not available at WW-Top tier

--- a/manifests/cypriot-company-data.yaml
+++ b/manifests/cypriot-company-data.yaml
@@ -1,10 +1,10 @@
-slug: dutch-company-data
-name: Dutch Company Data
+slug: cypriot-company-data
+name: Cypriot Company Data
 description: >-
-  Look up Dutch company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts Dutch VAT/BTW number
-  (NL + 9 digits + B + 2 digits). Returns name, registration number, status, registered address, registration
-  date, LEI, primary NACE code, and last-update timestamp. KvK 8-digit registration numbers are NOT accepted by
-  the upstream API.
+  Look up Cypriot company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts CY-prefix VAT, bare VAT
+  (8 digits + letter), or C-prefix CRO company number (e.g. C165). Returns name, registration number, status,
+  registered address, registration date, LEI, primary NACE code, and last-update timestamp. PARTIAL coverage —
+  some entities (e.g. Wargaming CY99000230P) return 204 from the Openapi catalog despite valid input shape.
 category: company-data
 cost_class: paid_per_call
 price_cents: 16
@@ -17,24 +17,26 @@ input_schema:
   properties:
     vat_number:
       type: string
-      description: Dutch VAT/BTW number (NL + 9 digits + B + 2 digits, e.g. NL803441526B01). KvK numbers are NOT accepted.
+      description: >-
+        Cypriot identifier — CY VAT (CY + 8 digits + letter), bare VAT (8 digits + letter), or company number
+        (C + digits, e.g. C165). The same entity can be reached via either shape.
 output_schema:
   type: object
   example:
-    company_name: ASML Holding N.V.
-    native_company_name: ASML Holding N.V.
-    registration_number: "17085815"
-    vat_number: NL803441526B01
-    country_code: NL
+    company_name: Bank of Cyprus Public Company Limited
+    native_company_name: Bank of Cyprus Public Company Limited
+    registration_number: "C165"
+    vat_number: C165
+    country_code: CY
     legal_form: null
     status: active
     is_active: true
-    registered_date: "1994-10-04"
-    registered_address: "De Run 6501, 6501, 5504 DR, Veldhoven, NL"
-    lei_code: 724500Y6DUVHQD6OXN27
+    registered_date: "1899-01-01"
+    registered_address: "Stasinou 51, 2002, Strovolos, CY"
+    lei_code: 5493000F3VYZX1KCO540
     nace_codes:
-      - code: "2611"
-        description: Manufacture of electronic components
+      - code: "6419"
+        description: Other monetary intermediation
     company_size: Very large company
     source_as_of: "2026-04-30T12:00:00.000Z"
   properties:
@@ -67,17 +69,16 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      vat_number: NL803441526B01
+      vat_number: "C165"
     expected_fields:
       - { field: company_name, operator: not_null, reliability: guaranteed }
-      - { field: vat_number, operator: equals, reliability: guaranteed, value: NL803441526B01 }
-      - { field: country_code, operator: equals, reliability: guaranteed, value: NL }
+      - { field: country_code, operator: equals, reliability: guaranteed, value: CY }
       - { field: status, operator: equals, reliability: guaranteed, value: active }
       - { field: is_active, operator: equals, reliability: guaranteed, value: true }
       - { field: registered_address, operator: not_null, reliability: guaranteed }
       - { field: registration_number, operator: not_null, reliability: guaranteed }
   health_check_input:
-    vat_number: NL803441526B01
+    vat_number: "C165"
 output_field_reliability:
   company_name: guaranteed
   native_company_name: common
@@ -90,7 +91,7 @@ output_field_reliability:
   registered_date: common
   registered_address: guaranteed
   lei_code: common
-  nace_codes: guaranteed
+  nace_codes: common
   company_size: common
   source_as_of: guaranteed
 limitations:
@@ -101,12 +102,15 @@ limitations:
       capability-unavailable.
     category: availability
     severity: warning
-  - title: KvK numbers rejected
-    text: Openapi WW-Top accepts only NL-prefix VAT format. KvK 8-digit registration numbers return 406.
+  - title: PARTIAL coverage — some entities not in Openapi catalog
+    text: >-
+      Openapi WW-Top accepts 3 CY identifier shapes (CY-prefix VAT, bare VAT, C-prefix company number) but the
+      underlying catalog has gaps. Wargaming CY99000230P returned 204 on 2026-05-15 v4 probe despite valid input
+      shape — anomaly logged on Openapi support case 151296. Bank of Cyprus (C165) confirmed populated.
     category: coverage
-    severity: info
+    severity: warning
   - title: Legal form not returned at WW-Top tier
-    text: Openapi WW-Top does not return Dutch legal form.
+    text: Openapi WW-Top does not return Cypriot legal form.
     category: coverage
     severity: info
   - title: Directors not available at WW-Top tier

--- a/manifests/hungarian-company-data.yaml
+++ b/manifests/hungarian-company-data.yaml
@@ -1,10 +1,9 @@
-slug: dutch-company-data
-name: Dutch Company Data
+slug: hungarian-company-data
+name: Hungarian Company Data
 description: >-
-  Look up Dutch company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts Dutch VAT/BTW number
-  (NL + 9 digits + B + 2 digits). Returns name, registration number, status, registered address, registration
-  date, LEI, primary NACE code, and last-update timestamp. KvK 8-digit registration numbers are NOT accepted by
-  the upstream API.
+  Look up Hungarian company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts Hungarian VAT (HU + 8
+  digits). Returns name, registration number, status, registered address, registration date, LEI, primary NACE
+  code, and last-update timestamp. Cégjegyzékszám (hyphenated 10-digit) is NOT accepted by the upstream API.
 category: company-data
 cost_class: paid_per_call
 price_cents: 16
@@ -17,24 +16,24 @@ input_schema:
   properties:
     vat_number:
       type: string
-      description: Dutch VAT/BTW number (NL + 9 digits + B + 2 digits, e.g. NL803441526B01). KvK numbers are NOT accepted.
+      description: Hungarian VAT (HU + 8 digits, e.g. HU10537914). Cégjegyzékszám is NOT accepted.
 output_schema:
   type: object
   example:
-    company_name: ASML Holding N.V.
-    native_company_name: ASML Holding N.V.
-    registration_number: "17085815"
-    vat_number: NL803441526B01
-    country_code: NL
+    company_name: OTP Bank Nyrt.
+    native_company_name: OTP Bank Nyrt.
+    registration_number: "10537914"
+    vat_number: HU10537914
+    country_code: HU
     legal_form: null
     status: active
     is_active: true
-    registered_date: "1994-10-04"
-    registered_address: "De Run 6501, 6501, 5504 DR, Veldhoven, NL"
-    lei_code: 724500Y6DUVHQD6OXN27
+    registered_date: "1990-12-31"
+    registered_address: "Nador utca 16, 1051, Budapest, HU"
+    lei_code: 529900W3MOO00A18X956
     nace_codes:
-      - code: "2611"
-        description: Manufacture of electronic components
+      - code: "6419"
+        description: Other monetary intermediation
     company_size: Very large company
     source_as_of: "2026-04-30T12:00:00.000Z"
   properties:
@@ -67,17 +66,17 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      vat_number: NL803441526B01
+      vat_number: HU10537914
     expected_fields:
       - { field: company_name, operator: not_null, reliability: guaranteed }
-      - { field: vat_number, operator: equals, reliability: guaranteed, value: NL803441526B01 }
-      - { field: country_code, operator: equals, reliability: guaranteed, value: NL }
+      - { field: vat_number, operator: equals, reliability: guaranteed, value: HU10537914 }
+      - { field: country_code, operator: equals, reliability: guaranteed, value: HU }
       - { field: status, operator: equals, reliability: guaranteed, value: active }
       - { field: is_active, operator: equals, reliability: guaranteed, value: true }
       - { field: registered_address, operator: not_null, reliability: guaranteed }
       - { field: registration_number, operator: not_null, reliability: guaranteed }
   health_check_input:
-    vat_number: NL803441526B01
+    vat_number: HU10537914
 output_field_reliability:
   company_name: guaranteed
   native_company_name: common
@@ -90,7 +89,7 @@ output_field_reliability:
   registered_date: common
   registered_address: guaranteed
   lei_code: common
-  nace_codes: guaranteed
+  nace_codes: common
   company_size: common
   source_as_of: guaranteed
 limitations:
@@ -101,12 +100,12 @@ limitations:
       capability-unavailable.
     category: availability
     severity: warning
-  - title: KvK numbers rejected
-    text: Openapi WW-Top accepts only NL-prefix VAT format. KvK 8-digit registration numbers return 406.
+  - title: Cégjegyzékszám format rejected
+    text: Openapi WW-Top accepts only HU-prefix VAT format. Cégjegyzékszám (10-digit hyphenated) returns 406.
     category: coverage
     severity: info
   - title: Legal form not returned at WW-Top tier
-    text: Openapi WW-Top does not return Dutch legal form.
+    text: Openapi WW-Top does not return Hungarian legal form.
     category: coverage
     severity: info
   - title: Directors not available at WW-Top tier

--- a/manifests/luxembourgish-company-data.yaml
+++ b/manifests/luxembourgish-company-data.yaml
@@ -1,10 +1,9 @@
-slug: dutch-company-data
-name: Dutch Company Data
+slug: luxembourgish-company-data
+name: Luxembourgish Company Data
 description: >-
-  Look up Dutch company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts Dutch VAT/BTW number
-  (NL + 9 digits + B + 2 digits). Returns name, registration number, status, registered address, registration
-  date, LEI, primary NACE code, and last-update timestamp. KvK 8-digit registration numbers are NOT accepted by
-  the upstream API.
+  Look up Luxembourgish company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts LU VAT
+  (LU + 8 digits). Returns name, registration number, status, registered address, registration date, LEI,
+  primary NACE code, and last-update timestamp. RCS B-prefix company numbers are NOT accepted by the upstream API.
 category: company-data
 cost_class: paid_per_call
 price_cents: 16
@@ -17,24 +16,24 @@ input_schema:
   properties:
     vat_number:
       type: string
-      description: Dutch VAT/BTW number (NL + 9 digits + B + 2 digits, e.g. NL803441526B01). KvK numbers are NOT accepted.
+      description: Luxembourgish VAT (LU + 8 digits, e.g. LU18513414). RCS B-prefix company numbers are NOT accepted.
 output_schema:
   type: object
   example:
-    company_name: ASML Holding N.V.
-    native_company_name: ASML Holding N.V.
-    registration_number: "17085815"
-    vat_number: NL803441526B01
-    country_code: NL
+    company_name: RTL Group S.A.
+    native_company_name: RTL Group S.A.
+    registration_number: LU18513414
+    vat_number: LU18513414
+    country_code: LU
     legal_form: null
     status: active
     is_active: true
-    registered_date: "1994-10-04"
-    registered_address: "De Run 6501, 6501, 5504 DR, Veldhoven, NL"
-    lei_code: 724500Y6DUVHQD6OXN27
+    registered_date: "1972-12-30"
+    registered_address: "Boulevard Pierre Frieden 43 43, 1543, Luxembourg, LU"
+    lei_code: 5493000C8J3C3SZYS040
     nace_codes:
-      - code: "2611"
-        description: Manufacture of electronic components
+      - code: "6020"
+        description: Television programming and broadcasting activities
     company_size: Very large company
     source_as_of: "2026-04-30T12:00:00.000Z"
   properties:
@@ -67,17 +66,17 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      vat_number: NL803441526B01
+      vat_number: LU18513414
     expected_fields:
       - { field: company_name, operator: not_null, reliability: guaranteed }
-      - { field: vat_number, operator: equals, reliability: guaranteed, value: NL803441526B01 }
-      - { field: country_code, operator: equals, reliability: guaranteed, value: NL }
+      - { field: vat_number, operator: equals, reliability: guaranteed, value: LU18513414 }
+      - { field: country_code, operator: equals, reliability: guaranteed, value: LU }
       - { field: status, operator: equals, reliability: guaranteed, value: active }
       - { field: is_active, operator: equals, reliability: guaranteed, value: true }
       - { field: registered_address, operator: not_null, reliability: guaranteed }
       - { field: registration_number, operator: not_null, reliability: guaranteed }
   health_check_input:
-    vat_number: NL803441526B01
+    vat_number: LU18513414
 output_field_reliability:
   company_name: guaranteed
   native_company_name: common
@@ -87,7 +86,7 @@ output_field_reliability:
   legal_form: rare
   status: guaranteed
   is_active: guaranteed
-  registered_date: common
+  registered_date: guaranteed
   registered_address: guaranteed
   lei_code: common
   nace_codes: guaranteed
@@ -101,12 +100,12 @@ limitations:
       capability-unavailable.
     category: availability
     severity: warning
-  - title: KvK numbers rejected
-    text: Openapi WW-Top accepts only NL-prefix VAT format. KvK 8-digit registration numbers return 406.
+  - title: RCS B-prefix company numbers rejected
+    text: Openapi WW-Top accepts only LU-prefix VAT format. B-prefix RCS company numbers return 406.
     category: coverage
     severity: info
   - title: Legal form not returned at WW-Top tier
-    text: Openapi WW-Top does not return Dutch legal form.
+    text: Openapi WW-Top does not return Luxembourgish legal form.
     category: coverage
     severity: info
   - title: Directors not available at WW-Top tier

--- a/manifests/maltese-company-data.yaml
+++ b/manifests/maltese-company-data.yaml
@@ -1,10 +1,10 @@
-slug: dutch-company-data
-name: Dutch Company Data
+slug: maltese-company-data
+name: Maltese Company Data
 description: >-
-  Look up Dutch company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts Dutch VAT/BTW number
-  (NL + 9 digits + B + 2 digits). Returns name, registration number, status, registered address, registration
-  date, LEI, primary NACE code, and last-update timestamp. KvK 8-digit registration numbers are NOT accepted by
-  the upstream API.
+  Look up Maltese company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts MT VAT (MT + 8 digits).
+  Returns name, registration number, status, registered address, registration date, LEI, primary NACE code, and
+  last-update timestamp. PARTIAL coverage — some major MT entities (Bank of Valletta, HSBC Malta) returned 204 in
+  2026-05-15 v3 probes. MFSA C-prefix company numbers are NOT accepted.
 category: company-data
 cost_class: paid_per_call
 price_cents: 16
@@ -17,24 +17,24 @@ input_schema:
   properties:
     vat_number:
       type: string
-      description: Dutch VAT/BTW number (NL + 9 digits + B + 2 digits, e.g. NL803441526B01). KvK numbers are NOT accepted.
+      description: Maltese VAT (MT + 8 digits, e.g. MT12826209). MFSA C-prefix company numbers are NOT accepted.
 output_schema:
   type: object
   example:
-    company_name: ASML Holding N.V.
-    native_company_name: ASML Holding N.V.
-    registration_number: "17085815"
-    vat_number: NL803441526B01
-    country_code: NL
+    company_name: GO P.L.C.
+    native_company_name: GO P.L.C.
+    registration_number: MT12826209
+    vat_number: MT12826209
+    country_code: MT
     legal_form: null
     status: active
     is_active: true
-    registered_date: "1994-10-04"
-    registered_address: "De Run 6501, 6501, 5504 DR, Veldhoven, NL"
-    lei_code: 724500Y6DUVHQD6OXN27
+    registered_date: "1997-08-19"
+    registered_address: "Fra Diegu Street, GO Headquarters, BKR 14, Marsa, MT"
+    lei_code: 213800V8BKIBDZ1U5X47
     nace_codes:
-      - code: "2611"
-        description: Manufacture of electronic components
+      - code: "6110"
+        description: Wired telecommunications activities
     company_size: Very large company
     source_as_of: "2026-04-30T12:00:00.000Z"
   properties:
@@ -67,17 +67,17 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      vat_number: NL803441526B01
+      vat_number: MT12826209
     expected_fields:
       - { field: company_name, operator: not_null, reliability: guaranteed }
-      - { field: vat_number, operator: equals, reliability: guaranteed, value: NL803441526B01 }
-      - { field: country_code, operator: equals, reliability: guaranteed, value: NL }
+      - { field: vat_number, operator: equals, reliability: guaranteed, value: MT12826209 }
+      - { field: country_code, operator: equals, reliability: guaranteed, value: MT }
       - { field: status, operator: equals, reliability: guaranteed, value: active }
       - { field: is_active, operator: equals, reliability: guaranteed, value: true }
       - { field: registered_address, operator: not_null, reliability: guaranteed }
       - { field: registration_number, operator: not_null, reliability: guaranteed }
   health_check_input:
-    vat_number: NL803441526B01
+    vat_number: MT12826209
 output_field_reliability:
   company_name: guaranteed
   native_company_name: common
@@ -90,7 +90,7 @@ output_field_reliability:
   registered_date: common
   registered_address: guaranteed
   lei_code: common
-  nace_codes: guaranteed
+  nace_codes: common
   company_size: common
   source_as_of: guaranteed
 limitations:
@@ -101,12 +101,19 @@ limitations:
       capability-unavailable.
     category: availability
     severity: warning
-  - title: KvK numbers rejected
-    text: Openapi WW-Top accepts only NL-prefix VAT format. KvK 8-digit registration numbers return 406.
+  - title: PARTIAL coverage — major banks not in catalog
+    text: >-
+      Openapi WW-Top accepts the strict MT-prefix VAT shape, but the underlying catalog has gaps. Bank of Valletta
+      and HSBC Malta returned 204 on 2026-05-15 v3 probes despite valid input. GO P.L.C. (MT12826209) confirmed
+      populated.
+    category: coverage
+    severity: warning
+  - title: MFSA C-prefix company numbers rejected
+    text: Openapi WW-Top accepts only MT-prefix VAT format. C-prefix MFSA company numbers (e.g. C 2833) return 406.
     category: coverage
     severity: info
   - title: Legal form not returned at WW-Top tier
-    text: Openapi WW-Top does not return Dutch legal form.
+    text: Openapi WW-Top does not return Maltese legal form.
     category: coverage
     severity: info
   - title: Directors not available at WW-Top tier

--- a/manifests/romanian-company-data.yaml
+++ b/manifests/romanian-company-data.yaml
@@ -1,10 +1,10 @@
-slug: dutch-company-data
-name: Dutch Company Data
+slug: romanian-company-data
+name: Romanian Company Data
 description: >-
-  Look up Dutch company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts Dutch VAT/BTW number
-  (NL + 9 digits + B + 2 digits). Returns name, registration number, status, registered address, registration
-  date, LEI, primary NACE code, and last-update timestamp. KvK 8-digit registration numbers are NOT accepted by
-  the upstream API.
+  Look up Romanian company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts Romanian VAT (RO + 8
+  digits), 13-digit CUI, or 8-digit CUI. Returns name, registration number, status, registered address,
+  registration date, LEI, primary NACE code, and last-update timestamp. PARTIAL coverage — 7-digit CUI entities
+  (legacy banks, older corporations) are structurally rejected by the upstream catalog.
 category: company-data
 cost_class: paid_per_call
 price_cents: 16
@@ -17,24 +17,26 @@ input_schema:
   properties:
     vat_number:
       type: string
-      description: Dutch VAT/BTW number (NL + 9 digits + B + 2 digits, e.g. NL803441526B01). KvK numbers are NOT accepted.
+      description: >-
+        Romanian VAT (RO + 8 digits, e.g. RO13267213), 13-digit CUI, or 8-digit CUI. 7-digit CUI entities are
+        not in the upstream catalog (Banca Transilvania RO5022670, OMV Petrom RO1590082 confirmed unreachable).
 output_schema:
   type: object
   example:
-    company_name: ASML Holding N.V.
-    native_company_name: ASML Holding N.V.
-    registration_number: "17085815"
-    vat_number: NL803441526B01
-    country_code: NL
+    company_name: Societatea de Producere a Energiei Electrice in Hidrocentrale Hidroelectrica S.A.
+    native_company_name: Societatea de Producere a Energiei Electrice in Hidrocentrale Hidroelectrica S.A.
+    registration_number: "13267213"
+    vat_number: RO13267213
+    country_code: RO
     legal_form: null
     status: active
     is_active: true
-    registered_date: "1994-10-04"
-    registered_address: "De Run 6501, 6501, 5504 DR, Veldhoven, NL"
-    lei_code: 724500Y6DUVHQD6OXN27
+    registered_date: "2000-07-29"
+    registered_address: "Bulevardul Ion Mihalache, Bucharest, RO"
+    lei_code: 787200IISRQXO9PRB732
     nace_codes:
-      - code: "2611"
-        description: Manufacture of electronic components
+      - code: "3511"
+        description: Production of electricity
     company_size: Very large company
     source_as_of: "2026-04-30T12:00:00.000Z"
   properties:
@@ -67,17 +69,17 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      vat_number: NL803441526B01
+      vat_number: RO13267213
     expected_fields:
       - { field: company_name, operator: not_null, reliability: guaranteed }
-      - { field: vat_number, operator: equals, reliability: guaranteed, value: NL803441526B01 }
-      - { field: country_code, operator: equals, reliability: guaranteed, value: NL }
+      - { field: vat_number, operator: equals, reliability: guaranteed, value: RO13267213 }
+      - { field: country_code, operator: equals, reliability: guaranteed, value: RO }
       - { field: status, operator: equals, reliability: guaranteed, value: active }
       - { field: is_active, operator: equals, reliability: guaranteed, value: true }
       - { field: registered_address, operator: not_null, reliability: guaranteed }
       - { field: registration_number, operator: not_null, reliability: guaranteed }
   health_check_input:
-    vat_number: NL803441526B01
+    vat_number: RO13267213
 output_field_reliability:
   company_name: guaranteed
   native_company_name: common
@@ -90,7 +92,7 @@ output_field_reliability:
   registered_date: common
   registered_address: guaranteed
   lei_code: common
-  nace_codes: guaranteed
+  nace_codes: common
   company_size: common
   source_as_of: guaranteed
 limitations:
@@ -101,12 +103,15 @@ limitations:
       capability-unavailable.
     category: availability
     severity: warning
-  - title: KvK numbers rejected
-    text: Openapi WW-Top accepts only NL-prefix VAT format. KvK 8-digit registration numbers return 406.
+  - title: PARTIAL coverage — 7-digit CUI entities structurally unreachable
+    text: >-
+      Openapi WW-Top regex is ^RO\d{8}$ | ^\d{13}$ | ^\d{8}$. Entities with 7-digit CUI (Banca Transilvania
+      RO5022670, OMV Petrom RO1590082) are structurally rejected with 406 across all 4 probe attempts. Anomaly
+      logged on Openapi support case 151296. 8-digit-CUI entities (Hidroelectrica RO13267213) work fine.
     category: coverage
-    severity: info
+    severity: warning
   - title: Legal form not returned at WW-Top tier
-    text: Openapi WW-Top does not return Dutch legal form.
+    text: Openapi WW-Top does not return Romanian legal form.
     category: coverage
     severity: info
   - title: Directors not available at WW-Top tier


### PR DESCRIPTION
## Summary

Replicates the AT openapi-resolver pattern from PR #121 (commit \`12ab156\`) across the 7 remaining WW-Top countries: **BG/CY/HU/LU/MT/NL/RO**. Each capability delegates to the shared resolver with country-specific config. Manifests declare \`price_cents: 16\` (€0.1586 = €0.13 net + 22% IT VAT; flips to 13 when Moonlighter AB VAT confirmation lands on Openapi case 151296). Tier reliability matches Matrix rows (T1=6/7, T2=4/5, T3=1/6).

Also ships [\`apps/api/scripts/smoke-openapi-resolver.ts\`](https://github.com/strale-io/strale/blob/feat/openapi-phase-2a-ww-top-7-countries/apps/api/scripts/smoke-openapi-resolver.ts) — committed regression smoke for all 8 WW-Top countries (AT + 7 new), \`--offline-only\` (default, free) and \`--live\` (€1.28/sweep).

## Per-country identifier shapes (Path A — single RegExp w/ alternation)

| Country | Regex | Fixture |
|---|---|---|
| BG | \`^\d{9}\$\` (bare EIK; BG-prefix stripped by handler) | Sopharma \`831902088\` |
| CY | \`^(CY\d{8}[A-Z]\|\d{8}[A-Z]\|C\d+)\$\` | Bank of Cyprus \`C165\` |
| HU | \`^HU\d{8}\$\` (Cégjegyzékszám rejected upstream) | OTP Bank \`HU10537914\` |
| LU | \`^LU\d{8}\$\` (B-prefix RCS rejected upstream) | RTL Group \`LU18513414\` |
| MT | \`^MT\d{8}\$\` (strict; C-prefix MFSA rejected upstream) | GO P.L.C. \`MT12826209\` |
| NL | \`^NL\d{9}B\d{2}\$\` (KvK rejected upstream) | ASML Holding \`NL803441526B01\` |
| RO | \`^(RO\d{8}\|\d{13}\|\d{8})\$\` | Hidroelectrica \`RO13267213\` |

## Partial-coverage caveats (documented in limitations)

- **CY**: Wargaming \`CY99000230P\` returns 204 from Openapi catalog despite valid shape (anomaly on case 151296). Bank of Cyprus + others populated.
- **MT**: Bank of Valletta + HSBC Malta returned 204 in v3 probes despite valid shape. GO P.L.C. confirmed populated.
- **RO**: 7-digit CUI entities (Banca Transilvania \`RO5022670\`, OMV Petrom \`RO1590082\`) structurally rejected by Openapi regex (case 151296). 8-digit CUI entities work.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 665 passed, 0 failed (unchanged from Phase 1 baseline)
- [x] \`check-manifest-guaranteed-consistency.mjs --strict\` — 22 total, 0 not in allowlist
- [x] \`check-fetch-timeout-coverage.mjs\` — 0 not in allowlist
- [x] \`check-no-bare-catch.mjs\` — clean
- [x] Auto-register: **307 executors / 0 errors / 14 skipped** (Phase 1 baseline: 300 / 0 / 15 — +7 new, NL out of skip list)
- [x] **Offline smoke**: \`smoke-openapi-resolver.ts --offline-only\` → 32/32 PASS (4 negative tests × 8 countries)
- [x] **Live smoke**: \`railway run -- smoke-openapi-resolver.ts --live\` → **80/80 PASS** across 8 countries, latencies 1.5-2.6s, all Tier scores match manifest declarations, AT regression intact. Cost ~€1.28.

## NL replacement

\`dutch-company-data.ts\` previously a \`northdata.com\` Browserless scraper (Tier 1 violation per DEC-20260427-I-1, deactivated 2026-04-29). Replaced with the openapi-resolver delegation pattern. NL removed from auto-register DEACTIVATED map with reactivation note. KVK Option B closed per DEC-20260512-A (Mirjam Boele confirmed KVK partner status is closed to foreign EU entities); Openapi is the licensed-aggregator path per DEC-20260507-B.

## Phase 2b/2c (out of scope)

- ES/PT need ES-Advanced / PT-Advanced product extensions to the resolver (richer response shape with NACE + financials) — separate prompt.
- IT needs IT-Advanced (shareholders) + IT-Full (managers/directors) — separate prompt.

## Double-gating preserved

\`OPENAPI_ENABLED=false\` in prod env + \`is_active=false\` on capability DB rows. Either gate alone blocks customer traffic. No prod side-effect until both gates flip (separate operator actions).

## Anchors

- DEC-20260507-B/C (Openapi mid-rebuild assignment)
- DEC-20260512-A (KVK Option B closure)
- DEC-20260427-I (scraping doctrine deactivations being reactivated as licensed-aggregator)
- Openapi case 151296 (resale addendum pending countersignature)
- PR #121 (Phase 1 AT template, commit \`12ab156\`)
- \`c:/tmp/openapi-research/phase1-to-phase2a-verification-2026-05-16.md\` (Phase 1→2a verification audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)