### PR TITLE
feat: openapi-resolver phase 2b — ES-Advanced + PT-Advanced product types + Spain and Portugal capabilities

### DIFF
--- a/apps/api/scripts/smoke-openapi-resolver.ts
+++ b/apps/api/scripts/smoke-openapi-resolver.ts
@@ -35,20 +35,27 @@ const OFFLINE_ONLY = !LIVE;
 interface CountryConfig {
   country: string;
   slug: string;
+  product: "ww-top" | "es-advanced" | "pt-advanced";
   validFixture: Record<string, string>;
   invalidShape: Record<string, string>; // pre-flight regex reject
   expectedCompanyName: string;          // for live verify (loose match)
+  // Tier 3 fields expected populated. WW-Top: just NACE (1/6).
+  // ES/PT-Advanced: NACE + last_filing_date (2/6). IT-Advanced (Phase 2c):
+  // adds shareHolders[] (4/6); IT-Full adds managers + subsidiaries.
+  expectedT3Fields: string[];
 }
 
 const COUNTRIES: CountryConfig[] = [
-  { country: "AT", slug: "austrian-company-data", validFixture: { vat_number: "ATU14189108" }, invalidShape: { vat_number: "FN93363z" }, expectedCompanyName: "OMV" },
-  { country: "BG", slug: "bulgarian-company-data", validFixture: { vat_number: "831902088" }, invalidShape: { vat_number: "ABC" }, expectedCompanyName: "Sopharma" },
-  { country: "CY", slug: "cypriot-company-data", validFixture: { vat_number: "C165" }, invalidShape: { vat_number: "INVALID" }, expectedCompanyName: "Bank of Cyprus" },
-  { country: "HU", slug: "hungarian-company-data", validFixture: { vat_number: "HU10537914" }, invalidShape: { vat_number: "01-10-041585" }, expectedCompanyName: "OTP" },
-  { country: "LU", slug: "luxembourgish-company-data", validFixture: { vat_number: "LU18513414" }, invalidShape: { vat_number: "B10807" }, expectedCompanyName: "RTL" },
-  { country: "MT", slug: "maltese-company-data", validFixture: { vat_number: "MT12826209" }, invalidShape: { vat_number: "C 2833" }, expectedCompanyName: "GO" },
-  { country: "NL", slug: "dutch-company-data", validFixture: { vat_number: "NL803441526B01" }, invalidShape: { vat_number: "17085815" }, expectedCompanyName: "ASML" },
-  { country: "RO", slug: "romanian-company-data", validFixture: { vat_number: "RO13267213" }, invalidShape: { vat_number: "INVALID" }, expectedCompanyName: "Hidroelectrica" },
+  { country: "AT", slug: "austrian-company-data", product: "ww-top", validFixture: { vat_number: "ATU14189108" }, invalidShape: { vat_number: "FN93363z" }, expectedCompanyName: "OMV", expectedT3Fields: ["nace_codes"] },
+  { country: "BG", slug: "bulgarian-company-data", product: "ww-top", validFixture: { vat_number: "831902088" }, invalidShape: { vat_number: "ABC" }, expectedCompanyName: "Sopharma", expectedT3Fields: ["nace_codes"] },
+  { country: "CY", slug: "cypriot-company-data", product: "ww-top", validFixture: { vat_number: "C165" }, invalidShape: { vat_number: "INVALID" }, expectedCompanyName: "Bank of Cyprus", expectedT3Fields: ["nace_codes"] },
+  { country: "HU", slug: "hungarian-company-data", product: "ww-top", validFixture: { vat_number: "HU10537914" }, invalidShape: { vat_number: "01-10-041585" }, expectedCompanyName: "OTP", expectedT3Fields: ["nace_codes"] },
+  { country: "LU", slug: "luxembourgish-company-data", product: "ww-top", validFixture: { vat_number: "LU18513414" }, invalidShape: { vat_number: "B10807" }, expectedCompanyName: "RTL", expectedT3Fields: ["nace_codes"] },
+  { country: "MT", slug: "maltese-company-data", product: "ww-top", validFixture: { vat_number: "MT12826209" }, invalidShape: { vat_number: "C 2833" }, expectedCompanyName: "GO", expectedT3Fields: ["nace_codes"] },
+  { country: "NL", slug: "dutch-company-data", product: "ww-top", validFixture: { vat_number: "NL803441526B01" }, invalidShape: { vat_number: "17085815" }, expectedCompanyName: "ASML", expectedT3Fields: ["nace_codes"] },
+  { country: "RO", slug: "romanian-company-data", product: "ww-top", validFixture: { vat_number: "RO13267213" }, invalidShape: { vat_number: "INVALID" }, expectedCompanyName: "Hidroelectrica", expectedT3Fields: ["nace_codes"] },
+  { country: "ES", slug: "spanish-company-data", product: "es-advanced", validFixture: { vat_number: "A28015865" }, invalidShape: { vat_number: "INVALID" }, expectedCompanyName: "Telefonica", expectedT3Fields: ["nace_codes", "last_filing_date"] },
+  { country: "PT", slug: "portuguese-company-data", product: "pt-advanced", validFixture: { vat_number: "504499777" }, invalidShape: { vat_number: "ABC" }, expectedCompanyName: "Galp", expectedT3Fields: ["nace_codes", "last_filing_date"] },
 ];
 
 // Disable DB sync in auto-register — smoke runs locally without prod DB access.
@@ -141,15 +148,25 @@ async function runLiveTest(cfg: CountryConfig) {
     const t2OutputPopulated = t2OutputFields.filter((f) => output[f] !== null && output[f] !== undefined);
     record(cfg.country, `T2 output 2/2 (vat + source_as_of)`, t2OutputPopulated.length === 2, `${t2OutputPopulated.length}/2`);
 
-    // Tier 2 provenance fields (source_register_name, authoritative)
-    const provSourceOk = provenance.source === "Openapi.com WW-Top";
+    // Tier 2 provenance fields (source_register_name, authoritative).
+    // Source label is product-aware: "Openapi.com WW-Top" / "...ES-Advanced" / etc.
+    const provSourceOk = typeof provenance.source === "string" && provenance.source.startsWith("Openapi.com ");
     const provAuthOk = provenance.authoritative === false;
     record(cfg.country, "T2 provenance source-name + authoritative=false", provSourceOk && provAuthOk, `source=${provenance.source} authoritative=${provenance.authoritative}`);
 
-    // Tier 3 (NACE)
-    const nace = output.nace_codes;
-    const naceOk = Array.isArray(nace) && nace.length > 0;
-    record(cfg.country, "T3 NACE populated", naceOk);
+    // Tier 3 — per-product field expectations
+    const t3Populated = cfg.expectedT3Fields.filter((f) => {
+      const v = output[f];
+      if (Array.isArray(v)) return v.length > 0;
+      return v !== null && v !== undefined && v !== "";
+    });
+    const t3Denom = cfg.expectedT3Fields.length;
+    record(
+      cfg.country,
+      `T3 ${t3Denom}/${cfg.product === "ww-top" ? 6 : 6} expected (${cfg.expectedT3Fields.join("+")})`,
+      t3Populated.length === t3Denom,
+      `populated: ${t3Populated.join(",")}`,
+    );
   } catch (err) {
     record(cfg.country, "live HTTP call", false, String(err).slice(0, 200));
   }

--- a/apps/api/src/capabilities/auto-register.ts
+++ b/apps/api/src/capabilities/auto-register.ts
@@ -139,27 +139,25 @@ const DEACTIVATED = new Map<string, string>([
   // is closed to foreign EU entities); Openapi is the licensed-aggregator
   // path per DEC-20260507-B. Double-gated: OPENAPI_ENABLED env flag +
   // capabilities DB row is_active. Same pattern as Phase 1 AT (PR #121).
-  [
-    "portuguese-company-data",
-    // DEC-20260427-I-2: Same as dutch-company-data — runtime fetched northdata.com,
-    // manifest claimed Registo Comercial. Full divergence.
-    // Reactivation trigger: licensed contract with the Portuguese Registo Comercial
-    // (via IRN/Justiça Portuguesa) or a multi-country licensed aggregator.
-    "northdata.com scraping prohibited by ToS; pending licensed PT registry or aggregator contract (see DEC-20260427-I)",
-  ],
+  // portuguese-company-data REACTIVATED 2026-05-16 (Phase 2b): migrated from
+  // northdata.com Browserless scrape (Tier 1 violation per DEC-20260427-I-2)
+  // to Openapi.com PT-Advanced (Tier 3 vendor aggregator). Satisfies the
+  // "licensed multi-country aggregator" reactivation trigger named in
+  // DEC-20260427-I-2. Double-gated: OPENAPI_ENABLED env flag + DB is_active.
+  // Direct Registo Comercial / publicacoes.mj.pt integration queued as v1.1
+  // quality upgrade per DEC-20260507-C.
   // lithuanian-company-data REACTIVATED 2026-04-29: migrated from
   // northdata.com aggregator scrape to direct data.gov.lt Spinta JSON API
   // (Registrų centras / JAR — Juridinių asmenų registras). Free, real-time
   // JSON, no signup, CC-BY 4.0 (commercial reuse permitted with attribution).
   // acquisition_method: direct_api per DEC-20260428-A Tier 2.
-  [
-    "spanish-company-data",
-    // DEC-20260427-I-4: Runtime fetched empresia.es and infocif.es (commercial Spanish
-    // KYB aggregators), manifest claimed Registro Mercantil Central. Full divergence.
-    // Reactivation trigger: licensed contract with the Spanish Registro Mercantil
-    // (via Colegio de Registradores) or a multi-country licensed aggregator.
-    "empresia.es / infocif.es scraping prohibited by ToS; pending licensed ES registry or aggregator contract (see DEC-20260427-I)",
-  ],
+  // spanish-company-data REACTIVATED 2026-05-16 (Phase 2b): migrated from
+  // empresia.es + infocif.es Browserless scraping (Tier 1 violation per
+  // DEC-20260427-I-4) to Openapi.com ES-Advanced (Tier 3 vendor aggregator).
+  // Satisfies the "licensed multi-country aggregator" reactivation trigger
+  // named in DEC-20260427-I-4. Double-gated: OPENAPI_ENABLED env flag + DB
+  // is_active. Direct Registradores integration queued as v1.1 quality
+  // upgrade per DEC-20260507-C.
   // german-company-data REACTIVATED 2026-05-06: migrated from northdata.com
   // ToS-prohibited scrape (DEC-20260427-I-5) to direct OpenRegister API
   // (api.openregister.de). Free tier 50 req/mo per DEC-20260505-H +

--- a/apps/api/src/capabilities/lib/openapi-resolver.ts
+++ b/apps/api/src/capabilities/lib/openapi-resolver.ts
@@ -1,15 +1,20 @@
-// Openapi.com WW-Top resolver — shared helper for Tier-3 vendor-aggregator
+// Openapi.com resolver — shared helper for Tier-3 vendor-aggregator
 // capabilities backed by the Openapi.com product line.
 //
 // Auth model: OAuth scope-exchange.
 //   1. POST https://oauth.openapi.it/token with HTTP Basic (email:api-token)
 //      and JSON body {"scopes":[scope],"ttl":600} → opaque Bearer, ~10 min TTL.
-//   2. GET https://company.openapi.com/WW-top/{country}/{identifier} with
+//   2. GET https://company.openapi.com/{PRODUCT}/{path...} with
 //      Authorization: Bearer <token>.
 //
-// Phase 1 only handles the WW-Top product. Phase 2 will extend the product
-// switch to handle country-specific Start/Advanced endpoints (ES-Advanced,
-// PT-Advanced, IT-Advanced, etc.) — those have richer response shapes.
+// Supported products (Phase 2b):
+//   ww-top      — global, country-keyed (BG/CY/HU/LU/MT/NL/RO/AT). T3=1/6 (NACE).
+//   es-advanced — Spain, NIF-keyed. T3=2/6 (NACE + last_filing_date).
+//   pt-advanced — Portugal, NIPC-keyed. T3=2/6 (NACE + last_filing_date).
+//
+// Phase 2c will add IT-advanced (shareHolders[]) + IT-full (managers,
+// subsidiaries, affiliateCompanies). The product-switch design (see
+// PRODUCT_REGISTRY below) is the extension point.
 //
 // Gating: process.env.OPENAPI_ENABLED must equal "true" or the resolver
 // returns a capability-unavailable error before any HTTP call. This is
@@ -17,15 +22,16 @@
 // countersignature (case 151296). The flag stays off in production until
 // that lands.
 //
-// Reference: c:/tmp/openapi-research/v4-2026-05-15/output.json + per-call
-// response files at c:/tmp/openapi-research/v4-2026-05-15/responses/.
+// Reference: c:/tmp/openapi-research/v4-2026-05-15/output.json (WW-Top
+// per-call responses) + c:/tmp/openapi-coverage-probe-v3-2026-05-15.json
+// (ES/PT-Advanced response shapes verified).
 
 import { log } from "../../lib/log.js";
 
-export type OpenapiProduct = "ww-top";
+export type OpenapiProduct = "ww-top" | "es-advanced" | "pt-advanced";
 
 export interface OpenapiResolverConfig {
-  countryCode: string;          // ISO 3166-1 alpha-2 (path segment for WW-Top)
+  countryCode: string;          // ISO 3166-1 alpha-2
   identifierRegex: RegExp;      // pre-flight identifier-shape validation
   openapiProduct: OpenapiProduct;
   capabilitySlug: string;       // for log context + error messages
@@ -95,8 +101,8 @@ async function issueToken(scope: string): Promise<string> {
   return data.token;
 }
 
-// ─── WW-Top response shape (subset; verified against v4 AT/OMV response) ───
-interface WWTopAddress {
+// ─── Shared response sub-types ─────────────────────────────────────────────
+interface OpenapiAddress {
   registeredOffice?: {
     town?: string | null;
     country?: string | null;
@@ -106,43 +112,83 @@ interface WWTopAddress {
     nativeTown?: string | null;
   };
 }
-interface WWTopMarker {
-  label?: string;
-  number?: string;
-  types?: string[];
-}
-interface WWTopNaceItem {
+interface WwTopNaceItem {
   code?: string;
   description?: string;
 }
-interface WWTopData {
+interface FlatNace {
+  code?: string;
+  description?: string;
+}
+interface BalanceSheetEntry {
+  year?: number;
+  balanceSheetDate?: string;
+  employees?: number;
+  netWorth?: number;
+  operatingRevenue?: number;
+  equity?: number;
+  totalAssets?: number;
+}
+
+// ─── WW-Top response shape (verified against v4 AT/OMV response) ───────────
+interface WwTopData {
   id?: string;
   lastUpdateTimestamp?: number;
   companyName?: string;
   nativeCompanyName?: string;
   companyNumber?: string;
   vatCode?: string;
+  taxCode?: string;
   leiCode?: string;
   companySize?: string;
-  markers?: WWTopMarker[];
-  address?: WWTopAddress;
+  address?: OpenapiAddress;
   activityStatus?: string;
   incorporationDate?: string;
   internationalClassification?: {
     nace?: {
-      primary?: WWTopNaceItem[];
-      secondary?: WWTopNaceItem[];
+      primary?: WwTopNaceItem[];
+      secondary?: WwTopNaceItem[];
     };
   };
 }
-interface WWTopResponse {
-  data?: WWTopData[];
+
+// ─── ES/PT-Advanced response shape (verified against v3 probe ─────────────
+// Phase B Telefonica + Galp responses). Shares identity fields with
+// WW-Top but NACE is flat (single object, not array) and adds
+// balanceSheets (last + 4-year history with employees, equity,
+// operatingRevenue, totalAssets, netWorth, balanceSheetDate).
+interface IberianAdvancedData {
+  id?: string;
+  lastUpdateTimestamp?: number;
+  companyName?: string;
+  nativeCompanyName?: string;
+  taxCode?: string;
+  vatCode?: string;
+  leiCode?: string;
+  address?: OpenapiAddress;
+  activityStatus?: string;
+  incorporationDate?: string;
+  contacts?: { fax?: string; phone?: string; website?: string };
+  internationalClassification?: {
+    nace?: FlatNace;
+    naics?: FlatNace;
+    sic?: FlatNace;
+  };
+  balanceSheets?: {
+    last?: BalanceSheetEntry;
+    all?: BalanceSheetEntry[];
+  };
+}
+
+interface OpenapiResponse<T> {
+  data?: T[];
   success?: boolean;
   message?: string;
   error?: unknown;
 }
 
-function composeAddress(addr: WWTopAddress | undefined): string | null {
+// ─── Shared mappers ────────────────────────────────────────────────────────
+function composeAddress(addr: OpenapiAddress | undefined): string | null {
   if (!addr?.registeredOffice) return null;
   const o = addr.registeredOffice;
   const street =
@@ -176,34 +222,134 @@ function normaliseStatus(raw: string | undefined): "active" | "inactive" | "unkn
   return "unknown";
 }
 
-function nacePrimary(
-  data: WWTopData,
+function wwTopNacePrimary(
+  data: WwTopData,
 ): { code: string; description: string } | null {
   const p = data.internationalClassification?.nace?.primary?.[0];
   if (!p?.code) return null;
   return { code: p.code, description: p.description ?? "" };
 }
 
-interface CallResult {
+function iberianNace(
+  data: IberianAdvancedData,
+): { code: string; description: string } | null {
+  const p = data.internationalClassification?.nace;
+  if (!p?.code) return null;
+  return { code: p.code, description: p.description ?? "" };
+}
+
+// ─── Per-product registry (URL builder + scope + mapper dispatch) ──────────
+interface ProductDispatch {
+  /** Build the fetch URL for a given country + identifier. */
+  buildUrl: (country: string, id: string) => string;
+  /** OAuth scope string required for this product. */
+  scope: string;
+  /** Human-readable provenance.source label. */
+  sourceLabel: string;
+}
+
+const PRODUCT_REGISTRY: Record<OpenapiProduct, ProductDispatch> = {
+  "ww-top": {
+    buildUrl: (country, id) =>
+      `https://company.openapi.com/WW-top/${encodeURIComponent(country)}/${encodeURIComponent(id)}`,
+    scope: "GET:company.openapi.com/WW-top",
+    sourceLabel: "Openapi.com WW-Top",
+  },
+  "es-advanced": {
+    // Country-specific products take a single path segment (the identifier).
+    // No country path segment because the product name encodes the country.
+    buildUrl: (_country, id) =>
+      `https://company.openapi.com/ES-advanced/${encodeURIComponent(id)}`,
+    scope: "GET:company.openapi.com/ES-advanced",
+    sourceLabel: "Openapi.com ES-Advanced",
+  },
+  "pt-advanced": {
+    buildUrl: (_country, id) =>
+      `https://company.openapi.com/PT-advanced/${encodeURIComponent(id)}`,
+    scope: "GET:company.openapi.com/PT-advanced",
+    sourceLabel: "Openapi.com PT-Advanced",
+  },
+};
+
+// ─── Mappers (produce Strale output{} per product) ─────────────────────────
+function mapWwTopOutput(
+  data: WwTopData,
+  config: OpenapiResolverConfig,
+  trimmed: string,
+): Record<string, unknown> {
+  const status = normaliseStatus(data.activityStatus);
+  const nace = wwTopNacePrimary(data);
+  const sourceAsOf = epochSecondsToIso(data.lastUpdateTimestamp);
+  return {
+    company_name: data.companyName ?? data.nativeCompanyName ?? null,
+    native_company_name: data.nativeCompanyName ?? null,
+    registration_number: data.companyNumber ?? trimmed,
+    vat_number: data.vatCode ?? trimmed,
+    country_code: config.countryCode,
+    legal_form: null,
+    status,
+    is_active: status === "active",
+    registered_date: data.incorporationDate ?? null,
+    registered_address: composeAddress(data.address),
+    lei_code: data.leiCode ?? null,
+    nace_codes: nace ? [nace] : [],
+    company_size: data.companySize ?? null,
+    source_as_of: sourceAsOf,
+  };
+}
+
+function mapIberianAdvancedOutput(
+  data: IberianAdvancedData,
+  config: OpenapiResolverConfig,
+  trimmed: string,
+): Record<string, unknown> {
+  const status = normaliseStatus(data.activityStatus);
+  const nace = iberianNace(data);
+  const sourceAsOf = epochSecondsToIso(data.lastUpdateTimestamp);
+  // last_filing_date comes from balanceSheets.last.balanceSheetDate (already
+  // ISO YYYY-MM-DD per probe data). NOTE: share_capital is NOT present in
+  // ES/PT-Advanced response — only IT-Advanced has shareCapital. Matrix's
+  // "T3 3/6 (NACE + share capital + last filing year)" claim is incorrect
+  // for ES/PT; reality is 2/6 (NACE + last_filing_date). See PR description.
+  const lastFilingDate = data.balanceSheets?.last?.balanceSheetDate ?? null;
+  return {
+    company_name: data.companyName ?? data.nativeCompanyName ?? null,
+    native_company_name: data.nativeCompanyName ?? null,
+    registration_number: data.taxCode ?? trimmed,
+    vat_number: data.vatCode ?? trimmed,
+    country_code: config.countryCode,
+    legal_form: null,
+    status,
+    is_active: status === "active",
+    registered_date: data.incorporationDate ?? null,
+    registered_address: composeAddress(data.address),
+    lei_code: data.leiCode ?? null,
+    nace_codes: nace ? [nace] : [],
+    company_size: null, // not returned at *-Advanced tier
+    source_as_of: sourceAsOf,
+    last_filing_date: lastFilingDate,
+  };
+}
+
+// ─── Fetch helpers ─────────────────────────────────────────────────────────
+interface CallResult<T> {
   status: number;
-  body: WWTopResponse | null;
+  body: OpenapiResponse<T> | null;
   text: string;
 }
 
-async function callWWTop(
-  country: string,
-  id: string,
+async function callProduct<T>(
+  url: string,
   bearer: string,
-): Promise<CallResult> {
-  const url = `https://company.openapi.com/WW-top/${encodeURIComponent(country)}/${encodeURIComponent(id)}`;
+): Promise<CallResult<T>> {
   const r = await fetch(url, {
     headers: { Authorization: `Bearer ${bearer}` },
     signal: AbortSignal.timeout(15_000),
   });
   const text = await r.text();
-  let body: WWTopResponse | null = null;
+  let body: OpenapiResponse<T> | null = null;
   try {
-    body = text ? (JSON.parse(text) as WWTopResponse) : null;
+    body = text ? (JSON.parse(text) as OpenapiResponse<T>) : null;
   } catch {
     body = null;
   }
@@ -211,15 +357,16 @@ async function callWWTop(
 }
 
 /**
- * Execute an Openapi-routed capability against the WW-Top product.
+ * Execute an Openapi-routed capability.
  *
  * Flow:
  *   1. Feature-flag check (OPENAPI_ENABLED).
- *   2. Credentials check (OPENAPI_COM_EMAIL + OPENAPI_COM_API_TOKEN_PROD).
+ *   2. Product validation (config.openapiProduct must be in PRODUCT_REGISTRY).
  *   3. Identifier shape validation against config.identifierRegex.
- *   4. Token acquire (cached per scope, 10-min TTL).
- *   5. WW-Top fetch with 15s timeout; single retry on 401 (token-stale) or 5xx.
- *   6. Map response to Strale Tier 1/2/3 shape; throw structured errors on
+ *   4. Credentials check (OPENAPI_COM_EMAIL + OPENAPI_COM_API_TOKEN_PROD).
+ *   5. Token acquire (cached per scope, 10-min TTL).
+ *   6. Product fetch with 15s timeout; single retry on 401 / 5xx.
+ *   7. Map response to Strale Tier 1/2/3 shape; throw structured errors on
  *      204/406/4xx/5xx/network.
  */
 export async function executeOpenapiCapability(
@@ -243,9 +390,10 @@ export async function executeOpenapiCapability(
     );
   }
 
-  if (config.openapiProduct !== "ww-top") {
+  const product = PRODUCT_REGISTRY[config.openapiProduct];
+  if (!product) {
     throw new Error(
-      `Openapi resolver phase 1 only supports the 'ww-top' product; received '${config.openapiProduct}'. Phase 2 extension pending.`,
+      `Openapi resolver does not support product '${config.openapiProduct}'. Supported: ${Object.keys(PRODUCT_REGISTRY).join(", ")}.`,
     );
   }
 
@@ -259,7 +407,7 @@ export async function executeOpenapiCapability(
     );
   }
 
-  const scope = "GET:company.openapi.com/WW-top";
+  const requestUrl = product.buildUrl(config.countryCode, trimmed);
   const maxAttempts = 2;
   let attempt = 0;
   let lastErr: unknown = null;
@@ -267,8 +415,8 @@ export async function executeOpenapiCapability(
   while (attempt < maxAttempts) {
     attempt += 1;
     try {
-      const bearer = await issueToken(scope);
-      const r = await callWWTop(config.countryCode, trimmed, bearer);
+      const bearer = await issueToken(product.scope);
+      const r = await callProduct<unknown>(requestUrl, bearer);
       const durationMs = Date.now() - t0;
 
       if (r.status === 200) {
@@ -283,10 +431,6 @@ export async function executeOpenapiCapability(
           );
         }
         const data = r.body.data[0];
-        const status = normaliseStatus(data.activityStatus);
-        const nace = nacePrimary(data);
-        const sourceAsOf = epochSecondsToIso(data.lastUpdateTimestamp);
-        const requestUrl = `https://company.openapi.com/WW-top/${encodeURIComponent(config.countryCode)}/${encodeURIComponent(trimmed)}`;
 
         log.info(
           {
@@ -299,31 +443,29 @@ export async function executeOpenapiCapability(
           "openapi-success",
         );
 
+        let output: Record<string, unknown>;
+        let recordId: string | null = null;
+        if (config.openapiProduct === "ww-top") {
+          const wwTopData = data as WwTopData;
+          output = mapWwTopOutput(wwTopData, config, trimmed);
+          recordId = wwTopData.id ?? null;
+        } else {
+          // es-advanced or pt-advanced share the same Iberian shape
+          const iberianData = data as IberianAdvancedData;
+          output = mapIberianAdvancedOutput(iberianData, config, trimmed);
+          recordId = iberianData.id ?? null;
+        }
+
         return {
-          output: {
-            company_name: data.companyName ?? data.nativeCompanyName ?? null,
-            native_company_name: data.nativeCompanyName ?? null,
-            registration_number: data.companyNumber ?? trimmed,
-            vat_number: data.vatCode ?? trimmed,
-            country_code: config.countryCode,
-            legal_form: null,
-            status,
-            is_active: status === "active",
-            registered_date: data.incorporationDate ?? null,
-            registered_address: composeAddress(data.address),
-            lei_code: data.leiCode ?? null,
-            nace_codes: nace ? [nace] : [],
-            company_size: data.companySize ?? null,
-            source_as_of: sourceAsOf,
-          },
+          output,
           provenance: {
-            source: "Openapi.com WW-Top",
+            source: product.sourceLabel,
             source_url: requestUrl,
             fetched_at: new Date().toISOString(),
             upstream_vendor: "openapi.com",
             acquisition_method: "vendor_aggregation",
             authoritative: false,
-            openapi_record_id: data.id ?? null,
+            openapi_record_id: recordId,
           },
         };
       }
@@ -361,7 +503,7 @@ export async function executeOpenapiCapability(
       }
 
       if (r.status === 401 && attempt === 1) {
-        tokenCache.delete(scope);
+        tokenCache.delete(product.scope);
         log.info(
           { label: "openapi-token-stale", ...baseCtx },
           "openapi-token-stale",

--- a/apps/api/src/capabilities/portuguese-company-data.ts
+++ b/apps/api/src/capabilities/portuguese-company-data.ts
@@ -1,28 +1,63 @@
-import { registerCapability, type CapabilityInput } from "./index.js";
-import { searchNorthdata } from "./lib/northdata.js";
+// Portugal — Openapi.com PT-Advanced (Tier-3 vendor aggregator).
+//
+// Phase 2b Openapi resolver replication. REPLACES the prior northdata.com
+// Browserless scraping path (Tier 1 violation per DEC-20260427-I-2,
+// deactivated 2026-04-29). Openapi is the licensed multi-country
+// aggregator path per DEC-20260507-C.
+//
+// Identifier shape: Portuguese NIPC (Número de Identificação de Pessoa
+// Coletiva) — bare 9-digit, e.g. 504499777 for Galp Energia. The
+// capability also accepts PT-prefix VAT (PT504499777) and strips the
+// prefix.
+//
+// Field coverage (Matrix row 34867c87-082c-81ea-a495-d9b01e9da1d9):
+// Tier 1 6/7 (no legal_form via *-Advanced),
+// Tier 2 4/5 (no directors via *-Advanced — IT-only product line),
+// Tier 3 2/6 (NACE + last_filing_date; share_capital NOT returned by
+// PT-Advanced — Matrix's 3/6 claim with "share capital" is over-stated
+// by 1; only IT-Advanced has shareCapital).
+//
+// Direct Registo Comercial / publicacoes.mj.pt integration queued as
+// v1.1 quality upgrade per DEC-20260507-C (separate workstream).
 
-/**
- * Portuguese Company Data — northdata.com JSON-LD extraction
- *
- * northdata.com covers Portuguese companies. Replaces the previous
- * Browserless+LLM scraper that was failing on racius.com.
- */
+import { registerCapability, type CapabilityInput } from "./index.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
+
+const PT_NIPC_RE = /^\d{9}$/;
+
+function normalisePtIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
+  // Strip PT-prefix VAT shape (PT504499777 → 504499777)
+  const stripped = cleaned.startsWith("PT") ? cleaned.slice(2) : cleaned;
+  return PT_NIPC_RE.test(stripped) ? stripped : null;
+}
 
 registerCapability("portuguese-company-data", async (input: CapabilityInput) => {
-  const raw = (input.nipc as string) ?? (input.company_name as string) ?? (input.task as string) ?? "";
-  if (typeof raw !== "string" || !raw.trim()) {
-    throw new Error("'nipc' or 'company_name' is required. Provide a Portuguese NIPC number or company name.");
+  const rawInput =
+    (input.vat_number as string) ??
+    (input.nipc as string) ??
+    (input.identifier as string) ??
+    "";
+  if (typeof rawInput !== "string" || !rawInput.trim()) {
+    throw new Error(
+      "'vat_number' or 'nipc' is required. Provide a Portuguese NIPC (9 digits, e.g. 504499777). PT-prefix VAT format is also accepted (e.g. PT504499777).",
+    );
   }
-
-  const companyName = (input.company_name as string) ?? null;
-  const nipc = (input.nipc as string) ?? null;
-  const output = await searchNorthdata(raw.trim(), "Portugal", { company_name: companyName, registration_number: nipc }) as unknown as Record<string, unknown>;
-
-  return {
-    output,
-    provenance: {
-      source: "northdata.com (Portuguese registry data)",
-      fetched_at: new Date().toISOString(),
+  const normalised = normalisePtIdentifier(rawInput.trim());
+  if (!normalised) {
+    throw new Error(
+      `'${rawInput.trim()}' is not a valid Portuguese NIPC. Expected format: 9 digits (e.g. 504499777).`,
+    );
+  }
+  return executeOpenapiCapability(
+    {
+      countryCode: "PT",
+      identifierRegex: PT_NIPC_RE,
+      openapiProduct: "pt-advanced",
+      capabilitySlug: "portuguese-company-data",
     },
-  };
+    normalised,
+  );
 });
+
+export { PT_NIPC_RE };

--- a/apps/api/src/capabilities/spanish-company-data.ts
+++ b/apps/api/src/capabilities/spanish-company-data.ts
@@ -1,105 +1,64 @@
+// Spain — Openapi.com ES-Advanced (Tier-3 vendor aggregator).
+//
+// Phase 2b Openapi resolver replication. REPLACES the prior empresia.es +
+// infocif.es Browserless scraping path (Tier 1 violation per
+// DEC-20260427-I-4, deactivated 2026-04-29). Openapi is the licensed
+// multi-country aggregator path per DEC-20260507-C.
+//
+// Identifier shape: Spanish CIF/NIF — letter + 7 digits + check character
+// (letter or digit), e.g. A28015865 for Telefónica. The capability also
+// accepts ES-prefix VAT (ESA28015865) and strips the prefix.
+//
+// Field coverage (Matrix row 34867c87-082c-8178-8061-eda241b42b63):
+// Tier 1 6/7 (no legal_form via *-Advanced),
+// Tier 2 4/5 (no directors via *-Advanced — IT-only product line),
+// Tier 3 2/6 (NACE + last_filing_date; share_capital NOT returned by
+// ES-Advanced — Matrix's 3/6 claim with "share capital" is over-stated
+// by 1; only IT-Advanced has shareCapital).
+//
+// Direct Registradores / opendata.registradores.org integration queued
+// as v1.1 quality upgrade per DEC-20260507-C (separate workstream).
+
 import { registerCapability, type CapabilityInput } from "./index.js";
-import { deriveVatES } from "../lib/vat-derivation.js";
-import {
-  fetchRenderedHtml,
-  htmlToText,
-  extractCompanyFromText,
-  extractCompanyName,
-} from "./lib/browserless-extract.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
 
-// Spain — CIF/NIF format: letter + 7 digits + check char
-const CIF_RE = /^[A-Z]\d{7}[A-Z0-9]$/;
+// CIF/NIF canonical: 1 letter + 7 digits + 1 check char (letter or digit).
+const ES_NIF_RE = /^[A-Z]\d{7}[A-Z0-9]$/;
 
-function findCif(input: string): string | null {
-  const cleaned = input.replace(/[\s.-]/g, "").toUpperCase();
-  if (CIF_RE.test(cleaned)) return cleaned;
-  const match = input.match(/[A-Z]\d{7}[A-Z0-9]/);
-  return match ? match[0] : null;
-}
-
-// Primary: empresia.es (BORME data, no SSL issues)
-async function lookupViaEmpresia(query: string, isCif: boolean): Promise<Record<string, unknown>> {
-  if (isCif) {
-    const html = await fetchRenderedHtml(`https://www.empresia.es/cif/${query}/`);
-    const text = htmlToText(html);
-    if (text.length < 200 || text.includes("404")) {
-      throw new Error(`No Spanish company found for CIF "${query}".`);
-    }
-    return extractCompanyFromText(text, "Spanish", query);
-  }
-
-  // Name lookup: try direct /empresa/{slug}/ first, fall back to search
-  const slug = query.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-  const directHtml = await fetchRenderedHtml(`https://www.empresia.es/empresa/${slug}/`);
-  const directText = htmlToText(directHtml);
-
-  if (directText.length >= 300 && !directText.includes("404") && !directText.includes("No encontrado")) {
-    return extractCompanyFromText(directText, "Spanish", query);
-  }
-
-  // Fallback: search page (requires JS rendering via Browserless)
-  const searchHtml = await fetchRenderedHtml(`https://www.empresia.es/buscador/?nombre=${encodeURIComponent(query)}`);
-  const searchText = htmlToText(searchHtml);
-
-  if (searchText.length < 200 || searchText.includes("No se encontraron")) {
-    throw new Error(`No Spanish company found matching "${query}".`);
-  }
-
-  return extractCompanyFromText(searchText, "Spanish", query);
-}
-
-// Fallback: infocif.es (may have SSL cert issues)
-async function lookupViaInfocif(query: string, isCif: boolean): Promise<Record<string, unknown>> {
-  const searchUrl = isCif
-    ? `https://www.infocif.es/ficha-empresa/${query}`
-    : `https://www.infocif.es/buscar-empresa?q=${encodeURIComponent(query)}`;
-
-  const html = await fetchRenderedHtml(searchUrl);
-  const text = htmlToText(html);
-
-  if (text.includes("No se encontraron") || text.includes("not found") || text.length < 200) {
-    throw new Error(`No Spanish company found matching "${query}".`);
-  }
-
-  return extractCompanyFromText(text, "Spanish", query);
+function normaliseEsIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
+  // Strip ES-prefix VAT shape (ESA28015865 → A28015865)
+  const stripped = cleaned.startsWith("ES") ? cleaned.slice(2) : cleaned;
+  return ES_NIF_RE.test(stripped) ? stripped : null;
 }
 
 registerCapability("spanish-company-data", async (input: CapabilityInput) => {
-  const raw = (input.cif as string) ?? (input.company_name as string) ?? (input.task as string) ?? "";
-  if (typeof raw !== "string" || !raw.trim()) {
-    throw new Error("'cif' or 'company_name' is required. Provide a CIF/NIF number (e.g. A28015865) or company name.");
+  const rawInput =
+    (input.vat_number as string) ??
+    (input.nif as string) ??
+    (input.cif as string) ??
+    (input.identifier as string) ??
+    "";
+  if (typeof rawInput !== "string" || !rawInput.trim()) {
+    throw new Error(
+      "'vat_number' or 'nif' is required. Provide a Spanish CIF/NIF (letter + 7 digits + check character, e.g. A28015865). ES-prefix VAT format is also accepted (e.g. ESA28015865).",
+    );
   }
-
-  const trimmed = raw.trim();
-  const cif = findCif(trimmed);
-  const query = cif ?? await extractCompanyName(trimmed, "Spanish");
-  const isCif = !!cif;
-
-  // Helper: add VAT derivation from CIF/NIF
-  const addVat = (output: Record<string, unknown>) => {
-    const regNum = (output.registration_number as string) ?? cif ?? "";
-    const vat = deriveVatES(regNum);
-    if (vat) output.vat_number = vat;
-    return output;
-  };
-
-  // Primary: empresia.es
-  try {
-    const output = addVat(await lookupViaEmpresia(query, isCif));
-    return {
-      output,
-      provenance: { source: "empresia.es", fetched_at: new Date().toISOString() },
-    };
-  } catch (primaryErr) {
-    // Fallback: infocif.es
-    try {
-      const output = addVat(await lookupViaInfocif(query, isCif));
-      return {
-        output,
-        provenance: { source: "infocif.es", fetched_at: new Date().toISOString() },
-      };
-    } catch {
-      throw primaryErr;
-    }
+  const normalised = normaliseEsIdentifier(rawInput.trim());
+  if (!normalised) {
+    throw new Error(
+      `'${rawInput.trim()}' is not a valid Spanish CIF/NIF. Expected format: letter + 7 digits + check character (e.g. A28015865).`,
+    );
   }
+  return executeOpenapiCapability(
+    {
+      countryCode: "ES",
+      identifierRegex: ES_NIF_RE,
+      openapiProduct: "es-advanced",
+      capabilitySlug: "spanish-company-data",
+    },
+    normalised,
+  );
 });
+
+export { ES_NIF_RE };

--- a/manifests/portuguese-company-data.yaml
+++ b/manifests/portuguese-company-data.yaml
@@ -1,54 +1,65 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
-
 slug: portuguese-company-data
 name: Portuguese Company Data
 description: >-
-  [TEMPORARILY UNAVAILABLE 2026-04-29 — pending licensed PT registry or aggregator contract per DEC-20260428-A.] Look
-  up Portuguese company data from RNPC. Accepts NIPC (9 digits) or fuzzy company name.
-category: data-extraction
-price_cents: 80
+  Look up Portuguese company data via Openapi.com PT-Advanced (Tier-3 vendor aggregator). Accepts Portuguese NIPC
+  (9 digits). Returns name, registration number, status, registered address, registration date, LEI, primary NACE
+  code, last filing date (from balance-sheet data), and last-update timestamp. Directors are not returned at the
+  *-Advanced tier (Italian product line only).
+category: company-data
+cost_class: paid_per_call
+price_cents: 6
 is_free_tier: false
+avg_latency_ms: 2400
 input_schema:
   type: object
   required:
-    - nipc
+    - vat_number
   properties:
-    nipc:
+    vat_number:
       type: string
-      description: NIPC number (9 digits) or company name
+      description: Portuguese NIPC (9 digits, e.g. 504499777) or PT-prefix VAT (PT504499777).
 output_schema:
   type: object
   example:
-    status: unknown
-    address: null
-    industry: null
-    directors: null
-    company_name: null
-    business_type: null
-    registration_date: null
-    registration_number: null
+    company_name: Galp Energia, Sgps, S.A.
+    native_company_name: null
+    registration_number: "504499777"
+    vat_number: PT504499777
+    country_code: PT
+    legal_form: null
+    status: active
+    is_active: true
+    registered_date: "1999-04-22"
+    registered_address: "Avenida Da India, 8 6, 1349-065, Lisboa, PT"
+    lei_code: 2138003319Y7NM75FG53
+    nace_codes:
+      - code: "0910"
+        description: Support activities for petroleum and natural gas extraction
+    company_size: null
+    source_as_of: "2026-05-10T15:19:30.000Z"
+    last_filing_date: "2024-12-31"
   properties:
-    vat_number:
-      type:
-        - string
-        - "null"
-    status:
-      type: string
-    address:
-      type: string
-    company_name:
-      type: string
-    business_type:
-      type: string
-    registration_number:
-      type: string
-data_source: Registo Comercial (Portuguese Commercial Register)
-data_source_type: scrape
-transparency_tag: ai_generated
+    company_name: { type: string }
+    native_company_name: { type: ["string", "null"] }
+    registration_number: { type: string }
+    vat_number: { type: string }
+    country_code: { type: string }
+    legal_form: { type: ["string", "null"] }
+    status: { type: string, enum: [active, inactive, unknown] }
+    is_active: { type: boolean }
+    registered_date: { type: ["string", "null"] }
+    registered_address: { type: ["string", "null"] }
+    lei_code: { type: ["string", "null"] }
+    nace_codes: { type: array }
+    company_size: { type: ["string", "null"] }
+    source_as_of: { type: ["string", "null"] }
+    last_filing_date: { type: ["string", "null"] }
+data_source: Openapi.com PT-Advanced (Tier-3 vendor aggregator; Portuguese company-data product line)
+data_source_type: api
+transparency_tag: algorithmic
 freshness_category: live-fetch
-maintenance_class: scraping-stable-target
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
+maintenance_class: commercial-stable-api
+gdpr_art_22_classification: data_lookup
 processes_personal_data: true
 personal_data_categories:
   - name
@@ -58,26 +69,58 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      nipc: "503504564"
+      vat_number: "504499777"
     expected_fields:
-      - field: status
-        operator: not_null
-        reliability: guaranteed
-      - field: status
-        operator: type
-        reliability: guaranteed
-        value: string
+      - { field: company_name, operator: not_null, reliability: guaranteed }
+      - { field: country_code, operator: equals, reliability: guaranteed, value: PT }
+      - { field: status, operator: equals, reliability: guaranteed, value: active }
+      - { field: is_active, operator: equals, reliability: guaranteed, value: true }
+      - { field: registered_address, operator: not_null, reliability: guaranteed }
+      - { field: registration_number, operator: not_null, reliability: guaranteed }
+      - { field: nace_codes, operator: not_null, reliability: guaranteed }
+      - { field: last_filing_date, operator: not_null, reliability: guaranteed }
   health_check_input:
-    nipc: "503504564"
+    vat_number: "504499777"
 output_field_reliability:
-  status: guaranteed
-  address: guaranteed
   company_name: guaranteed
-  business_type: guaranteed
+  native_company_name: rare
   registration_number: guaranteed
+  vat_number: guaranteed
+  country_code: guaranteed
+  legal_form: rare
+  status: guaranteed
+  is_active: guaranteed
+  registered_date: guaranteed
+  registered_address: guaranteed
+  lei_code: common
+  nace_codes: guaranteed
+  company_size: rare
+  source_as_of: guaranteed
+  last_filing_date: guaranteed
 limitations:
-  - title: Extracted from Portal da Empresa via Browserless — detailed financial data requires paid IES filing access
-    text: Extracted from Portal da Empresa via Browserless — detailed financial data requires paid access to IES filings
+  - title: Gated behind OPENAPI_ENABLED flag pending resale addendum countersignature
+    text: >-
+      Strale's resale of Openapi.com data requires the addendum issued via Openapi case 151296 (2026-05-08) to be
+      countersigned. Until then, OPENAPI_ENABLED stays false in production and this capability returns
+      capability-unavailable. price_cents flips from 6 to 5 (€0.061 → €0.05 net) when Moonlighter AB VAT confirms.
+    category: availability
+    severity: warning
+  - title: Legal form not returned at PT-Advanced tier
+    text: Openapi PT-Advanced does not return Portuguese legal form (S.A., Lda., etc.).
     category: coverage
     severity: info
-    workaround: Use the NIF from the response to access company filings via racius.com or einforma.pt
+  - title: Directors not available at PT-Advanced tier
+    text: >-
+      Directors / officers / shareholders are NOT returned at PT-Advanced — the directors-gap closure is IT-only
+      via Openapi IT-Full. Direct Registo Comercial / publicacoes.mj.pt integration queued as v1.1 quality
+      upgrade per DEC-20260507-C.
+    category: coverage
+    severity: info
+  - title: Share capital not returned at PT-Advanced tier
+    text: >-
+      Despite the Matrix's "share capital via balanceSheets" claim, the PT-Advanced response contains employees /
+      netWorth / operatingRevenue / equity / totalAssets per year, but NOT a dedicated shareCapital field. Tier 3
+      coverage is 2/6 (NACE + last_filing_date), not 3/6. Matrix needs reconciliation; documented for chat to
+      address separately. Only IT-Advanced surfaces shareCapital.
+    category: coverage
+    severity: info

--- a/manifests/spanish-company-data.yaml
+++ b/manifests/spanish-company-data.yaml
@@ -1,54 +1,65 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
-
 slug: spanish-company-data
 name: Spanish Company Data
 description: >-
-  [TEMPORARILY UNAVAILABLE 2026-04-29 — pending licensed ES registry or aggregator contract per DEC-20260428-A.] Look
-  up Spanish company data from the Registro Mercantil. Accepts CIF/NIF (e.g. A28015865) or fuzzy company name.
-category: data-extraction
-price_cents: 80
+  Look up Spanish company data via Openapi.com ES-Advanced (Tier-3 vendor aggregator). Accepts Spanish CIF/NIF
+  (letter + 7 digits + check char). Returns name, registration number, status, registered address, registration
+  date, LEI, primary NACE code, last filing date (from balance-sheet data), and last-update timestamp. Directors
+  are not returned at the *-Advanced tier (Italian product line only).
+category: company-data
+cost_class: paid_per_call
+price_cents: 6
 is_free_tier: false
+avg_latency_ms: 2400
 input_schema:
   type: object
   required:
-    - cif
+    - vat_number
   properties:
-    cif:
+    vat_number:
       type: string
-      description: CIF/NIF number (e.g. A28015865) or company name
+      description: Spanish CIF/NIF (letter + 7 digits + check char, e.g. A28015865) or ES-prefix VAT (ESA28015865).
 output_schema:
   type: object
   example:
-    status: unknown
-    address: null
-    industry: null
-    directors: null
-    company_name: null
-    business_type: null
-    registration_date: null
-    registration_number: null
+    company_name: Telefonica, SA
+    native_company_name: null
+    registration_number: A28015865
+    vat_number: ESA28015865
+    country_code: ES
+    legal_form: null
+    status: active
+    is_active: true
+    registered_date: "1924-04-19"
+    registered_address: "Calle Gran Via, 28 5 28, 28013, Madrid, ES"
+    lei_code: 549300EEJH4FEPDBBR25
+    nace_codes:
+      - code: "6190"
+        description: Other telecommunications activities
+    company_size: null
+    source_as_of: "2026-05-10T14:33:21.000Z"
+    last_filing_date: "2024-12-31"
   properties:
-    vat_number:
-      type:
-        - string
-        - "null"
-    status:
-      type: string
-    address:
-      type: string
-    company_name:
-      type: string
-    business_type:
-      type: string
-    registration_number:
-      type: string
-data_source: Registro Mercantil Central (Spanish Commercial Register)
-data_source_type: scrape
-transparency_tag: ai_generated
+    company_name: { type: string }
+    native_company_name: { type: ["string", "null"] }
+    registration_number: { type: string }
+    vat_number: { type: string }
+    country_code: { type: string }
+    legal_form: { type: ["string", "null"] }
+    status: { type: string, enum: [active, inactive, unknown] }
+    is_active: { type: boolean }
+    registered_date: { type: ["string", "null"] }
+    registered_address: { type: ["string", "null"] }
+    lei_code: { type: ["string", "null"] }
+    nace_codes: { type: array }
+    company_size: { type: ["string", "null"] }
+    source_as_of: { type: ["string", "null"] }
+    last_filing_date: { type: ["string", "null"] }
+data_source: Openapi.com ES-Advanced (Tier-3 vendor aggregator; Spanish company-data product line)
+data_source_type: api
+transparency_tag: algorithmic
 freshness_category: live-fetch
-maintenance_class: scraping-stable-target
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
+maintenance_class: commercial-stable-api
+gdpr_art_22_classification: data_lookup
 processes_personal_data: true
 personal_data_categories:
   - name
@@ -58,40 +69,58 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      cif: "A15075062"
+      vat_number: A28015865
     expected_fields:
-      - field: status
-        operator: not_null
-        reliability: guaranteed
-      - field: status
-        operator: type
-        reliability: guaranteed
-        value: string
-      - field: company_name
-        operator: not_null
-        reliability: guaranteed
-      - field: company_name
-        operator: type
-        reliability: guaranteed
-        value: string
-      - field: business_type
-        operator: not_null
-        reliability: guaranteed
-      - field: business_type
-        operator: type
-        reliability: guaranteed
-        value: string
+      - { field: company_name, operator: not_null, reliability: guaranteed }
+      - { field: country_code, operator: equals, reliability: guaranteed, value: ES }
+      - { field: status, operator: equals, reliability: guaranteed, value: active }
+      - { field: is_active, operator: equals, reliability: guaranteed, value: true }
+      - { field: registered_address, operator: not_null, reliability: guaranteed }
+      - { field: registration_number, operator: not_null, reliability: guaranteed }
+      - { field: nace_codes, operator: not_null, reliability: guaranteed }
+      - { field: last_filing_date, operator: not_null, reliability: guaranteed }
   health_check_input:
-    company_name: Telefonica
+    vat_number: A28015865
 output_field_reliability:
-  status: guaranteed
-  address: guaranteed
   company_name: guaranteed
-  business_type: guaranteed
+  native_company_name: rare
   registration_number: guaranteed
+  vat_number: guaranteed
+  country_code: guaranteed
+  legal_form: rare
+  status: guaranteed
+  is_active: guaranteed
+  registered_date: guaranteed
+  registered_address: guaranteed
+  lei_code: common
+  nace_codes: guaranteed
+  company_size: rare
+  source_as_of: guaranteed
+  last_filing_date: guaranteed
 limitations:
-  - title: Extracted from Spanish Registro Mercantil via Browserless — financial data requires a paid access subscription
-    text: Extracted from Registro Mercantil via Browserless — financial data requires paid access to the Registro Mercantil
+  - title: Gated behind OPENAPI_ENABLED flag pending resale addendum countersignature
+    text: >-
+      Strale's resale of Openapi.com data requires the addendum issued via Openapi case 151296 (2026-05-08) to be
+      countersigned. Until then, OPENAPI_ENABLED stays false in production and this capability returns
+      capability-unavailable. price_cents flips from 6 to 5 (€0.061 → €0.05 net) when Moonlighter AB VAT confirms.
+    category: availability
+    severity: warning
+  - title: Legal form not returned at ES-Advanced tier
+    text: Openapi ES-Advanced does not return Spanish legal form (S.A., S.L., etc.).
     category: coverage
     severity: info
-    workaround: Use the CIF from the response to access full filings at registradores.org or infocif.es
+  - title: Directors not available at ES-Advanced tier
+    text: >-
+      Directors / officers / shareholders are NOT returned at ES-Advanced — the directors-gap closure is IT-only
+      via Openapi IT-Full. Direct Registradores / opendata.registradores.org integration queued as v1.1 quality
+      upgrade per DEC-20260507-C.
+    category: coverage
+    severity: info
+  - title: Share capital not returned at ES-Advanced tier
+    text: >-
+      Despite the Matrix's "share capital via balanceSheets" claim, the ES-Advanced response contains employees /
+      netWorth / operatingRevenue / equity / totalAssets per year, but NOT a dedicated shareCapital field. Tier 3
+      coverage is 2/6 (NACE + last_filing_date), not 3/6. Matrix needs reconciliation; documented for chat to
+      address separately. Only IT-Advanced surfaces shareCapital.
+    category: coverage
+    severity: info


### PR DESCRIPTION
## Summary

Extends the openapi-resolver's product switch with two new types (\`es-advanced\`, \`pt-advanced\`) for the richer Iberian product line. Adds 2 capability files (\`spanish-company-data\`, \`portuguese-company-data\`) delegating with country-specific configs. Extends the committed regression smoke from 8 to 10 country coverage.

**Path A** chosen — per-product mapper functions + a \`PRODUCT_REGISTRY\` dispatch object alongside WW-Top. No signature change to \`executeOpenapiCapability\`; \`OpenapiProduct\` type union extended. Defer the base/extension refactor to Phase 2c if IT-Advanced + IT-Full warrants it.

## Per-country identifier shapes

| Country | Regex | Fixture | URL pattern |
|---|---|---|---|
| ES | \`^[A-Z]\d{7}[A-Z0-9]\$\` (CIF/NIF: letter + 7 digits + check char; ES-prefix stripped by handler) | Telefónica \`A28015865\` | \`company.openapi.com/ES-advanced/{nif}\` |
| PT | \`^\d{9}\$\` (bare 9-digit NIPC; PT-prefix stripped by handler) | Galp Energia \`504499777\` | \`company.openapi.com/PT-advanced/{nipc}\` |

## Matrix reconciliation finding

ES + PT Matrix rows claim Tier 3 = **3/6** with \"NACE + share capital + last filing year via balanceSheets\". Empirical v3 probe responses confirm the \`balanceSheets\` block contains \`employees / netWorth / operatingRevenue / equity / totalAssets\` per year, but **NOT a dedicated \`shareCapital\` field** — that's IT-Advanced only.

Phase 2b manifests declare the **accurate Tier 3 = 2/6 (NACE + last_filing_date)**. Documented as a limitation in both ES + PT manifests so customers don't expect share-capital from these capabilities.

**Action for chat:** reconcile Matrix rows \`34867c87-082c-8178-...\` (ES) and \`34867c87-082c-81ea-...\` (PT) from Tier 3 = 3/6 → 2/6.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 665 passed, 0 failed (unchanged from Phase 2a baseline)
- [x] \`check-manifest-guaranteed-consistency.mjs --strict\` — 22 total, 0 not in allowlist
- [x] \`check-fetch-timeout-coverage.mjs\` — 0 not in allowlist
- [x] \`check-no-bare-catch.mjs\` — clean
- [x] Auto-register: **309 executors / 0 errors / 13 skipped** (Phase 2a: 307/0/14 → +2 new, ES/PT out of skip list)
- [x] **Offline smoke**: \`--offline-only\` → 40/40 PASS (4 negative tests × 10 countries)
- [x] **Live smoke**: \`railway run -- --live\` → **100/100 PASS** across 10 countries. AT + 7 WW-Top countries regression intact; ES + PT live-verified with T3=2/6.
- [x] Live spend ~€1.40 (8 × €0.16 WW-Top + 2 × €0.06 *-Advanced).

## ES + PT replacement

Both \`spanish-company-data.ts\` (previously empresia.es/infocif.es scraper, DEC-20260427-I-4 Tier 1 violation) and \`portuguese-company-data.ts\` (previously northdata.com scraper, DEC-20260427-I-2 Tier 1 violation) replaced with the openapi-resolver delegation pattern. Both removed from auto-register DEACTIVATED with reactivation notes. Direct Registradores (ES) and direct Registo Comercial (PT) integrations queued as v1.1 quality upgrades per DEC-20260507-C.

## Double-gating preserved

\`OPENAPI_ENABLED=false\` in prod env + \`is_active=false\` on capability DB rows for all 10 capabilities. Either alone blocks customer traffic.

## VAT-flip trigger

When Moonlighter AB VAT confirmation lands (Openapi case 151296):
- 8 WW-Top manifests: \`price_cents: 16 → 13\`
- 2 *-Advanced manifests (ES + PT): \`price_cents: 6 → 5\`

One coordinated edit across all 10 when ready.

## Phase 2c (out of scope)

Only **IT** remains for full EU30 code parity. Requires \`IT-Advanced\` (shareHolders[] in response) + \`IT-Full\` (managers, subsidiaries, affiliateCompanies). Resolver's \`PRODUCT_REGISTRY\` is the extension point for both. IT-Full's 12s latency (per v2 probe) requires async execution path — separate prompt.

## Anchors

- DEC-20260507-C (Openapi mid-rebuild assignment for IT/ES/PT/AT)
- DEC-20260427-I-2/-4 (PT/ES scraping deactivations being reactivated as licensed-aggregator)
- Openapi case 151296 (resale addendum pending countersignature)
- PR #122 (Phase 2a, commit \`ef25d42\`)
- \`c:/tmp/openapi-research/phase1-to-phase2a-verification-2026-05-16.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)