### PR TITLE
feat: openapi-resolver phase 2c — IT-Advanced + italian-company-data + shareholders shape contract

### DIFF
--- a/apps/api/scripts/smoke-openapi-resolver.ts
+++ b/apps/api/scripts/smoke-openapi-resolver.ts
@@ -56,6 +56,11 @@ const COUNTRIES: CountryConfig[] = [
   { country: "RO", slug: "romanian-company-data", product: "ww-top", validFixture: { vat_number: "RO13267213" }, invalidShape: { vat_number: "INVALID" }, expectedCompanyName: "Hidroelectrica", expectedT3Fields: ["nace_codes"] },
   { country: "ES", slug: "spanish-company-data", product: "es-advanced", validFixture: { vat_number: "A28015865" }, invalidShape: { vat_number: "INVALID" }, expectedCompanyName: "Telefonica", expectedT3Fields: ["nace_codes", "last_filing_date"] },
   { country: "PT", slug: "portuguese-company-data", product: "pt-advanced", validFixture: { vat_number: "504499777" }, invalidShape: { vat_number: "ABC" }, expectedCompanyName: "Galp", expectedT3Fields: ["nace_codes", "last_filing_date"] },
+  // IT-Advanced is unique in v1: T1=7/7 (legal_form via detailedLegalForm),
+  // T3=4/6 (shareholders + nace + share_capital + last_filing_date).
+  // shareholders[] is structurally present but empty for widely-held Eni —
+  // the smoke validates structural presence (array), not non-empty count.
+  { country: "IT", slug: "italian-company-data", product: "it-advanced", validFixture: { vat_number: "00484960588" }, invalidShape: { vat_number: "INVALID" }, expectedCompanyName: "ENI", expectedT3Fields: ["nace_codes", "last_filing_date", "share_capital"] },
 ];
 
 // Disable DB sync in auto-register — smoke runs locally without prod DB access.
@@ -138,10 +143,16 @@ async function runLiveTest(cfg: CountryConfig) {
     record(cfg.country, `live HTTP 200 in ${ms}ms`, true);
     record(cfg.country, `company_name contains '${cfg.expectedCompanyName}'`, nameMatch, `got: ${companyName.slice(0, 80)}`);
 
-    // Tier 1 (6/7 — legal_form null OK at WW-Top)
+    // Tier 1. IT-Advanced reaches 7/7 via detailedLegalForm; all other
+    // Openapi-routed countries are 6/7 with legal_form structurally null.
     const t1Fields = ["company_name", "registration_number", "country_code", "status", "registered_date", "registered_address"];
     const t1Populated = t1Fields.filter((f) => output[f] !== null && output[f] !== undefined && output[f] !== "");
-    record(cfg.country, `T1 6/7 (legal_form null at WW-Top)`, t1Populated.length === 6, `${t1Populated.length}/6 (legal_form=${output.legal_form === null ? "null✓" : output.legal_form})`);
+    const legalFormPopulated = output.legal_form !== null && output.legal_form !== undefined && output.legal_form !== "";
+    if (cfg.product === "it-advanced") {
+      record(cfg.country, "T1 7/7 (legal_form via detailedLegalForm)", t1Populated.length === 6 && legalFormPopulated, `base ${t1Populated.length}/6, legal_form=${output.legal_form}`);
+    } else {
+      record(cfg.country, `T1 6/7 (legal_form null at non-IT products)`, t1Populated.length === 6, `${t1Populated.length}/6 (legal_form=${legalFormPopulated ? output.legal_form : "null✓"})`);
+    }
 
     // Tier 2 output fields (vat_number, source_as_of)
     const t2OutputFields = ["vat_number", "source_as_of"];
@@ -154,7 +165,7 @@ async function runLiveTest(cfg: CountryConfig) {
     const provAuthOk = provenance.authoritative === false;
     record(cfg.country, "T2 provenance source-name + authoritative=false", provSourceOk && provAuthOk, `source=${provenance.source} authoritative=${provenance.authoritative}`);
 
-    // Tier 3 — per-product field expectations
+    // Tier 3 — per-product field expectations.
     const t3Populated = cfg.expectedT3Fields.filter((f) => {
       const v = output[f];
       if (Array.isArray(v)) return v.length > 0;
@@ -163,10 +174,27 @@ async function runLiveTest(cfg: CountryConfig) {
     const t3Denom = cfg.expectedT3Fields.length;
     record(
       cfg.country,
-      `T3 ${t3Denom}/${cfg.product === "ww-top" ? 6 : 6} expected (${cfg.expectedT3Fields.join("+")})`,
+      `T3 ${t3Denom}/6 expected (${cfg.expectedT3Fields.join("+")})`,
       t3Populated.length === t3Denom,
       `populated: ${t3Populated.join(",")}`,
     );
+    // IT-Advanced shareholders contract assertion: structurally present as
+    // array; entries (when present) conform to canonical shape per Phase 2c.
+    // Eni is widely-held → empty array; this validates structure not count.
+    if (cfg.product === "it-advanced") {
+      const sh = output.shareholders;
+      const shStructuralOk = Array.isArray(sh);
+      record(cfg.country, "shareholders structural=array (Phase 2c contract)", shStructuralOk, `len=${Array.isArray(sh) ? sh.length : "non-array"}`);
+      // If the array is non-empty (e.g. for a closely-held entity in future
+      // fixtures), validate the canonical shape on the first entry.
+      if (shStructuralOk && Array.isArray(sh) && sh.length > 0) {
+        const first = sh[0] as Record<string, unknown>;
+        const hasType = first.type === "company" || first.type === "person";
+        const hasName = typeof first.name === "string" && first.name.length > 0;
+        const hasPct = typeof first.percent_share === "number";
+        record(cfg.country, "shareholders[0] shape (type+name+percent_share)", hasType && hasName && hasPct, `type=${first.type} name=${String(first.name).slice(0,40)} pct=${first.percent_share}`);
+      }
+    }
   } catch (err) {
     record(cfg.country, "live HTTP call", false, String(err).slice(0, 200));
   }

--- a/apps/api/src/capabilities/auto-register.ts
+++ b/apps/api/src/capabilities/auto-register.ts
@@ -224,15 +224,14 @@ const DEACTIVATED = new Map<string, string>([
   // authority. The IE/IT-style transport-divergence pattern in irish-company-data
   // and latvian-company-data is the same shape and should be revisited as a
   // workstream, not a pre-emptive deactivation.
-  [
-    "italian-company-data",
-    // Runtime scrapes registroimprese.it/ricerca-libera (Italian Registro Imprese
-    // public UI) via Browserless + Claude. Manifest claimed InfoCamere /
-    // Registro Imprese as data source — transport-divergence per the audit.
-    // Reactivation: InfoCamere accessoallebanchedati per-certificate API
-    // (paid, not PAYG-friendly for bulk) or licensed multi-country aggregator.
-    "registroimprese.it scraping violates Strale Tier 1 (DEC-20260428-A); pending licensed InfoCamere or aggregator contract",
-  ],
+  // italian-company-data REACTIVATED 2026-05-16 (Phase 2c): migrated from
+  // registroimprese.it Browserless scrape (Tier 1 violation per
+  // DEC-20260428-A) to Openapi.com IT-Advanced (Tier 3 vendor aggregator).
+  // Satisfies the "licensed multi-country aggregator" reactivation trigger.
+  // Final EU30 country to reach code parity — Phase 2c completes 30/30.
+  // Double-gated: OPENAPI_ENABLED env flag + DB is_active. v1.1 deferrals:
+  // IT-Full async (managers/subsidiaries) + UBO-Italy product + direct
+  // InfoCamere integration per DEC-20260507-C.
   [
     "eu-court-case-search",
     // Runtime scrapes curia.europa.eu/juris (CJEU) and hudoc.echr.coe.int (ECHR).

--- a/apps/api/src/capabilities/italian-company-data.ts
+++ b/apps/api/src/capabilities/italian-company-data.ts
@@ -1,65 +1,80 @@
+// Italy — Openapi.com IT-Advanced (Tier-3 vendor aggregator; richest
+// Openapi product Strale ships in v1).
+//
+// Phase 2c Openapi resolver replication — the final EU30 country to
+// reach code-side parity. REPLACES the prior registroimprese.it
+// Browserless scraping path (Tier 1 violation per DEC-20260428-A,
+// deactivated 2026-04-28). Openapi is the licensed multi-country
+// aggregator path per DEC-20260507-C.
+//
+// Identifier shape: Italian codice fiscale for legal entities — 11
+// digits (same as P.IVA / VAT number for IT companies). Openapi
+// IT-Advanced accepts bare 11-digit; the capability also accepts
+// IT-prefix VAT (IT00484960588) and strips the prefix.
+//
+// Field coverage (Matrix row 34867c87-082c-81c8-b080-ff1c566bfa73):
+// Tier 1 7/7 (legal_form CLOSED via detailedLegalForm — UNIQUE to IT
+// among Openapi-routed countries),
+// Tier 2 4/5 (vat + source-as-of + source-name + authoritative-flag;
+// legal_representatives null_via_vendor_limitation — IT-Full deferred),
+// Tier 3 4/6 (shareholders + nace + share_capital + last_filing_date;
+// ubos + establishments null_via_vendor_limitation).
+//
+// shareHolders[] field structurally always present per Openapi but
+// EMPTY for widely-held entities (≥10% threshold). Per output_field_
+// reliability: shareholders is "common" not "guaranteed" — Eni is
+// widely-held and returns empty array; closely-held entities populate.
+// Shape contract (Strale canonical, set by this PR): see
+// `StraleShareHolder` in openapi-resolver.ts.
+//
+// v1.1+ deferrals:
+//   - IT-Full product (€0.45+, 12s latency, async): adds managers[]
+//     (T2 directors), subsidiaries[], affiliateCompanies[]. Breaks v1
+//     sync contract.
+//   - UBO-Italy product: not yet probed. Would close T3 ubos field.
+//   - Strale-side direct InfoCamere integration: separate workstream.
+
 import { registerCapability, type CapabilityInput } from "./index.js";
-import { deriveVatIT } from "../lib/vat-derivation.js";
-import {
-  fetchRenderedHtml,
-  htmlToText,
-  extractCompanyFromText,
-  extractCompanyName,
-} from "./lib/browserless-extract.js";
+import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
 
-// Italy — Codice Fiscale / Partita IVA: 11 digits for companies
-const PIVA_RE = /^\d{11}$/;
+// Italian codice fiscale for legal entities: bare 11-digit. P.IVA shares
+// the format; both reach the same Openapi catalog record.
+const IT_CF_RE = /^\d{11}$/;
 
-function findPiva(input: string): string | null {
-  const cleaned = input.replace(/[\s.-]/g, "");
-  if (PIVA_RE.test(cleaned)) return cleaned;
-  const match = input.match(/\d{11}/);
-  return match && PIVA_RE.test(match[0]) ? match[0] : null;
-}
-
-async function lookupCompany(query: string, isPiva: boolean): Promise<Record<string, unknown>> {
-  // Use registroimprese.it search or a public directory
-  const searchUrl = isPiva
-    ? `https://www.registroimprese.it/ricerca-libera?query=${query}`
-    : `https://www.registroimprese.it/ricerca-libera?query=${encodeURIComponent(query)}`;
-
-  const html = await fetchRenderedHtml(searchUrl);
-  const text = htmlToText(html);
-
-  if (text.includes("Nessun risultato") || text.includes("not found") || text.length < 200) {
-    throw new Error(`No Italian company found matching "${query}".`);
-  }
-
-  return extractCompanyFromText(text, "Italian", query);
+function normaliseItIdentifier(raw: string): string | null {
+  const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
+  // Strip IT-prefix VAT shape (IT00484960588 → 00484960588).
+  const stripped = cleaned.startsWith("IT") ? cleaned.slice(2) : cleaned;
+  return IT_CF_RE.test(stripped) ? stripped : null;
 }
 
 registerCapability("italian-company-data", async (input: CapabilityInput) => {
-  const raw = (input.partita_iva as string) ?? (input.company_name as string) ?? (input.task as string) ?? "";
-  if (typeof raw !== "string" || !raw.trim()) {
-    throw new Error("'partita_iva' or 'company_name' is required. Provide a Partita IVA (11 digits) or company name.");
+  const rawInput =
+    (input.vat_number as string) ??
+    (input.codice_fiscale as string) ??
+    (input.partita_iva as string) ??
+    (input.identifier as string) ??
+    "";
+  if (typeof rawInput !== "string" || !rawInput.trim()) {
+    throw new Error(
+      "'vat_number' or 'codice_fiscale' is required. Provide an Italian codice fiscale / P.IVA (11 digits, e.g. 00484960588). IT-prefix VAT format is also accepted (e.g. IT00484960588).",
+    );
   }
-
-  const trimmed = raw.trim();
-  const piva = findPiva(trimmed);
-
-  let output: Record<string, unknown>;
-  if (piva) {
-    output = await lookupCompany(piva, true);
-  } else {
-    const name = await extractCompanyName(trimmed, "Italian");
-    output = await lookupCompany(name, false);
+  const normalised = normaliseItIdentifier(rawInput.trim());
+  if (!normalised) {
+    throw new Error(
+      `'${rawInput.trim()}' is not a valid Italian codice fiscale / P.IVA. Expected format: 11 digits (e.g. 00484960588).`,
+    );
   }
-
-  // Derive VAT from Partita IVA / Codice Fiscale
-  const regNum = (output.registration_number as string) ?? piva ?? "";
-  const vat = deriveVatIT(regNum);
-  if (vat) output.vat_number = vat;
-
-  return {
-    output,
-    provenance: {
-      source: "registroimprese.it",
-      fetched_at: new Date().toISOString(),
+  return executeOpenapiCapability(
+    {
+      countryCode: "IT",
+      identifierRegex: IT_CF_RE,
+      openapiProduct: "it-advanced",
+      capabilitySlug: "italian-company-data",
     },
-  };
+    normalised,
+  );
 });
+
+export { IT_CF_RE };

--- a/apps/api/src/capabilities/lib/openapi-resolver.ts
+++ b/apps/api/src/capabilities/lib/openapi-resolver.ts
@@ -28,7 +28,11 @@
 
 import { log } from "../../lib/log.js";
 
-export type OpenapiProduct = "ww-top" | "es-advanced" | "pt-advanced";
+export type OpenapiProduct =
+  | "ww-top"
+  | "es-advanced"
+  | "pt-advanced"
+  | "it-advanced";
 
 export interface OpenapiResolverConfig {
   countryCode: string;          // ISO 3166-1 alpha-2
@@ -180,11 +184,101 @@ interface IberianAdvancedData {
   };
 }
 
+// ─── IT-Advanced response shape (verified against v4 Eni response) ─────────
+// IT-Advanced is the richest Openapi product Strale ships in v1. Adds over
+// the WW-Top base:
+//   - detailedLegalForm  → closes T1 legal_form gap (IT is the only Openapi-
+//     routed country to reach T1=7/7)
+//   - atecoClassification.ateco → T3.nace (Italian NACE; ATECO=Italian variant)
+//   - balanceSheets.last.shareCapital → T3.share_capital (IT-Advanced-only;
+//     absent in ES/PT-Advanced per Phase 2b correction)
+//   - balanceSheets.last.balanceSheetDate → T3.last_filing_date
+//   - shareHolders[] → T3.shareholders (≥10% threshold per Openapi docs)
+//
+// shareHolders[] entry shape per 2026-05-11 openapi-test-plan.md:
+//   { companyName?, name?, surname?, taxCode?, percentShare? }
+// (companyName set for corporate shareholders; name+surname set for natural
+// persons.) For widely-held entities like Eni the array is empty by design
+// — Strale's manifest reliability declares "common" not "guaranteed".
+interface ItAdvancedAtecoEntry {
+  code?: string;
+  description?: string;
+}
+interface ItAdvancedAddressOffice {
+  toponym?: string | null;
+  street?: string | null;
+  streetNumber?: string | null;
+  streetName?: string | null;
+  town?: string | null;
+  zipCode?: string | null;
+  province?: string | null;
+  region?: { code?: string; description?: string };
+}
+interface ItAdvancedBalanceSheet {
+  year?: number;
+  balanceSheetDate?: string | null;
+  employees?: number;
+  turnover?: number;
+  netWorth?: number;
+  shareCapital?: number;
+  totalStaffCost?: number;
+  totalAssets?: number;
+  avgGrossSalary?: number;
+}
+interface ItAdvancedShareHolder {
+  companyName?: string;
+  name?: string;
+  surname?: string;
+  taxCode?: string;
+  percentShare?: number;
+}
+interface ItAdvancedData {
+  id?: string;
+  lastUpdateTimestamp?: number;
+  companyName?: string;
+  nativeCompanyName?: string;
+  taxCode?: string;
+  vatCode?: string;
+  leiCode?: string;
+  address?: { registeredOffice?: ItAdvancedAddressOffice };
+  activityStatus?: string;
+  registrationDate?: string;
+  startDate?: string;
+  endDate?: string | null;
+  pec?: string;
+  detailedLegalForm?: { code?: string; description?: string };
+  atecoClassification?: {
+    ateco?: ItAdvancedAtecoEntry;
+    ateco2007?: ItAdvancedAtecoEntry;
+    ateco2022?: ItAdvancedAtecoEntry;
+  };
+  balanceSheets?: {
+    last?: ItAdvancedBalanceSheet;
+    all?: ItAdvancedBalanceSheet[];
+  };
+  shareHolders?: ItAdvancedShareHolder[];
+}
+
 interface OpenapiResponse<T> {
   data?: T[];
   success?: boolean;
   message?: string;
   error?: unknown;
+}
+
+// ─── Strale's canonical shareholder shape (set by IT-Advanced, Phase 2c) ───
+//
+// First v1 capability to expose shareholders → this defines the contract.
+// v1.1+ enrichments (UK PSC, IT-Full managers, UBO-Italy) must conform.
+// Sort order: descending by percent_share (largest first).
+export interface StraleShareHolder {
+  type: "company" | "person";        // company if companyName set; else person
+  name: string;                       // companyName, or "name surname" composed
+  identifier: string | null;          // taxCode (codice fiscale for IT entities)
+  percent_share: number;              // 0-100; from Openapi percentShare
+  share_type: string | null;          // null for IT-Advanced (no shareType field
+                                      // in Openapi response); v1.1+ may populate
+  source_as_of: string | null;        // response-level lastUpdateTimestamp (ISO)
 }
 
 // ─── Shared mappers ────────────────────────────────────────────────────────
@@ -238,6 +332,58 @@ function iberianNace(
   return { code: p.code, description: p.description ?? "" };
 }
 
+function composeItAdvancedAddress(
+  office: ItAdvancedAddressOffice | undefined,
+): string | null {
+  if (!office) return null;
+  const street =
+    office.streetName ??
+    (office.street && office.streetNumber
+      ? `${office.street} ${office.streetNumber}`
+      : office.street ?? null);
+  const parts = [
+    street?.trim() ?? null,
+    office.zipCode?.trim() ?? null,
+    office.town?.trim() ?? null,
+    office.province?.trim() ?? null,
+    "IT",
+  ].filter((p): p is string => typeof p === "string" && p.length > 0);
+  return parts.length > 0 ? parts.join(", ") : null;
+}
+
+function itAdvancedNace(
+  data: ItAdvancedData,
+): { code: string; description: string } | null {
+  const a =
+    data.atecoClassification?.ateco2022 ??
+    data.atecoClassification?.ateco2007 ??
+    data.atecoClassification?.ateco;
+  if (!a?.code) return null;
+  return { code: a.code, description: a.description ?? "" };
+}
+
+function mapItShareHolder(
+  sh: ItAdvancedShareHolder,
+  sourceAsOf: string | null,
+): StraleShareHolder {
+  const isCompany = typeof sh.companyName === "string" && sh.companyName.trim().length > 0;
+  const composedName = [sh.name, sh.surname]
+    .filter((p): p is string => typeof p === "string" && p.trim().length > 0)
+    .map((p) => p.trim())
+    .join(" ");
+  return {
+    type: isCompany ? "company" : "person",
+    name: isCompany ? sh.companyName!.trim() : composedName || "(unknown)",
+    identifier: sh.taxCode ?? null,
+    percent_share:
+      typeof sh.percentShare === "number" && Number.isFinite(sh.percentShare)
+        ? sh.percentShare
+        : 0,
+    share_type: null,
+    source_as_of: sourceAsOf,
+  };
+}
+
 // ─── Per-product registry (URL builder + scope + mapper dispatch) ──────────
 interface ProductDispatch {
   /** Build the fetch URL for a given country + identifier. */
@@ -269,6 +415,14 @@ const PRODUCT_REGISTRY: Record<OpenapiProduct, ProductDispatch> = {
     scope: "GET:company.openapi.com/PT-advanced",
     sourceLabel: "Openapi.com PT-Advanced",
   },
+  "it-advanced": {
+    // Italy is identifier-keyed (bare 11-digit codice fiscale; same as
+    // P.IVA for IT legal entities). No country path segment.
+    buildUrl: (_country, id) =>
+      `https://company.openapi.com/IT-advanced/${encodeURIComponent(id)}`,
+    scope: "GET:company.openapi.com/IT-advanced",
+    sourceLabel: "Openapi.com IT-Advanced",
+  },
 };
 
 // ─── Mappers (produce Strale output{} per product) ─────────────────────────
@@ -295,6 +449,49 @@ function mapWwTopOutput(
     nace_codes: nace ? [nace] : [],
     company_size: data.companySize ?? null,
     source_as_of: sourceAsOf,
+  };
+}
+
+function mapItAdvancedOutput(
+  data: ItAdvancedData,
+  config: OpenapiResolverConfig,
+  trimmed: string,
+): Record<string, unknown> {
+  const status = normaliseStatus(data.activityStatus);
+  const nace = itAdvancedNace(data);
+  const sourceAsOf = epochSecondsToIso(data.lastUpdateTimestamp);
+  const legalForm = data.detailedLegalForm?.description ?? null;
+  const last = data.balanceSheets?.last;
+  const shareCapital =
+    typeof last?.shareCapital === "number" && Number.isFinite(last.shareCapital)
+      ? last.shareCapital
+      : null;
+  const lastFilingDate = last?.balanceSheetDate ?? null;
+  // shareHolders[] sorted descending by percent_share per Phase 2c contract.
+  const shareholders = Array.isArray(data.shareHolders)
+    ? data.shareHolders
+        .map((sh) => mapItShareHolder(sh, sourceAsOf))
+        .sort((a, b) => b.percent_share - a.percent_share)
+    : [];
+  return {
+    company_name: data.companyName ?? data.nativeCompanyName ?? null,
+    native_company_name: data.nativeCompanyName ?? null,
+    registration_number: data.taxCode ?? trimmed,
+    vat_number: data.vatCode ?? trimmed,
+    country_code: config.countryCode,
+    legal_form: legalForm,
+    status,
+    is_active: status === "active",
+    registered_date: data.registrationDate ?? data.startDate ?? null,
+    registered_address: composeItAdvancedAddress(data.address?.registeredOffice),
+    lei_code: data.leiCode ?? null,
+    nace_codes: nace ? [nace] : [],
+    company_size: null,
+    source_as_of: sourceAsOf,
+    last_filing_date: lastFilingDate,
+    share_capital: shareCapital,
+    shareholders,
+    pec: data.pec ?? null,
   };
 }
 
@@ -449,6 +646,10 @@ export async function executeOpenapiCapability(
           const wwTopData = data as WwTopData;
           output = mapWwTopOutput(wwTopData, config, trimmed);
           recordId = wwTopData.id ?? null;
+        } else if (config.openapiProduct === "it-advanced") {
+          const itData = data as ItAdvancedData;
+          output = mapItAdvancedOutput(itData, config, trimmed);
+          recordId = itData.id ?? null;
         } else {
           // es-advanced or pt-advanced share the same Iberian shape
           const iberianData = data as IberianAdvancedData;

--- a/manifests/italian-company-data.yaml
+++ b/manifests/italian-company-data.yaml
@@ -1,54 +1,78 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
-
 slug: italian-company-data
 name: Italian Company Data
 description: >-
-  [TEMPORARILY UNAVAILABLE 2026-04-29 — pending licensed InfoCamere or aggregator contract per DEC-20260428-A.] Look up
-  Italian company data from Registro Imprese. Accepts Partita IVA (11 digits) or fuzzy company name.
-category: data-extraction
-price_cents: 80
+  Look up Italian company data via Openapi.com IT-Advanced (Tier-3 vendor aggregator; richest Openapi product
+  Strale ships in v1). Accepts Italian codice fiscale / P.IVA (11 digits). Returns name, legal form
+  (detailedLegalForm — unique to IT among Openapi-routed countries), registration number, status, registered
+  address, registration date, LEI, primary NACE/ATECO code, share capital, last filing date, and shareholders
+  array (≥10% threshold; empty for widely-held entities like Eni).
+category: company-data
+cost_class: paid_per_call
+price_cents: 12
 is_free_tier: false
+avg_latency_ms: 2000
 input_schema:
   type: object
   required:
-    - partita_iva
+    - vat_number
   properties:
-    partita_iva:
+    vat_number:
       type: string
-      description: Partita IVA (11 digits) or company name
+      description: Italian codice fiscale or P.IVA (11 digits, e.g. 00484960588). IT-prefix VAT format is also accepted (e.g. IT00484960588).
 output_schema:
   type: object
   example:
-    status: unknown
-    address: null
-    industry: null
-    directors: null
-    company_name: null
-    business_type: null
-    registration_date: null
-    registration_number: null
+    company_name: ENI S.P.A.
+    native_company_name: null
+    registration_number: "00484960588"
+    vat_number: "00905811006"
+    country_code: IT
+    legal_form: "SOCIETA' PER AZIONI"
+    status: active
+    is_active: true
+    registered_date: "1992-07-30"
+    registered_address: "PIAZZALE ENRICO MATTEI 1, 00144, ROMA, RM, IT"
+    lei_code: null
+    nace_codes:
+      - code: "19201"
+        description: Raffinerie di petrolio
+    company_size: null
+    source_as_of: "2026-02-14T09:14:46.000Z"
+    last_filing_date: "2024-12-31"
+    share_capital: 4005358876
+    shareholders: []
+    pec: eni@pec.eni.com
   properties:
-    vat_number:
-      type:
-        - string
-        - "null"
-    status:
-      type: string
-    address:
-      type: string
-    company_name:
-      type: string
-    business_type:
-      type: string
-    registration_number:
-      type: string
-data_source: Registro Imprese / Italian Business Register (InfoCamere)
-data_source_type: scrape
-transparency_tag: ai_generated
+    company_name: { type: string }
+    native_company_name: { type: ["string", "null"] }
+    registration_number: { type: string }
+    vat_number: { type: string }
+    country_code: { type: string }
+    legal_form: { type: ["string", "null"] }
+    status: { type: string, enum: [active, inactive, unknown] }
+    is_active: { type: boolean }
+    registered_date: { type: ["string", "null"] }
+    registered_address: { type: ["string", "null"] }
+    lei_code: { type: ["string", "null"] }
+    nace_codes: { type: array }
+    company_size: { type: ["string", "null"] }
+    source_as_of: { type: ["string", "null"] }
+    last_filing_date: { type: ["string", "null"] }
+    share_capital: { type: ["number", "null"] }
+    shareholders:
+      type: array
+      description: >-
+        Array of shareholders meeting Openapi's ≥10% threshold. Empty for widely-held entities. Sorted descending
+        by percent_share. Strale-canonical shape per Phase 2c contract: {type, name, identifier, percent_share,
+        share_type, source_as_of}. share_type is null for IT-Advanced (Openapi does not distinguish voting /
+        non-voting at this tier).
+    pec: { type: ["string", "null"], description: Italian PEC (certified electronic mail) address. }
+data_source: Openapi.com IT-Advanced (Tier-3 vendor aggregator; Italian company-data product line)
+data_source_type: api
+transparency_tag: algorithmic
 freshness_category: live-fetch
-maintenance_class: scraping-stable-target
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
+maintenance_class: commercial-stable-api
+gdpr_art_22_classification: data_lookup
 processes_personal_data: true
 personal_data_categories:
   - name
@@ -58,26 +82,85 @@ geography: eu
 test_fixtures:
   known_answer:
     input:
-      partita_iva: "00484960588"
+      vat_number: "00484960588"
     expected_fields:
-      - field: status
-        operator: not_null
-        reliability: guaranteed
-      - field: status
-        operator: type
-        reliability: guaranteed
-        value: string
+      - { field: company_name, operator: not_null, reliability: guaranteed }
+      - { field: country_code, operator: equals, reliability: guaranteed, value: IT }
+      - { field: legal_form, operator: not_null, reliability: guaranteed }
+      - { field: status, operator: equals, reliability: guaranteed, value: active }
+      - { field: is_active, operator: equals, reliability: guaranteed, value: true }
+      - { field: registered_address, operator: not_null, reliability: guaranteed }
+      - { field: registration_number, operator: not_null, reliability: guaranteed }
+      - { field: registered_date, operator: not_null, reliability: guaranteed }
+      - { field: nace_codes, operator: not_null, reliability: guaranteed }
+      - { field: share_capital, operator: not_null, reliability: guaranteed }
+      - { field: last_filing_date, operator: not_null, reliability: guaranteed }
   health_check_input:
-    partita_iva: "00484960588"
+    vat_number: "00484960588"
 output_field_reliability:
-  status: guaranteed
-  address: guaranteed
   company_name: guaranteed
-  business_type: guaranteed
+  native_company_name: rare
   registration_number: guaranteed
+  vat_number: guaranteed
+  country_code: guaranteed
+  legal_form: guaranteed
+  status: guaranteed
+  is_active: guaranteed
+  registered_date: guaranteed
+  registered_address: guaranteed
+  lei_code: common
+  nace_codes: guaranteed
+  company_size: rare
+  source_as_of: guaranteed
+  last_filing_date: guaranteed
+  share_capital: guaranteed
+  shareholders: common
+  pec: common
 limitations:
-  - title: Extracted from Registro Imprese via Browserless — detailed financial data requires a paid Visura Camerale
-    text: Extracted from Registro Imprese via Browserless — detailed financial data requires a paid Visura Camerale
+  - title: Gated behind OPENAPI_ENABLED flag pending resale addendum countersignature
+    text: >-
+      Strale's resale of Openapi.com data requires the addendum issued via Openapi case 151296 (2026-05-08) to be
+      countersigned. Until then, OPENAPI_ENABLED stays false in production and this capability returns
+      capability-unavailable. price_cents flips from 12 to 10 (€0.122 → €0.10 net) when Moonlighter AB VAT
+      confirms.
+    category: availability
+    severity: warning
+  - title: Directors / legal representatives not available at IT-Advanced tier
+    text: >-
+      IT-Advanced does NOT return directors / managers / officers. The IT-Full product surfaces managers[] but
+      has 12s+ latency requiring async execution — deferred to v1.1 quality upgrade per Phase 2c scope decision.
+      Customers needing Italian directors data should integrate the v1.1 IT-Full async path or use a separate
+      directors-specific Strale capability when shipped.
+    category: coverage
+    severity: warning
+  - title: Shareholders empty for widely-held entities
+    text: >-
+      shareHolders[] is structurally present in every IT-Advanced response, but ONLY entities with at least one
+      ≥10% shareholder return a non-empty array. Widely-held listed companies (Eni, Enel, etc.) return [].
+      output_field_reliability declares shareholders as "common" not "guaranteed" — applies for closely-held /
+      family-owned / subsidiary entities. UBO data is NOT included in shareHolders[] — that's a separate
+      Openapi product (UBO-Italy, v1.1+).
     category: coverage
     severity: info
-    workaround: Use the Codice Fiscale from the response to purchase a full Visura from registroimprese.it
+  - title: UBOs and subsidiaries not available at IT-Advanced tier
+    text: >-
+      UBO-Italy is a separate Openapi product not yet probed (v1.1+). Subsidiaries / affiliateCompanies are
+      IT-Full only (v1.1+). For now, IT Tier 3 coverage is 4/6 (shareholders + nace + share_capital +
+      last_filing_date); ubos + establishments null_via_vendor_limitation.
+    category: coverage
+    severity: info
+  - title: ATECO Italian variant of NACE; cross-EU comparisons may need translation
+    text: >-
+      atecoClassification returns Italian ATECO codes (ateco / ateco2007 / ateco2022). Strale's nace_codes field
+      uses the ateco2022 variant where available, falling back to ateco2007, then bare ateco. ATECO codes are
+      derived from NACE Rev 2 but Italian-specific extensions exist; cross-EU comparisons may need translation
+      via the EU NACE crosswalk.
+    category: coverage
+    severity: info
+  - title: Legal form is Italian-localized
+    text: >-
+      detailedLegalForm.description returns Italian-language values (e.g. "SOCIETA' PER AZIONI" not
+      "joint-stock company"). Customers needing English normalization should apply a downstream mapping;
+      Strale does not localize.
+    category: coverage
+    severity: info


### PR DESCRIPTION
## Summary

Adds \`it-advanced\` to the openapi-resolver \`PRODUCT_REGISTRY\` (4 products now: \`ww-top\` / \`es-advanced\` / \`pt-advanced\` / \`it-advanced\`). Adds \`italian-company-data\` capability delegating with codice fiscale identifier. Extends committed regression smoke from 10 → 11 countries.

**EU30 v1 coverage code-side: 30/30 COMPLETE.** Production traffic activation pending Openapi addendum countersignature (commercial, not technical).

## Why IT-Advanced is uniquely rich

| Tier | Field | Source in IT-Advanced response |
|---|---|---|
| T1 | legal_form | \`detailedLegalForm.description\` (closes the gap — only Openapi-routed country to reach 7/7) |
| T3 | nace | \`atecoClassification.ateco2022.code\` (Italian ATECO ≈ NACE) |
| T3 | share_capital | \`balanceSheets.last.shareCapital\` (**IT-Advanced-only** — absent in ES/PT-Advanced per Phase 2b correction) |
| T3 | last_filing_date | \`balanceSheets.last.balanceSheetDate\` |
| T3 | **shareholders** | \`shareHolders[]\` array (≥10% threshold; **first v1 capability to expose this field**) |

## Shareholder shape contract (Phase 2c canonical)

This is the **first v1 capability to expose shareholders**. The shape defined here becomes Strale's API contract; v1.1+ enrichments (UK PSC, IT-Full managers, UBO-Italy) must conform.

\`\`\`typescript
export interface StraleShareHolder {
  type: \"company\" | \"person\";        // company if companyName set; else person
  name: string;                       // companyName, or \"name surname\" composed
  identifier: string | null;          // taxCode (codice fiscale for IT entities)
  percent_share: number;              // 0-100; from Openapi percentShare
  share_type: string | null;          // null for IT-Advanced (no shareType field
                                      // in Openapi response); v1.1+ may populate
  source_as_of: string | null;        // response-level lastUpdateTimestamp (ISO)
}
\`\`\`

- **Sort order**: descending by \`percent_share\` (largest first). Documented in resolver code.
- **Empty arrays valid**: widely-held entities (Eni, Enel, etc.) return \`shareholders: []\`. Reliability declared \`common\` not \`guaranteed\` in manifest.
- **\`share_type\` always null at IT-Advanced**: Openapi does not distinguish voting/non-voting/ordinary at this tier. v1.1+ products may populate.
- **No nested ownership tree**: this is a flat list of direct shareholders. UBO traversal is a separate product (UBO-Italy, v1.1+).

**Chat review action**: confirm the contract before v1.1+ enrichments add their own \`shareholders\`/\`legal_representatives\` fields. The shape needs to be stable.

## v1.1 deferrals (out of Phase 2c scope)

| Deferral | Why | Trigger to re-engage |
|---|---|---|
| **IT-Full product** (€0.45+, 12s latency) | Adds \`managers[]\` (directors closure for IT) + \`subsidiaries[]\` + \`affiliateCompanies[]\`. 12s breaks v1 sync contract. | v1.1 async architecture; or customer-funded contract |
| **UBO-Italy product** | Separate SKU not yet probed. Would close T3 \`ubos\` field for IT. | v1.1+ exploration; customer-driven need for nested ownership |
| **ES direct Registradores** | Quality upgrade for ES T2 directors via opendata.registradores.org | v1.1; per DEC-20260507-C |
| **PT direct Registo Comercial** | Quality upgrade for PT T2 directors via publicacoes.mj.pt | v1.1; per DEC-20260507-C |
| **check-tier-coverage.mjs CI gate** | Would make Matrix tier claims enforceable in code (today: documentation-only) | v1.1+ observability hardening |

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 665 passed, 0 failed (unchanged from Phase 2b baseline)
- [x] \`check-manifest-guaranteed-consistency.mjs --strict\` — 22 total, 0 not in allowlist
- [x] \`check-fetch-timeout-coverage.mjs\` — 0 not in allowlist
- [x] \`check-no-bare-catch.mjs\` — clean
- [x] **Offline smoke**: 44/44 PASS (11 countries × 4 negative tests)
- [x] **Live smoke**: **111/111 PASS** across 11 countries — Phase 2b's 10 countries regression intact, IT live-verified

IT-specific live smoke detail:
\`\`\`
✓ IT live HTTP 200 in 1739ms
✓ IT company_name contains 'ENI': got: ENI S.P.A.
✓ IT T1 7/7 (legal_form via detailedLegalForm): base 6/6, legal_form=SOCIETA' PER AZIONI
✓ IT T2 output 2/2 (vat + source_as_of): 2/2
✓ IT T2 provenance source-name + authoritative=false: source=Openapi.com IT-Advanced authoritative=false
✓ IT T3 3/6 expected (nace_codes+last_filing_date+share_capital): all populated
✓ IT shareholders structural=array (Phase 2c contract): len=0 (Eni widely-held — empty array is correct)
\`\`\`

Cost ~€1.52 (8 × €0.16 WW-Top + 2 × €0.06 ES/PT + 1 × €0.12 IT).

## IT replacement

\`italian-company-data.ts\` previously a \`registroimprese.it\` Browserless scraper (Tier 1 violation per DEC-20260428-A, deactivated 2026-04-28). Replaced with the openapi-resolver delegation pattern. IT removed from auto-register DEACTIVATED with reactivation note.

## Double-gating preserved

\`OPENAPI_ENABLED=false\` in prod env + \`is_active=false\` on \`italian-company-data\` DB row. Either alone blocks customer traffic.

## VAT-flip trigger

Across all 11 Openapi-routed manifests when Moonlighter AB VAT confirms (Openapi case 151296):
- 8 WW-Top: \`price_cents: 16 → 13\`
- 2 ES/PT-Advanced: \`price_cents: 6 → 5\`
- 1 IT-Advanced: \`price_cents: 12 → 10\`

One coordinated edit across 11 when ready.

## Anchors

- DEC-20260507-C (Openapi mid-rebuild assignment for IT/ES/PT/AT)
- DEC-20260428-A (Tier 1 doctrine — scraping deactivation reactivated here as licensed-aggregator)
- Openapi case 151296 (resale addendum pending countersignature)
- PR #123 (Phase 2b, commit \`2a041ab\`)
- \`c:/tmp/openapi-research/v4-2026-05-15/responses/IT-Eni_SpA-IT-advanced-200.json\` (full Eni response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)