### PR TITLE
fix: declare 4 undeclared fields in CH + UK manifests (post check-tier-coverage gate)

### DIFF
--- a/apps/api/scripts/tier-coverage-allowlist.txt
+++ b/apps/api/scripts/tier-coverage-allowlist.txt
@@ -20,6 +20,4 @@ japanese-company-data
 norwegian-company-data
 polish-company-data
 swedish-company-data
-swiss-company-data
-uk-company-data
 us-company-data

--- a/manifests/swiss-company-data.yaml
+++ b/manifests/swiss-company-data.yaml
@@ -48,6 +48,8 @@ output_schema:
       type: integer
     legal_form:
       type: string
+    legal_form_id:
+      type: integer
     status:
       type: string
     canton:
@@ -105,6 +107,7 @@ output_field_reliability:
   ehraid: guaranteed
   ch_id: common
   legal_form: guaranteed
+  legal_form_id: guaranteed
   status: guaranteed
   canton: common
   municipality: common

--- a/manifests/uk-company-data.yaml
+++ b/manifests/uk-company-data.yaml
@@ -46,6 +46,16 @@ output_schema:
       type: string
     incorporation_date:
       type: string
+    jurisdiction:
+      type:
+        - string
+        - "null"
+    sic_codes:
+      type: array
+      items:
+        type: string
+    has_charges:
+      type: boolean
 data_source: Companies House (UK Government)
 data_source_type: api
 transparency_tag: ai_generated
@@ -100,6 +110,9 @@ output_field_reliability:
   business_type: guaranteed
   company_number: guaranteed
   incorporation_date: guaranteed
+  jurisdiction: guaranteed
+  sic_codes: common
+  has_charges: guaranteed
 limitations:
   - title: Companies House API includes LLPs but sole traders and unregistered partnerships are not covered
     text: >-


### PR DESCRIPTION
## Summary

- Post-PR #125 follow-up: closes 4 manifest-drift candidates the new tier-coverage gate surfaced. Additive declarations only, no handler edits, no existing-field tier changes.
- CH gains `legal_form_id`; UK gains `jurisdiction`, `sic_codes`, `has_charges`.
- Tier-coverage allowlist trimmed 10 → 8 (both swiss + uk drop to zero findings post-fix).
- Gate WARN baseline: 12 → 9 findings (3 cleared; prompt anticipated 4 due to a per-slug grouping detail in the gate output format).

## Tier + type rationale (empirical)

| Field | Tier | Type | Why |
|---|---|---|---|
| `swiss-company-data.legal_form_id` | guaranteed | integer | Parallel to existing `legal_form: guaranteed`; Zefix structurally requires legal form; fixture: `3` |
| `uk-company-data.jurisdiction` | guaranteed | string\|null | Handler is `c.jurisdiction \|\| null` but Companies House always populates; fixture: `"england-wales"` |
| `uk-company-data.sic_codes` | common | array of string | Handler is `c.sic_codes \|\| []`; empty array for dormant entities → `common` not `guaranteed` (gate treats `[]` as not-populated) |
| `uk-company-data.has_charges` | guaranteed | boolean | Always-boolean per Companies House schema; gate counts booleans as populated; fixture: `false` |

## Verification

- `node apps/api/scripts/check-tier-coverage.mjs`: 33 fixtures, 9 findings (was 12), 0 not in allowlist. Both `swiss-company-data` and `uk-company-data` no longer in findings list.
- `node apps/api/scripts/check-manifest-guaranteed-consistency.mjs --strict`: clean (22 total, 0 not in allowlist — additions didn't introduce new guaranteed-not-in-schema drift)
- `node apps/api/scripts/check-fetch-timeout-coverage.mjs --strict`: clean (no change)
- `node apps/api/scripts/check-no-bare-catch.mjs`: clean
- `npx tsc --noEmit` (apps/api): clean
- `npm --workspace=apps/api test`: 665 passed, 33 skipped (no regression)

## Reviewer findings — clean (no /go invoked; mechanical additive declarations matching the FI 64d8a30 reference pattern)

## Cross-repo

None. No capability categories, endpoints, auth flow, or pricing changed. Customer-facing CH + UK capability docs (OpenAPI/MCP/A2A) refresh on next deploy with the 4 new declared fields. No `llms.txt` update needed.

## Test plan

- [ ] CI passes (gate runs against new manifests, exits 0)
- [ ] Inspect CI log for tier-coverage gate output — confirm `33 with fixtures, 9 findings (0 not in allowlist)` (was 12 findings)
- [ ] Skim diff on `manifests/swiss-company-data.yaml` — confirm only `legal_form_id` added to schema + reliability, no other changes
- [ ] Skim diff on `manifests/uk-company-data.yaml` — confirm only `jurisdiction` + `sic_codes` + `has_charges` added to schema + reliability, no other changes
- [ ] Skim `apps/api/scripts/tier-coverage-allowlist.txt` — confirm `swiss-company-data` and `uk-company-data` removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)