### PR TITLE
Fix coverage-matrix data quality: GR/SK provider names + pep-check products

### DIFF
--- a/apps/api/coverage-matrix/COVERAGE.md
+++ b/apps/api/coverage-matrix/COVERAGE.md
@@ -43,7 +43,7 @@ Total rows: 46
 | spanish-company-data | ES | Company registry | Openapi.com | Committed | €0.06 | live-verified | 2026-05-15 |
 | finnish-company-data | FI | Company registry | PRH | Live | €0.05 | live-verified | 2026-05-15 |
 | french-company-data | FR | Company registry | INSEE | Live | €0.05 | live-verified | 2026-05-15 |
-| greek-company-data | GR | Company registry | Other | Live | €0 | live-verified | 2026-05-15 |
+| greek-company-data | GR | Company registry | GEMI | Live | €0 | live-verified | 2026-05-15 |
 | croatian-company-data | HR | Company registry | Sudreg | Live | €0.05 | live-verified | 2026-05-15 |
 | hungarian-company-data | HU | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
 | irish-company-data | IE | Company registry | CRO | Live | €0.05 | live-verified | 2026-05-15 |
@@ -59,7 +59,7 @@ Total rows: 46
 | romanian-company-data | RO | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
 | swedish-company-data | SE | Company registry | Bolagsverket | Live | €0.05 | live-verified | 2026-05-15 |
 | slovenian-company-data | SI | Company registry | Other | Live | €0.05 | n/a | 2026-05-15 |
-| slovak-company-data | SK | Company registry | Other | Live | €0.05 | live-verified | 2026-05-15 |
+| slovak-company-data | SK | Company registry | RPO | Live | €0.05 | live-verified | 2026-05-15 |
 | uk-company-data | UK | Company registry | Companies House | Live | €0.05 | live-verified | 2026-05-15 |
 | us-company-data-cobalt | US | Company registry | Cobalt Intelligence | Committed | €1 | — | 2026-04-28 |
 
@@ -188,7 +188,7 @@ Total rows: 46
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| greek-company-data | GR | Company registry | Other | Live | €0 | live-verified | 2026-05-15 |
+| greek-company-data | GR | Company registry | GEMI | Live | €0 | live-verified | 2026-05-15 |
 
 ### Global (6)
 
@@ -296,7 +296,7 @@ Total rows: 46
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| slovak-company-data | SK | Company registry | Other | Live | €0.05 | live-verified | 2026-05-15 |
+| slovak-company-data | SK | Company registry | RPO | Live | €0.05 | live-verified | 2026-05-15 |
 
 ### UK (5)
 

--- a/apps/api/coverage-matrix/greek-company-data__gr__company-registry.yaml
+++ b/apps/api/coverage-matrix/greek-company-data__gr__company-registry.yaml
@@ -1,7 +1,7 @@
 capability_slug: greek-company-data
 country: GR
 evidence_type: Company registry
-provider: Other
+provider: GEMI
 status: Live
 sourcing_pattern: Direct API
 per_call_price_eur: 0
@@ -13,7 +13,7 @@ last_verified: "2026-05-15"
 products:
   - Counterparty Assurance
 vendor_roster_url: null
-provider_tos_notes: N/A - no provider integrated
+provider_tos_notes: Direct integration with GEMI Open Data API (opendata-api.businessportal.gr) — Greek Ministry of Development. Requires GEMI_API_KEY. 8 req/min rate limit.
 doctrine_reference: GEMI direct API; HELLENiQ ENERGY parent fixture (296601000 / EL094049864) per DEC-20260513-E
 notes: >-
   2026-05-15 identity audit Batch 4 confirmed GR functional via GEMI (Greek General Commercial

--- a/apps/api/coverage-matrix/pep-check__global__sanctions-pep.yaml
+++ b/apps/api/coverage-matrix/pep-check__global__sanctions-pep.yaml
@@ -10,7 +10,8 @@ tier_1_coverage: null
 tier_2_coverage: null
 tier_3_coverage: null
 last_verified: "2026-05-05"
-products: []
+products:
+  - Counterparty Assurance
 vendor_roster_url: null
 provider_tos_notes: >-
   Reseller-tier SA with embedded-in-bundles use governed by Basic+ pricing tier. Starter informal

--- a/apps/api/coverage-matrix/slovak-company-data__sk__company-registry.yaml
+++ b/apps/api/coverage-matrix/slovak-company-data__sk__company-registry.yaml
@@ -1,7 +1,7 @@
 capability_slug: slovak-company-data
 country: SK
 evidence_type: Company registry
-provider: Other
+provider: RPO
 status: Live
 sourcing_pattern: Direct API
 per_call_price_eur: 0.05
@@ -13,7 +13,7 @@ last_verified: "2026-05-15"
 products:
   - Counterparty Assurance
 vendor_roster_url: null
-provider_tos_notes: N/A - no provider integrated
+provider_tos_notes: Direct integration with Slovak RPO public API (api.statistics.sk/rpo/v1) — ŠÚ SR. EU High-Value Dataset under Reg. (EU) 2023/138. 60 req/min rate limit (shared across Strale egress).
 doctrine_reference: >-
   RPO public API; SK DIČ (VAT) schema gap deferred from PR #120 pending RPO identifiers array shape
   investigation


### PR DESCRIPTION
## Summary

Three reference-data fixes flagged by the 2026-05-17 post-migration verification report (loose threads #4 + #5). All faithful to handler ground truth. No schema/code changes.

| File | Field | Before | After |
|---|---|---|---|
| `greek-company-data__gr__company-registry.yaml` | `provider` | `Other` | `GEMI` |
| `greek-company-data__gr__company-registry.yaml` | `provider_tos_notes` | `N/A - no provider integrated` | factual GEMI direct-integration description |
| `slovak-company-data__sk__company-registry.yaml` | `provider` | `Other` | `RPO` |
| `slovak-company-data__sk__company-registry.yaml` | `provider_tos_notes` | `N/A - no provider integrated` | factual RPO direct-integration description |
| `pep-check__global__sanctions-pep.yaml` | `products` | `[]` | `["Counterparty Assurance"]` |

`sourcing_pattern` was already `Direct API` on both GR and SK rows — no flip needed.

## Handler ground truth

- **GR**: `apps/api/src/capabilities/greek-company-data.ts:1-9` defines `GEMI_BASE_URL = "https://opendata-api.businessportal.gr/api/opendata/v1"`. Confirmed integration with GEMI (Γενικό Εμπορικό Μητρώο / Greek Business Registry).
- **SK**: `apps/api/src/capabilities/slovak-company-data.ts:1-12` defines `RPO_API = "https://api.statistics.sk/rpo/v1"`. Confirmed integration with RPO (Register právnických osôb / Statistical Office of Slovakia). Not ORSR.
- **pep-check**: Split-row artefact from the 2026-05-17 chat-side cleanup that split `sanctions-check, pep-check` into two single-slug rows. Companion `sanctions-check__global__sanctions-pep.yaml` carries `Counterparty Assurance`; `pep-check` should too (functionally identical product membership).

## Verification

- `npm run validate:coverage-matrix` → 0 violations
- `npm run coverage-matrix:check` → clean (round-trip + staleness)
- `git diff --stat` → 4 files (3 YAMLs + regenerated COVERAGE.md), +10/-9
- No code changes outside the matrix

## Reviewer findings

To be filled by `/go` six-lens review pass before self-merge per Rule 16.

## Cross-repo

None.

## Test plan

- [ ] CI workflow `Coverage matrix validation` green on this PR
- [ ] Confirm `git diff apps/api/coverage-matrix/*.yaml` shows only the four field changes (3 provider/products + 2 provider_tos_notes); nothing else
- [ ] Confirm regenerated `COVERAGE.md` shows GEMI/RPO under By-country tables (was "Other")

Governing rule: **Working Rule J / PROTOCOL.md** (`apps/api/coverage-matrix/PROTOCOL.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)