### PR TITLE
Coverage-matrix cleanup: backfill sourcing_pattern + add singapore-company-data + close EMPTY-SLUG-FOLLOWUP

### DIFF
--- a/apps/api/coverage-matrix/COVERAGE.md
+++ b/apps/api/coverage-matrix/COVERAGE.md
@@ -2,11 +2,11 @@
 
 > Auto-generated. Do not edit by hand. Regenerate via `npm run coverage-matrix:summary`.
 
-Total rows: 46
+Total rows: 47
 
 ## By status
 
-- Live: 27
+- Live: 28
 - Committed: 19
 
 ## By evidence type
@@ -27,7 +27,7 @@ Total rows: 46
 | beneficial-ownership-lookup | UK | Beneficial ownership | OpenOwnership | Committed | €0 | — | 2026-04-28 |
 | uk-company-data | UK | Beneficial ownership | PSC register | Live | — | — | 2026-04-20 |
 
-### Company registry (31)
+### Company registry (32)
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -58,6 +58,7 @@ Total rows: 46
 | portuguese-company-data | PT | Company registry | Openapi.com | Committed | €0.06 | live-verified | 2026-05-15 |
 | romanian-company-data | RO | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
 | swedish-company-data | SE | Company registry | Bolagsverket | Live | €0.05 | live-verified | 2026-05-15 |
+| singapore-company-data | SG | Company registry | ACRA | Live | €0 | live-verified | 2026-05-17 |
 | slovenian-company-data | SI | Company registry | Other | Live | €0.05 | n/a | 2026-05-15 |
 | slovak-company-data | SK | Company registry | RPO | Live | €0.05 | live-verified | 2026-05-15 |
 | uk-company-data | UK | Company registry | Companies House | Live | €0.05 | live-verified | 2026-05-15 |
@@ -285,6 +286,12 @@ Total rows: 46
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | swedish-company-data | SE | Company registry | Bolagsverket | Live | €0.05 | live-verified | 2026-05-15 |
+
+### SG (1)
+
+| capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| singapore-company-data | SG | Company registry | ACRA | Live | €0 | live-verified | 2026-05-17 |
 
 ### SI (1)
 

--- a/apps/api/coverage-matrix/EMPTY-SLUG-FOLLOWUP.md
+++ b/apps/api/coverage-matrix/EMPTY-SLUG-FOLLOWUP.md
@@ -1,41 +1,42 @@
-# Empty-slug rows — chat-side follow-up
+# Empty-slug rows — resolution log (closed 2026-05-17)
 
-12 Live/Committed rows in the Notion Provider-Coverage matrix had an empty
-`Capability slug` at v4 migration time (2026-05-17) and were skipped from the
-repo migration. They live here in markdown rather than YAML because they
-don't carry a slug to satisfy the primary key.
+12 rows in the pre-migration Provider-Coverage matrix had an empty `Capability slug` at v4 migration time (2026-05-17) and were skipped from the repo migration. **All 12 have been resolved** as of 2026-05-17 via this PR's resolution pass. No further action required on these rows.
 
-## What this list is for
+This file is retained as an audit record. The original Notion page IDs reference the archived Provider-Coverage matrix database (parent page `34867c87-082c-8187-9391-ebc05a9b3d90`), which is scheduled for trash on ~2026-06-17 per to-do `36367c87-082c-819e-8766-c4775bbc04fe`.
 
-Each row below needs a chat-side decision:
+## Group A — Sources, not capabilities (3 rows, out of matrix scope)
 
-1. **Assign a real slug** — the row corresponds to a built or planned Strale
-   capability that should have a kebab-case slug; pick one (e.g. assign
-   `sg-company-data` to the Singapore ACRA row, since the manifest exists).
-2. **Reclassify Status to In discovery / Gap** — the row is aspirational and
-   shouldn't be in the migration-eligible set.
-3. **Out-of-scope reference** — the row documents a source used inside
-   another capability (e.g. EU Consolidated List feeds `sanctions-check`),
-   not a standalone capability. Could be moved to a separate "Sources" list
-   or annotated with a slug pointing to the consuming capability.
+The following rows documented cross-verification sources used inside the `sanctions-check` capability handler, not standalone capabilities. Removed from matrix scope. If documentation is needed for these verification paths, it belongs inside the `sanctions-check` capability manifest or the AVS narrative — not as YAML rows in the coverage matrix.
 
-To resolve a row, ask in chat: "Update Provider-Coverage matrix row
-`<page_id>` to ...". Chat-side issues a CC-prompt per Working Rule J, CC
-adds the row to repo YAML and removes it from this list.
+| Notion page_id (archived) | Country | Original entry |
+| --- | --- | --- |
+| 34867c87-082c-8107-b47d-cc355eade334 | EU-wide | Sanctions - EU Consolidated List (verification) |
+| 34867c87-082c-814e-bd8a-fda44a758744 | Global | Sanctions - OFAC direct (fallback/verification) |
+| 34867c87-082c-81e4-a264-e3328393fbbf | UK | Sanctions - UK HMT (verification) |
 
-## Rows (12)
+## Group B — Added to repo (1 row)
 
-| page_id | Status | Country | Entry |
-| --- | --- | --- | --- |
-| `35167c87-082c-8188-85ab-fe2e21c51fe5` | Live | SG | Company registry - Singapore - data.gov.sg ACRA (direct API, shipped) |
-| `35067c87-082c-81de-9ecc-ec5f4f968506` | Live | SE | Bolagsverket bankruptcy + SE + Litigation |
-| `34867c87-082c-8169-b2b3-c69aaf4b25a5` | Live | EU-wide | BO - EU partial - OpenOwnership Register |
-| `34867c87-082c-8107-b47d-cc355eade334` | Live | EU-wide | Sanctions - EU Consolidated List (verification) |
-| `34867c87-082c-814e-bd8a-fda44a758744` | Live | Global | Sanctions - OFAC direct (fallback/verification) |
-| `34867c87-082c-81e4-a264-e3328393fbbf` | Live | UK | Sanctions - UK HMT (verification) |
-| `35067c87-082c-812b-9d10-de3ad145f576` | Committed | CH | Zefix SHAB + CH + Litigation |
-| `35067c87-082c-815a-94b5-f238ed8d8c2e` | Committed | AT | Ediktsdatei + AT + Litigation |
-| `35067c87-082c-8169-bef5-ede78180f062` | Committed | US | CourtListener + RECAP + US + Litigation |
-| `35067c87-082c-819e-afb3-c99c80454412` | Committed | UK | UK FCA Final Notices + UK + Litigation |
-| `35067c87-082c-81b1-8d56-d26f986c6291` | Committed | UK | UK Find Case Law + UK + Litigation |
-| `35067c87-082c-8184-be14-e09340009266` | Committed | SK | OpenOwnership + SK + Beneficial ownership |
+| Notion page_id (archived) | Country | Resolution |
+| --- | --- | --- |
+| 35167c87-082c-8188-85ab-fe2e21c51fe5 | SG | Slug `singapore-company-data` assigned. YAML added at `apps/api/coverage-matrix/singapore-company-data__sg__company-registry.yaml`. |
+
+## Group C — Deferred (8 rows)
+
+6 Litigation rows: Litigation evidence type is out of Counterparty Assurance v1 scope; revisit in v1.1+. If/when any becomes in-scope, a new YAML row will be created with the appropriate slug at that time.
+
+2 OpenOwnership BO rows: documented OpenOwnership as a beneficial-ownership data source pattern, not standalone capabilities. Per-country BO data, when needed, flows through the corresponding company-data capability (e.g. `uk-company-data` returns BO from PSC register). Removed from matrix scope; no new slug needed.
+
+| Notion page_id (archived) | Pre-archival status | Country | Original entry | Disposition |
+| --- | --- | --- | --- | --- |
+| 35067c87-082c-81de-9ecc-ec5f4f968506 | Live | SE | Bolagsverket bankruptcy + SE + Litigation | v1.1 deferred (Litigation out of v1 scope) |
+| 35067c87-082c-812b-9d10-de3ad145f576 | Committed | CH | Zefix SHAB + CH + Litigation | v1.1 deferred (Litigation out of v1 scope) |
+| 35067c87-082c-815a-94b5-f238ed8d8c2e | Committed | AT | Ediktsdatei + AT + Litigation | v1.1 deferred (Litigation out of v1 scope) |
+| 35067c87-082c-8169-bef5-ede78180f062 | Committed | US | CourtListener + RECAP + US + Litigation | v1.1 deferred (Litigation out of v1 scope) |
+| 35067c87-082c-819e-afb3-c99c80454412 | Committed | UK | UK FCA Final Notices + UK + Litigation | v1.1 deferred (Litigation out of v1 scope) |
+| 35067c87-082c-81b1-8d56-d26f986c6291 | Committed | UK | UK Find Case Law + UK + Litigation | v1.1 deferred (Litigation out of v1 scope) |
+| 34867c87-082c-8169-b2b3-c69aaf4b25a5 | Live | EU-wide | BO - EU partial - OpenOwnership Register | Source, not capability (OpenOwnership feeds per-country BO via company-data handlers; not a standalone matrix row) |
+| 35067c87-082c-8184-be14-e09340009266 | Committed | SK | OpenOwnership + SK + Beneficial ownership | Source, not capability (same pattern as above) |
+
+## Resolution authority
+
+Decisions made by Petter in chat session 2026-05-17 post-PR #129. This PR (#130 or successor) closes all 12 rows. No further action required.

--- a/apps/api/coverage-matrix/README.md
+++ b/apps/api/coverage-matrix/README.md
@@ -81,16 +81,19 @@ this migration merged.
 
 ## Known follow-ups (not blocking)
 
-- [`EMPTY-SLUG-FOLLOWUP.md`](./EMPTY-SLUG-FOLLOWUP.md) lists 12 Live/Committed rows in
-  the Notion DB that had empty `Capability slug` at v4 migration time. Each row needs
-  a chat-side decision (assign a real slug, reclassify Status, or move to a separate
-  "Sources" list). Not blocking for this PR.
-- `sourcing_pattern` is null on several rows pending classification backfill
-  (chat-side). Schema permits null until backfill lands.
-- `provider: "Other"` on a couple of rows (e.g. `greek-company-data` / GEMI,
-  `slovak-company-data` / RPO). Notion-source data quality issue; the canonical
-  provider name lives in `notes`. Migration is faithful to source; chat-side will
-  correct in Notion + re-prompt.
 - The migration snapshot redacts `Provider ToS notes` / `Notes` / `Doctrine reference`
   free-text for rows with Status ∈ {In discovery, Gap} (commercial-negotiation notes
   for unsigned vendors). Live/Committed/Deprecated rows are kept verbatim.
+
+## Resolved post-migration (2026-05-17)
+
+- [`EMPTY-SLUG-FOLLOWUP.md`](./EMPTY-SLUG-FOLLOWUP.md) — all 12 originally-skipped
+  rows resolved via PR #130 (3 sources-not-capabilities, 1 added as
+  `singapore-company-data`, 8 deferred per v1 scope). File retained as audit log.
+- `sourcing_pattern: null` backfill — closed via PR #130 (11 Live rows updated to
+  `Direct API` with handler-source verification; Polish handler confirmed direct
+  KRS API, not scraper).
+- `provider: "Other"` on `greek-company-data` / `slovak-company-data` — closed
+  via PR #129 (fixed to `GEMI` and `RPO` respectively, with factual
+  `provider_tos_notes`). `adverse-media-check` and a few Committed rows still
+  carry `Other` legitimately (vendor TBD).

--- a/apps/api/coverage-matrix/cz-company-data__cz__company-registry.yaml
+++ b/apps/api/coverage-matrix/cz-company-data__cz__company-registry.yaml
@@ -3,7 +3,7 @@ country: CZ
 evidence_type: Company registry
 provider: ARES
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 7/7

--- a/apps/api/coverage-matrix/estonian-company-data__ee__company-registry.yaml
+++ b/apps/api/coverage-matrix/estonian-company-data__ee__company-registry.yaml
@@ -3,7 +3,7 @@ country: EE
 evidence_type: Company registry
 provider: Ariregister
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 6/7

--- a/apps/api/coverage-matrix/finnish-company-data__fi__company-registry.yaml
+++ b/apps/api/coverage-matrix/finnish-company-data__fi__company-registry.yaml
@@ -3,7 +3,7 @@ country: FI
 evidence_type: Company registry
 provider: PRH
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 6/7

--- a/apps/api/coverage-matrix/french-company-data__fr__company-registry.yaml
+++ b/apps/api/coverage-matrix/french-company-data__fr__company-registry.yaml
@@ -3,7 +3,7 @@ country: FR
 evidence_type: Company registry
 provider: INSEE
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 7/7

--- a/apps/api/coverage-matrix/lei-lookup__global__lei.yaml
+++ b/apps/api/coverage-matrix/lei-lookup__global__lei.yaml
@@ -3,7 +3,7 @@ country: Global
 evidence_type: LEI
 provider: GLEIF
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: 0
 evidence_grade: null
 tier_1_coverage: null

--- a/apps/api/coverage-matrix/norwegian-company-data__no__company-registry.yaml
+++ b/apps/api/coverage-matrix/norwegian-company-data__no__company-registry.yaml
@@ -3,7 +3,7 @@ country: "NO"
 evidence_type: Company registry
 provider: Brreg
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 7/7

--- a/apps/api/coverage-matrix/polish-company-data__pl__company-registry.yaml
+++ b/apps/api/coverage-matrix/polish-company-data__pl__company-registry.yaml
@@ -3,7 +3,7 @@ country: PL
 evidence_type: Company registry
 provider: KRS
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 4/7 (address + registration_date null 3/3)

--- a/apps/api/coverage-matrix/singapore-company-data__sg__company-registry.yaml
+++ b/apps/api/coverage-matrix/singapore-company-data__sg__company-registry.yaml
@@ -6,9 +6,9 @@ status: Live
 sourcing_pattern: "Direct API"
 per_call_price_eur: 0
 evidence_grade: live-verified
-tier_1_coverage: null
-tier_2_coverage: null
-tier_3_coverage: null
+tier_1_coverage: 7/7 (first-pass estimate, pending audit-batch verification)
+tier_2_coverage: 1/5 (only source_register_name via issuance_agency)
+tier_3_coverage: 0/6 (CKAN snapshot has no shareholders / UBOs / NACE / share_capital / filings)
 last_verified: "2026-05-17"
 products:
   - Counterparty Assurance

--- a/apps/api/coverage-matrix/singapore-company-data__sg__company-registry.yaml
+++ b/apps/api/coverage-matrix/singapore-company-data__sg__company-registry.yaml
@@ -1,0 +1,33 @@
+capability_slug: singapore-company-data
+country: SG
+evidence_type: Company registry
+provider: ACRA
+status: Live
+sourcing_pattern: "Direct API"
+per_call_price_eur: 0
+evidence_grade: live-verified
+tier_1_coverage: null
+tier_2_coverage: null
+tier_3_coverage: null
+last_verified: "2026-05-17"
+products:
+  - Counterparty Assurance
+vendor_roster_url: null
+provider_tos_notes: >-
+  Direct integration with the data.gov.sg CKAN datastore_search API
+  (data.gov.sg/api/action/datastore_search) — "Entities Registered with ACRA"
+  dataset published by Singapore's Accounting and Corporate Regulatory Authority.
+  Singapore Open Data Licence v1.0 (commercial reuse permitted with attribution).
+  Free, no signup required. Monthly-refresh snapshot (~2.1M records covering
+  active and deregistered entities since UEN was introduced). Replaces the prior
+  opencorporates.com Browserless scrape (Tier-1 violation per DEC-20260428-A).
+doctrine_reference: DEC-20260428-A (replaces opencorporates.com Tier-1 violation with direct gov open data)
+notes: >-
+  Shipped capability uses the data.gov.sg CKAN datastore endpoint with resource
+  ID d_3f960c10fed6145404ca7b821f263b87. Accepts UEN (9-10 alphanumeric) or
+  fuzzy entity name. Returns entity_name, uen, entity_type, status, is_active,
+  issuance_agency, uen_issue_date, registered_street, registered_postal_code,
+  registered_address, jurisdiction. Empty `Capability slug` in the pre-migration
+  Notion row (page 35167c87-082c-8188-85ab-fe2e21c51fe5); slug assigned and YAML
+  added 2026-05-17 via EMPTY-SLUG-FOLLOWUP resolution pass.
+_source_notion_page_id: 35167c87-082c-8188-85ab-fe2e21c51fe5

--- a/apps/api/coverage-matrix/swedish-company-data__se__company-registry.yaml
+++ b/apps/api/coverage-matrix/swedish-company-data__se__company-registry.yaml
@@ -3,7 +3,7 @@ country: SE
 evidence_type: Company registry
 provider: Bolagsverket
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 7/7

--- a/apps/api/coverage-matrix/swedish-company-data__se__company-registry.yaml
+++ b/apps/api/coverage-matrix/swedish-company-data__se__company-registry.yaml
@@ -31,5 +31,8 @@ provider_tos_notes: >-
 doctrine_reference: null
 notes: >-
   2026-05-15 identity audit Batch 1 confirmed SE functional via Bolagsverket HVD API. Direct API,
-  authoritative, free. Canonical SE source.
+  authoritative, free. Canonical SE source. Integration uses OAuth2 client_credentials grant
+  against portal.api.bolagsverket.se/oauth2/token with BOLAGSVERKET_CLIENT_ID +
+  BOLAGSVERKET_CLIENT_SECRET (cached token, ~30 min TTL); credential-outage failure mode is
+  distinct from the anonymous-open-data rows like NO/Brreg or FI/PRH.
 _source_notion_page_id: 34a67c87-082c-8144-a195-f8d1a43b1512

--- a/apps/api/coverage-matrix/uk-company-data__uk__beneficial-ownership.yaml
+++ b/apps/api/coverage-matrix/uk-company-data__uk__beneficial-ownership.yaml
@@ -3,7 +3,7 @@ country: UK
 evidence_type: Beneficial ownership
 provider: PSC register
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: null
 evidence_grade: null
 tier_1_coverage: null

--- a/apps/api/coverage-matrix/uk-company-data__uk__company-registry.yaml
+++ b/apps/api/coverage-matrix/uk-company-data__uk__company-registry.yaml
@@ -3,7 +3,7 @@ country: UK
 evidence_type: Company registry
 provider: Companies House
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 7/7

--- a/apps/api/coverage-matrix/vat-validate__eu-wide__vat.yaml
+++ b/apps/api/coverage-matrix/vat-validate__eu-wide__vat.yaml
@@ -3,7 +3,7 @@ country: EU-wide
 evidence_type: VAT
 provider: VIES
 status: Live
-sourcing_pattern: null
+sourcing_pattern: "Direct API"
 per_call_price_eur: 0
 evidence_grade: null
 tier_1_coverage: null


### PR DESCRIPTION
## Summary

Closes the three carry-over items from the post-PR #127 migration arc.

- **(A) Backfill `sourcing_pattern: null → "Direct API"` on 11 Live rows** — all confirmed direct integrations with named government registries / standards bodies (ARES, Ariregister, PRH, INSEE, Brreg, KRS, Bolagsverket, Companies House, PSC register, GLEIF, VIES). No vendor wrappers. Polish handler scraper-check passed (api-krs.ms.gov.pl, no browserless/puppeteer).
- **(B) Add `singapore-company-data__sg__company-registry.yaml`** — provider `ACRA` via data.gov.sg CKAN datastore. Singapore Open Data Licence v1.0. Free. Matrix grows 46 → 47 rows.
- **(C) Rewrite `EMPTY-SLUG-FOLLOWUP.md` as resolution log** — all 12 originally-skipped rows resolved (3 sources-not-capabilities, 1 added to repo, 8 deferred per v1 scope). File retained as audit record.

## Verification

- `npm run validate:coverage-matrix` → 47 scanned, 0 violations
- `npm run coverage-matrix:check` → round-trip clean
- Diff scope (14 files):
  - 11 YAMLs: 1-line `sourcing_pattern` change each (22 lines total — 11 minus / 11 plus)
  - 1 new YAML (`singapore-company-data__sg__company-registry.yaml`)
  - 1 EMPTY-SLUG-FOLLOWUP.md rewrite (resolution log format)
  - 1 auto-regenerated COVERAGE.md
- Polish scraper-check (Halt #1): `apps/api/src/capabilities/polish-company-data.ts:5` = `const KRS_API = "https://api-krs.ms.gov.pl/api/krs"`. Direct API confirmed; no scraping anywhere in the file.
- SG handler verification: `apps/api/src/capabilities/singapore-company-data.ts:18-20` uses `data.gov.sg/api/action/datastore_search` resource `d_3f960c10fed6145404ca7b821f263b87`. Per attribution: "Accounting and Corporate Regulatory Authority (ACRA) — Entities Registered with ACRA, via data.gov.sg". Provider = `ACRA`.
- No handler / manifest / schema changes.

## Migration arc

- PR #127 — matrix migration from Notion to repo
- PR #128 — post-#127 cleanup (drift script retirement, CRLF/LF, PROTOCOL.md)
- PR #129 — data quality (GR/SK provider names, pep-check products)
- **This PR** — sourcing_pattern backfill + Singapore add + EMPTY-SLUG-FOLLOWUP closure

## Reviewer findings

To be filled by `/go` six-lens review before self-merge per Rule 16.

## Cross-repo

None. No customer-facing surface changes.

## Test plan

- [ ] CI `Coverage matrix validation` green on this PR
- [ ] Spot-check `git diff apps/api/coverage-matrix/polish-company-data__pl__company-registry.yaml` — confirm only `sourcing_pattern` line changed
- [ ] Open the new `singapore-company-data__sg__company-registry.yaml` — confirm provider=ACRA, sourcing_pattern=Direct API, all schema-required fields present
- [ ] Open `EMPTY-SLUG-FOLLOWUP.md` — confirm Groups A/B/C structure + all 12 page IDs accounted for
- [ ] Open regenerated `COVERAGE.md` — confirm SG row appears under "By country > SG (1)" and Live count is now 28 (up from 27)

Per **Working Rule J / PROTOCOL.md**. Source decisions: DEC-20260517-A + DEC-20260517-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)