### PR TITLE
feat(evidence-tier): labeling sweep across 31 company-data handlers

### DIFF
--- a/apps/api/src/capabilities/austrian-company-data.ts
+++ b/apps/api/src/capabilities/austrian-company-data.ts
@@ -47,7 +47,7 @@ registerCapability("austrian-company-data", async (input: CapabilityInput) => {
       `'${rawInput.trim()}' is not a valid Austrian UID-Nummer. Expected format: ATU + 8 digits (e.g. ATU14189108).`,
     );
   }
-  return executeOpenapiCapability(
+  const __etResult = await executeOpenapiCapability(
     {
       countryCode: "AT",
       identifierRegex: AT_VAT_RE,
@@ -56,6 +56,21 @@ registerCapability("austrian-company-data", async (input: CapabilityInput) => {
     },
     normalised,
   );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "restricted",
+      ubo_availability_reason: "WiEReG UBO register access restricted to AML-obliged entities per Austrian Beneficial Owners Register Act",
+    },
+  };
 });
 
 export { AT_VAT_RE };

--- a/apps/api/src/capabilities/belgian-company-data.ts
+++ b/apps/api/src/capabilities/belgian-company-data.ts
@@ -163,6 +163,22 @@ registerCapability("belgian-company-data", async (input: CapabilityInput) => {
     ? `https://kbopub.economie.fgov.be/kbopub/toonondernemingps.html?ondernemingsnummer=${cbeNumber}`
     : "https://kbopub.economie.fgov.be/kbopub/zoekofficielenummerform.html";
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.ubo_availability = "restricted";
+    o.ubo_availability_reason = "UBO register (FPS Finance) access restricted post-CJEU 2022 ruling";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/belgian-company-data.ts
+++ b/apps/api/src/capabilities/belgian-company-data.ts
@@ -169,7 +169,11 @@ registerCapability("belgian-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/bulgarian-company-data.ts
+++ b/apps/api/src/capabilities/bulgarian-company-data.ts
@@ -46,7 +46,7 @@ registerCapability("bulgarian-company-data", async (input: CapabilityInput) => {
       `'${rawInput.trim()}' is not a valid Bulgarian UIC/EIK. Expected format: 9 digits, optionally with BG prefix (e.g. 831902088).`,
     );
   }
-  return executeOpenapiCapability(
+  const __etResult = await executeOpenapiCapability(
     {
       countryCode: "BG",
       identifierRegex: BG_CANONICAL_RE,
@@ -55,6 +55,21 @@ registerCapability("bulgarian-company-data", async (input: CapabilityInput) => {
     },
     normalised,
   );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "unavailable_no_registry",
+      ubo_availability_reason: "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation",
+    },
+  };
 });
 
 export { BG_INPUT_RE, BG_CANONICAL_RE };

--- a/apps/api/src/capabilities/croatian-company-data.ts
+++ b/apps/api/src/capabilities/croatian-company-data.ts
@@ -156,6 +156,22 @@ registerCapability("croatian-company-data", async (input: CapabilityInput) => {
   const detail = await fetchDetail(identifier.tip, identifier.value, token);
   const output = mapDetail(detail);
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.ubo_availability = "unavailable_no_registry";
+    o.ubo_availability_reason = "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/croatian-company-data.ts
+++ b/apps/api/src/capabilities/croatian-company-data.ts
@@ -162,7 +162,11 @@ registerCapability("croatian-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/cypriot-company-data.ts
+++ b/apps/api/src/capabilities/cypriot-company-data.ts
@@ -43,7 +43,7 @@ registerCapability("cypriot-company-data", async (input: CapabilityInput) => {
       `'${rawInput.trim()}' is not a valid Cypriot identifier. Expected: CY + 8 digits + 1 letter (VAT), 8 digits + 1 letter (bare VAT), or C + digits (company number).`,
     );
   }
-  return executeOpenapiCapability(
+  const __etResult = await executeOpenapiCapability(
     {
       countryCode: "CY",
       identifierRegex: CY_RE,
@@ -52,6 +52,21 @@ registerCapability("cypriot-company-data", async (input: CapabilityInput) => {
     },
     normalised,
   );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "unavailable_no_registry",
+      ubo_availability_reason: "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation",
+    },
+  };
 });
 
 export { CY_RE };

--- a/apps/api/src/capabilities/cz-company-data.ts
+++ b/apps/api/src/capabilities/cz-company-data.ts
@@ -123,6 +123,17 @@ registerCapability("cz-company-data", async (input: CapabilityInput) => {
       status: deriveStatus(data.seznamRegistraci),
       primary_source: data.primarniZdroj ?? null,
       jurisdiction: "CZ",
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: data.obchodniJmeno ?? "",
+      primary_registration_id: data.ico,
+      legal_form: data.pravniForma ?? null,
+      registered_address: data.sidlo?.textovaAdresa ?? "",
+      date_incorporated: data.datumVzniku ?? null,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked",
+      ubo_availability: "restricted",
+      ubo_availability_reason: "UBO evidence register access restricted to AML-obliged entities post-CJEU 2022",
     },
     provenance: {
       source: "ares.gov.cz",

--- a/apps/api/src/capabilities/danish-company-data.ts
+++ b/apps/api/src/capabilities/danish-company-data.ts
@@ -138,7 +138,11 @@ registerCapability("danish-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/danish-company-data.ts
+++ b/apps/api/src/capabilities/danish-company-data.ts
@@ -132,6 +132,22 @@ registerCapability("danish-company-data", async (input: CapabilityInput) => {
     ? `https://datacvr.virk.dk/enhed/virksomhed/${cvrForRef}`
     : "https://datacvr.virk.dk/";
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "cvrapi.dk free tier does not expose directors; Virk system-til-system direct integration tracked separately";
+    o.ubo_availability = "available";
+    o.ubo_availability_reason = "Beneficial owner data accessible via CVR / OpenOwnership BODS DK extraction (handler integration pending; flag reflects jurisdictional availability)";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/dutch-company-data.ts
+++ b/apps/api/src/capabilities/dutch-company-data.ts
@@ -41,7 +41,7 @@ registerCapability("dutch-company-data", async (input: CapabilityInput) => {
       `'${rawInput.trim()}' is not a valid Dutch VAT/BTW number. Expected format: NL + 9 digits + B + 2 digits (e.g. NL803441526B01).`,
     );
   }
-  return executeOpenapiCapability(
+  const __etResult = await executeOpenapiCapability(
     {
       countryCode: "NL",
       identifierRegex: NL_VAT_RE,
@@ -50,6 +50,21 @@ registerCapability("dutch-company-data", async (input: CapabilityInput) => {
     },
     normalised,
   );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "restricted",
+      ubo_availability_reason: "UBO register access restricted post-CJEU 2022 Wwft ruling",
+    },
+  };
 });
 
 export { NL_VAT_RE };

--- a/apps/api/src/capabilities/estonian-company-data.ts
+++ b/apps/api/src/capabilities/estonian-company-data.ts
@@ -134,6 +134,22 @@ registerCapability("estonian-company-data", async (input: CapabilityInput) => {
     ? `https://ariregister.rik.ee/eng/company/${regCodeForRef}`
     : "https://ariregister.rik.ee/eng";
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.ubo_availability = "unavailable_no_registry";
+    o.ubo_availability_reason = "Programmatic UBO access not currently exposed by Ariregister at v1; verification pending public-source confirmation";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/estonian-company-data.ts
+++ b/apps/api/src/capabilities/estonian-company-data.ts
@@ -140,7 +140,11 @@ registerCapability("estonian-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/finnish-company-data.ts
+++ b/apps/api/src/capabilities/finnish-company-data.ts
@@ -155,7 +155,11 @@ registerCapability("finnish-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/finnish-company-data.ts
+++ b/apps/api/src/capabilities/finnish-company-data.ts
@@ -149,6 +149,22 @@ registerCapability("finnish-company-data", async (input: CapabilityInput) => {
 
   const output = await fetchCompany(businessId);
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.ubo_availability = "restricted";
+    o.ubo_availability_reason = "PRH UBO data access restricted to AML-obliged entities";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/french-company-data.ts
+++ b/apps/api/src/capabilities/french-company-data.ts
@@ -100,7 +100,11 @@ registerCapability("french-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/french-company-data.ts
+++ b/apps/api/src/capabilities/french-company-data.ts
@@ -94,6 +94,22 @@ registerCapability("french-company-data", async (input: CapabilityInput) => {
   const query = siren || await extractCompanyName(trimmed);
   const output = await searchCompany(query);
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.ubo_availability = "restricted";
+    o.ubo_availability_reason = "RBE (Registre des bénéficiaires effectifs) access restricted post-CJEU 2022";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/german-company-data.ts
+++ b/apps/api/src/capabilities/german-company-data.ts
@@ -300,6 +300,13 @@ registerCapability("german-company-data", async (input: CapabilityInput) => {
       lei: company.lei?.trim() || null,
       incorporated_at: company.incorporated_at ? company.incorporated_at.split("T")[0] : null,
       terminated_at: company.terminated_at ? company.terminated_at.split("T")[0] : null,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: resolvedName,
+      primary_registration_id: registrationNumber,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: true,
+      ubo_availability: "restricted",
+      ubo_availability_reason: "Transparenzregister access restricted to obliged entities per GwG §23 post-CJEU 2022",
     },
     provenance: {
       source: "OpenRegister",

--- a/apps/api/src/capabilities/german-company-data.ts
+++ b/apps/api/src/capabilities/german-company-data.ts
@@ -303,8 +303,10 @@ registerCapability("german-company-data", async (input: CapabilityInput) => {
       // Evidence Tier 1 canonical aliases (DEC-20260518-A)
       legal_name: resolvedName,
       primary_registration_id: registrationNumber,
+      date_incorporated: company.incorporated_at ? company.incorporated_at.split("T")[0] : null,
       // Evidence Tier framework labels (DEC-20260518-A)
       tier_2_available: true,
+      tier_2_available_reason: "OpenRegister exposes legal representatives (directors / managing directors) per Handelsregister filing; signing_authority not currently extracted",
       ubo_availability: "restricted",
       ubo_availability_reason: "Transparenzregister access restricted to obliged entities per GwG §23 post-CJEU 2022",
     },

--- a/apps/api/src/capabilities/greek-company-data.ts
+++ b/apps/api/src/capabilities/greek-company-data.ts
@@ -231,6 +231,21 @@ registerCapability("greek-company-data", async (input: CapabilityInput) => {
 
   const output = mapToOutput(company);
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = true;
+    o.ubo_availability = "unavailable_no_registry";
+    o.ubo_availability_reason = "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/greek-company-data.ts
+++ b/apps/api/src/capabilities/greek-company-data.ts
@@ -237,11 +237,16 @@ registerCapability("greek-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
     o.tier_2_available = true;
+    o.tier_2_available_reason = "GEMI exposes legal representatives via representation array; signing_authority not currently extracted";
     o.ubo_availability = "unavailable_no_registry";
     o.ubo_availability_reason = "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation";
   }

--- a/apps/api/src/capabilities/hungarian-company-data.ts
+++ b/apps/api/src/capabilities/hungarian-company-data.ts
@@ -40,7 +40,7 @@ registerCapability("hungarian-company-data", async (input: CapabilityInput) => {
       `'${rawInput.trim()}' is not a valid Hungarian VAT. Expected format: HU + 8 digits (e.g. HU10537914).`,
     );
   }
-  return executeOpenapiCapability(
+  const __etResult = await executeOpenapiCapability(
     {
       countryCode: "HU",
       identifierRegex: HU_VAT_RE,
@@ -49,6 +49,21 @@ registerCapability("hungarian-company-data", async (input: CapabilityInput) => {
     },
     normalised,
   );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "restricted",
+      ubo_availability_reason: "UBO register access restricted to AML-obliged entities post-CJEU 2022",
+    },
+  };
 });
 
 export { HU_VAT_RE };

--- a/apps/api/src/capabilities/irish-company-data.ts
+++ b/apps/api/src/capabilities/irish-company-data.ts
@@ -153,6 +153,22 @@ registerCapability("irish-company-data", async (input: CapabilityInput) => {
   const filterRef = encodeURIComponent(JSON.stringify({ company_num: record.company_num }));
   const primarySourceUrl = `${CRO_DATASTORE_API}?resource_id=${CRO_RESOURCE_ID}&filters=${filterRef}`;
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.ubo_availability = "restricted";
+    o.ubo_availability_reason = "RBO (Register of Beneficial Ownership) access restricted post-CJEU 2022";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/irish-company-data.ts
+++ b/apps/api/src/capabilities/irish-company-data.ts
@@ -159,7 +159,11 @@ registerCapability("irish-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/italian-company-data.ts
+++ b/apps/api/src/capabilities/italian-company-data.ts
@@ -66,7 +66,7 @@ registerCapability("italian-company-data", async (input: CapabilityInput) => {
       `'${rawInput.trim()}' is not a valid Italian codice fiscale / P.IVA. Expected format: 11 digits (e.g. 00484960588).`,
     );
   }
-  return executeOpenapiCapability(
+  const __etResult = await executeOpenapiCapability(
     {
       countryCode: "IT",
       identifierRegex: IT_CF_RE,
@@ -75,6 +75,21 @@ registerCapability("italian-company-data", async (input: CapabilityInput) => {
     },
     normalised,
   );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "restricted",
+      ubo_availability_reason: "RIT (Registro dei Titolari Effettivi) access restricted; UBO-Italy product deferred to v1.1 per DEC-20260507-C",
+    },
+  };
 });
 
 export { IT_CF_RE };

--- a/apps/api/src/capabilities/latvian-company-data.ts
+++ b/apps/api/src/capabilities/latvian-company-data.ts
@@ -153,6 +153,22 @@ registerCapability("latvian-company-data", async (input: CapabilityInput) => {
   const filterRef = encodeURIComponent(JSON.stringify({ regcode: String(record.regcode) }));
   const primarySourceUrl = `${LV_DATASTORE_API}?resource_id=${LV_RESOURCE_ID}&filters=${filterRef}`;
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.ubo_availability = "unavailable_no_registry";
+    o.ubo_availability_reason = "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/latvian-company-data.ts
+++ b/apps/api/src/capabilities/latvian-company-data.ts
@@ -159,7 +159,11 @@ registerCapability("latvian-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/lithuanian-company-data.ts
+++ b/apps/api/src/capabilities/lithuanian-company-data.ts
@@ -194,6 +194,22 @@ registerCapability("lithuanian-company-data", async (input: CapabilityInput) => 
 
   const primarySourceUrl = `${JA_MODEL}?eq(ja_kodas,${record.ja_kodas})`;
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.ubo_availability = "unavailable_no_registry";
+    o.ubo_availability_reason = "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/lithuanian-company-data.ts
+++ b/apps/api/src/capabilities/lithuanian-company-data.ts
@@ -200,7 +200,11 @@ registerCapability("lithuanian-company-data", async (input: CapabilityInput) => 
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/luxembourgish-company-data.ts
+++ b/apps/api/src/capabilities/luxembourgish-company-data.ts
@@ -41,7 +41,7 @@ registerCapability(
         `'${rawInput.trim()}' is not a valid Luxembourgish VAT. Expected format: LU + 8 digits (e.g. LU18513414).`,
       );
     }
-    return executeOpenapiCapability(
+    const __etResult = await executeOpenapiCapability(
       {
         countryCode: "LU",
         identifierRegex: LU_VAT_RE,
@@ -50,6 +50,21 @@ registerCapability(
       },
       normalised,
     );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "restricted",
+      ubo_availability_reason: "RBE (Registre des bénéficiaires effectifs) access restricted post-CJEU 2022",
+    },
+  };
   },
 );
 

--- a/apps/api/src/capabilities/maltese-company-data.ts
+++ b/apps/api/src/capabilities/maltese-company-data.ts
@@ -40,7 +40,7 @@ registerCapability("maltese-company-data", async (input: CapabilityInput) => {
       `'${rawInput.trim()}' is not a valid Maltese VAT. Expected format: MT + 8 digits (e.g. MT12826209).`,
     );
   }
-  return executeOpenapiCapability(
+  const __etResult = await executeOpenapiCapability(
     {
       countryCode: "MT",
       identifierRegex: MT_VAT_RE,
@@ -49,6 +49,21 @@ registerCapability("maltese-company-data", async (input: CapabilityInput) => {
     },
     normalised,
   );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "unavailable_no_registry",
+      ubo_availability_reason: "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation",
+    },
+  };
 });
 
 export { MT_VAT_RE };

--- a/apps/api/src/capabilities/norwegian-company-data.ts
+++ b/apps/api/src/capabilities/norwegian-company-data.ts
@@ -86,7 +86,11 @@ registerCapability("norwegian-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/norwegian-company-data.ts
+++ b/apps/api/src/capabilities/norwegian-company-data.ts
@@ -80,6 +80,22 @@ registerCapability("norwegian-company-data", async (input: CapabilityInput) => {
   const data = await fetchBrregEntity(orgNumber);
   const output = shapeBrregOutput(data);
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.ubo_availability = "unavailable_no_registry";
+    o.ubo_availability_reason = "Norwegian UBO register implementation delayed; not operational at v1";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/polish-company-data.ts
+++ b/apps/api/src/capabilities/polish-company-data.ts
@@ -157,6 +157,22 @@ registerCapability("polish-company-data", async (input: CapabilityInput) => {
   }
 
   const output = await fetchByKrs(krs);
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.ubo_availability = "restricted";
+    o.ubo_availability_reason = "CRBR (Centralny Rejestr Beneficjentów Rzeczywistych) access restricted post-CJEU 2022";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/polish-company-data.ts
+++ b/apps/api/src/capabilities/polish-company-data.ts
@@ -163,7 +163,11 @@ registerCapability("polish-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/portuguese-company-data.ts
+++ b/apps/api/src/capabilities/portuguese-company-data.ts
@@ -49,7 +49,7 @@ registerCapability("portuguese-company-data", async (input: CapabilityInput) => 
       `'${rawInput.trim()}' is not a valid Portuguese NIPC. Expected format: 9 digits (e.g. 504499777).`,
     );
   }
-  return executeOpenapiCapability(
+  const __etResult = await executeOpenapiCapability(
     {
       countryCode: "PT",
       identifierRegex: PT_NIPC_RE,
@@ -58,6 +58,21 @@ registerCapability("portuguese-company-data", async (input: CapabilityInput) => 
     },
     normalised,
   );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "restricted",
+      ubo_availability_reason: "RCBE (Registo Central do Beneficiário Efetivo) access restricted post-CJEU 2022",
+    },
+  };
 });
 
 export { PT_NIPC_RE };

--- a/apps/api/src/capabilities/romanian-company-data.ts
+++ b/apps/api/src/capabilities/romanian-company-data.ts
@@ -42,7 +42,7 @@ registerCapability("romanian-company-data", async (input: CapabilityInput) => {
       `'${rawInput.trim()}' is not a valid Romanian identifier. Expected: RO + 8 digits (VAT), 13 digits (full CUI), or 8 digits (CUI). 7-digit CUI entities (legacy banks, older corporations) are not reachable.`,
     );
   }
-  return executeOpenapiCapability(
+  const __etResult = await executeOpenapiCapability(
     {
       countryCode: "RO",
       identifierRegex: RO_RE,
@@ -51,6 +51,21 @@ registerCapability("romanian-company-data", async (input: CapabilityInput) => {
     },
     normalised,
   );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "unavailable_no_registry",
+      ubo_availability_reason: "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation",
+    },
+  };
 });
 
 export { RO_RE };

--- a/apps/api/src/capabilities/singapore-company-data.ts
+++ b/apps/api/src/capabilities/singapore-company-data.ts
@@ -148,6 +148,22 @@ registerCapability("singapore-company-data", async (input: CapabilityInput) => {
   const filterRef = encodeURIComponent(JSON.stringify({ uen: record.uen }));
   const primarySourceUrl = `${SG_DATASTORE_API}?resource_id=${SG_RESOURCE_ID}&filters=${filterRef}`;
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "ACRA data.gov.sg snapshot does not expose directors";
+    o.ubo_availability = "unavailable_no_registry";
+    o.ubo_availability_reason = "UBO data not exposed in ACRA data.gov.sg public dataset";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/singapore-company-data.ts
+++ b/apps/api/src/capabilities/singapore-company-data.ts
@@ -152,9 +152,13 @@ registerCapability("singapore-company-data", async (input: CapabilityInput) => {
   // Resolves alias keys at runtime; only sets a canonical if not already present.
   {
     const o = output as Record<string, unknown>;
-    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.entity_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/slovak-company-data.ts
+++ b/apps/api/src/capabilities/slovak-company-data.ts
@@ -188,6 +188,16 @@ registerCapability("slovak-company-data", async (input: CapabilityInput) => {
       directors,
       last_updated: entity.dbModificationDate ?? null,
       jurisdiction: "SK",
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: currentName?.value ?? "",
+      primary_registration_id: currentRegNumber?.value ?? null,
+      registered_address: formatAddress(currentAddress),
+      date_incorporated: entity.establishment ?? null,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked",
+      ubo_availability: "unavailable_no_registry",
+      ubo_availability_reason: "RPVS (Register partnerov verejného sektora) not accessible for foreign users at v1; verification pending public-source confirmation",
     },
     provenance: {
       source: "api.statistics.sk/rpo",

--- a/apps/api/src/capabilities/slovenian-company-data.ts
+++ b/apps/api/src/capabilities/slovenian-company-data.ts
@@ -166,7 +166,11 @@ registerCapability("slovenian-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/slovenian-company-data.ts
+++ b/apps/api/src/capabilities/slovenian-company-data.ts
@@ -160,6 +160,22 @@ registerCapability("slovenian-company-data", async (input: CapabilityInput) => {
   );
   const primarySourceUrl = `${SI_DATASTORE_API}?resource_id=${SI_RESOURCE_ID}&filters=${filterRef}`;
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "data.gov.si CKAN PRS dataset does not expose directors";
+    o.ubo_availability = "unavailable_no_registry";
+    o.ubo_availability_reason = "PRS dataset does not expose UBO data programmatically";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/spanish-company-data.ts
+++ b/apps/api/src/capabilities/spanish-company-data.ts
@@ -50,7 +50,7 @@ registerCapability("spanish-company-data", async (input: CapabilityInput) => {
       `'${rawInput.trim()}' is not a valid Spanish CIF/NIF. Expected format: letter + 7 digits + check character (e.g. A28015865).`,
     );
   }
-  return executeOpenapiCapability(
+  const __etResult = await executeOpenapiCapability(
     {
       countryCode: "ES",
       identifierRegex: ES_NIF_RE,
@@ -59,6 +59,21 @@ registerCapability("spanish-company-data", async (input: CapabilityInput) => {
     },
     normalised,
   );
+  return {
+    ...__etResult,
+    output: {
+      ...__etResult.output,
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: (__etResult.output as Record<string, unknown>).company_name,
+      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
+      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: false,
+      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
+      ubo_availability: "restricted",
+      ubo_availability_reason: "RCTIR (Registro Central de Titularidades Reales) access restricted to AML-obliged entities",
+    },
+  };
 });
 
 export { ES_NIF_RE };

--- a/apps/api/src/capabilities/swedish-company-data.ts
+++ b/apps/api/src/capabilities/swedish-company-data.ts
@@ -276,6 +276,15 @@ registerCapability(
             ?.pagaendeAvvecklingsEllerOmstruktureringsforfarandeLista,
         ),
         alternative_names: alternativeNames(nameList),
+        // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+        legal_name: pickPrimaryName(nameList),
+        primary_registration_id: normalised.formatted,
+        date_incorporated: toIsoDate(org.organisationsdatum?.registreringsdatum),
+        // Evidence Tier framework labels (DEC-20260518-A)
+        tier_2_available: false,
+        tier_2_available_reason: "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked",
+        ubo_availability: "unavailable_no_registry",
+        ubo_availability_reason: "Bolagsverket BO data not exposed programmatically at v1; verification pending public-source confirmation",
       },
       provenance: {
         source: "Bolagsverket Värdefulla datamängder API",

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -136,7 +136,11 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
     const o = output as Record<string, unknown>;
     if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
     if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
-    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.status === undefined) {
+    if (typeof o.company_status === "string") o.status = o.company_status;
+    else if (o.is_active === true || o.active === true) o.status = "active";
+    else if (o.is_active === false || o.active === false) o.status = "inactive";
+  }
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -130,6 +130,22 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
 
   const output = await fetchCompany(companyNumber);
 
+  // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
+  // Resolves alias keys at runtime; only sets a canonical if not already present.
+  {
+    const o = output as Record<string, unknown>;
+    if (o.legal_name === undefined) o.legal_name = (o.company_name ?? o.name);
+    if (o.primary_registration_id === undefined) o.primary_registration_id = (o.company_number ?? o.registration_number ?? o.uen ?? o.fn_number ?? o.ico ?? o.krs_number ?? o.org_number ?? o.cnpj ?? o.reg_number);
+    if (o.status === undefined) o.status = (o.company_status ?? o.is_active ?? o.active);
+    if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
+    if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
+    if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
+    o.tier_2_available = false;
+    o.tier_2_available_reason = "Companies House summary endpoint does not expose officers in current handler implementation; officers extraction is a follow-up labeling task";
+    o.ubo_availability = "available";
+    o.ubo_availability_reason = "PSC (Persons with Significant Control) register publicly accessible via Companies House";
+  }
+
   return {
     output,
     provenance: {

--- a/apps/api/src/capabilities/us-company-data-cobalt.ts
+++ b/apps/api/src/capabilities/us-company-data-cobalt.ts
@@ -130,6 +130,15 @@ registerCapability("us-company-data-cobalt", async (input: CapabilityInput) => {
       filings: result.filings?.slice(0, 25) ?? null,
       sos_url: result.sosUrl ?? null,
       data_source: "Cobalt Intelligence (50-state SoS live)",
+      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+      legal_name: result.title ?? result.businessName ?? result.name ?? null,
+      legal_form: result.businessType ?? result.entityType ?? null,
+      registered_address: result.address ??
+        (result.principalAddress ? Object.values(result.principalAddress).filter(Boolean).join(", ") : null),
+      // Evidence Tier framework labels (DEC-20260518-A)
+      tier_2_available: true,
+      ubo_availability: "unavailable_no_registry",
+      ubo_availability_reason: "US has no federal UBO register operational at v1; CTA implementation deferred; verification pending per-state register evaluation",
     },
     provenance: {
       source: "cobaltintelligence.com",

--- a/apps/api/src/capabilities/us-company-data-cobalt.ts
+++ b/apps/api/src/capabilities/us-company-data-cobalt.ts
@@ -137,6 +137,7 @@ registerCapability("us-company-data-cobalt", async (input: CapabilityInput) => {
         (result.principalAddress ? Object.values(result.principalAddress).filter(Boolean).join(", ") : null),
       // Evidence Tier framework labels (DEC-20260518-A)
       tier_2_available: true,
+      tier_2_available_reason: "Cobalt Intelligence exposes officers and filings per state; signing_authority not currently extracted",
       ubo_availability: "unavailable_no_registry",
       ubo_availability_reason: "US has no federal UBO register operational at v1; CTA implementation deferred; verification pending per-state register evaluation",
     },

--- a/audit-output/labeling-sweep-summary-2026-05-18.md
+++ b/audit-output/labeling-sweep-summary-2026-05-18.md
@@ -1,0 +1,119 @@
+# Labeling sweep summary — Evidence Tier framework compliance
+Date: 2026-05-18
+Branch: feat/evidence-tier-labeling-sweep
+Files modified: 31 (1 deferred — swiss-company-data throw-stub)
+
+## Per-handler changes
+
+| Handler | Pattern | tier_2_available | ubo_availability | Notes |
+| --- | --- | --- | --- | --- |
+| german-company-data | inline-literal | true | restricted | patched |
+| greek-company-data | variable-output | true | unavailable_no_registry | patched |
+| us-company-data-cobalt | inline-literal | true | unavailable_no_registry | patched |
+| austrian-company-data | openapi | false | restricted | patched |
+| bulgarian-company-data | openapi | false | unavailable_no_registry | patched |
+| cypriot-company-data | openapi | false | unavailable_no_registry | patched |
+| hungarian-company-data | openapi | false | restricted | patched |
+| luxembourgish-company-data | openapi | false | restricted | patched |
+| maltese-company-data | openapi | false | unavailable_no_registry | patched |
+| dutch-company-data | openapi | false | restricted | patched |
+| romanian-company-data | openapi | false | unavailable_no_registry | patched |
+| italian-company-data | openapi | false | restricted | patched |
+| spanish-company-data | openapi | false | restricted | patched |
+| portuguese-company-data | openapi | false | restricted | patched |
+| slovenian-company-data | variable-output | false | unavailable_no_registry | patched |
+| singapore-company-data | variable-output | false | unavailable_no_registry | patched |
+| danish-company-data | variable-output | false | available | patched |
+| swiss-company-data | throw-stub | — | — | throw-only stub; real path via providers/ DataProvider chain (out of scope) |
+| uk-company-data | variable-output | false | available | patched |
+| belgian-company-data | variable-output | false | restricted | patched |
+| cz-company-data | inline-literal | false | restricted | patched |
+| estonian-company-data | variable-output | false | unavailable_no_registry | patched |
+| finnish-company-data | variable-output | false | restricted | patched |
+| french-company-data | variable-output | false | restricted | patched |
+| croatian-company-data | variable-output | false | unavailable_no_registry | patched |
+| irish-company-data | variable-output | false | restricted | patched |
+| lithuanian-company-data | variable-output | false | unavailable_no_registry | patched |
+| latvian-company-data | variable-output | false | unavailable_no_registry | patched |
+| norwegian-company-data | variable-output | false | unavailable_no_registry | patched |
+| polish-company-data | variable-output | false | restricted | patched |
+| swedish-company-data | inline-literal | false | unavailable_no_registry | patched |
+| slovak-company-data | inline-literal | false | unavailable_no_registry | patched |
+
+## Aggregate counts
+
+- Handlers patched: 31
+- Handlers deferred (throw-only stubs): 1 — swiss-company-data
+- Handlers with `tier_2_available: true`: 3 (german-company-data, greek-company-data, us-company-data-cobalt)
+- Handlers with `tier_2_available: false`: 28
+- Handlers with `ubo_availability: available`: 2 (danish-company-data, uk-company-data)
+- Handlers with `ubo_availability: restricted`: 14
+- Handlers with `ubo_availability: unavailable_no_registry`: 15
+
+### Pattern distribution
+
+- inline-literal: 5 handlers
+- variable-output: 15 handlers
+- openapi: 11 handlers
+
+Edit semantics per pattern:
+
+- **openapi** (11): wrapped `executeOpenapiCapability(...)` call with `const __etResult = await ...; return { ...__etResult, output: { ...__etResult.output, [canonical aliases + labels] } };` — labels live at the country-handler level; the shared resolver at `lib/openapi-resolver.ts` is untouched.
+- **inline-literal** (5): injected canonical-alias key/value pairs (mirroring the original value expression) + labels into the existing `output: { ... }` literal block.
+- **variable-output** (15): inserted a runtime-resolver block before `return { output, provenance }` that conditionally sets canonical aliases (only if not already present) plus the two label flags.
+
+## Follow-up flagged
+
+### v1.1 verification — `ubo_availability` values marked "verification pending public-source confirmation"
+
+The following countries' UBO availability values are chat-side estimates and should be verified against the jurisdiction's official source within the v1.1 cycle. Capture as a Notion to-do:
+
+- `greek-company-data`
+- `bulgarian-company-data`
+- `cypriot-company-data`
+- `maltese-company-data`
+- `romanian-company-data`
+- `estonian-company-data`
+- `croatian-company-data`
+- `lithuanian-company-data`
+- `latvian-company-data`
+- `swedish-company-data`
+- `slovak-company-data`
+
+Total: 11 countries.
+
+### Follow-up — handler-side `legal_representatives` extraction where upstream registry exposes data
+
+The following handlers carry `tier_2_available: false` with reason "handler does not currently extract legal representatives from upstream registry". Many of these registries DO expose director data upstream (e.g. Companies House Officers API, INSEE dirigeants, PRH ytj.fi managers). A separate follow-up sweep should add per-handler extraction logic:
+
+- `belgian-company-data`
+- `cz-company-data`
+- `estonian-company-data`
+- `finnish-company-data`
+- `french-company-data`
+- `croatian-company-data`
+- `irish-company-data`
+- `lithuanian-company-data`
+- `latvian-company-data`
+- `norwegian-company-data`
+- `polish-company-data`
+- `swedish-company-data`
+- `slovak-company-data`
+
+Total: 13 handlers.
+
+Plus `uk-company-data` (separate reason citing Companies House Officers extraction as the specific follow-up): the Officers API exists; current handler implementation doesn't extract it.
+
+### Throw-stub deferral — `swiss-company-data`
+
+`apps/api/src/capabilities/swiss-company-data.ts` is a throw-only stub. The real CH runtime path is via `apps/api/src/capabilities/providers/swiss-company-data.ts` (DataProvider chain). The chain provider builds the actual output object. Labeling the chain provider is OUT OF SCOPE for this sweep per the prompt's explicit scope statement.
+
+Follow-up: extend the labeling sweep to cover `providers/swiss-company-data.ts` so CH gains Evidence Tier compliance via the runtime path it actually uses.
+
+### OpenAPI spec regeneration
+
+If `apps/api/openapi.json` or equivalent is generated from the handler return types, it may need a regen pass to reflect the new fields. Verify after merge.
+
+### YAML rescore against new 6/3/3 rubric
+
+Coverage-matrix YAML rows still encode the legacy 7/5/6 BR rubric in `tier_1_coverage` / `tier_2_coverage` / `tier_3_coverage` strings. A separate sweep should rescore against the Evidence Tier 6/3/3 framework. Not blocking for v1 launch.


### PR DESCRIPTION
## Summary

Implements DEC-20260518-A (Evidence Tier framework) + DEC-20260518-C (T1 bank verification optional) compliance at the handler level. Three additive edits per file:

1. Add `tier_2_available` boolean (+ optional reason) — framework-mandatory
2. Add `ubo_availability` string enum (+ optional reason) — framework-mandatory
3. Add canonical Evidence Tier 1 field names alongside existing aliases (backward-compatible additive)

## Audit source

Triggered by 2026-05-18 EU30 coverage audit findings (`audit-output/eu-coverage-use-case-tier-audit-2026-05-18.md`). Audit reported 0 of 30 EU countries deliverable at any Use-case Tier due to framework-mandatory flags being silently omitted.

## Scope

**31 handlers patched, 1 deferred.** Three structural patterns detected and handled:

- **11 Openapi-delegated**: wrapped `executeOpenapiCapability()` call with spread + augmentation at the country-handler level. `lib/openapi-resolver.ts` itself stays untouched per prompt.
- **5 inline-literal** (`return { output: { ... } }`): injected canonical aliases (mirroring source value expressions) + label fields into the existing object literal.
- **15 variable-output** (`const output = ...; return { output, provenance }`): inserted a runtime-resolver block before the return that conditionally sets canonical aliases (only when not already present) + the two label flags.

**Deferred (1)**: `swiss-company-data.ts` is a throw-only stub. The real CH runtime path is `providers/swiss-company-data.ts` (DataProvider chain). The chain provider builds the actual output; that file is OUT OF SCOPE per the prompt. Follow-up flagged in the summary.

## Aggregate per-flag distribution

- `tier_2_available: true` → 3 handlers (DE, GR, US-Cobalt — emit directors)
- `tier_2_available: false` → 28 handlers (with country-specific reason strings)
- `ubo_availability: available` → 2 (DK, UK)
- `ubo_availability: restricted` → 14
- `ubo_availability: unavailable_no_registry` → 15

Per-handler change matrix at [`audit-output/labeling-sweep-summary-2026-05-18.md`](../blob/feat/evidence-tier-labeling-sweep/audit-output/labeling-sweep-summary-2026-05-18.md).

## Backward compatibility

- 0 existing field names removed or renamed
- All existing consumers continue to read existing field names unchanged
- New fields are additive

## Verification

- `npx tsc --noEmit` (apps/api): clean
- `npm --workspace=apps/api test`: 665 passed, 33 skipped (no regression)
- Per-handler grep: every patched file contains `tier_2_available` and `ubo_availability` (verified across the 31)

## Reviewer findings

To be filled by `/go` six-lens review before self-merge per Rule 16.

## What this PR does NOT do

- No upstream data fetching changes
- No `lib/openapi-resolver.ts` modifications
- No `legal_form` fix for Openapi-routed countries (real data gap, separate)
- No `legal_representatives` extraction additions (separate follow-up — 13 handlers flagged in summary as candidates)
- No `providers/swiss-company-data.ts` labeling (deferred — see scope notes)
- No coverage-matrix YAML rescore against new 6/3/3 rubric (separate)
- No Digiteal / SEPA bank-verification handler creation (separate)
- No ongoing-monitoring handler creation (deferred v1.1)

## Follow-up flagged in summary

- 11 countries' UBO availability values marked "verification pending public-source confirmation" — v1.1 verification task
- 13 handlers carrying `tier_2_available: false` because the handler doesn't currently extract upstream directors data (where upstream registry DOES expose it) — follow-up extraction sweep
- `swiss-company-data` chain-provider labeling — follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)