### PR TITLE
feat(ubo): activate UK PSC + flip DK to honest unavailable (DEC-20260518-D)

### DIFF
--- a/apps/api/coverage-matrix/COVERAGE.md
+++ b/apps/api/coverage-matrix/COVERAGE.md
@@ -6,8 +6,8 @@ Total rows: 47
 
 ## By status
 
-- Live: 28
-- Committed: 19
+- Live: 29
+- Committed: 18
 
 ## By evidence type
 
@@ -24,7 +24,7 @@ Total rows: 47
 | beneficial-ownership-lookup | DK | Beneficial ownership | OpenOwnership | Committed | €0 | — | 2026-04-28 |
 | gleif-l2-children-lookup | Global | Beneficial ownership | GLEIF | Committed | €0 | — | 2026-04-28 |
 | gleif-l2-ubo-lookup | Global | Beneficial ownership | GLEIF | Committed | €0 | — | 2026-04-28 |
-| beneficial-ownership-lookup | UK | Beneficial ownership | OpenOwnership | Committed | €0 | — | 2026-04-28 |
+| beneficial-ownership-lookup | UK | Beneficial ownership | OpenOwnership | Live | €0 | — | 2026-05-18 |
 | uk-company-data | UK | Beneficial ownership | PSC register | Live | — | — | 2026-04-20 |
 
 ### Company registry (32)
@@ -309,7 +309,7 @@ Total rows: 47
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| beneficial-ownership-lookup | UK | Beneficial ownership | OpenOwnership | Committed | €0 | — | 2026-04-28 |
+| beneficial-ownership-lookup | UK | Beneficial ownership | OpenOwnership | Live | €0 | — | 2026-05-18 |
 | insolvency-check | UK | Litigation / bankruptcy | Companies House | Live | €0 | — | 2026-04-28 |
 | uk-company-data | UK | Beneficial ownership | PSC register | Live | — | — | 2026-04-20 |
 | uk-company-data | UK | Company registry | Companies House | Live | €0.05 | live-verified | 2026-05-15 |

--- a/apps/api/coverage-matrix/beneficial-ownership-lookup__uk__beneficial-ownership.yaml
+++ b/apps/api/coverage-matrix/beneficial-ownership-lookup__uk__beneficial-ownership.yaml
@@ -2,14 +2,14 @@ capability_slug: beneficial-ownership-lookup
 country: UK
 evidence_type: Beneficial ownership
 provider: OpenOwnership
-status: Committed
-sourcing_pattern: Free open data
+status: Live
+sourcing_pattern: Direct API
 per_call_price_eur: 0
 evidence_grade: null
 tier_1_coverage: null
 tier_2_coverage: null
 tier_3_coverage: null
-last_verified: "2026-04-28"
+last_verified: "2026-05-18"
 products:
   - Counterparty Assurance
 vendor_roster_url: null

--- a/apps/api/src/capabilities/danish-company-data.ts
+++ b/apps/api/src/capabilities/danish-company-data.ts
@@ -148,8 +148,8 @@ registerCapability("danish-company-data", async (input: CapabilityInput) => {
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
     o.tier_2_available = false;
     o.tier_2_available_reason = "cvrapi.dk free tier does not expose directors; Virk system-til-system direct integration tracked separately";
-    o.ubo_availability = "available";
-    o.ubo_availability_reason = "Beneficial owner data accessible via CVR / OpenOwnership BODS DK extraction (handler integration pending; flag reflects jurisdictional availability)";
+    o.ubo_availability = "unavailable_no_registry";
+    o.ubo_availability_reason = "Danish beneficial ownership data integration in progress; coverage in v1.1.";
   }
 
   return {

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -147,7 +147,7 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
     o.tier_2_available = false;
     o.tier_2_available_reason = "Companies House summary endpoint does not expose officers in current handler implementation; officers extraction is a follow-up labeling task";
     o.ubo_availability = "available";
-    o.ubo_availability_reason = "PSC (Persons with Significant Control) register publicly accessible via Companies House";
+    o.ubo_availability_reason = "Beneficial ownership data available via UK PSC register.";
   }
 
   return {

--- a/audit-output/ubo-activation-uk-dk-2026-05-18.md
+++ b/audit-output/ubo-activation-uk-dk-2026-05-18.md
@@ -1,0 +1,122 @@
+# UBO activation summary — UK + DK
+Date: 2026-05-18
+Branch: feat/ubo-activation-uk-dk
+
+Methodology note: smoke tests were performed via static code-path analysis
+only — no local API harness was started, no Railway production calls were
+issued. Each Outcome below is marked `(static analysis only)`. The code paths
+were short and unambiguous enough that running the API was not necessary to
+reach high-confidence conclusions; an end-to-end smoke test against Railway
+prod is queued as a chat-side follow-up before any external customer claim is
+made.
+
+## UK
+
+Outcome: GREEN (static analysis only)
+
+Pre-PR ubo_availability: available (per PR #131)
+Pre-PR populated ubo[]: yes — `beneficial-ownership-lookup` handler integrates
+directly with Companies House PSC API (`apps/api/src/capabilities/beneficial-ownership-lookup.ts:97-184`)
+and is wired as step 2 of the UK Counterparty Assurance solution bundle
+(`apps/api/src/db/seed-solutions.ts:1792-1797`), returning a populated
+`beneficial_owners[]` array on a real PSC fetch.
+
+Post-PR ubo_availability: available (unchanged — flag was already capability-state-true)
+Post-PR populated ubo[]: yes (unchanged)
+
+Changes:
+- `apps/api/src/capabilities/uk-company-data.ts`: refined `ubo_availability_reason`
+  from operational-language ("PSC register publicly accessible via Companies
+  House") to customer-friendly language ("Beneficial ownership data available
+  via UK PSC register.") per DEC-20260518-D capability-state semantics.
+- `apps/api/coverage-matrix/beneficial-ownership-lookup__uk__beneficial-ownership.yaml`:
+  - `status: Committed` → `status: Live`
+  - `sourcing_pattern: Free open data` → `sourcing_pattern: Direct API`
+    (matches the handler's actual integration shape, mirroring
+    `uk-company-data__uk__beneficial-ownership.yaml`)
+  - `last_verified: 2026-04-28` → `2026-05-18`
+- `apps/api/coverage-matrix/uk-company-data__uk__beneficial-ownership.yaml`:
+  no changes (already `Live`).
+
+## DK
+
+Outcome: RED (static analysis only)
+
+Pre-PR ubo_availability: available (per PR #131)
+Pre-PR populated ubo[]: no — `beneficial-ownership-lookup.ts:37-54` explicitly
+returns `supported_jurisdiction: false` for all non-UK jurisdictions. No
+DK-specific UBO integration exists anywhere in the codebase (grep confirmed:
+no DK→UBO call path). The reason string set by PR #131 itself admitted
+"handler integration pending; flag reflects jurisdictional availability" —
+which is the exact DEC-20260518-D violation: the flag was reflecting
+jurisdictional state, not capability state.
+
+Post-PR ubo_availability: unavailable_no_registry
+Post-PR populated ubo[]: no (unchanged — but now flag matches state)
+
+Changes:
+- `apps/api/src/capabilities/danish-company-data.ts`: flipped
+  `ubo_availability` from `available` to `unavailable_no_registry`; updated
+  reason to: "Danish beneficial ownership data integration in progress;
+  coverage in v1.1."
+- `apps/api/coverage-matrix/beneficial-ownership-lookup__dk__beneficial-ownership.yaml`:
+  no change — already `Committed`, which is the correct pre-integration
+  status. (The YAML row pre-dates the handler-level flag enforcement; it
+  continues to track the planned DK integration as a deferred build item.)
+
+Gap identified: the Danish UBO register (operated by Erhvervsstyrelsen via
+Virk) is publicly accessible per EU 5AMLD transposition, but Strale has no
+integration. Options for v1.1 enablement:
+- Add DK branch to `beneficial-ownership-lookup.ts` that calls
+  datacvr.virk.dk's UBO endpoint (requires system-to-system access setup,
+  already queued separately for identity data).
+- Consume OpenOwnership BODS DK extracts (the YAML's stated plan) as a
+  bulk-import path.
+
+Semantic note on enum value: the chosen value `unavailable_no_registry` is
+the closest match in the existing enum but is slightly imprecise — a DK BO
+register does exist, the capability gap is on the platform side. The enum
+does not currently have an `integration_pending` or `not_yet_integrated`
+bucket. Chat-side may consider adding one in v1.1 if customer
+explainability suffers. The reason string carries the truthful detail
+either way.
+
+## YAML status changes
+
+- `beneficial-ownership-lookup__uk__beneficial-ownership.yaml`: status was
+  `Committed`, now `Live`. Sourcing pattern was "Free open data", now
+  "Direct API". Last-verified was 2026-04-28, now 2026-05-18.
+- `beneficial-ownership-lookup__dk__beneficial-ownership.yaml`: no change.
+  Remains `Committed` — correct pre-integration state.
+
+## Follow-up to-dos flagged (chat-side filing)
+
+This CC session does not have Notion MCP write access. The following
+to-dos are flagged for chat-side filing under the To-do DB
+(collection://33a67c87-082c-8033-8ac5-000ba9922392):
+
+1. **[v1.1] Ship DK UBO integration**. Add a DK branch to
+   `beneficial-ownership-lookup.ts` that consumes the Danish public BO
+   register (via datacvr.virk.dk system-to-system access or OpenOwnership
+   BODS DK extracts). On ship: flip `danish-company-data.ts`
+   `ubo_availability` back to `available` with reason "Beneficial ownership
+   data available via Danish BO register." and lift the
+   `beneficial-ownership-lookup__dk__beneficial-ownership.yaml` status from
+   `Committed` to `Live`.
+
+2. **[v1.0 pre-launch] End-to-end smoke test for UK UBO**. Run a real
+   Counterparty Assurance call against a known-good UK entity (e.g.
+   Companies House number `00006245` / BP P.L.C.) and confirm the response
+   carries a populated `beneficial_owners[]` array and that the per-handler
+   `ubo_availability: available` flag is consistent with the data. This
+   PR's UK Outcome was reached by static analysis only; one live call before
+   v1 launch validates the conclusion.
+
+3. **[v1.1 consideration] Add `integration_pending` value to the
+   `ubo_availability` enum**. The current enum (`available`, `restricted`,
+   `unavailable_no_registry`) does not have a precise bucket for "the
+   register exists in this jurisdiction but the platform has not yet
+   integrated it." DK currently lives in this gap and is labeled
+   `unavailable_no_registry` as a least-bad match. Adding a dedicated value
+   would improve customer-facing honesty without conflating two distinct
+   states.


### PR DESCRIPTION
## Summary

Activates UK + DK UBO coverage end-to-end where the integration works (UK),
or falls back to honest `unavailable_no_registry` where it does not (DK).

Implements DEC-20260518-D capability-state semantics for the two countries
flagged by PR #131. PR #131's labeling sweep set both `ubo_availability:
available` on jurisdictional grounds; DEC-20260518-D locked the flag to mean
*capability state, not jurisdictional state* — so this PR closes the gap.

## Per-country outcome (static analysis only)

### UK: GREEN

- `apps/api/src/capabilities/beneficial-ownership-lookup.ts:28-197` has a
  fully working integration against the Companies House PSC API (free,
  direct, key-gated by `COMPANIES_HOUSE_API_KEY`).
- The UK Counterparty Assurance solution bundle wires it as step 2
  (`apps/api/src/db/seed-solutions.ts:1792-1797`, `jurisdiction:
  $input.country_code`) and returns a populated `beneficial_owners[]`
  array on a live PSC fetch.
- Changes:
  - Refined `uk-company-data.ts` `ubo_availability_reason` to customer-
    friendly: `"Beneficial ownership data available via UK PSC register."`
  - Lifted `beneficial-ownership-lookup__uk__beneficial-ownership.yaml`
    from `Committed` → `Live`; `sourcing_pattern: Free open data` →
    `Direct API`; `last_verified: 2026-05-18`.

### DK: RED

- `beneficial-ownership-lookup.ts:37-54` explicitly rejects non-UK
  jurisdictions and returns `supported_jurisdiction: false`. Grep confirmed
  no DK→UBO code path exists anywhere in the codebase.
- The PR #131 reason string for DK itself admitted "handler integration
  pending; flag reflects jurisdictional availability" — the exact
  DEC-20260518-D violation.
- No fixable in-session gap (the integration would require building a new
  provider branch against datacvr.virk.dk system-to-system access or
  OpenOwnership BODS DK extracts — out of scope for this PR).
- Changes:
  - Flipped `danish-company-data.ts` `ubo_availability: available` →
    `unavailable_no_registry`; reason: `"Danish beneficial ownership data
    integration in progress; coverage in v1.1."`
  - DK YAML unchanged (already `Committed`, correct pre-integration state).

## Smoke test methodology

Static code-path analysis only. The two paths are short and unambiguous:
- UK: solution-bundle step → `beneficial-ownership-lookup` handler →
  Companies House PSC API → populated array. Live integration in place
  since 2026-04-20 per the `uk-company-data__uk__beneficial-ownership.yaml`
  Live YAML row.
- DK: solution-bundle step → `beneficial-ownership-lookup` handler →
  early return with `supported_jurisdiction: false`. No populated array.

A live smoke test against Railway production (e.g. CH number `00006245` /
BP P.L.C.) is flagged as a **v1.0 pre-launch follow-up** to validate the
UK conclusion before any external customer claim. The flag-level
correctness shipped here doesn't depend on the live smoke, only on the
code-path correctness, which is unambiguous.

## What this PR does NOT do

- Does not relabel other countries' `ubo_availability` flags (covered by
  the v1.1 verification follow-up for the 11 countries flagged in the PR
  #131 sweep summary).
- Does not build the DK UBO integration itself (separate v1.1 build item;
  no provider integration exists yet).
- Does not file Notion to-dos directly — this CC session does not have
  Notion MCP write access. Three follow-ups are flagged in
  `audit-output/ubo-activation-uk-dk-2026-05-18.md` for chat-side filing.

## Files changed

- `apps/api/src/capabilities/uk-company-data.ts` — reason string refined
- `apps/api/src/capabilities/danish-company-data.ts` — flag flipped + reason
- `apps/api/coverage-matrix/beneficial-ownership-lookup__uk__beneficial-ownership.yaml` — status Live
- `audit-output/ubo-activation-uk-dk-2026-05-18.md` — summary (new file)

## Verification

- `npx tsc --noEmit` clean
- Audit phase output in `audit-output/ubo-activation-uk-dk-2026-05-18.md`
- Per-country smoke result documented above and in summary file
- Follow-up to-dos surfaced for chat-side filing (Notion access not in CC scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)