### PR TITLE
feat(t2): Class A labeling fix for FR + SK + UK + SE YAML cleanup

### DIFF
--- a/apps/api/coverage-matrix/swedish-company-data__se__company-registry.yaml
+++ b/apps/api/coverage-matrix/swedish-company-data__se__company-registry.yaml
@@ -7,7 +7,7 @@ sourcing_pattern: "Direct API"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 7/7
-tier_2_coverage: 4/5 (directors via Bolagsverket; VAT via VIES routing)
+tier_2_coverage: 3/5 (VAT via VIES routing; directors integration planned Phase 4)
 tier_3_coverage: 2/6 (NACE + last filing date)
 last_verified: "2026-05-15"
 products:

--- a/apps/api/src/capabilities/french-company-data.ts
+++ b/apps/api/src/capabilities/french-company-data.ts
@@ -108,8 +108,9 @@ registerCapability("french-company-data", async (input: CapabilityInput) => {
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
-    o.tier_2_available = false;
-    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    if (o.legal_representatives === undefined) o.legal_representatives = o.directors;
+    o.tier_2_available = true;
+    o.tier_2_available_reason = "Legal representatives extracted from INPI Registre national des entreprises (RNE) via recherche-entreprises.api.gouv.fr.";
     o.ubo_availability = "restricted";
     o.ubo_availability_reason = "RBE (Registre des bénéficiaires effectifs) access restricted post-CJEU 2022";
   }

--- a/apps/api/src/capabilities/slovak-company-data.ts
+++ b/apps/api/src/capabilities/slovak-company-data.ts
@@ -193,9 +193,10 @@ registerCapability("slovak-company-data", async (input: CapabilityInput) => {
       primary_registration_id: currentRegNumber?.value ?? null,
       registered_address: formatAddress(currentAddress),
       date_incorporated: entity.establishment ?? null,
+      legal_representatives: directors,
       // Evidence Tier framework labels (DEC-20260518-A)
-      tier_2_available: false,
-      tier_2_available_reason: "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked",
+      tier_2_available: true,
+      tier_2_available_reason: "Legal representatives extracted from Slovak Register of Legal Persons (RPO).",
       ubo_availability: "unavailable_no_registry",
       ubo_availability_reason: "RPVS (Register partnerov verejného sektora) not accessible for foreign users at v1; verification pending public-source confirmation",
     },

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -61,6 +61,29 @@ async function searchCompany(name: string): Promise<string> {
   return items[0].company_number;
 }
 
+async function fetchOfficers(companyNumber: string): Promise<Array<{ name: string; role: string; start_date: string | null }>> {
+  const key = getApiKey();
+  const url = `${API}/company/${companyNumber}/officers?items_per_page=100`;
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Basic ${Buffer.from(key + ":").toString("base64")}`,
+    },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (response.status === 404) return [];
+  if (!response.ok) throw new Error(`Companies House officers returned HTTP ${response.status}`);
+  const data = (await response.json()) as any;
+  const items: any[] = Array.isArray(data?.items) ? data.items : [];
+  return items
+    .filter((o) => !o.resigned_on)
+    .map((o) => ({
+      name: o.name ?? "",
+      role: o.officer_role ?? "",
+      start_date: o.appointed_on ?? null,
+    }));
+}
+
 async function fetchCompany(companyNumber: string): Promise<Record<string, unknown>> {
   const key = getApiKey();
   const url = `${API}/company/${companyNumber}`;
@@ -128,7 +151,10 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
     companyNumber = await searchCompany(name);
   }
 
-  const output = await fetchCompany(companyNumber);
+  const [output, officers] = await Promise.all([
+    fetchCompany(companyNumber),
+    fetchOfficers(companyNumber),
+  ]);
 
   // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
   // Resolves alias keys at runtime; only sets a canonical if not already present.
@@ -144,8 +170,9 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
-    o.tier_2_available = false;
-    o.tier_2_available_reason = "Companies House summary endpoint does not expose officers in current handler implementation; officers extraction is a follow-up labeling task";
+    o.legal_representatives = officers;
+    o.tier_2_available = true;
+    o.tier_2_available_reason = "Legal representatives extracted from UK Companies House Officers register.";
     o.ubo_availability = "available";
     o.ubo_availability_reason = "Beneficial ownership data available via UK PSC register.";
   }

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -71,7 +71,6 @@ async function fetchOfficers(companyNumber: string): Promise<Array<{ name: strin
     },
     signal: AbortSignal.timeout(10000),
   });
-  if (response.status === 404) return [];
   if (!response.ok) throw new Error(`Companies House officers returned HTTP ${response.status}`);
   const data = (await response.json()) as any;
   const items: any[] = Array.isArray(data?.items) ? data.items : [];
@@ -170,7 +169,7 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
-    o.legal_representatives = officers;
+    if (o.legal_representatives === undefined) o.legal_representatives = officers;
     o.tier_2_available = true;
     o.tier_2_available_reason = "Legal representatives extracted from UK Companies House Officers register.";
     o.ubo_availability = "available";


### PR DESCRIPTION
## Summary

Phase 1 of cost-free coverage sprint. Lifts EU30 binding-ready T2 from 2 (DE, GR) to 5 (DE, FR, GR, SK, UK). No per-call cost increase; all upstream sources already in use.

Three Class A audit-bug fixes (FR, SK, UK) plus one YAML drift cleanup (SE), per the 2026-05-18 verification reports (`audit-output/registry-source-research-2026-05-18.md` + handler-side directors verification).

### What changed per country

- **FR** (`french-company-data.ts`) — handler already emitted `directors[]` from INPI RNE via `recherche-entreprises.api.gouv.fr`; PR-131 labeling sweep wrongly set `tier_2_available: false`. Flipped to `true`, added `legal_representatives` canonical alias mirroring `directors`, rewrote reason string.
- **SK** (`slovak-company-data.ts`) — handler already emitted `directors[]` from RPO `statutoryBodies` with active-only filter. Same Class A fix as FR.
- **UK** (`uk-company-data.ts`) — bundled Companies House Officers extraction inline (new `fetchOfficers()` running in parallel with `fetchCompany` via `Promise.all`). `legal_representatives[]` populated with canonical `{name, role, start_date}` for active officers. Sibling capability `uk-companies-house-officers.ts` preserved standalone.
- **SE** (`swedish-company-data__se__company-registry.yaml`) — annotation removed `directors via Bolagsverket` claim handler doesnt deliver. SE extraction deferred to Phase 4.

## Verification

- TSC: clean for files in this PR
- Tests: 665 passed, 33 skipped, 0 failed (whole suite)
- `validate-capability.ts`: SK 19/19; FR 19/20 + UK 19/20 — the single failed gate (`company_name` entry point lacks fixture) is **pre-existing on main**, not introduced by this PR
- `smoke-test.ts`: SK 11/11 live; FR/UK 10/11 with step 2 blocked by `cost_class=paid_prepaid` ALLOW_MATRIX (expected, same on main)
- `checkReadiness`: requires DATABASE_URL, skipped locally; covered by `validate-capability` ground

## /go six-lens review — findings

### Inline fixes applied (commit `87d21ae`)

- **UK alias-guard consistency** (Pass A architect/quality) — changed `o.legal_representatives = officers;` to `if (o.legal_representatives === undefined) o.legal_representatives = officers;` matching the surrounding canonical-alias block invariant.
- **UK `fetchOfficers` 404 swallow** (Pass A senior-developer) — removed `if (response.status === 404) return [];`. Previously a 404 on the officers endpoint silently produced `legal_representatives: []` with `tier_2_available: true`, making the flag misleading. Now propagates as a structured error consistent with `fetchCompany`.

### MEDIUM findings flagged for chat-side decision (not blocking)

1. **Cross-country `legal_representatives` shape mismatch** (Pass B product, originally HIGH) — FR/SK emit `string[]` (`"FirstName LastName (Role)"` and formatted-name respectively); UK emits `Array<{name, role, start_date}>`. A multi-country normalizer cannot treat them uniformly. This is **prompt-directed** (Phase 1 prompt said `mirror existing directors array` for FR/SK and structured shape for UK), so I did not auto-fix. Demoted from HIGH because the design was deliberate; surfacing here for explicit decision before customers bind to the contract. Two ways to close:
   - Normalize FR/SK to `{name, role, start_date}` (FR can split `prenoms`/`nom`/`qualite`; SK has only `formatedName` so `role`/`start_date` would be `null`).
   - Document the per-country shape variance in the manifest and accept the contract asymmetry.
2. **Manifest `output_field_reliability` gap** (Pass A protocol) — manifests for FR / SK / UK do not yet declare `legal_representatives`. Per DEC-20260320-B Capability Onboarding Protocol the new field should be annotated (likely `reliability: common` — empty for shell entities or unpopulated cases). Follow-up PR.
3. **SE YAML roadmap leak** (Pass B UX) — annotation reads `3/5 (VAT via VIES routing; directors integration planned Phase 4)`. The "planned Phase 4" phrasing bakes a roadmap promise into a coverage-matrix artifact. Consider rewriting to describe state only (e.g. `directors not extracted from this source`).
4. **`tier_2_available_reason` voice** (Pass B UX) — the new strings read past-tense passive ("Legal representatives extracted from...") rather than caller-oriented ("Returns active legal representatives from..."). Voice diverges from the `ubo_availability_reason` style in the same files. Pattern-consistency call.
5. **UK 100-officer pagination cap** (Pass B / efficiency) — `items_per_page=100` with no follow-up page or `legal_representatives_truncated` flag. Rare edge case (FTSE-100 conglomerates with 100+ active officers + lifetime resignations), but mirrors the FR audit finding documented in `docs/fr-directors-truncation-2026-05-15.md` that we already fixed there. Consider parity.
6. **Companies House auth-header duplication** (architect) — `Basic ${Buffer.from(key + ":").toString("base64")}` now appears 3× in `uk-company-data.ts` plus 1× in sibling `uk-companies-house-officers.ts`. Extract to a shared helper in a follow-up.

## What this PR does NOT do

- Does NOT delete `uk-companies-house-officers` (kept standalone)
- Does NOT change the other 27 EU30 handlers
- Does NOT add new vendor integrations
- Does NOT update manifests for `legal_representatives` (flagged as follow-up)
- Does NOT ship SE Funktionärer extraction (deferred to Phase 4)
- Does NOT normalize FR/SK shapes to match UK (awaiting decision per MEDIUM #1)

## Doctrine

- DEC-20260518-A — Evidence Tier framework (T2 Bindability semantics)
- DEC-20260518-D — `ubo_availability` capability state (parallel pattern)
- DEC-20260320-B — Capability Onboarding Protocol (manifest annotations follow-up)

## Test plan

- [ ] CI green (both `check` and Coverage matrix validation passed on `c2e4974`; re-running on `87d21ae`)
- [ ] Post-merge: production smoke test of FR Renault SIREN 441639465, SK Slovnaft ICO 31322832, UK Monzo CH 09446231 via `/v1/do` returning each handler — confirm `tier_2_available: true` and `legal_representatives[]` populated
- [ ] MEDIUM #1 decision — normalize shapes vs document asymmetry

Generated with [Claude Code](https://claude.com/claude-code)