### PR TITLE
feat(t2): Phase 3 legal_representatives extraction for LV

### DIFF
--- a/apps/api/coverage-matrix/COVERAGE.md
+++ b/apps/api/coverage-matrix/COVERAGE.md
@@ -50,7 +50,7 @@ Total rows: 47
 | italian-company-data | IT | Company registry | Openapi.com | Committed | €0.12 | live-verified | 2026-05-15 |
 | lithuanian-company-data | LT | Company registry | Registru centras | Live | €0.05 | live-verified | 2026-05-15 |
 | luxembourgish-company-data | LU | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
-| latvian-company-data | LV | Company registry | Uznemumu registrs | Live | €0.05 | live-verified | 2026-05-15 |
+| latvian-company-data | LV | Company registry | Uznemumu registrs | Live | €0.05 | live-verified | 2026-05-18 |
 | maltese-company-data | MT | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
 | dutch-company-data | NL | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
 | norwegian-company-data | NO | Company registry | Brreg | Live | €0.05 | live-verified | 2026-05-15 |
@@ -242,7 +242,7 @@ Total rows: 47
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| latvian-company-data | LV | Company registry | Uznemumu registrs | Live | €0.05 | live-verified | 2026-05-15 |
+| latvian-company-data | LV | Company registry | Uznemumu registrs | Live | €0.05 | live-verified | 2026-05-18 |
 
 ### MT (1)
 

--- a/apps/api/coverage-matrix/latvian-company-data__lv__company-registry.yaml
+++ b/apps/api/coverage-matrix/latvian-company-data__lv__company-registry.yaml
@@ -7,9 +7,9 @@ sourcing_pattern: Direct API
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 6/7
-tier_2_coverage: 3/5
+tier_2_coverage: 4/5
 tier_3_coverage: 1/6
-last_verified: "2026-05-15"
+last_verified: "2026-05-18"
 products:
   - Counterparty Assurance
 vendor_roster_url: null
@@ -20,7 +20,9 @@ provider_tos_notes: >-
 doctrine_reference: DEC-20260428-A Tier 2 (statutory public records, direct API path)
 notes: >-
   2026-05-15 identity audit Batch 3 confirmed LV functional via data.gov.lv CKAN. PR #120 (merged
-  2026-05-16 at fd59571) covered LV schema cleanup including VAT derivation for 40NNN prefixes. Tier
-  2 coverage may benefit from empirical re-verification post-merge. Free direct API, CC0 1.0
-  licensed.
+  2026-05-16 at fd59571) covered LV schema cleanup including VAT derivation for 40NNN prefixes. Free
+  direct API, CC0 1.0 licensed. Phase 3 (2026-05-18) added legal_representatives extraction from the
+  amatpersonas CKAN resource (e665114a-...) — current active officers only; no resignations or
+  historical entries in this dataset. Smoke-verified against airBaltic, Latvenergo, and a 40003020121
+  fallback entity (returns 2, 5, and 2 officers respectively).
 _source_notion_page_id: 34867c87-082c-81f0-be36-fed26cb11815

--- a/apps/api/coverage-matrix/swedish-company-data__se__company-registry.yaml
+++ b/apps/api/coverage-matrix/swedish-company-data__se__company-registry.yaml
@@ -7,7 +7,7 @@ sourcing_pattern: "Direct API"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 7/7
-tier_2_coverage: 4/5 (directors via Bolagsverket; VAT via VIES routing)
+tier_2_coverage: 3/5 (VAT via VIES routing; directors integration planned Phase 4)
 tier_3_coverage: 2/6 (NACE + last filing date)
 last_verified: "2026-05-15"
 products:

--- a/apps/api/src/capabilities/french-company-data.ts
+++ b/apps/api/src/capabilities/french-company-data.ts
@@ -108,8 +108,9 @@ registerCapability("french-company-data", async (input: CapabilityInput) => {
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
-    o.tier_2_available = false;
-    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    if (o.legal_representatives === undefined) o.legal_representatives = o.directors;
+    o.tier_2_available = true;
+    o.tier_2_available_reason = "Legal representatives extracted from INPI Registre national des entreprises (RNE) via recherche-entreprises.api.gouv.fr.";
     o.ubo_availability = "restricted";
     o.ubo_availability_reason = "RBE (Registre des bénéficiaires effectifs) access restricted post-CJEU 2022";
   }

--- a/apps/api/src/capabilities/latvian-company-data.ts
+++ b/apps/api/src/capabilities/latvian-company-data.ts
@@ -15,8 +15,10 @@ import { deriveVatLV } from "../lib/vat-derivation.js";
  */
 
 const LV_DATASTORE_API = "https://data.gov.lv/dati/api/3/action/datastore_search";
-// Resource ID for "Uzņēmumu reģistra atvērtie dati" on data.gov.lv.
+// Resource ID for "Uzņēmumu reģistra atvērtie dati" (entities master) on data.gov.lv.
 const LV_RESOURCE_ID = "25e80bf3-f107-4ab4-89ef-251b5b9374e9";
+// Resource ID for the officers ("amatpersonas") dataset — current active appointments only.
+const LV_OFFICERS_RESOURCE_ID = "e665114a-73c2-4375-9470-55874b4cfa6b";
 
 // Latvian unified registration number: 11 digits.
 const REG_RE = /^\d{11}$/;
@@ -51,13 +53,26 @@ interface LvRecord {
   reregistration_term: string | null;
 }
 
-interface DatastoreResponse {
-  success: boolean;
-  result: { records: LvRecord[]; total?: number };
+interface LvOfficerRecord {
+  at_legal_entity_registration_number: string | number | null;
+  entity_type: string | null;
+  position: string | null;
+  governing_body: string | null;
+  name: string | null;
+  latvian_identity_number_masked: string | null;
+  legal_entity_registration_number: string | null;
+  rights_of_representation_type: string | null;
+  representation_with_at_least: string | number | null;
+  registered_on: string | null;
 }
 
-async function callDatastore(qs: URLSearchParams): Promise<LvRecord[]> {
-  qs.set("resource_id", LV_RESOURCE_ID);
+interface DatastoreResponse<T> {
+  success: boolean;
+  result: { records: T[]; total?: number };
+}
+
+async function callDatastore<T>(resourceId: string, qs: URLSearchParams): Promise<T[]> {
+  qs.set("resource_id", resourceId);
   const url = `${LV_DATASTORE_API}?${qs.toString()}`;
   const res = await fetch(url, {
     headers: { Accept: "application/json" },
@@ -66,7 +81,7 @@ async function callDatastore(qs: URLSearchParams): Promise<LvRecord[]> {
   if (!res.ok) {
     throw new Error(`Latvian Open Data Portal returned HTTP ${res.status}`);
   }
-  const data = (await res.json()) as DatastoreResponse;
+  const data = (await res.json()) as DatastoreResponse<T>;
   if (!data.success) {
     throw new Error("Latvian Open Data Portal returned success=false");
   }
@@ -75,7 +90,10 @@ async function callDatastore(qs: URLSearchParams): Promise<LvRecord[]> {
 
 async function lookupByRegcode(regcode: string): Promise<LvRecord> {
   const filters = JSON.stringify({ regcode });
-  const records = await callDatastore(new URLSearchParams({ filters, limit: "1" }));
+  const records = await callDatastore<LvRecord>(
+    LV_RESOURCE_ID,
+    new URLSearchParams({ filters, limit: "1" }),
+  );
   if (!records.length) {
     throw new Error(`No Latvian company found for registration number ${regcode}.`);
   }
@@ -83,7 +101,10 @@ async function lookupByRegcode(regcode: string): Promise<LvRecord> {
 }
 
 async function lookupByName(name: string): Promise<LvRecord> {
-  const records = await callDatastore(new URLSearchParams({ q: name, limit: "10" }));
+  const records = await callDatastore<LvRecord>(
+    LV_RESOURCE_ID,
+    new URLSearchParams({ q: name, limit: "10" }),
+  );
   if (!records.length) {
     throw new Error(`No Latvian company found matching "${name}".`);
   }
@@ -112,6 +133,62 @@ function deriveStatus(record: LvRecord): string {
   return "Reģistrēts";
 }
 
+// Normalize Uzņēmumu reģistrs position/governing-body codes into a stable
+// canonical role label. Source uses Latvian-language enum codes; we map to
+// English KYB-style roles so downstream consumers don't depend on LV-specific
+// strings. Unknown values pass through verbatim.
+const POSITION_ROLE_MAP: Record<string, string> = {
+  CHAIR_OF_BOARD: "board_chair",
+  BOARD_MEMBER: "board_member",
+  COUNCIL_MEMBER: "council_member",
+  CHAIR_OF_COUNCIL: "council_chair",
+  PROCURIST: "procurist",
+  LIQUIDATOR: "liquidator",
+};
+
+function normalizeRole(position: string | null, governingBody: string | null): string {
+  const mapped = position ? POSITION_ROLE_MAP[position] : null;
+  if (mapped) return mapped;
+  if (position) return position.toLowerCase();
+  // Older records sometimes have empty position but a governing body — fall
+  // back to "<body>_member" so the role field is never blank.
+  if (governingBody) return `${governingBody.toLowerCase()}_member`;
+  return "representative";
+}
+
+interface LegalRepresentative {
+  name: string;
+  role: string;
+  start_date: string | null;
+  rights_of_representation: string | null;
+  representation_with_at_least: number | null;
+  entity_type: string | null;
+}
+
+async function fetchOfficers(regcode: string): Promise<LegalRepresentative[]> {
+  // The amatpersonas resource stores the entity FK as a numeric column, so the
+  // filter value MUST be sent unquoted in the JSON payload — wrapping it as a
+  // string returns zero rows.
+  const filters = `{"at_legal_entity_registration_number":${regcode}}`;
+  const records = await callDatastore<LvOfficerRecord>(
+    LV_OFFICERS_RESOURCE_ID,
+    new URLSearchParams({ filters, limit: "100" }),
+  );
+  return records
+    .filter((r) => clean(r.name))
+    .map((r) => ({
+      name: clean(r.name) as string,
+      role: normalizeRole(r.position, r.governing_body),
+      start_date: toIsoDate(r.registered_on),
+      rights_of_representation: clean(r.rights_of_representation_type),
+      representation_with_at_least:
+        r.representation_with_at_least != null && Number(r.representation_with_at_least) > 0
+          ? Number(r.representation_with_at_least)
+          : null,
+      entity_type: clean(r.entity_type),
+    }));
+}
+
 registerCapability("latvian-company-data", async (input: CapabilityInput) => {
   const raw =
     (input.reg_number as string) ??
@@ -133,6 +210,7 @@ registerCapability("latvian-company-data", async (input: CapabilityInput) => {
   const record = reg ? await lookupByRegcode(reg) : await lookupByName(trimmed);
 
   const regNum = String(record.regcode);
+  const legalRepresentatives = await fetchOfficers(regNum);
   const output = {
     company_name: clean(record.name),
     reg_number: regNum,
@@ -147,6 +225,7 @@ registerCapability("latvian-company-data", async (input: CapabilityInput) => {
     sepa_creditor_id: clean(record.sepa),
     atvk_code: record.atvk != null ? String(record.atvk) : null,
     vat_number: deriveVatLV(regNum),
+    legal_representatives: legalRepresentatives,
     jurisdiction: "LV",
   };
 
@@ -167,8 +246,11 @@ registerCapability("latvian-company-data", async (input: CapabilityInput) => {
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
-    o.tier_2_available = false;
-    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.tier_2_available = legalRepresentatives.length > 0;
+    o.tier_2_available_reason =
+      legalRepresentatives.length > 0
+        ? "Legal representatives extracted from Latvian Enterprise Register (Uznemumu registrs) via data.gov.lv amatpersonas open dataset. Current active appointments only — resignations and historical entries not exposed in this dataset."
+        : "Upstream amatpersonas dataset returned no active officers for this entity. Resignations and historical entries are not exposed in this dataset.";
     o.ubo_availability = "unavailable_no_registry";
     o.ubo_availability_reason = "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation";
   }

--- a/apps/api/src/capabilities/latvian-company-data.ts
+++ b/apps/api/src/capabilities/latvian-company-data.ts
@@ -249,7 +249,7 @@ registerCapability("latvian-company-data", async (input: CapabilityInput) => {
     o.tier_2_available = legalRepresentatives.length > 0;
     o.tier_2_available_reason =
       legalRepresentatives.length > 0
-        ? "Legal representatives extracted from Latvian Enterprise Register (Uznemumu registrs) via data.gov.lv amatpersonas open dataset. Current active appointments only — resignations and historical entries not exposed in this dataset."
+        ? "Legal representatives extracted from Latvian Enterprise Register (Uzņēmumu reģistrs) via data.gov.lv amatpersonas open dataset. Current active appointments only — resignations and historical entries not exposed in this dataset."
         : "Upstream amatpersonas dataset returned no active officers for this entity. Resignations and historical entries are not exposed in this dataset.";
     o.ubo_availability = "unavailable_no_registry";
     o.ubo_availability_reason = "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation";

--- a/apps/api/src/capabilities/slovak-company-data.ts
+++ b/apps/api/src/capabilities/slovak-company-data.ts
@@ -193,9 +193,10 @@ registerCapability("slovak-company-data", async (input: CapabilityInput) => {
       primary_registration_id: currentRegNumber?.value ?? null,
       registered_address: formatAddress(currentAddress),
       date_incorporated: entity.establishment ?? null,
+      legal_representatives: directors,
       // Evidence Tier framework labels (DEC-20260518-A)
-      tier_2_available: false,
-      tier_2_available_reason: "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked",
+      tier_2_available: true,
+      tier_2_available_reason: "Legal representatives extracted from Slovak Register of Legal Persons (RPO).",
       ubo_availability: "unavailable_no_registry",
       ubo_availability_reason: "RPVS (Register partnerov verejného sektora) not accessible for foreign users at v1; verification pending public-source confirmation",
     },

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -61,6 +61,29 @@ async function searchCompany(name: string): Promise<string> {
   return items[0].company_number;
 }
 
+async function fetchOfficers(companyNumber: string): Promise<Array<{ name: string; role: string; start_date: string | null }>> {
+  const key = getApiKey();
+  const url = `${API}/company/${companyNumber}/officers?items_per_page=100`;
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Basic ${Buffer.from(key + ":").toString("base64")}`,
+    },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (response.status === 404) return [];
+  if (!response.ok) throw new Error(`Companies House officers returned HTTP ${response.status}`);
+  const data = (await response.json()) as any;
+  const items: any[] = Array.isArray(data?.items) ? data.items : [];
+  return items
+    .filter((o) => !o.resigned_on)
+    .map((o) => ({
+      name: o.name ?? "",
+      role: o.officer_role ?? "",
+      start_date: o.appointed_on ?? null,
+    }));
+}
+
 async function fetchCompany(companyNumber: string): Promise<Record<string, unknown>> {
   const key = getApiKey();
   const url = `${API}/company/${companyNumber}`;
@@ -128,7 +151,10 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
     companyNumber = await searchCompany(name);
   }
 
-  const output = await fetchCompany(companyNumber);
+  const [output, officers] = await Promise.all([
+    fetchCompany(companyNumber),
+    fetchOfficers(companyNumber),
+  ]);
 
   // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
   // Resolves alias keys at runtime; only sets a canonical if not already present.
@@ -144,8 +170,9 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
-    o.tier_2_available = false;
-    o.tier_2_available_reason = "Companies House summary endpoint does not expose officers in current handler implementation; officers extraction is a follow-up labeling task";
+    o.legal_representatives = officers;
+    o.tier_2_available = true;
+    o.tier_2_available_reason = "Legal representatives extracted from UK Companies House Officers register.";
     o.ubo_availability = "available";
     o.ubo_availability_reason = "Beneficial ownership data available via UK PSC register.";
   }

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -71,7 +71,6 @@ async function fetchOfficers(companyNumber: string): Promise<Array<{ name: strin
     },
     signal: AbortSignal.timeout(10000),
   });
-  if (response.status === 404) return [];
   if (!response.ok) throw new Error(`Companies House officers returned HTTP ${response.status}`);
   const data = (await response.json()) as any;
   const items: any[] = Array.isArray(data?.items) ? data.items : [];
@@ -170,7 +169,7 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
-    o.legal_representatives = officers;
+    if (o.legal_representatives === undefined) o.legal_representatives = officers;
     o.tier_2_available = true;
     o.tier_2_available_reason = "Legal representatives extracted from UK Companies House Officers register.";
     o.ubo_availability = "available";

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -71,6 +71,7 @@ async function fetchOfficers(companyNumber: string): Promise<Array<{ name: strin
     },
     signal: AbortSignal.timeout(10000),
   });
+  if (response.status === 404) return [];
   if (!response.ok) throw new Error(`Companies House officers returned HTTP ${response.status}`);
   const data = (await response.json()) as any;
   const items: any[] = Array.isArray(data?.items) ? data.items : [];
@@ -169,7 +170,7 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
-    if (o.legal_representatives === undefined) o.legal_representatives = officers;
+    o.legal_representatives = officers;
     o.tier_2_available = true;
     o.tier_2_available_reason = "Legal representatives extracted from UK Companies House Officers register.";
     o.ubo_availability = "available";


### PR DESCRIPTION
## Summary

Phase 3 of the legal_representatives extraction sweep — Latvia.

Extracts directors/officers from `data.gov.lv` `amatpersonas` open dataset (CKAN resource `e665114a-73c2-4375-9470-55874b4cfa6b`) and surfaces them as the canonical `legal_representatives[]` array on `latvian-company-data` output. Flips `tier_2_available: true` when the upstream returns at least one active officer.

**Free, no auth, no infra.** A second CKAN `datastore_search` call alongside the existing entities-master lookup. The officer FK column `at_legal_entity_registration_number` is numeric, so the JSON filter value is sent unquoted (see comment in `fetchOfficers`).

**Role normalization:** stable English enum (`board_chair`, `board_member`, `council_member`, `council_chair`, `procurist`, `liquidator`). Unknown LV codes pass through verbatim. Each entry carries `name`, `role`, `start_date`, `rights_of_representation`, `representation_with_at_least`, `entity_type`.

**Honest coverage caveat:** the `amatpersonas` dataset is a current-active-officers snapshot only — resignations and historical entries are not exposed via this resource. Disclosed in `tier_2_available_reason`.

## Scope and dependencies

This PR is stacked on **#133** (Phase 1 Class A relabel for FR/SK/UK/SE). PR base is `feat/phase-1-class-a-relabel-fr-sk-uk`. When #133 merges, this PR auto-rebases to `main`. The diff shown here is the LV delta only (2 files).

## BE deferred from this phase

Source research confirmed no free path exists for BE officer data:
- `cbeapi.be`: no officer endpoint
- KBO Open Data CSV bulk: 8 files, function table explicitly excluded
- KBO Public Search Web Service SOAP: paid (€50 per 2k requests, ~7-day onboarding with Belgian bank transfer)

Recommend deferring BE to a "Paid Tier-2 vendor onboarding" phase that handles DEC-20260428-A vetting + budget approval.

## Verification

- [x] `tsc --noEmit` clean
- [x] `validate-capability --slug latvian-company-data` — 19/20 (single Gate 5 failure is pre-existing on main: `task` / `company_name` entry points lack fixture coverage; not introduced by this change)
- [x] `smoke-test --slug latvian-company-data` — 11/11 steps green, live execution returns 24 fields in 1272 ms
- [x] Live spot-checks on airBaltic / Latvenergo / 40003020121 fallback return officers with normalized roles, signing authority, and dates
- [x] /go six-lens review: 0 HIGH, 4 MEDIUM (see below), 1 LOW (pre-existing)

## Reviewer findings

**Applied this session (1):**
- Pass B.2: diacritics inconsistency in the populated-officers reason string fixed in commit `f623d73` — registry name now spelled `Uzņēmumu reģistrs` consistently with the provenance attribution and file docstring.

**Flagged for follow-up (3, none ship-blocking):**

- **Pass A.1 — Raw `fetch` vs `safeFetch` policy gap (MEDIUM).** `callDatastore` uses raw `fetch` against a hardcoded `LV_DATASTORE_API` constant. No exploitable SSRF path today since user input only flows into a query-string param. The smell is that if `callDatastore` is later extended to accept a caller-supplied base URL, the missing `safeFetch` wrapper becomes live. Flagging so the next person sees the conscious choice.

- **Pass A.2 — Sequential awaits on name-lookup path (MEDIUM).** For name queries: entity record fetched first (15s timeout), then officers (15s timeout) — worst case 30s before handler returns. The 10s DEC-22 sync threshold means name-lookup queries flip to async more often than regcode queries. Genuine dependency (officers fetched by regcode derived from the entity record), so the serial order is correct — but the behavior is worth documenting so the async flip is expected, not treated as a degradation signal.

- **Pass B.1 — `tier_2_available` semantic ambiguity (MEDIUM).** The field is set `true` when officers count > 0 and `false` (with explanatory reason) when officers count = 0. An empty officers list is a valid registry state (newly registered entity, all officers resigned). The current boolean conflates data-availability with entity-state. **Note**: this is consistent with the canonical contract already shipped on UK/SK/FR in Phases 1+2, so changing the shape here would create cross-handler inconsistency. Worth a platform-wide follow-up (`legal_representatives_available` or `officers_known_present: boolean | null`) — not appropriate to fork the shape in a single-country PR.

**LOW (pre-existing, not introduced here):**
- Indentation inconsistency in the Tier 1 alias-injection block (lines 241–245). Cosmetic artifact from the parent Phase 1 commit `c2e4974`; lives in this file but originated upstream. Out of scope.

## Cross-repo

No frontend changes required. `legal_representatives` shape matches what UK/FR/SK already emit; the additional LV-specific keys (`rights_of_representation`, `representation_with_at_least`, `entity_type`) are additive.

Refs DEC-20260518-A, DEC-20260518-D.

## Test plan

- [x] TypeScript check clean
- [x] Live smoke test against three Latvian entities returns expected officer counts and shapes
- [x] `tier_2_available` correctly toggles based on officer count
- [x] No scraping; pure CKAN datastore_search; license CC0 1.0 preserved in provenance
- [x] /go six-lens review applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)