### PR TITLE
feat(t2): EE binding-ready T2 via RIK Ariregister Open Data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM node:20-slim
 
+# `unzip` is required by `apps/api/src/jobs/ingest-ee-directors.ts` — that
+# job streams the RIK Ariregister CC BY 4.0 open-data ZIP and pipes its
+# entry through `unzip -p` rather than carrying a Node ZIP dependency.
+# Without it the nightly ingest would fail at job start and the EE
+# tier-2 cache would never refresh. `apt-get clean` keeps the slim image
+# slim.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends unzip ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Copy package files first for better layer caching

--- a/apps/api/coverage-matrix/COVERAGE.md
+++ b/apps/api/coverage-matrix/COVERAGE.md
@@ -2,11 +2,11 @@
 
 > Auto-generated. Do not edit by hand. Regenerate via `npm run coverage-matrix:summary`.
 
-Total rows: 47
+Total rows: 48
 
 ## By status
 
-- Live: 29
+- Live: 30
 - Committed: 18
 
 ## By evidence type
@@ -27,7 +27,7 @@ Total rows: 47
 | beneficial-ownership-lookup | UK | Beneficial ownership | OpenOwnership | Live | €0 | — | 2026-05-18 |
 | uk-company-data | UK | Beneficial ownership | PSC register | Live | — | — | 2026-04-20 |
 
-### Company registry (32)
+### Company registry (33)
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -39,7 +39,7 @@ Total rows: 47
 | cz-company-data | CZ | Company registry | ARES | Live | €0.05 | live-verified | 2026-05-18 |
 | german-company-data | DE | Company registry | OpenRegister | Live | €0.05 | live-verified | 2026-05-15 |
 | danish-company-data | DK | Company registry | cvrapi.dk | Live | €0.05 | live-verified | 2026-05-15 |
-| estonian-company-data | EE | Company registry | Ariregister | Live | €0.05 | live-verified | 2026-05-15 |
+| estonian-company-data | EE | Company registry | Ariregister | Live | €0.05 | live-verified | 2026-05-18 |
 | spanish-company-data | ES | Company registry | Openapi.com | Committed | €0.06 | live-verified | 2026-05-15 |
 | finnish-company-data | FI | Company registry | PRH | Live | €0.05 | live-verified | 2026-05-15 |
 | french-company-data | FR | Company registry | INSEE | Live | €0.05 | live-verified | 2026-05-15 |
@@ -48,6 +48,7 @@ Total rows: 47
 | hungarian-company-data | HU | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
 | irish-company-data | IE | Company registry | CRO | Live | €0.05 | live-verified | 2026-05-15 |
 | italian-company-data | IT | Company registry | Openapi.com | Committed | €0.12 | live-verified | 2026-05-15 |
+| italian-company-stakeholders | IT | Company registry | Openapi.com | Live | €0.18 | live-verified | 2026-05-18 |
 | lithuanian-company-data | LT | Company registry | Registru centras | Live | €0.05 | live-verified | 2026-05-15 |
 | luxembourgish-company-data | LU | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
 | latvian-company-data | LV | Company registry | Uznemumu registrs | Live | €0.05 | live-verified | 2026-05-15 |
@@ -158,7 +159,7 @@ Total rows: 47
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| estonian-company-data | EE | Company registry | Ariregister | Live | €0.05 | live-verified | 2026-05-15 |
+| estonian-company-data | EE | Company registry | Ariregister | Live | €0.05 | live-verified | 2026-05-18 |
 
 ### ES (1)
 
@@ -220,11 +221,12 @@ Total rows: 47
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | irish-company-data | IE | Company registry | CRO | Live | €0.05 | live-verified | 2026-05-15 |
 
-### IT (1)
+### IT (2)
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | italian-company-data | IT | Company registry | Openapi.com | Committed | €0.12 | live-verified | 2026-05-15 |
+| italian-company-stakeholders | IT | Company registry | Openapi.com | Live | €0.18 | live-verified | 2026-05-18 |
 
 ### LT (1)
 

--- a/apps/api/coverage-matrix/COVERAGE.md
+++ b/apps/api/coverage-matrix/COVERAGE.md
@@ -2,11 +2,11 @@
 
 > Auto-generated. Do not edit by hand. Regenerate via `npm run coverage-matrix:summary`.
 
-Total rows: 48
+Total rows: 47
 
 ## By status
 
-- Live: 30
+- Live: 29
 - Committed: 18
 
 ## By evidence type
@@ -27,7 +27,7 @@ Total rows: 48
 | beneficial-ownership-lookup | UK | Beneficial ownership | OpenOwnership | Live | €0 | — | 2026-05-18 |
 | uk-company-data | UK | Beneficial ownership | PSC register | Live | — | — | 2026-04-20 |
 
-### Company registry (33)
+### Company registry (32)
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -48,7 +48,6 @@ Total rows: 48
 | hungarian-company-data | HU | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
 | irish-company-data | IE | Company registry | CRO | Live | €0.05 | live-verified | 2026-05-15 |
 | italian-company-data | IT | Company registry | Openapi.com | Committed | €0.12 | live-verified | 2026-05-15 |
-| italian-company-stakeholders | IT | Company registry | Openapi.com | Live | €0.18 | live-verified | 2026-05-18 |
 | lithuanian-company-data | LT | Company registry | Registru centras | Live | €0.05 | live-verified | 2026-05-15 |
 | luxembourgish-company-data | LU | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
 | latvian-company-data | LV | Company registry | Uznemumu registrs | Live | €0.05 | live-verified | 2026-05-15 |
@@ -221,12 +220,11 @@ Total rows: 48
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | irish-company-data | IE | Company registry | CRO | Live | €0.05 | live-verified | 2026-05-15 |
 
-### IT (2)
+### IT (1)
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | italian-company-data | IT | Company registry | Openapi.com | Committed | €0.12 | live-verified | 2026-05-15 |
-| italian-company-stakeholders | IT | Company registry | Openapi.com | Live | €0.18 | live-verified | 2026-05-18 |
 
 ### LT (1)
 

--- a/apps/api/coverage-matrix/estonian-company-data__ee__company-registry.yaml
+++ b/apps/api/coverage-matrix/estonian-company-data__ee__company-registry.yaml
@@ -3,21 +3,27 @@ country: EE
 evidence_type: Company registry
 provider: Ariregister
 status: Live
-sourcing_pattern: "Direct API"
+sourcing_pattern: "Direct API + bulk open data (RIK Ariregister CC BY 4.0)"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 6/7
-tier_2_coverage: 3/5
+tier_2_coverage: 5/5
 tier_3_coverage: 1/6
-last_verified: "2026-05-15"
+last_verified: "2026-05-18"
 products:
   - Counterparty Assurance
 vendor_roster_url: null
-provider_tos_notes: Direct API, open data. Estonia's strong e-government posture. Free-stable-api classification.
-doctrine_reference: null
+provider_tos_notes: Direct API + nightly bulk open-data ingest from avaandmed.ariregister.rik.ee. CC BY 4.0; attribution preserved in provenance. Strong e-government posture. cost_class=free_unlimited.
+doctrine_reference: "DEC-20260518-E (exhaustive enumeration); DEC-20260518-F (attribution); DEC-20260518-A (canonical legal_representatives shape)"
 notes: >-
-  2026-05-15 identity audit Batch 3 confirmed EE functional via Ariregister direct API. PR #120
-  (merged 2026-05-16 at fd59571) covered EE schema cleanup including VAT derivation (EE + 9-digit)
-  and business_type label normalization. Tier 2 coverage may benefit from empirical re-verification
-  post-merge. Free direct API.
+  2026-05-18: legal_representatives[] now populated from RIK Ariregister Open Data bulk JSON
+  (`ettevotja_rekvisiidid__kaardile_kantud_isikud.json.zip`, ~45 MB compressed / ~1 GB JSON,
+  daily refresh ~10:37 UTC, CC BY 4.0). Nightly ingest job
+  `apps/api/src/jobs/ingest-ee-directors.ts` populates the `ee_directors` Postgres cache; handler
+  queries cache and shapes per DEC-20260518-A canonical legal_representatives[] shape. Phase 2/3
+  classified EE blocked because only the /autocomplete endpoint was checked and deeper SOAP
+  endpoints require a 5-day RIK contract; DEC-20260518-E exhaustive enumeration surfaced the
+  no-contract no-lead-time Path 5 (bulk open data). GDPR note: isikukood + DOB redacted upstream
+  since 2024-11-01; field kept null for canonical-shape parity. v1.1 upgrade path: RIK contract
+  API (`detailandmed_v2` / `esindus_v1`) for real-time + non-redacted PIDs.
 _source_notion_page_id: 34867c87-082c-81a7-aa67-e9b7afd87069

--- a/apps/api/coverage-matrix/estonian-company-data__ee__company-registry.yaml
+++ b/apps/api/coverage-matrix/estonian-company-data__ee__company-registry.yaml
@@ -3,7 +3,7 @@ country: EE
 evidence_type: Company registry
 provider: Ariregister
 status: Live
-sourcing_pattern: "Direct API + bulk open data (RIK Ariregister CC BY 4.0)"
+sourcing_pattern: "Free open data"
 per_call_price_eur: 0.05
 evidence_grade: live-verified
 tier_1_coverage: 6/7

--- a/apps/api/scripts/smoke-ee-directors-parse.ts
+++ b/apps/api/scripts/smoke-ee-directors-parse.ts
@@ -1,0 +1,145 @@
+/**
+ * Parse-only smoke for the EE-directors ingest building blocks.
+ *
+ * Runs `unzip -p` against the upstream ZIP (downloaded to /tmp by the
+ * caller via curl, or by this script if missing), feeds bytes through
+ * `JsonArrayObjectStreamer`, filters via `shapeRow`, and reports:
+ *   - total entities streamed
+ *   - total rows kept (representative-bearing)
+ *   - per-role-code histogram
+ *   - the rows for the smoke entities (Bolt Technology 12417834, Wise 10947145)
+ *
+ * No DB. No prod side-effects. Validates that the parse + filter chain
+ * works against the actual 1 GB dump.
+ *
+ * Usage:
+ *   npx tsx apps/api/scripts/smoke-ee-directors-parse.ts
+ */
+
+import { spawn } from "node:child_process";
+import { promises as fsp, createWriteStream } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import {
+  JsonArrayObjectStreamer,
+  shapeRow,
+} from "../src/jobs/ingest-ee-directors.js";
+
+const UPSTREAM_URL =
+  "https://avaandmed.ariregister.rik.ee/sites/default/files/avaandmed/ettevotja_rekvisiidid__kaardile_kantud_isikud.json.zip";
+const ZIP_ENTRY = "ettevotja_rekvisiidid__kaardile_kantud_isikud.json";
+const SMOKE_ENTITIES = new Set(["12417834", "10947145", "11415592"]);
+
+async function ensureLocalZip(): Promise<string> {
+  const path = join(tmpdir(), "ee_persons.zip");
+  try {
+    const stat = await fsp.stat(path);
+    if (stat.size > 1_000_000) {
+      console.log(`[smoke] using cached ${path} (${stat.size} bytes)`);
+      return path;
+    }
+  } catch {
+    /* fall through to download */
+  }
+  console.log(`[smoke] downloading ${UPSTREAM_URL} → ${path}`);
+  const res = await fetch(UPSTREAM_URL, { signal: AbortSignal.timeout(180_000) });
+  if (!res.ok || !res.body) {
+    throw new Error(`download HTTP ${res.status}`);
+  }
+  await pipeline(
+    Readable.fromWeb(res.body as unknown as import("node:stream/web").ReadableStream),
+    createWriteStream(path),
+  );
+  return path;
+}
+
+async function main() {
+  const zipPath = await ensureLocalZip();
+  const startedAt = Date.now();
+  const child = spawn("unzip", ["-p", zipPath, ZIP_ENTRY], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stderr?.on("data", (b: Buffer) => {
+    process.stderr.write(`[unzip] ${b.toString("utf8")}`);
+  });
+  const stream = child.stdout;
+  if (!stream) throw new Error("no stdout from unzip child");
+  stream.setEncoding("utf8");
+
+  const streamer = new JsonArrayObjectStreamer();
+  let entitiesSeen = 0;
+  let rowsKept = 0;
+  const roleHistogram: Map<string, number> = new Map();
+  const smokeRows: Record<string, unknown[]> = {};
+  for (const id of SMOKE_ENTITIES) smokeRows[id] = [];
+
+  for await (const chunk of stream) {
+    for (const obj of streamer.push(chunk as string)) {
+      const e = obj as {
+        ariregistri_kood: number;
+        nimi?: string;
+        kaardile_kantud_isikud?: unknown[];
+      };
+      if (!e || typeof e.ariregistri_kood !== "number") continue;
+      entitiesSeen++;
+      if (entitiesSeen % 50_000 === 0) {
+        console.log(
+          `[smoke] entities streamed: ${entitiesSeen} (rows kept: ${rowsKept}) — ${Math.round(
+            (Date.now() - startedAt) / 1000,
+          )}s`,
+        );
+      }
+      const code = String(e.ariregistri_kood);
+      const persons = Array.isArray(e.kaardile_kantud_isikud)
+        ? e.kaardile_kantud_isikud
+        : [];
+      for (const p of persons) {
+        // p is typed loosely here — shapeRow returns null on filter-out.
+        const row = shapeRow(code, p as never);
+        if (!row) continue;
+        rowsKept++;
+        roleHistogram.set(row.role_code, (roleHistogram.get(row.role_code) ?? 0) + 1);
+        if (SMOKE_ENTITIES.has(code)) {
+          smokeRows[code].push({
+            name: [row.first_name, row.last_name].filter(Boolean).join(" "),
+            role: `${row.role_code} (${row.role_text})`,
+            type: row.person_type,
+            start_date: row.start_date,
+            end_date: row.end_date,
+          });
+        }
+      }
+    }
+  }
+
+  const exitCode: number = await new Promise((resolve) => {
+    child.on("exit", (code) => resolve(code ?? 0));
+  });
+
+  console.log("");
+  console.log("──────────── EE directors parse smoke ────────────");
+  console.log(`unzip exit code:       ${exitCode}`);
+  console.log(`entities streamed:     ${entitiesSeen}`);
+  console.log(`rows kept (post-filter): ${rowsKept}`);
+  console.log(`elapsed:               ${Math.round((Date.now() - startedAt) / 1000)}s`);
+  console.log("");
+  console.log("role-code histogram (top 10):");
+  const sorted = [...roleHistogram.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
+  for (const [code, n] of sorted) console.log(`  ${code.padEnd(12)} ${n}`);
+  console.log("");
+  for (const id of SMOKE_ENTITIES) {
+    console.log(`smoke entity ${id} — ${smokeRows[id].length} representative(s):`);
+    for (const r of smokeRows[id]) console.log(`  ${JSON.stringify(r)}`);
+    console.log("");
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error("[smoke] fatal:", err);
+    process.exit(1);
+  },
+);

--- a/apps/api/src/capabilities/estonian-company-data.ts
+++ b/apps/api/src/capabilities/estonian-company-data.ts
@@ -1,9 +1,95 @@
 import Anthropic from "@anthropic-ai/sdk";
+import { and, eq, isNull } from "drizzle-orm";
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { getBrowserlessConfig, htmlToText } from "./lib/browserless-extract.js";
+import { getDb } from "../db/index.js";
+import { eeDirectors, eeDirectorsSync } from "../db/schema.js";
 
 // Estonian company data via ariregister.rik.ee — FREE, no auth
 const API = "https://ariregister.rik.ee/est/api";
+
+interface LegalRepresentative {
+  type: "person" | "organisation";
+  name: string;
+  role: string;
+  role_code: string;
+  role_group: string;
+  date_of_birth: string | null;
+  start_date: string | null;
+}
+
+// RIK role-code → semantic group. Forward-compat: any code not listed
+// maps to "other". Kept conservative — only the well-known governance
+// codes are explicitly tagged.
+const ROLE_GROUPS: Record<string, string> = {
+  JUHL: "management_board",
+  NOOK: "supervisory_council",
+  PROK: "procuration",
+  LIK: "liquidation",
+  PR: "management_board",
+};
+
+function deriveRoleGroup(roleCode: string): string {
+  return ROLE_GROUPS[roleCode] ?? "other";
+}
+
+function shapeName(personType: string, firstName: string | null, lastName: string | null): string {
+  // For legal-entity directors (personType === "J") the business name
+  // lands in last_name (upstream field `nimi_arinimi` is polymorphic).
+  if (personType === "J") return (lastName ?? "").trim();
+  return [firstName ?? "", lastName ?? ""].filter(Boolean).join(" ").trim();
+}
+
+async function fetchLegalRepresentatives(regCode: string): Promise<{
+  representatives: LegalRepresentative[];
+  lastSyncedAt: Date | null;
+}> {
+  if (!regCode) return { representatives: [], lastSyncedAt: null };
+  const db = getDb();
+  const rows = await db
+    .select({
+      personType: eeDirectors.personType,
+      roleCode: eeDirectors.roleCode,
+      roleText: eeDirectors.roleText,
+      firstName: eeDirectors.firstName,
+      lastName: eeDirectors.lastName,
+      startDate: eeDirectors.startDate,
+      lastSyncedAt: eeDirectors.lastSyncedAt,
+    })
+    .from(eeDirectors)
+    .where(and(eq(eeDirectors.entityRegCode, regCode), isNull(eeDirectors.endDate)));
+  const reps: LegalRepresentative[] = [];
+  let maxSynced: Date | null = null;
+  for (const r of rows) {
+    const name = shapeName(r.personType, r.firstName, r.lastName);
+    if (!name) continue;
+    reps.push({
+      type: r.personType === "J" ? "organisation" : "person",
+      name,
+      role: r.roleText,
+      role_code: r.roleCode,
+      role_group: deriveRoleGroup(r.roleCode),
+      // Always null in practice — RIK redacts DOB upstream since Nov 2024.
+      // Field kept for canonical-shape parity with NO/CZ.
+      date_of_birth: null,
+      start_date: r.startDate ? String(r.startDate) : null,
+    });
+    if (r.lastSyncedAt && (!maxSynced || r.lastSyncedAt > maxSynced)) {
+      maxSynced = r.lastSyncedAt;
+    }
+  }
+  return { representatives: reps, lastSyncedAt: maxSynced };
+}
+
+async function readSyncTimestamp(): Promise<Date | null> {
+  const db = getDb();
+  const rows = await db
+    .select({ lastSuccessAt: eeDirectorsSync.lastSuccessAt })
+    .from(eeDirectorsSync)
+    .where(eq(eeDirectorsSync.id, 1))
+    .limit(1);
+  return rows[0]?.lastSuccessAt ?? null;
+}
 
 // Estonian registry code: 8 digits
 const REG_CODE_RE = /^\d{8}$/;
@@ -134,6 +220,23 @@ registerCapability("estonian-company-data", async (input: CapabilityInput) => {
     ? `https://ariregister.rik.ee/eng/company/${regCodeForRef}`
     : "https://ariregister.rik.ee/eng";
 
+  // Fetch legal_representatives from the ee_directors cache populated by
+  // the nightly RIK Open Data ingest (`jobs/ingest-ee-directors.ts`). If
+  // the cache hasn't been populated yet (fresh deploy before first
+  // ingest tick), the query returns empty and we surface that explicitly
+  // via tier_2_available_reason rather than silently dropping the field.
+  let legalReps: LegalRepresentative[] = [];
+  let lastSyncedAt: Date | null = null;
+  let cacheError: string | null = null;
+  try {
+    const result = await fetchLegalRepresentatives(regCodeForRef);
+    legalReps = result.representatives;
+    lastSyncedAt = result.lastSyncedAt ?? (await readSyncTimestamp());
+  } catch (err) {
+    // Cache miss / DB error is non-fatal — tier-1 data still surfaces.
+    cacheError = err instanceof Error ? err.message : String(err);
+  }
+
   // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
   // Resolves alias keys at runtime; only sets a canonical if not already present.
   {
@@ -148,8 +251,27 @@ registerCapability("estonian-company-data", async (input: CapabilityInput) => {
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
-    o.tier_2_available = false;
-    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    o.legal_representatives = legalReps;
+    o.total_legal_representatives = legalReps.length;
+    o.tier_2_available = legalReps.length > 0;
+    if (cacheError) {
+      o.tier_2_available_reason = `ee_directors cache query failed (${cacheError}); tier_1 data unaffected.`;
+    } else if (legalReps.length > 0) {
+      const syncedNote = lastSyncedAt
+        ? ` Last cache refresh: ${lastSyncedAt.toISOString()}.`
+        : "";
+      o.tier_2_available_reason =
+        "Legal representatives sourced from RIK Ariregister Open Data " +
+        "(ettevotja_rekvisiidid__kaardile_kantud_isikud, CC BY 4.0). " +
+        "Personal ID codes (isikukood) and date of birth are redacted by RIK " +
+        "upstream since 2024-11-01 — fields kept null for canonical-shape parity." +
+        syncedNote;
+    } else {
+      o.tier_2_available_reason =
+        "ee_directors cache returned no active representatives for this " +
+        "registry code (newly registered entity, all directors resigned, or " +
+        "cache not yet populated by first nightly ingest tick).";
+    }
     o.ubo_availability = "unavailable_no_registry";
     o.ubo_availability_reason = "Programmatic UBO access not currently exposed by Ariregister at v1; verification pending public-source confirmation";
   }
@@ -167,7 +289,7 @@ registerCapability("estonian-company-data", async (input: CapabilityInput) => {
       attribution:
         "Source: e-Business Register (Centre of Registers and Information Systems / RIK), Estonia.",
       source_note:
-        "Estonian e-Business Register open data is published by RIK under CC BY 4.0 via avaandmed.ariregister.rik.ee. Designated as an EU High-Value Dataset under Reg. (EU) 2023/138.",
+        "Estonian e-Business Register open data is published by RIK under CC BY 4.0 via avaandmed.ariregister.rik.ee. Designated as an EU High-Value Dataset under Reg. (EU) 2023/138. legal_representatives[] populated from the daily-refreshed kaardile_kantud_isikud bulk dump per DEC-20260518-E.",
     },
   };
 });

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -810,3 +810,50 @@ export const digestSnapshots = pgTable("digest_snapshots", {
     .notNull()
     .defaultNow(),
 });
+
+// ─── ee_directors ───────────────────────────────────────────────────────────
+// Estonian directors/representatives cache. Daily ingest of the RIK Ariregister
+// CC BY 4.0 open-data dump (`kaardile_kantud_isikud.json.zip`) — see
+// `apps/api/src/jobs/ingest-ee-directors.ts`. Primary key is `kirje_id` from
+// upstream (unique per registry-card filing). PIDs are redacted by RIK at
+// source since 2024-11-01; the hashed UUID lands in `isikukood_hash`. Names
+// + roles + start/end dates are retained.
+export const eeDirectors = pgTable(
+  "ee_directors",
+  {
+    kirjeId: integer("kirje_id").primaryKey(),
+    entityRegCode: text("entity_reg_code").notNull(),
+    personType: text("person_type").notNull(), // 'F' (natural) | 'J' (legal entity)
+    roleCode: text("role_code").notNull(), // JUHL, NOOK, PROK, LIK, etc.
+    roleText: text("role_text").notNull(), // localised label, e.g. "Juhatuse liige"
+    firstName: text("first_name"),
+    lastName: text("last_name"), // also business name when person_type='J'
+    isikukoodHash: text("isikukood_hash"),
+    foreignCode: text("foreign_code"),
+    foreignCountryCode: text("foreign_country_code"),
+    foreignCountryText: text("foreign_country_text"),
+    addressText: text("address_text"),
+    addressCountryCode: text("address_country_code"),
+    startDate: date("start_date"),
+    endDate: date("end_date"),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("ee_directors_entity_idx").on(table.entityRegCode),
+    index("ee_directors_last_synced_idx").on(table.lastSyncedAt),
+  ],
+);
+
+// ─── ee_directors_sync ──────────────────────────────────────────────────────
+// Single-row marker for the EE directors ingest. Tracks the upstream
+// `Last-Modified` header so the ingest can skip when there's no new data.
+// `id = 1` is the only valid row (CHECK constraint enforced by the migration).
+export const eeDirectorsSync = pgTable("ee_directors_sync", {
+  id: integer("id").primaryKey(),
+  lastModifiedUpstream: text("last_modified_upstream"),
+  lastSuccessAt: timestamp("last_success_at", { withTimezone: true }),
+  lastAttemptAt: timestamp("last_attempt_at", { withTimezone: true }),
+  rowCount: integer("row_count"),
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -116,6 +116,14 @@ async function main() {
   const { startReindexTransactions } = await import("./jobs/reindex-transactions.js");
   startReindexTransactions();
 
+  // Nightly EE-directors ingest from RIK Ariregister CC BY 4.0 open
+  // data. Refreshes the `ee_directors` cache that backs the
+  // `estonian-company-data` handler's `legal_representatives[]`
+  // (DEC-20260518-E). 10-minute startup delay + 24h interval; advisory
+  // lock 20260518 dedups across replicas.
+  const { startEeDirectorsIngest } = await import("./jobs/ingest-ee-directors.js");
+  startEeDirectorsIngest();
+
   const port = parseInt(process.env.PORT || "3000", 10);
 
   const server = serve({ fetch: app.fetch, port }, (info) => {

--- a/apps/api/src/jobs/ingest-ee-directors.test.ts
+++ b/apps/api/src/jobs/ingest-ee-directors.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Regression tests for the EE-directors ingest building blocks.
+ *
+ * These cover the parts that don't need a Postgres / Railway / RIK
+ * end-to-end: the JSON-array streaming tokenizer, the DD.MM.YYYY date
+ * parser, and the row-shape filter. The orchestration (`runIngestOnce`)
+ * is integration-territory and is exercised separately via the live
+ * smoke documented in the PR description.
+ *
+ * Per DEC-20260504-A — every cert-audit / extraction follow-up needs at
+ * least one regression test capturing the structural shape of the fix.
+ * Here the shape is: bounded memory streaming + DD.MM date conversion +
+ * OSAN-shareholder filter.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  JsonArrayObjectStreamer,
+  parseEeDate,
+  shapeRow,
+} from "./ingest-ee-directors.js";
+
+describe("parseEeDate", () => {
+  it("converts DD.MM.YYYY → YYYY-MM-DD", () => {
+    expect(parseEeDate("05.06.2023")).toBe("2023-06-05");
+    expect(parseEeDate("19.11.2009")).toBe("2009-11-19");
+    expect(parseEeDate("01.01.2000")).toBe("2000-01-01");
+  });
+
+  it("returns null for empty / null / undefined / malformed", () => {
+    expect(parseEeDate(null)).toBeNull();
+    expect(parseEeDate(undefined)).toBeNull();
+    expect(parseEeDate("")).toBeNull();
+    expect(parseEeDate("   ")).toBeNull();
+    expect(parseEeDate("2023-06-05")).toBeNull(); // ISO is not the upstream shape
+    expect(parseEeDate("5.6.2023")).toBeNull(); // missing leading zeros
+    expect(parseEeDate("garbage")).toBeNull();
+  });
+});
+
+describe("JsonArrayObjectStreamer", () => {
+  function collectAll(streamer: JsonArrayObjectStreamer, chunks: string[]): unknown[] {
+    const out: unknown[] = [];
+    for (const chunk of chunks) {
+      for (const obj of streamer.push(chunk)) {
+        out.push(obj);
+      }
+    }
+    return out;
+  }
+
+  it("yields top-level objects from a simple array", () => {
+    const s = new JsonArrayObjectStreamer();
+    const out = collectAll(s, ['[{"a":1},{"a":2},{"a":3}]']);
+    expect(out).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }]);
+  });
+
+  it("handles nested objects + arrays inside an entity", () => {
+    const s = new JsonArrayObjectStreamer();
+    const input = `[
+      {"kood":1, "kaardile_kantud_isikud":[{"kirje_id":7,"r":"JUHL"}], "x":{"y":"z"}},
+      {"kood":2, "kaardile_kantud_isikud":[]}
+    ]`;
+    const out = collectAll(s, [input]);
+    expect(out).toHaveLength(2);
+    expect((out[0] as { kood: number }).kood).toBe(1);
+    expect((out[1] as { kood: number }).kood).toBe(2);
+    expect(
+      (out[0] as { kaardile_kantud_isikud: Array<{ kirje_id: number }> })
+        .kaardile_kantud_isikud[0].kirje_id,
+    ).toBe(7);
+  });
+
+  it("handles braces inside string values (no false-positive object boundary)", () => {
+    const s = new JsonArrayObjectStreamer();
+    const tricky = '[{"text":"contains } closing brace","n":1},{"text":"{open","n":2}]';
+    const out = collectAll(s, [tricky]);
+    expect(out).toEqual([
+      { text: "contains } closing brace", n: 1 },
+      { text: "{open", n: 2 },
+    ]);
+  });
+
+  it("handles escaped quotes inside string values", () => {
+    const s = new JsonArrayObjectStreamer();
+    const tricky = '[{"text":"a \\"quoted\\" word","n":1}]';
+    const out = collectAll(s, [tricky]);
+    expect(out).toEqual([{ text: 'a "quoted" word', n: 1 }]);
+  });
+
+  it("works when object spans multiple chunk boundaries", () => {
+    const s = new JsonArrayObjectStreamer();
+    // Split mid-string, mid-object, and mid-brace to exercise the state machine.
+    const out = collectAll(s, [
+      '[{"name":"He',
+      'llo","items":[1,2,',
+      "3]},",
+      '{"name":"World"}]',
+    ]);
+    expect(out).toEqual([
+      { name: "Hello", items: [1, 2, 3] },
+      { name: "World" },
+    ]);
+  });
+
+  it("does not grow buffer unboundedly across many objects", () => {
+    const s = new JsonArrayObjectStreamer();
+    const objs: unknown[] = [];
+    for (let i = 0; i < 1000; i++) {
+      for (const o of s.push(`,{"i":${i},"pad":"${"x".repeat(50)}"}`)) {
+        objs.push(o);
+      }
+    }
+    expect(objs).toHaveLength(1000);
+    // Internal buffer post-yield should be empty because every object closed.
+    // Touch a private to assert — kept loose since the assertion is mostly
+    // a smoke check that trimming actually happened.
+    const buf = (s as unknown as { buf: string }).buf;
+    expect(buf.length).toBeLessThan(100);
+  });
+});
+
+describe("shapeRow", () => {
+  const basePerson = {
+    kirje_id: 12345,
+    kaardi_piirkond: 5,
+    kaardi_nr: 1,
+    kaardi_tyyp: "R",
+    kande_nr: 1,
+    isiku_tyyp: "F",
+    isiku_roll: "JUHL",
+    isiku_roll_tekstina: "Juhatuse liige",
+    eesnimi: "Markus",
+    nimi_arinimi: "Villig",
+    isikukood_hash: "abc-uuid",
+    isikukood_registrikood: null,
+    valis_kood: null,
+    valis_kood_riik: null,
+    valis_kood_riik_tekstina: null,
+    synniaeg: null,
+    osamaks: null,
+    osamaksu_valuuta: null,
+    osamaksu_valuuta_tekstina: null,
+    volituste_loppemise_kpv: "",
+    aadress_riik: null,
+    aadress_riik_tekstina: null,
+    aadress_ehak: null,
+    aadress_ehak_tekstina: "",
+    aadress_tanav_maja_korter: null,
+    aadress_postiindeks: null,
+    algus_kpv: "05.06.2023",
+    lopp_kpv: null,
+    email: null,
+    aadress_ads__adr_id: null,
+    aadress_ads__ads_oid: null,
+    aadress_ads__ads_normaliseeritud_taisaadress: null,
+    aadress_ads__ads_normaliseeritud_taisaadress_tapsustus: null,
+    aadress_ads__koodaadress: null,
+    aadress_ads__adob_id: null,
+    aadress_ads__tyyp: null,
+  };
+
+  it("shapes a natural-person board member", () => {
+    const row = shapeRow("12417834", basePerson);
+    expect(row).not.toBeNull();
+    expect(row!.kirje_id).toBe(12345);
+    expect(row!.entity_reg_code).toBe("12417834");
+    expect(row!.person_type).toBe("F");
+    expect(row!.role_code).toBe("JUHL");
+    expect(row!.role_text).toBe("Juhatuse liige");
+    expect(row!.first_name).toBe("Markus");
+    expect(row!.last_name).toBe("Villig");
+    expect(row!.start_date).toBe("2023-06-05");
+    expect(row!.end_date).toBeNull();
+  });
+
+  it("filters out OSAN (shareholder) — not a representative", () => {
+    const shareholder = { ...basePerson, isiku_roll: "OSAN", isiku_roll_tekstina: "Osanik" };
+    expect(shapeRow("12417834", shareholder)).toBeNull();
+  });
+
+  it("filters out ASUTAJA (founder, historical)", () => {
+    const founder = { ...basePerson, isiku_roll: "ASUTAJA" };
+    expect(shapeRow("12417834", founder)).toBeNull();
+  });
+
+  it("filters out rows with no name (no first, no last)", () => {
+    const nameless = { ...basePerson, eesnimi: null, nimi_arinimi: null };
+    expect(shapeRow("12417834", nameless)).toBeNull();
+  });
+
+  it("handles legal-entity directors (isiku_tyyp = 'J', name in nimi_arinimi)", () => {
+    const corpDirector = {
+      ...basePerson,
+      isiku_tyyp: "J",
+      eesnimi: null,
+      nimi_arinimi: "Some Holdings OÜ",
+    };
+    const row = shapeRow("12417834", corpDirector);
+    expect(row).not.toBeNull();
+    expect(row!.person_type).toBe("J");
+    expect(row!.last_name).toBe("Some Holdings OÜ");
+    expect(row!.first_name).toBeNull();
+  });
+
+  it("preserves the resignation date when present", () => {
+    const resigned = { ...basePerson, lopp_kpv: "31.12.2024" };
+    const row = shapeRow("12417834", resigned);
+    expect(row).not.toBeNull();
+    expect(row!.end_date).toBe("2024-12-31");
+  });
+
+  it("forward-compat: passes through unknown role codes (not in excluded set)", () => {
+    const unknown = { ...basePerson, isiku_roll: "FUTURE_CODE", isiku_roll_tekstina: "Some role" };
+    const row = shapeRow("12417834", unknown);
+    expect(row).not.toBeNull();
+    expect(row!.role_code).toBe("FUTURE_CODE");
+  });
+
+  it("rejects rows with no kirje_id", () => {
+    const bad = { ...basePerson, kirje_id: undefined as unknown as number };
+    expect(shapeRow("12417834", bad)).toBeNull();
+  });
+});

--- a/apps/api/src/jobs/ingest-ee-directors.ts
+++ b/apps/api/src/jobs/ingest-ee-directors.ts
@@ -1,0 +1,564 @@
+/**
+ * Nightly ingest — EE directors / representatives.
+ *
+ * Pulls the daily-refreshed CC BY 4.0 open-data dump
+ * `ettevotja_rekvisiidid__kaardile_kantud_isikud.json.zip` from RIK
+ * Ariregister and populates the `ee_directors` table. The handler
+ * (`capabilities/estonian-company-data.ts`) queries this table at
+ * request time to populate `legal_representatives[]` for tier-2
+ * KYB coverage. Implements DEC-20260518-E exhaustive-enumeration outcome
+ * for EE and DEC-20260518-F attribution requirements.
+ *
+ * Upstream:
+ *   URL:    https://avaandmed.ariregister.rik.ee/sites/default/files/
+ *           avaandmed/ettevotja_rekvisiidid__kaardile_kantud_isikud.json.zip
+ *   Size:   ~45 MB compressed, ~1 GB uncompressed JSON (single file in ZIP)
+ *   Format: top-level array of entity objects, each carrying a nested
+ *           `kaardile_kantud_isikud[]` array of person-on-card filings
+ *   Refresh: daily, typically ~10:37 UTC
+ *   License: CC BY 4.0 (attribution preserved in handler provenance)
+ *
+ * GDPR caveat: since 2024-11-01 RIK redacts personal-ID codes from the
+ * open-data files. `isikukood_registrikood` and `synniaeg` (DOB) are
+ * always null in the dump; the hashed UUID lands in `isikukood_hash`.
+ * Names, roles, addresses, start/end dates remain.
+ *
+ * Schedule. 24h interval after a 10-minute startup delay so a redeploy
+ * doesn't trigger a 1 GB pull during boot rush. The advisory lock is
+ * session-scoped on a dedicated postgres connection (DEC-20260504-B
+ * bulk-operation pattern — long-running work cannot share the request
+ * pool connection because lock-held-while-busy would starve customer
+ * traffic). Cross-instance dedup: only one replica's pull lands per
+ * cycle even if many are scheduled to fire simultaneously.
+ *
+ * Bounded-WAL pattern. UPSERT in batches of UPSERT_BATCH_SIZE rows per
+ * statement, each batch in its own short transaction. After all rows
+ * upserted, sweep deletes anything whose `last_synced_at < sync_start`
+ * — bounded per-tick because the table doesn't grow without bound. This
+ * matches DEC-20260504-B (no single transaction can blow WAL).
+ *
+ * Idempotency. The upstream `Last-Modified` header is checked against
+ * `ee_directors_sync.last_modified_upstream`. A re-run on the same
+ * upstream version is a no-op (logged as `skipped-unchanged`).
+ */
+
+import { spawn } from "node:child_process";
+import { createWriteStream, promises as fsp } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { sql } from "drizzle-orm";
+import postgres from "postgres";
+import { getDb } from "../db/index.js";
+import { fireAndForget } from "../lib/fire-and-forget.js";
+import { log, logError, logWarn } from "../lib/log.js";
+import { isShuttingDown } from "../lib/shutdown.js";
+
+const INGEST_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const STARTUP_DELAY_MS = 10 * 60 * 1000;
+const ADVISORY_LOCK_ID = 20260518; // unique across job files; matches DEC date
+const UPSERT_BATCH_SIZE = 1000;
+const UPSTREAM_URL =
+  "https://avaandmed.ariregister.rik.ee/sites/default/files/avaandmed/ettevotja_rekvisiidid__kaardile_kantud_isikud.json.zip";
+const ZIP_ENTRY_NAME = "ettevotja_rekvisiidid__kaardile_kantud_isikud.json";
+
+// Role-code allow-list — what counts as a "legal representative".
+// Excluded: OSAN (osanik / shareholder), ASUTAJA / FOOMETS (founders, historical
+// not currently-active). Anything else passes — forward-compat with RIK
+// adding new representation role codes. The handler can refine per its
+// own rules; ingest stays permissive.
+const EXCLUDED_ROLE_CODES = new Set(["OSAN", "ASUTAJA", "FOOMETS"]);
+
+// ─── Types matching the upstream JSON shape ──────────────────────────────────
+
+interface UpstreamPerson {
+  kirje_id: number;
+  isiku_tyyp: string; // "F" (natural) | "J" (legal entity)
+  isiku_roll: string;
+  isiku_roll_tekstina: string;
+  eesnimi: string | null;
+  nimi_arinimi: string | null;
+  isikukood_hash: string | null;
+  isikukood_registrikood: string | null;
+  valis_kood: string | null;
+  valis_kood_riik: string | null;
+  valis_kood_riik_tekstina: string | null;
+  algus_kpv: string | null;
+  lopp_kpv: string | null;
+  aadress_ads__ads_normaliseeritud_taisaadress: string | null;
+  aadress_riik: string | null;
+}
+
+interface UpstreamEntity {
+  ariregistri_kood: number;
+  nimi: string;
+  kaardile_kantud_isikud: UpstreamPerson[];
+}
+
+interface EeDirectorRow {
+  kirje_id: number;
+  entity_reg_code: string;
+  person_type: string;
+  role_code: string;
+  role_text: string;
+  first_name: string | null;
+  last_name: string | null;
+  isikukood_hash: string | null;
+  foreign_code: string | null;
+  foreign_country_code: string | null;
+  foreign_country_text: string | null;
+  address_text: string | null;
+  address_country_code: string | null;
+  start_date: string | null; // ISO date
+  end_date: string | null;
+}
+
+// ─── Date conversion ─────────────────────────────────────────────────────────
+
+/** Upstream emits "DD.MM.YYYY" or "" (empty string means null). Convert
+ *  to ISO YYYY-MM-DD or null. Anything that doesn't match the shape
+ *  returns null rather than throwing — bad data should not crash ingest. */
+export function parseEeDate(s: string | null | undefined): string | null {
+  if (!s || typeof s !== "string") return null;
+  const trimmed = s.trim();
+  if (!trimmed) return null;
+  const m = trimmed.match(/^(\d{2})\.(\d{2})\.(\d{4})$/);
+  if (!m) return null;
+  return `${m[3]}-${m[2]}-${m[1]}`;
+}
+
+// ─── Streaming JSON tokenizer ────────────────────────────────────────────────
+
+/**
+ * Streams a top-level JSON array of objects, yielding one object at a time.
+ *
+ * The upstream file is ~1 GB and cannot be JSON.parse'd whole — that would
+ * spike Node's heap to ~3 GB and likely OOM on Railway. This walks the
+ * byte stream maintaining brace depth + string state and yields each
+ * top-level object as soon as its closing brace is seen.
+ *
+ * Constraint: assumes a top-level array of objects (matches the RIK file).
+ * Will throw on malformed JSON via the inner `JSON.parse`.
+ */
+export class JsonArrayObjectStreamer {
+  private buf = "";
+  private pos = 0;
+  private depth = 0;
+  private inString = false;
+  private escape = false;
+  private objStart = -1;
+
+  *push(chunk: string): IterableIterator<unknown> {
+    this.buf += chunk;
+    while (this.pos < this.buf.length) {
+      const c = this.buf[this.pos];
+      if (this.escape) {
+        this.escape = false;
+      } else if (this.inString) {
+        if (c === "\\") this.escape = true;
+        else if (c === '"') this.inString = false;
+      } else if (c === '"') {
+        this.inString = true;
+      } else if (c === "{") {
+        if (this.depth === 0) this.objStart = this.pos;
+        this.depth++;
+      } else if (c === "}") {
+        this.depth--;
+        if (this.depth === 0 && this.objStart >= 0) {
+          const objStr = this.buf.slice(this.objStart, this.pos + 1);
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(objStr);
+          } catch (err) {
+            throw new Error(
+              `JsonArrayObjectStreamer: parse failure near byte ${this.pos}: ${(err as Error).message}`,
+            );
+          }
+          yield parsed;
+          const trimAt = this.pos + 1;
+          this.buf = this.buf.slice(trimAt);
+          this.pos = -1; // ++'d to 0 below
+          this.objStart = -1;
+        }
+      }
+      this.pos++;
+    }
+  }
+}
+
+// ─── HEAD probe for Last-Modified ────────────────────────────────────────────
+
+async function headLastModified(): Promise<string | null> {
+  const res = await fetch(UPSTREAM_URL, {
+    method: "HEAD",
+    signal: AbortSignal.timeout(15000),
+  });
+  if (!res.ok) {
+    throw new Error(`HEAD ${UPSTREAM_URL} returned HTTP ${res.status}`);
+  }
+  return res.headers.get("last-modified");
+}
+
+// ─── ZIP entry → Readable stream ─────────────────────────────────────────────
+
+/**
+ * Extract the single JSON entry from the downloaded ZIP via `unzip -p`,
+ * returning a Readable stream over the JSON bytes. Streams to stdout, so
+ * the 1 GB uncompressed JSON never lands on disk (only the 45 MB ZIP).
+ *
+ * Why unzip and not a Node ZIP lib: avoids adding a new dependency tree.
+ * `node:20-slim` Dockerfile would need `apt-get install unzip` — see the
+ * `unzip` line added to the Dockerfile in this PR.
+ *
+ * The spawn returns the child process; the caller is responsible for
+ * awaiting `exit` (the `pipeline` in `runIngestOnce` does that via its
+ * stdout consumption).
+ */
+function extractJsonStream(zipPath: string): { child: ReturnType<typeof spawn>; stdout: Readable } {
+  const child = spawn("unzip", ["-p", zipPath, ZIP_ENTRY_NAME], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (!child.stdout) {
+    throw new Error("unzip child has no stdout stream");
+  }
+  child.stderr?.on("data", (chunk: Buffer) => {
+    logWarn(
+      "ingest-ee-directors-unzip-stderr",
+      "unzip emitted stderr",
+      { chunk: chunk.toString("utf8").slice(0, 400) },
+    );
+  });
+  return { child, stdout: child.stdout as Readable };
+}
+
+// ─── Row shaping + filter ────────────────────────────────────────────────────
+
+/** Convert an upstream person record + parent entity reg code into the row
+ *  we persist. Returns null when the row should be skipped (excluded role
+ *  code, no name, missing kirje_id). */
+export function shapeRow(
+  entityRegCode: string,
+  p: UpstreamPerson,
+): EeDirectorRow | null {
+  if (!p || typeof p.kirje_id !== "number") return null;
+  const roleCode = (p.isiku_roll ?? "").trim();
+  if (!roleCode) return null;
+  if (EXCLUDED_ROLE_CODES.has(roleCode)) return null;
+  const firstName = (p.eesnimi ?? "").trim() || null;
+  const lastName = (p.nimi_arinimi ?? "").trim() || null;
+  if (!firstName && !lastName) return null; // no name → no representative we can surface
+  return {
+    kirje_id: p.kirje_id,
+    entity_reg_code: entityRegCode,
+    person_type: (p.isiku_tyyp ?? "").trim() || "F",
+    role_code: roleCode,
+    role_text: (p.isiku_roll_tekstina ?? roleCode).trim(),
+    first_name: firstName,
+    last_name: lastName,
+    isikukood_hash: p.isikukood_hash ?? null,
+    foreign_code: p.valis_kood ?? null,
+    foreign_country_code: p.valis_kood_riik ?? null,
+    foreign_country_text: p.valis_kood_riik_tekstina ?? null,
+    address_text: p.aadress_ads__ads_normaliseeritud_taisaadress ?? null,
+    address_country_code: p.aadress_riik ?? null,
+    start_date: parseEeDate(p.algus_kpv),
+    end_date: parseEeDate(p.lopp_kpv),
+  };
+}
+
+// ─── Batched UPSERT ──────────────────────────────────────────────────────────
+
+async function upsertBatch(
+  client: postgres.Sql,
+  rows: EeDirectorRow[],
+  syncStartIso: string,
+): Promise<void> {
+  if (rows.length === 0) return;
+  // postgres.js tagged-template + helper() handles parameter binding for
+  // bulk inserts. ON CONFLICT (kirje_id) DO UPDATE keeps the table at
+  // upstream-current; the SET clause references EXCLUDED.* (the would-be
+  // insert) which is the standard upsert idiom.
+  await client`
+    INSERT INTO ee_directors ${client(
+      rows.map((r) => ({
+        kirje_id: r.kirje_id,
+        entity_reg_code: r.entity_reg_code,
+        person_type: r.person_type,
+        role_code: r.role_code,
+        role_text: r.role_text,
+        first_name: r.first_name,
+        last_name: r.last_name,
+        isikukood_hash: r.isikukood_hash,
+        foreign_code: r.foreign_code,
+        foreign_country_code: r.foreign_country_code,
+        foreign_country_text: r.foreign_country_text,
+        address_text: r.address_text,
+        address_country_code: r.address_country_code,
+        start_date: r.start_date,
+        end_date: r.end_date,
+        last_synced_at: syncStartIso,
+      })),
+    )}
+    ON CONFLICT (kirje_id) DO UPDATE SET
+      entity_reg_code = EXCLUDED.entity_reg_code,
+      person_type = EXCLUDED.person_type,
+      role_code = EXCLUDED.role_code,
+      role_text = EXCLUDED.role_text,
+      first_name = EXCLUDED.first_name,
+      last_name = EXCLUDED.last_name,
+      isikukood_hash = EXCLUDED.isikukood_hash,
+      foreign_code = EXCLUDED.foreign_code,
+      foreign_country_code = EXCLUDED.foreign_country_code,
+      foreign_country_text = EXCLUDED.foreign_country_text,
+      address_text = EXCLUDED.address_text,
+      address_country_code = EXCLUDED.address_country_code,
+      start_date = EXCLUDED.start_date,
+      end_date = EXCLUDED.end_date,
+      last_synced_at = EXCLUDED.last_synced_at
+  `;
+}
+
+// ─── Sync-marker helpers (dedicated client; tiny rows; no advisory lock here) ─
+
+async function readSyncMarker(client: postgres.Sql): Promise<{
+  last_modified_upstream: string | null;
+  row_count: number | null;
+} | null> {
+  const rows = await client<
+    { last_modified_upstream: string | null; row_count: number | null }[]
+  >`
+    SELECT last_modified_upstream, row_count
+      FROM ee_directors_sync WHERE id = 1
+  `;
+  return rows[0] ?? null;
+}
+
+async function recordSyncAttempt(client: postgres.Sql): Promise<void> {
+  await client`
+    INSERT INTO ee_directors_sync (id, last_attempt_at)
+    VALUES (1, NOW())
+    ON CONFLICT (id) DO UPDATE SET last_attempt_at = NOW()
+  `;
+}
+
+async function recordSyncSuccess(
+  client: postgres.Sql,
+  lastModified: string | null,
+  rowCount: number,
+): Promise<void> {
+  await client`
+    INSERT INTO ee_directors_sync (id, last_modified_upstream, last_success_at, last_attempt_at, row_count)
+    VALUES (1, ${lastModified}, NOW(), NOW(), ${rowCount})
+    ON CONFLICT (id) DO UPDATE SET
+      last_modified_upstream = EXCLUDED.last_modified_upstream,
+      last_success_at = EXCLUDED.last_success_at,
+      last_attempt_at = EXCLUDED.last_attempt_at,
+      row_count = EXCLUDED.row_count
+  `;
+}
+
+// ─── Ingest orchestration (single tick) ──────────────────────────────────────
+
+export interface IngestResult {
+  outcome:
+    | "skipped-unchanged"
+    | "skipped-lock-busy"
+    | "skipped-shutting-down"
+    | "completed"
+    | "errored";
+  detail?: string;
+  rows_upserted?: number;
+  rows_deleted?: number;
+  last_modified?: string | null;
+  duration_ms: number;
+}
+
+export async function runIngestOnce(): Promise<IngestResult> {
+  const startedAt = Date.now();
+
+  if (isShuttingDown()) {
+    return { outcome: "skipped-shutting-down", duration_ms: 0 };
+  }
+
+  const connStr = process.env.DATABASE_URL;
+  if (!connStr) {
+    return {
+      outcome: "errored",
+      detail: "DATABASE_URL not set",
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+
+  // Dedicated session-scoped connection for the advisory lock + the long
+  // batched UPSERT loop. Pool max=1 so we definitely don't fan out and
+  // step on customer-traffic connections. Idle timeout is short so the
+  // connection releases promptly after the job ends.
+  const sqlClient = postgres(connStr, { max: 1, idle_timeout: 30 });
+  let tmpZipPath: string | null = null;
+
+  try {
+    // Cross-instance dedup. Session-scoped (not xact-scoped) because the
+    // work runs across many short transactions; xact-scoped would release
+    // on the first commit.
+    const [{ acquired }] = await sqlClient<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(${ADVISORY_LOCK_ID}) AS acquired
+    `;
+    if (!acquired) {
+      return { outcome: "skipped-lock-busy", duration_ms: Date.now() - startedAt };
+    }
+
+    try {
+      const upstreamLastModified = await headLastModified();
+      const prior = await readSyncMarker(sqlClient);
+
+      if (
+        upstreamLastModified &&
+        prior?.last_modified_upstream === upstreamLastModified &&
+        (prior.row_count ?? 0) > 0
+      ) {
+        return {
+          outcome: "skipped-unchanged",
+          last_modified: upstreamLastModified,
+          duration_ms: Date.now() - startedAt,
+        };
+      }
+
+      await recordSyncAttempt(sqlClient);
+
+      // Download to /tmp. Streams through pipeline so we don't buffer the
+      // full 45 MB body in memory.
+      tmpZipPath = join(tmpdir(), `ee_persons_${Date.now()}.zip`);
+      const dlRes = await fetch(UPSTREAM_URL, { signal: AbortSignal.timeout(120_000) });
+      if (!dlRes.ok || !dlRes.body) {
+        throw new Error(`Download HTTP ${dlRes.status} (no body=${!dlRes.body})`);
+      }
+      await pipeline(
+        Readable.fromWeb(dlRes.body as unknown as import("node:stream/web").ReadableStream),
+        createWriteStream(tmpZipPath),
+      );
+
+      // Stream the embedded JSON through the array tokenizer.
+      const syncStartIso = new Date().toISOString();
+      const streamer = new JsonArrayObjectStreamer();
+      const { child, stdout } = extractJsonStream(tmpZipPath);
+      let entitiesSeen = 0;
+      let rowsUpserted = 0;
+      let pending: EeDirectorRow[] = [];
+
+      stdout.setEncoding("utf8");
+      for await (const chunk of stdout) {
+        for (const obj of streamer.push(chunk as string)) {
+          const e = obj as UpstreamEntity;
+          if (!e || typeof e.ariregistri_kood !== "number") continue;
+          entitiesSeen++;
+          const entityRegCode = String(e.ariregistri_kood);
+          const persons = Array.isArray(e.kaardile_kantud_isikud)
+            ? e.kaardile_kantud_isikud
+            : [];
+          for (const p of persons) {
+            const row = shapeRow(entityRegCode, p);
+            if (!row) continue;
+            pending.push(row);
+            if (pending.length >= UPSERT_BATCH_SIZE) {
+              await upsertBatch(sqlClient, pending, syncStartIso);
+              rowsUpserted += pending.length;
+              pending = [];
+              if (isShuttingDown()) {
+                throw new Error("shutdown-during-ingest");
+              }
+            }
+          }
+        }
+      }
+      if (pending.length > 0) {
+        await upsertBatch(sqlClient, pending, syncStartIso);
+        rowsUpserted += pending.length;
+        pending = [];
+      }
+
+      // Drain the child. unzip exits 0 on clean extract.
+      const childCode: number = await new Promise((resolve, reject) => {
+        child.on("exit", (code) => resolve(code ?? 0));
+        child.on("error", reject);
+      });
+      if (childCode !== 0) {
+        throw new Error(`unzip exited with code ${childCode}`);
+      }
+
+      // Sweep rows no longer present upstream. Bounded — the table is at
+      // most ~10 M rows and only the delta from the last sync deletes.
+      const delRes = await sqlClient`
+        DELETE FROM ee_directors
+         WHERE last_synced_at < ${syncStartIso}
+      `;
+      const rowsDeleted = (delRes as unknown as { count?: number }).count ?? 0;
+
+      await recordSyncSuccess(sqlClient, upstreamLastModified, rowsUpserted);
+
+      log.info(
+        {
+          label: "ingest-ee-directors-success",
+          entities_seen: entitiesSeen,
+          rows_upserted: rowsUpserted,
+          rows_deleted: rowsDeleted,
+          duration_ms: Date.now() - startedAt,
+          last_modified: upstreamLastModified,
+        },
+        "ingest-ee-directors-success",
+      );
+
+      return {
+        outcome: "completed",
+        rows_upserted: rowsUpserted,
+        rows_deleted: rowsDeleted,
+        last_modified: upstreamLastModified,
+        duration_ms: Date.now() - startedAt,
+      };
+    } finally {
+      await sqlClient`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`.catch(() => {});
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logError("ingest-ee-directors-failed", err, {
+      duration_ms: Date.now() - startedAt,
+    });
+    return {
+      outcome: "errored",
+      detail: message,
+      duration_ms: Date.now() - startedAt,
+    };
+  } finally {
+    if (tmpZipPath) {
+      await fsp.unlink(tmpZipPath).catch(() => {});
+    }
+    await sqlClient.end({ timeout: 5 }).catch(() => {});
+  }
+}
+
+// ─── Lifecycle wiring ────────────────────────────────────────────────────────
+
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
+let startupTimeout: ReturnType<typeof setTimeout> | null = null;
+
+export function startEeDirectorsIngest(): void {
+  if (intervalHandle || startupTimeout) return;
+  startupTimeout = setTimeout(() => {
+    fireAndForget(() => runIngestOnce(), { label: "ingest-ee-directors-tick" });
+    intervalHandle = setInterval(() => {
+      if (isShuttingDown()) return;
+      fireAndForget(() => runIngestOnce(), { label: "ingest-ee-directors-tick" });
+    }, INGEST_INTERVAL_MS);
+  }, STARTUP_DELAY_MS);
+}
+
+export function stopEeDirectorsIngestForTest(): void {
+  if (startupTimeout) {
+    clearTimeout(startupTimeout);
+    startupTimeout = null;
+  }
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+}

--- a/apps/api/src/jobs/ingest-ee-directors.ts
+++ b/apps/api/src/jobs/ingest-ee-directors.ts
@@ -516,7 +516,11 @@ export async function runIngestOnce(): Promise<IngestResult> {
         duration_ms: Date.now() - startedAt,
       };
     } finally {
-      await sqlClient`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`.catch(() => {});
+      // Cleanup; failures here should not mask the primary outcome. Log
+      // rather than swallow so an unlock-leak shows up in production.
+      await sqlClient`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`.catch((err) =>
+        logError("ingest-ee-directors-unlock-failed", err),
+      );
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -530,9 +534,13 @@ export async function runIngestOnce(): Promise<IngestResult> {
     };
   } finally {
     if (tmpZipPath) {
-      await fsp.unlink(tmpZipPath).catch(() => {});
+      await fsp.unlink(tmpZipPath).catch((err) =>
+        logError("ingest-ee-directors-tmp-unlink-failed", err, { tmpZipPath }),
+      );
     }
-    await sqlClient.end({ timeout: 5 }).catch(() => {});
+    await sqlClient.end({ timeout: 5 }).catch((err) =>
+      logError("ingest-ee-directors-client-end-failed", err),
+    );
   }
 }
 

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1019,6 +1019,49 @@ describe("startup-migrations — block 0077 (free_quota overrides — BAG + EP-O
   });
 });
 
+// Per DEC-20260504-A: every cert-audit / new-code-path commit needs at
+// least one regression test capturing the structural shape of the fix.
+// Block 0079 is a new DDL path with a non-trivial constraint-guard
+// branch — these two cases lock down both the create path and the
+// "constraint already present" skip path.
+describe("startup-migrations — block 0079 (ee_directors)", () => {
+  it("first run: creates tables + indexes + singleton CHECK constraint", async () => {
+    // The block issues 4 DDL statements (whose return values are
+    // discarded), then a pg_constraint SELECT (call #5), then the
+    // ALTER TABLE ADD CONSTRAINT (call #6). `makeStub.queue` shifts
+    // per-call positionally, so we pad with 4 nulls before the SELECT
+    // response — only call #5 reads the result.
+    const stub = makeStub({ queue: [null, null, null, null, [{ cnt: "0" }]] });
+    const { runMigration0079_eeDirectors } = await import("./startup-migrations.js");
+    const result = await runMigration0079_eeDirectors(stub);
+    expect(result.outcome).toMatch(/ee_directors.*ensured/i);
+    expect(stub.captured).toHaveLength(6);
+    const allSql = stub.renderedSql.join("\n").toLowerCase();
+    expect(allSql).toContain("create table if not exists ee_directors");
+    expect(allSql).toContain("create index if not exists ee_directors_entity_idx");
+    expect(allSql).toContain("create index if not exists ee_directors_last_synced_idx");
+    expect(allSql).toContain("create table if not exists ee_directors_sync");
+    expect(allSql).toContain("add constraint ee_directors_sync_singleton_chk");
+    expect(allSql).toContain("check (id = 1)");
+    // Idempotency markers must be on every DDL — IF NOT EXISTS on creates,
+    // pg_constraint lookup before the ALTER TABLE.
+    expect(stub.renderedSql.filter((s) => /create table if not exists/i.test(s))).toHaveLength(2);
+    expect(stub.renderedSql.filter((s) => /create index if not exists/i.test(s))).toHaveLength(2);
+  });
+
+  it("second run: skips the ALTER TABLE when CHECK constraint already exists", async () => {
+    // pg_constraint SELECT returns cnt="1" → constraint present → ALTER is
+    // not executed. CREATE TABLE / CREATE INDEX statements still run
+    // because they're IF NOT EXISTS no-ops.
+    const stub = makeStub({ queue: [null, null, null, null, [{ cnt: "1" }]] });
+    const { runMigration0079_eeDirectors } = await import("./startup-migrations.js");
+    await runMigration0079_eeDirectors(stub);
+    // Five statements only — no ALTER TABLE ADD CONSTRAINT on this path.
+    expect(stub.captured).toHaveLength(5);
+    expect(stub.renderedSql.some((s) => /alter table.*add constraint/i.test(s))).toBe(false);
+  });
+});
+
 describe("startup-migrations — phase-b5 slug lists (invariants)", () => {
   it("PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS has the expected 10 entries", async () => {
     const { PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS } = await import("./startup-migrations.js");
@@ -1078,7 +1121,7 @@ describe("startup-migrations — phase-b5 slug lists (invariants)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 21 blocks in historical order", () => {
+  it("exports the expected 22 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1106,6 +1149,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0076_classifyNonAnthropicPaidPrepaid",
       "runMigration0077_classifyFreeQuotaOverrides",
       "runMigration0078_transactionsCapabilityIdCreatedAtIdx",
+      "runMigration0079_eeDirectors",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1347,6 +1347,88 @@ export async function runMigration0078_transactionsCapabilityIdCreatedAtIdx(
   };
 }
 
+// ─── Block 0079: ee_directors + ee_directors_sync tables ────────────────────
+//
+// Estonian directors/representatives cache, populated by the nightly
+// `ingest-ee-directors.ts` job from the RIK Ariregister CC BY 4.0 open-data
+// dump. PK is `kirje_id` from upstream (unique per registry-card filing);
+// queries filter by `entity_reg_code` and `end_date IS NULL` for active
+// representatives. `ee_directors_sync` is a single-row marker tracking the
+// upstream Last-Modified header so the ingest can skip on no-op days.
+//
+// Idempotency: CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+// Re-runs on a healthy DB are no-ops.
+
+export async function runMigration0079_eeDirectors(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  await tx.execute(sql`
+    CREATE TABLE IF NOT EXISTS ee_directors (
+      kirje_id INTEGER PRIMARY KEY,
+      entity_reg_code TEXT NOT NULL,
+      person_type TEXT NOT NULL,
+      role_code TEXT NOT NULL,
+      role_text TEXT NOT NULL,
+      first_name TEXT,
+      last_name TEXT,
+      isikukood_hash TEXT,
+      foreign_code TEXT,
+      foreign_country_code TEXT,
+      foreign_country_text TEXT,
+      address_text TEXT,
+      address_country_code TEXT,
+      start_date DATE,
+      end_date DATE,
+      last_synced_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS ee_directors_entity_idx
+      ON ee_directors (entity_reg_code)
+  `);
+
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS ee_directors_last_synced_idx
+      ON ee_directors (last_synced_at)
+  `);
+
+  await tx.execute(sql`
+    CREATE TABLE IF NOT EXISTS ee_directors_sync (
+      id INTEGER PRIMARY KEY,
+      last_modified_upstream TEXT,
+      last_success_at TIMESTAMP WITH TIME ZONE,
+      last_attempt_at TIMESTAMP WITH TIME ZONE,
+      row_count INTEGER
+    )
+  `);
+
+  // CHECK constraint guarded against re-add. Pinning id=1 keeps the marker
+  // a single-row table without needing a separate enum / UUID.
+  const checkExists = await tx.execute(sql`
+    SELECT count(*)::text AS cnt FROM pg_constraint
+    WHERE conname = 'ee_directors_sync_singleton_chk'
+      AND conrelid = 'ee_directors_sync'::regclass
+  `);
+  const rows = Array.isArray(checkExists)
+    ? checkExists
+    : (checkExists as { rows?: unknown[] })?.rows ?? [];
+  if ((rows[0] as { cnt?: string })?.cnt === "0") {
+    await tx.execute(sql`
+      ALTER TABLE ee_directors_sync
+        ADD CONSTRAINT ee_directors_sync_singleton_chk CHECK (id = 1)
+    `);
+  }
+
+  return {
+    block: "0079_ee_directors",
+    outcome: "ee_directors + ee_directors_sync tables + indexes ensured",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -1379,6 +1461,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0076_classifyNonAnthropicPaidPrepaid,
   runMigration0077_classifyFreeQuotaOverrides,
   runMigration0078_transactionsCapabilityIdCreatedAtIdx,
+  runMigration0079_eeDirectors,
 ];
 
 /**

--- a/apps/api/tests/fixtures/tier-coverage/estonian-company-data.json
+++ b/apps/api/tests/fixtures/tier-coverage/estonian-company-data.json
@@ -7,5 +7,16 @@
   "status": "active",
   "historical_names": [],
   "registry_url": "https://ariregister.rik.ee/est/company/17449106/Bolt-App-Services-AS",
-  "jurisdiction": "EE"
+  "jurisdiction": "EE",
+  "legal_name": "Bolt App Services AS",
+  "primary_registration_id": "17449106",
+  "legal_form": "AS (Public limited company)",
+  "registered_address": "Harju maakond, Tallinn, Kesklinna linnaosa, Vana-Lõuna tn 15",
+  "date_incorporated": null,
+  "legal_representatives": "[REDACTED]",
+  "total_legal_representatives": 1,
+  "tier_2_available": true,
+  "tier_2_available_reason": "Legal representatives sourced from RIK Ariregister Open Data (ettevotja_rekvisiidid__kaardile_kantud_isikud, CC BY 4.0). Personal ID codes (isikukood) and date of birth are redacted by RIK upstream since 2024-11-01 — fields kept null for canonical-shape parity. Last cache refresh: [CAPTURE_TIMESTAMP].",
+  "ubo_availability": "unavailable_no_registry",
+  "ubo_availability_reason": "Programmatic UBO access not currently exposed by Ariregister at v1; verification pending public-source confirmation"
 }

--- a/manifests/estonian-company-data.yaml
+++ b/manifests/estonian-company-data.yaml
@@ -39,6 +39,23 @@ output_schema:
       type: string
     jurisdiction:
       type: string
+    legal_representatives:
+      type: array
+      description: Canonical legal-representatives shape (DEC-20260518-A). Each entry is { type, name, role, role_code, role_group, date_of_birth, start_date }. date_of_birth is always null for EE — redacted upstream by RIK since 2024-11-01.
+    total_legal_representatives:
+      type: integer
+      description: Count of active legal_representatives returned. 0 when ee_directors cache has no active rows for this registry code.
+    tier_2_available:
+      type: boolean
+      description: True when at least one active legal representative is returned from the ee_directors cache.
+    tier_2_available_reason:
+      type: string
+      description: Explanation of tier-2 availability (source + redacted-PIDs caveat + last cache refresh) or non-availability.
+    ubo_availability:
+      type: string
+      description: UBO availability flag. EE is unavailable_no_registry — programmatic UBO access not exposed by Ariregister at v1.
+    ubo_availability_reason:
+      type: string
 data_source: Äriregister / Estonian Business Register
 data_source_type: api
 transparency_tag: ai_generated

--- a/manifests/estonian-company-data.yaml
+++ b/manifests/estonian-company-data.yaml
@@ -1,8 +1,8 @@
 slug: estonian-company-data
 name: Estonian Company Data
-description: Look up Estonian company data from the e-Business Register. Accepts registry code (8 digits) or fuzzy company name.
+description: Look up Estonian company data from the e-Business Register. Accepts registry code (8 digits) or fuzzy company name. Returns legal_representatives[] from RIK Ariregister Open Data (CC BY 4.0).
 category: data-extraction
-cost_class: paid_prepaid
+cost_class: free_unlimited
 quota_window: none
 price_cents: 5
 is_free_tier: false
@@ -99,9 +99,25 @@ output_field_reliability:
   zip_code: guaranteed
   historical_names: guaranteed
   registry_url: guaranteed
+  legal_representatives: common
+  total_legal_representatives: guaranteed
+  tier_2_available: guaranteed
+  tier_2_available_reason: guaranteed
+  ubo_availability: guaranteed
+  ubo_availability_reason: guaranteed
 limitations:
   - title: Estonian e-Business Register (ariregister) may block requests from certain external IP ranges
     text: Estonian e-Business Register (ariregister) may block requests from certain IP ranges
     category: availability
     severity: info
     workaround: If lookup fails, use the registry code to search directly at ariregister.rik.ee
+  - title: legal_representatives.date_of_birth is always null for EE
+    text: Estonian Personal Identification Codes (isikukood) and Date of Birth are redacted upstream by RIK in the Open Data dump since 2024-11-01 per data-protection policy. The legal_representatives[] array preserves the date_of_birth field for canonical-shape parity with peer jurisdictions, but it is always null for EE entries.
+    category: completeness
+    severity: info
+    workaround: Use the RIK contract-gated API (`detailandmed_v2` / `esindus_v1`) for non-redacted personal codes when needed. Contract is free; ~5 working day approval lead time.
+  - title: legal_representatives reflects state as of last nightly ingest (≤24h stale)
+    text: legal_representatives[] is populated from a daily-refreshed bulk dump (~10:37 UTC), not real-time. New appointments / resignations may not appear for up to 24 hours after they are filed.
+    category: freshness
+    severity: info
+    workaround: For real-time accuracy, query the RIK contract API (`esindus_v1` Rights of Representation) directly.


### PR DESCRIPTION
## Summary

Implements **DEC-20260518-E** (exhaustive enumeration) outcome for Estonia: daily ingest of the RIK Ariregister CC BY 4.0 open-data dump (`ettevotja_rekvisiidid__kaardile_kantud_isikud.json.zip`, ~45 MB / ~1 GB uncompressed JSON, ~372k entities). Populates the canonical `legal_representatives[]` field on `estonian-company-data` per **DEC-20260518-A**.

Phase 2 had classified EE "blocked" because only the `/autocomplete` endpoint was checked and deeper SOAP endpoints require a 5-day RIK contract. The 8-path enumeration surfaced the bulk Open Data path: free, no auth, no lead time.

Lifts EU30 binding-ready T2 from **7 to 8**.

## Architecture

- **Drizzle**: `ee_directors` table (PK `kirje_id`, index on `entity_reg_code` + `last_synced_at`) + `ee_directors_sync` singleton-row marker.
- **Migration**: `startup-migrations.ts` Block 0079, idempotent (`CREATE TABLE IF NOT EXISTS` + pg_constraint-lookup guard around the CHECK). Wired into `BLOCKS[]` → fires at API boot before `validateSchema()` per DEC-20260504-C.
- **Job**: `apps/api/src/jobs/ingest-ee-directors.ts`. Custom streaming JSON tokenizer (no `JSON.parse` on 1 GB); `unzip -p` extraction via `child_process.spawn` (no Node ZIP dep — `apt-get install unzip` added to Dockerfile); session-scoped advisory lock 20260518 for cross-replica dedup; 1000-row batched UPSERT in per-batch transactions (DEC-20260504-B WAL bound); sweep `DELETE WHERE last_synced_at < sync_start`. 10-min startup delay + 24h interval; HEAD probe skips when upstream `Last-Modified` unchanged.
- **Handler**: `estonian-company-data.ts` queries the cache via Drizzle, emits canonical `legal_representatives[]` (DEC-20260518-A shape). Cache miss is non-fatal — tier_1 unaffected.

## Cost class

`free_unlimited` — no vendor cost; ingest infra is Strale's own; per-call cost €0.00 for the cache lookup.

## GDPR

Personal ID codes (`isikukood`) and DOB are redacted upstream by RIK since **2024-11-01** per Estonian data-protection policy. Schema persists only `isikukood_hash` (UUID); handler emits `date_of_birth: null` always. `PII_ARRAY_FIELDS` scrubber already covers `legal_representatives` (PR #125). Documented in `tier_2_available_reason` and a manifest limitation.

## Smoke evidence

**Parse-only smoke** vs real 1 GB dump (`apps/api/scripts/smoke-ee-directors-parse.ts`):

\`\`\`
entities streamed:     372041
rows kept (filter):    517355
elapsed:               14s

role-code histogram (top):
  JUHL         443446   (Juhatuse liige / board member)
  FIE          23536    (sole proprietor)
  KISIK        13850
  LIKV         8608     (liquidator)
  TOSAN        5927
  PROK         2004     (procurator)

Bolt Technology OÜ (12417834): 2 active board members
  Ahto Kink     JUHL (Juhatuse liige)  since 2021-08-06
  Markus Villig JUHL (Juhatuse liige)  since 2013-02-07
\`\`\`

Bolt's representatives match the public RIK profile. OSAN / ASUTAJA / FOOMETS (ownership / historical-founder codes) are filtered at ingest.

The Wise backup entity from the prompt (10947145) does not exist in the dump — that was a stale reg-code in the prompt, not a coverage gap.

**Live ingest vs production DB** is deferred to post-deploy smoke per DEC-20260504-C (Block 0079 is wired into the verified `runStartupMigrations()` boot path; running an un-merged migration against prod from a dev session would create schema state that doesn't match deployed code).

## Test plan

- [x] `tsc --noEmit` clean (one pre-existing unrelated error in `italian-company-stakeholders.ts`, untracked)
- [x] Vitest: 92/92 passing for `startup-migrations.test.ts` (incl. new Block 0079 first-run + idempotent-second-run cases) and `ingest-ee-directors.test.ts` (16 cases: parseEeDate, JsonArrayObjectStreamer multi-chunk + escape + braces-in-strings, shapeRow filter + edge cases)
- [x] Full `apps/api` test suite: 680 passing, 1 unrelated failure (`manifest-completeness` for untracked `italian-company-stakeholders` work)
- [x] `validate-capability --slug estonian-company-data`: 19/20 (Gate 5 failure is pre-existing on main, not introduced by this PR)
- [x] `check-tier-coverage.mjs --slug estonian-company-data`: WARN-only Phase 1; fixture updated to reflect new tier-2 fields
- [x] Parse-only smoke against real 1 GB dump (Bolt 12417834 returns 2 active board members, correct dates)
- [x] /go six-lens review (code-reviewer agent): 1 finding addressed inline — added Block 0079 behavioral tests per DEC-20260504-A
- [ ] **Post-deploy smoke** (after merge): verify first ingest tick fires ~10 min after deploy; curl `/v1/do` against `estonian-company-data` for Bolt; expect `tier_2_available: true` + 2-3 active board members. Documented as the v1.1 verification step per DEC-20260504-C.

## Doctrine

- **DEC-20260518-E** — Exhaustive Source Enumeration (the doctrine this PR implements for EE)
- **DEC-20260518-A** — Canonical `legal_representatives[]` shape (parity with NO #136 + CZ #137)
- **DEC-20260518-F** — Attribution preserved in handler provenance (`license: CC BY 4.0`, `source_note` enumerates HVD designation under Reg. (EU) 2023/138)
- **DEC-20260428-A** — Tier 1 compliant (direct first-party government open data; no Strale-operated scraping)
- **DEC-20260504-B** — Bulk-operation deploy protocol (batched UPSERT + bounded DELETE; no single big transaction)
- **DEC-20260504-C** — Deploy-mechanism verification (Block 0079 is on the import graph from `index.ts:74` via `runStartupMigrations()`; ingest job wired at `index.ts:125`)
- **DEC-20260504-A** — Audit-follow-up test coverage (Block 0079 has stub-based behavioral tests; ingest tokenizer + shaper have 16 unit-test cases)

## v1.1 upgrade path

RIK contract API (`esindus_v1` / `detailandmed_v2`) for real-time SOAP + non-redacted PIDs. Free, ~5 working-day approval lead time. Tracked separately as Notion to-do `36467c87-082c-812c-b60d-dceca91f645f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)