### PR TITLE
feat(t2): CY binding-ready T2 via data.gov.cy DRCOR open data

### DIFF
--- a/apps/api/coverage-matrix/COVERAGE.md
+++ b/apps/api/coverage-matrix/COVERAGE.md
@@ -6,8 +6,8 @@ Total rows: 47
 
 ## By status
 
-- Live: 29
-- Committed: 18
+- Live: 30
+- Committed: 17
 
 ## By evidence type
 
@@ -35,7 +35,7 @@ Total rows: 47
 | belgian-company-data | BE | Company registry | cbeapi.be | Live | €0.05 | live-verified | 2026-05-15 |
 | bulgarian-company-data | BG | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
 | swiss-company-data | CH | Company registry | Zefix | Live | €0.05 | live-verified | 2026-05-15 |
-| cypriot-company-data | CY | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
+| cypriot-company-data | CY | Company registry | Openapi.com + DRCOR open data | Live | €0.16 | live-verified | 2026-05-19 |
 | cz-company-data | CZ | Company registry | ARES | Live | €0.05 | live-verified | 2026-05-18 |
 | german-company-data | DE | Company registry | OpenRegister | Live | €0.05 | live-verified | 2026-05-15 |
 | danish-company-data | DK | Company registry | cvrapi.dk | Live | €0.05 | live-verified | 2026-05-15 |
@@ -133,7 +133,7 @@ Total rows: 47
 
 | capability_slug | country | evidence_type | provider | status | per_call_price_eur | evidence_grade | last_verified |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| cypriot-company-data | CY | Company registry | Openapi.com | Committed | €0.16 | live-verified | 2026-05-15 |
+| cypriot-company-data | CY | Company registry | Openapi.com + DRCOR open data | Live | €0.16 | live-verified | 2026-05-19 |
 
 ### CZ (1)
 

--- a/apps/api/coverage-matrix/cypriot-company-data__cy__company-registry.yaml
+++ b/apps/api/coverage-matrix/cypriot-company-data__cy__company-registry.yaml
@@ -1,23 +1,35 @@
 capability_slug: cypriot-company-data
 country: CY
 evidence_type: Company registry
-provider: Openapi.com
-status: Committed
-sourcing_pattern: Vendor (Tier 3 aggregator)
+provider: Openapi.com + DRCOR open data
+status: Live
+sourcing_pattern: "Free open data"
 per_call_price_eur: 0.16
 evidence_grade: live-verified
-tier_1_coverage: 6/7 (no legal_form via WW-Top)
-tier_2_coverage: 4/5 (vatCode + source-as-of + source-name + authoritative-flag=false; no directors via WW-Top)
-tier_3_coverage: 1/6 (NACE only)
-last_verified: "2026-05-15"
+tier_1_coverage: 6/7
+tier_2_coverage: 5/5
+tier_3_coverage: 1/6
+last_verified: "2026-05-19"
 products:
   - Counterparty Assurance
 vendor_roster_url: null
-provider_tos_notes: N/A - no provider integrated
-doctrine_reference: Openapi addendum (countersignature pending); partial coverage
+provider_tos_notes: >-
+  Tier-1 identity via Openapi WW-Top (subject to Openapi addendum still pending countersignature — gated by
+  OPENAPI_ENABLED flag). Tier-2 legal_representatives[] sourced from data.gov.cy DRCOR open-data CSV
+  (organisation_officials_83.csv) under CC BY 4.0 — attribution preserved in handler provenance per
+  DEC-20260518-F constraint (d). cost_class=paid_per_call (Openapi €0.16/call passthrough).
+doctrine_reference: "DEC-20260518-E (Phase 6 exhaustive enumeration); DEC-20260518-A (canonical legal_representatives shape); DEC-20260518-F (attribution); DEC-20260428-A (Tier 1 direct gov open data)"
 notes: >-
-  v4 probe 2026-05-15: 3 regex variants accepted (^CYd{8}[A-Z]$ / ^d{8}[A-Z]$ / ^Cd+$). Bank of
-  Cyprus on C-format confirmed 200 (per 2026-05-11 prior probe). Wargaming CY99000230P returned 204
-  (Openapi correspondence claimed coverage — anomaly bundled for support ticket). PARTIAL: catalog
-  populated for some CY entities, thin for others.
+  2026-05-19: legal_representatives[] populated from data.gov.cy DRCOR open data via monthly bulk CSV
+  (organisation_officials_83.csv, 120 MB, CC BY 4.0, monthly refresh). Weekly ingest job
+  `apps/api/src/jobs/ingest-cy-directors.ts` with Last-Modified-skip populates the `cy_directors`
+  Postgres cache; handler queries cache and shapes per DEC-20260518-A canonical legal_representatives[].
+  Smoke 2026-05-19: parses 1,168,758 officer rows (635K directors + 438K secretaries + others) in 3.1s;
+  Bank of Cyprus C165 → 12 officers, Wargaming 290868 → 5 officers (matches Phase 6 partial). Identifier
+  mapping: only C-prefix inputs (e.g. C165) resolve against DRCOR; VAT-format inputs (CY-prefix or bare)
+  return tier_2_available=false with explicit reason — DRCOR indexes by numeric REGISTRATION_NO only, not
+  by VAT. Wargaming CY99000230P 204 anomaly from prior 2026-05-15 probe explained as invalid Openapi test
+  value (not a valid DRCOR registration number in any format). Phase 6 enumeration partial reconfirmed
+  DEC-20260507-G "Tier-1 direct buildable" finding with live evidence. Per-row appointment dates not
+  published in DRCOR open data (start_date kept null for canonical-shape parity).
 _source_notion_page_id: 34867c87-082c-8115-8442-e152ede99b8c

--- a/apps/api/scripts/smoke-cy-directors-parse.ts
+++ b/apps/api/scripts/smoke-cy-directors-parse.ts
@@ -1,0 +1,130 @@
+/**
+ * Parse-only smoke for the CY DRCOR open-data ingest.
+ *
+ * Streams the live 120 MB `organisation_officials_83.csv` via the same
+ * CsvStreamer + shapeRow pipeline the production ingest uses, but DOES
+ * NOT touch the DB. Validates:
+ *   - end-to-end streaming completes without memory blow-up
+ *   - row count is in the expected ~1.17M range
+ *   - role histogram matches the Phase 6 enumeration partial
+ *   - real entities (Wargaming 290868, Bank of Cyprus 165) return their
+ *     known officer counts
+ *
+ * Usage: `npx tsx scripts/smoke-cy-directors-parse.ts`
+ *
+ * Network: 120 MB download. Expect ~30s on a fast EU/US link. The file
+ * is consumed via stream; nothing is buffered whole in memory.
+ */
+
+import { createWriteStream, createReadStream, promises as fsp } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import {
+  CsvStreamer,
+  shapeRow,
+  type CyDirectorRow,
+} from "../src/jobs/ingest-cy-directors.js";
+
+const UPSTREAM_URL =
+  "https://data.gov.cy/sites/default/files/organisation_officials_83.csv";
+
+const SPOTLIGHT_REG_CODES = new Set([
+  "165", // Bank of Cyprus
+  "290868", // Wargaming Group Limited
+  "11", // The Sun Insurance Office Limited (first file row)
+]);
+
+async function main(): Promise<void> {
+  const startedAt = Date.now();
+  console.log(`[smoke-cy] HEAD ${UPSTREAM_URL}`);
+  const head = await fetch(UPSTREAM_URL, { method: "HEAD" });
+  console.log(
+    `[smoke-cy] HEAD HTTP ${head.status} Last-Modified=${head.headers.get("last-modified")} Content-Length=${head.headers.get("content-length")}`,
+  );
+
+  const tmpPath = join(tmpdir(), `cy_smoke_${Date.now()}.csv`);
+  console.log(`[smoke-cy] downloading → ${tmpPath}`);
+  const dl = await fetch(UPSTREAM_URL);
+  if (!dl.ok || !dl.body) throw new Error(`Download HTTP ${dl.status}`);
+  await pipeline(
+    Readable.fromWeb(dl.body as unknown as import("node:stream/web").ReadableStream),
+    createWriteStream(tmpPath),
+  );
+  const dlElapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1);
+  console.log(`[smoke-cy] download complete in ${dlElapsedSec}s`);
+
+  const parseStartedAt = Date.now();
+  const stream = createReadStream(tmpPath, { encoding: "utf8" });
+  const streamer = new CsvStreamer();
+
+  let rowsSeen = 0;
+  let rowsShaped = 0;
+  const roleHist = new Map<string, number>();
+  const spotlight = new Map<string, CyDirectorRow[]>();
+
+  for await (const chunk of stream) {
+    for (const cols of streamer.push(chunk as string)) {
+      rowsSeen++;
+      const row = shapeRow(cols);
+      if (!row) continue;
+      rowsShaped++;
+      roleHist.set(
+        row.role_standardized,
+        (roleHist.get(row.role_standardized) ?? 0) + 1,
+      );
+      if (SPOTLIGHT_REG_CODES.has(row.entity_reg_code)) {
+        const arr = spotlight.get(row.entity_reg_code) ?? [];
+        arr.push(row);
+        spotlight.set(row.entity_reg_code, arr);
+      }
+    }
+  }
+  for (const cols of streamer.flush()) {
+    rowsSeen++;
+    const row = shapeRow(cols);
+    if (!row) continue;
+    rowsShaped++;
+  }
+
+  const parseElapsedSec = ((Date.now() - parseStartedAt) / 1000).toFixed(1);
+  console.log("");
+  console.log(`[smoke-cy] parse complete in ${parseElapsedSec}s`);
+  console.log(`[smoke-cy] rows seen:     ${rowsSeen}`);
+  console.log(`[smoke-cy] rows shaped:   ${rowsShaped}`);
+  console.log("");
+  console.log("[smoke-cy] role_standardized histogram:");
+  const sorted = [...roleHist.entries()].sort((a, b) => b[1] - a[1]);
+  for (const [role, count] of sorted) {
+    console.log(`  ${role.padEnd(22)} ${count}`);
+  }
+
+  console.log("");
+  for (const code of SPOTLIGHT_REG_CODES) {
+    const rows = spotlight.get(code) ?? [];
+    if (rows.length === 0) {
+      console.log(`[smoke-cy] reg_code ${code}: NO ROWS FOUND`);
+      continue;
+    }
+    const orgName = rows[0].organisation_name;
+    const orgType = rows[0].organisation_type;
+    console.log(
+      `[smoke-cy] reg_code ${code} (${orgName}, ${orgType}): ${rows.length} officer rows`,
+    );
+    for (const r of rows) {
+      console.log(
+        `  - ${r.person_or_organisation_name.padEnd(50)} ${r.role_standardized.padEnd(20)} (${r.official_position})`,
+      );
+    }
+  }
+
+  await fsp.unlink(tmpPath).catch(() => {});
+  console.log("");
+  console.log(`[smoke-cy] total elapsed: ${((Date.now() - startedAt) / 1000).toFixed(1)}s`);
+}
+
+main().catch((err) => {
+  console.error("[smoke-cy] FAILED:", err);
+  process.exit(1);
+});

--- a/apps/api/src/capabilities/cypriot-company-data.ts
+++ b/apps/api/src/capabilities/cypriot-company-data.ts
@@ -1,29 +1,136 @@
-// Cyprus — Openapi.com WW-Top (Tier-3 vendor aggregator).
+// Cyprus — Openapi.com WW-Top (Tier-3 vendor aggregator) + DRCOR open data.
 //
-// Phase 2a Openapi resolver replication. PARTIAL coverage: Openapi
-// catalog has some CY entities (Bank of Cyprus on C-format `C165`
-// confirmed 200 by 2026-05-11 probe) but returned 204 for Wargaming
-// (CY99000230P) on 2026-05-15 v4 — anomaly bundled on Openapi case
-// 151296. The capability accepts the shape; vendor returns not-found
-// for some entities.
+// Tier-1 identity flows through Openapi WW-Top (PARTIAL coverage; some CY
+// entities return 204 — anomaly bundled on Openapi case 151296). Tier-2
+// `legal_representatives[]` is sourced from the `cy_directors` cache that
+// `jobs/ingest-cy-directors.ts` populates monthly from data.gov.cy DRCOR
+// open data (CC BY 4.0). Phase 6 enumeration (DEC-20260518-E) and DEC-
+// 20260518-A canonical shape.
 //
-// Identifier shape: Openapi WW-Top accepts THREE regex variants for
-// CY: ^CY\d{8}[A-Z]$ (CY-prefix VAT), ^\d{8}[A-Z]$ (bare VAT, no
-// prefix), or ^C\d+$ (CRO company number, e.g. C165). The capability
-// validates against the union shape and passes through to Openapi.
+// Identifier shape: Openapi WW-Top accepts THREE regex variants for CY:
+//   ^CY\d{8}[A-Z]$   (CY-prefix VAT)
+//   ^\d{8}[A-Z]$     (bare VAT, no prefix)
+//   ^C\d+$           (CRO company number, e.g. C165)
 //
-// Field coverage (Matrix row 34867c87-082c-8115-8442-e152ede99b8c):
-// Tier 1 6/7 (no legal_form via WW-Top), Tier 2 4/5 (no directors),
-// Tier 3 1/6 (NACE only).
+// Only the C-prefix variant maps cleanly to DRCOR (strip "C" → numeric
+// REGISTRATION_NO lookup). VAT-format inputs (CY-prefix or bare) cannot
+// be resolved against the DRCOR cache because DRCOR doesn't index by
+// VAT — the cache stores numeric registration_no only. For VAT inputs
+// we surface `tier_2_available: false` with an explicit reason rather
+// than silently dropping the field.
 
+import { and, eq } from "drizzle-orm";
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
+import { getDb } from "../db/index.js";
+import { cyDirectors, cyDirectorsSync } from "../db/schema.js";
 
 const CY_RE = /^(CY\d{8}[A-Z]|\d{8}[A-Z]|C\d+)$/;
 
 function normaliseCyIdentifier(raw: string): string | null {
   const cleaned = raw.replace(/\s/g, "").toUpperCase();
   return CY_RE.test(cleaned) ? cleaned : null;
+}
+
+/** Map a normalised CY identifier to its DRCOR REGISTRATION_NO (numeric
+ *  string) if possible. C-prefix strips to the digits; VAT-format
+ *  identifiers don't resolve and return null. */
+export function drcorRegCodeFromIdentifier(normalised: string): string | null {
+  if (/^C\d+$/.test(normalised)) return normalised.slice(1);
+  return null;
+}
+
+interface LegalRepresentative {
+  type: "person" | "organisation";
+  name: string;
+  role: string;
+  role_code: string;
+  role_group: string;
+  date_of_birth: string | null;
+  start_date: string | null;
+}
+
+// DRCOR role-standardized → role_group. Forward-compat: anything not
+// listed maps to "other". role_standardized values are produced by
+// `standardizeRole()` in the ingest job.
+const ROLE_GROUPS: Record<string, string> = {
+  director: "management_board",
+  alternate_director: "management_board",
+  secretary: "secretarial",
+  assistant_secretary: "secretarial",
+  deputy_secretary: "secretarial",
+  authorised_person: "authorised_representation",
+  owner: "ownership",
+  general_partner: "partnership",
+  limited_partner: "partnership",
+};
+
+function deriveRoleGroup(roleStandardized: string): string {
+  return ROLE_GROUPS[roleStandardized] ?? "other";
+}
+
+/** Heuristic for distinguishing legal-entity directors (corporate
+ *  nominees) from natural persons. DRCOR open data does not flag this
+ *  explicitly, but corporate names reliably end in LIMITED / LTD /
+ *  ETAIREIA / SECRETARIAL SERVICES etc. Names with no corporate marker
+ *  are treated as natural persons. False-positives are tolerable —
+ *  consumers care about role+name, the type tag is supplementary. */
+const ORGANISATION_NAME_RE =
+  /\b(LIMITED|LTD|LIMITED\.|LTD\.|S\.A\.?|PLC|LLC|LLP|HOLDINGS|TRUST|FOUNDATION|SECRETARIAL SERVICES|MANAGEMENT|NOMINEES|TRUSTEES|ΕΤΑΙΡΕΙΑ|ΕΠΕ|ΛΤΔ)\b/;
+
+function deriveType(name: string): "person" | "organisation" {
+  return ORGANISATION_NAME_RE.test(name) ? "organisation" : "person";
+}
+
+async function fetchLegalRepresentatives(drcorRegCode: string): Promise<{
+  representatives: LegalRepresentative[];
+  lastSyncedAt: Date | null;
+}> {
+  if (!drcorRegCode) return { representatives: [], lastSyncedAt: null };
+  const db = getDb();
+  const rows = await db
+    .select({
+      personOrOrganisationName: cyDirectors.personOrOrganisationName,
+      officialPosition: cyDirectors.officialPosition,
+      roleStandardized: cyDirectors.roleStandardized,
+      lastSyncedAt: cyDirectors.lastSyncedAt,
+    })
+    .from(cyDirectors)
+    .where(eq(cyDirectors.entityRegCode, drcorRegCode));
+  const reps: LegalRepresentative[] = [];
+  let maxSynced: Date | null = null;
+  for (const r of rows) {
+    const name = r.personOrOrganisationName.trim();
+    if (!name) continue;
+    reps.push({
+      type: deriveType(name),
+      name,
+      role: r.officialPosition,
+      role_code: r.roleStandardized,
+      role_group: deriveRoleGroup(r.roleStandardized),
+      // DRCOR open data does not include personal IDs or DOB at row level —
+      // kept null for canonical-shape parity with EE/NO/CZ.
+      date_of_birth: null,
+      // DRCOR snapshot doesn't carry per-row appointment dates either —
+      // kept null per Phase 6 enumeration caveat (current-state snapshot,
+      // not change log).
+      start_date: null,
+    });
+    if (r.lastSyncedAt && (!maxSynced || r.lastSyncedAt > maxSynced)) {
+      maxSynced = r.lastSyncedAt;
+    }
+  }
+  return { representatives: reps, lastSyncedAt: maxSynced };
+}
+
+async function readSyncTimestamp(): Promise<Date | null> {
+  const db = getDb();
+  const rows = await db
+    .select({ lastSuccessAt: cyDirectorsSync.lastSuccessAt })
+    .from(cyDirectorsSync)
+    .where(eq(cyDirectorsSync.id, 1))
+    .limit(1);
+  return rows[0]?.lastSuccessAt ?? null;
 }
 
 registerCapability("cypriot-company-data", async (input: CapabilityInput) => {
@@ -52,20 +159,84 @@ registerCapability("cypriot-company-data", async (input: CapabilityInput) => {
     },
     normalised,
   );
+
+  // Tier-2 lookup against the cy_directors cache (monthly DRCOR ingest).
+  // Only C-prefix inputs map to DRCOR; VAT-format inputs cannot be
+  // resolved against the open-data file's numeric REGISTRATION_NO index.
+  // Cache miss / DB error is non-fatal — tier-1 still surfaces.
+  const drcorRegCode = drcorRegCodeFromIdentifier(normalised);
+  let legalReps: LegalRepresentative[] = [];
+  let lastSyncedAt: Date | null = null;
+  let cacheError: string | null = null;
+  if (drcorRegCode) {
+    try {
+      const result = await fetchLegalRepresentatives(drcorRegCode);
+      legalReps = result.representatives;
+      lastSyncedAt = result.lastSyncedAt ?? (await readSyncTimestamp());
+    } catch (err) {
+      cacheError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  const o = __etResult.output as Record<string, unknown>;
+  // Evidence Tier 1 canonical aliases (DEC-20260518-A)
+  o.legal_name = o.company_name;
+  o.primary_registration_id = o.registration_number;
+  o.date_incorporated = o.registered_date;
+  o.legal_representatives = legalReps;
+  o.total_legal_representatives = legalReps.length;
+  o.tier_2_available = legalReps.length > 0;
+  if (cacheError) {
+    o.tier_2_available_reason = `cy_directors cache query failed (${cacheError}); tier_1 data unaffected.`;
+  } else if (legalReps.length > 0) {
+    const syncedNote = lastSyncedAt
+      ? ` Last cache refresh: ${lastSyncedAt.toISOString()}.`
+      : "";
+    o.tier_2_available_reason =
+      "Legal representatives sourced from Cyprus DRCOR (Department of " +
+      "Registrar of Companies and Intellectual Property) via monthly-refreshed " +
+      "open data: data.gov.cy organisation_officials_83.csv, CC BY 4.0. " +
+      "Up to 4-week freshness; per-row appointment dates and personal " +
+      "identifiers are not published in the open-data file." +
+      syncedNote;
+  } else if (!drcorRegCode) {
+    o.tier_2_available_reason =
+      "VAT-format identifier cannot be resolved against the DRCOR open-data " +
+      "cache (cache indexes numeric REGISTRATION_NO only). Re-query with the " +
+      "C-prefix company number (e.g. C165) for legal_representatives coverage.";
+  } else {
+    o.tier_2_available_reason =
+      "cy_directors cache returned no rows for this DRCOR registration " +
+      "number (newly registered entity, struck-off, or cache not yet " +
+      "populated by first ingest tick).";
+  }
+  o.ubo_availability = "unavailable_no_registry";
+  o.ubo_availability_reason =
+    "Cyprus UBO Register access closed to public since 2023-01-03 per CJEU " +
+    "C-37/20 ruling; legitimate-interest gate applies. Programmatic UBO " +
+    "lookup not exposed at v1.";
+
+  // Augment provenance with the open-data attribution per DEC-20260518-F
+  // constraint (d). The Openapi-resolver already populated the top-level
+  // provenance with required {source, fetched_at}; we add tier-2 fields.
+  const baseProvenance = __etResult.provenance;
+  const augmentedProvenance: typeof baseProvenance & Record<string, unknown> = {
+    ...baseProvenance,
+  };
+  if (legalReps.length > 0) {
+    augmentedProvenance.tier_2_source = "data.gov.cy DRCOR open data";
+    augmentedProvenance.tier_2_source_url = "https://data.gov.cy/sites/default/files/organisation_officials_83.csv";
+    augmentedProvenance.tier_2_license = "CC BY 4.0";
+    augmentedProvenance.tier_2_license_url = "https://creativecommons.org/licenses/by/4.0/legalcode";
+    augmentedProvenance.tier_2_attribution =
+      "Source: Department of Registrar of Companies and Intellectual Property (DRCIP), Republic of Cyprus, via data.gov.cy.";
+    if (lastSyncedAt) augmentedProvenance.tier_2_last_synced_at = lastSyncedAt.toISOString();
+  }
+
   return {
     ...__etResult,
-    output: {
-      ...__etResult.output,
-      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
-      legal_name: (__etResult.output as Record<string, unknown>).company_name,
-      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
-      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
-      // Evidence Tier framework labels (DEC-20260518-A)
-      tier_2_available: false,
-      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
-      ubo_availability: "unavailable_no_registry",
-      ubo_availability_reason: "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation",
-    },
+    output: o,
+    provenance: augmentedProvenance,
   };
 });
 

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -857,3 +857,51 @@ export const eeDirectorsSync = pgTable("ee_directors_sync", {
   lastAttemptAt: timestamp("last_attempt_at", { withTimezone: true }),
   rowCount: integer("row_count"),
 });
+
+// ─── cy_directors ───────────────────────────────────────────────────────────
+// Cyprus directors/officers cache. Monthly ingest of the data.gov.cy DRCOR
+// open-data CSV (`organisation_officials_83.csv`, CC BY 4.0) — see
+// `apps/api/src/jobs/ingest-cy-directors.ts`. DRCOR publishes no stable per-row
+// identifier, so the natural composite key is (entity_reg_code,
+// person_or_organisation_name, official_position). The CSV does NOT include
+// per-row appointment/cessation dates — all rows are treated as currently-active
+// per the snapshot semantics of the upstream file. Greek role labels are stored
+// verbatim plus a normalized English `role_standardized` for handler ergonomics.
+export const cyDirectors = pgTable(
+  "cy_directors",
+  {
+    entityRegCode: text("entity_reg_code").notNull(),
+    personOrOrganisationName: text("person_or_organisation_name").notNull(),
+    officialPosition: text("official_position").notNull(),
+    organisationName: text("organisation_name"),
+    organisationTypeCode: text("organisation_type_code"),
+    organisationType: text("organisation_type"),
+    roleStandardized: text("role_standardized").notNull(),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [
+        table.entityRegCode,
+        table.personOrOrganisationName,
+        table.officialPosition,
+      ],
+    }),
+    index("cy_directors_entity_idx").on(table.entityRegCode),
+    index("cy_directors_last_synced_idx").on(table.lastSyncedAt),
+  ],
+);
+
+// ─── cy_directors_sync ──────────────────────────────────────────────────────
+// Single-row marker for the CY directors ingest. Tracks the upstream
+// `Last-Modified` header so the weekly ingest can skip when the monthly
+// DRCOR refresh hasn't fired yet. `id = 1` only (CHECK constraint).
+export const cyDirectorsSync = pgTable("cy_directors_sync", {
+  id: integer("id").primaryKey(),
+  lastModifiedUpstream: text("last_modified_upstream"),
+  lastSuccessAt: timestamp("last_success_at", { withTimezone: true }),
+  lastAttemptAt: timestamp("last_attempt_at", { withTimezone: true }),
+  rowCount: integer("row_count"),
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -124,6 +124,13 @@ async function main() {
   const { startEeDirectorsIngest } = await import("./jobs/ingest-ee-directors.js");
   startEeDirectorsIngest();
 
+  // CY directors / officers monthly ingest — DRCOR open-data CSV
+  // (DEC-20260518-E Phase 6). Same pattern as EE; weekly tick with
+  // Last-Modified skip since DRCOR refreshes monthly. Advisory lock
+  // 20260519 dedups across replicas.
+  const { startCyDirectorsIngest } = await import("./jobs/ingest-cy-directors.js");
+  startCyDirectorsIngest();
+
   const port = parseInt(process.env.PORT || "3000", 10);
 
   const server = serve({ fetch: app.fetch, port }, (info) => {

--- a/apps/api/src/jobs/ingest-cy-directors.test.ts
+++ b/apps/api/src/jobs/ingest-cy-directors.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Regression tests for the CY-directors ingest building blocks.
+ *
+ * Covers the streaming CSV tokenizer (RFC-4180 quoted fields, doubled-
+ * quote escaping, BOM, CRLF/LF terminators), the role-standardization
+ * map, and the row-shape filter. The orchestration (`runIngestOnce`) is
+ * integration-territory and is exercised separately via the parse-only
+ * smoke documented in the PR description.
+ *
+ * Per DEC-20260504-A — every Phase-6 follow-up needs at least one
+ * regression test capturing the structural shape of the fix. Here the
+ * shape is: streaming CSV with quoted fields + Greek role
+ * standardization + header-row skip.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CsvStreamer,
+  ROLE_STANDARDIZATION,
+  shapeRow,
+  standardizeRole,
+} from "./ingest-cy-directors.js";
+
+describe("CsvStreamer", () => {
+  function collectAll(streamer: CsvStreamer, chunks: string[]): string[][] {
+    const out: string[][] = [];
+    for (const chunk of chunks) {
+      for (const row of streamer.push(chunk)) {
+        out.push(row);
+      }
+    }
+    for (const row of streamer.flush()) {
+      out.push(row);
+    }
+    return out;
+  }
+
+  it("parses a simple comma-separated row terminated by LF", () => {
+    const out = collectAll(new CsvStreamer(), ["a,b,c\n"]);
+    expect(out).toEqual([["a", "b", "c"]]);
+  });
+
+  it("parses CRLF row terminators (DRCOR shape)", () => {
+    const out = collectAll(new CsvStreamer(), ["a,b,c\r\nd,e,f\r\n"]);
+    expect(out).toEqual([
+      ["a", "b", "c"],
+      ["d", "e", "f"],
+    ]);
+  });
+
+  it("strips a leading UTF-8 BOM", () => {
+    const out = collectAll(new CsvStreamer(), ["﻿a,b\r\n"]);
+    expect(out).toEqual([["a", "b"]]);
+  });
+
+  it("handles empty fields", () => {
+    const out = collectAll(new CsvStreamer(), ["a,,c\n,,\n"]);
+    expect(out).toEqual([
+      ["a", "", "c"],
+      ["", "", ""],
+    ]);
+  });
+
+  it("emits a final row without a trailing newline via flush()", () => {
+    const out = collectAll(new CsvStreamer(), ["a,b,c"]);
+    expect(out).toEqual([["a", "b", "c"]]);
+  });
+
+  it("parses quoted fields with embedded commas", () => {
+    const out = collectAll(new CsvStreamer(), [
+      `"NEAPOLIS, INC",290800,"with, comma"\r\n`,
+    ]);
+    expect(out).toEqual([["NEAPOLIS, INC", "290800", "with, comma"]]);
+  });
+
+  it("parses quoted fields with doubled-quote escaping (the DRCOR ΨΗΣΤΑΡΙΕΣ case)", () => {
+    const out = collectAll(new CsvStreamer(), [
+      `"ΨΗΣΤΑΡΙΕΣ ""ΤΩΝ ΦΡΟΝΙΜΩΝ ΤΑ ΠΑΙΔΙΑ""",29837,B\r\n`,
+    ]);
+    expect(out).toEqual([
+      [`ΨΗΣΤΑΡΙΕΣ "ΤΩΝ ΦΡΟΝΙΜΩΝ ΤΑ ΠΑΙΔΙΑ"`, "29837", "B"],
+    ]);
+  });
+
+  it("parses quoted fields with embedded CRLF inside the quote", () => {
+    const out = collectAll(new CsvStreamer(), [
+      `"line one\r\nline two",b,c\r\n`,
+    ]);
+    expect(out).toEqual([["line one\r\nline two", "b", "c"]]);
+  });
+
+  it("handles row split across multiple chunk boundaries", () => {
+    const streamer = new CsvStreamer();
+    const out: string[][] = [];
+    for (const row of streamer.push("a,b,")) out.push(row);
+    for (const row of streamer.push("c\r\nd,e,f")) out.push(row);
+    for (const row of streamer.flush()) out.push(row);
+    expect(out).toEqual([
+      ["a", "b", "c"],
+      ["d", "e", "f"],
+    ]);
+  });
+
+  it("handles quoted field split mid-quote across chunks", () => {
+    const streamer = new CsvStreamer();
+    const out: string[][] = [];
+    for (const row of streamer.push(`"ΨΗΣΤΑΡΙΕΣ `)) out.push(row);
+    for (const row of streamer.push(`""ΤΩΝ`)) out.push(row);
+    for (const row of streamer.push(` ΦΡΟΝΙΜΩΝ""",29837,B\r\n`)) out.push(row);
+    expect(out).toEqual([
+      [`ΨΗΣΤΑΡΙΕΣ "ΤΩΝ ΦΡΟΝΙΜΩΝ"`, "29837", "B"],
+    ]);
+  });
+
+  it("parses the DRCOR header row (with BOM) verbatim", () => {
+    const out = collectAll(new CsvStreamer(), [
+      "﻿ORGANISATION_NAME,REGISTRATION_NO,ORGANISATION_TYPE_CODE,ORGANISATION_TYPE,PERSON_OR_ORGANISATION_NAME,OFFICIAL_POSITION\r\n",
+    ]);
+    expect(out).toEqual([
+      [
+        "ORGANISATION_NAME",
+        "REGISTRATION_NO",
+        "ORGANISATION_TYPE_CODE",
+        "ORGANISATION_TYPE",
+        "PERSON_OR_ORGANISATION_NAME",
+        "OFFICIAL_POSITION",
+      ],
+    ]);
+  });
+});
+
+describe("standardizeRole", () => {
+  it("maps the documented Greek role labels to English codes", () => {
+    expect(standardizeRole("Διευθυντής")).toBe("director");
+    expect(standardizeRole("Γραμματέας")).toBe("secretary");
+    expect(standardizeRole("Ιδιοκτήτης")).toBe("owner");
+    expect(standardizeRole("Ομόρρυθμος Συνέταιρος")).toBe("general_partner");
+    expect(standardizeRole("Αντικαταστάτης Διευθυντής")).toBe("alternate_director");
+    expect(standardizeRole("Βοηθός Γραμματέας")).toBe("assistant_secretary");
+    expect(standardizeRole("Εξουσιοδοτημένο Πρόσωπο")).toBe("authorised_person");
+    expect(standardizeRole("Ετερόρρυθμος Συνέταιρος")).toBe("limited_partner");
+    expect(standardizeRole("Αναπληρωτής Γραμματέας")).toBe("deputy_secretary");
+  });
+
+  it("trims whitespace before mapping", () => {
+    expect(standardizeRole("  Διευθυντής  ")).toBe("director");
+  });
+
+  it("falls back to 'other' for unknown role labels (forward-compat)", () => {
+    expect(standardizeRole("ΝΕΑ ΡΟΛΟΣ")).toBe("other");
+    expect(standardizeRole("")).toBe("other");
+  });
+
+  it("covers all 9 documented role labels in the standardization map", () => {
+    // Guard against accidental deletion. The Phase 6 enumeration partial
+    // documents exactly 9 role labels in the role histogram.
+    expect(Object.keys(ROLE_STANDARDIZATION).length).toBe(9);
+  });
+});
+
+describe("shapeRow", () => {
+  it("shapes a typical DRCOR director row", () => {
+    const out = shapeRow([
+      "WARGAMING GROUP LIMITED",
+      "290868",
+      "C",
+      "Εταιρεία",
+      "VICTOR KISLYI",
+      "Διευθυντής",
+    ]);
+    expect(out).toEqual({
+      entity_reg_code: "290868",
+      person_or_organisation_name: "VICTOR KISLYI",
+      official_position: "Διευθυντής",
+      organisation_name: "WARGAMING GROUP LIMITED",
+      organisation_type_code: "C",
+      organisation_type: "Εταιρεία",
+      role_standardized: "director",
+    });
+  });
+
+  it("shapes a corporate-nominee secretary row", () => {
+    const out = shapeRow([
+      "WARGAMING GROUP LIMITED",
+      "290868",
+      "C",
+      "Εταιρεία",
+      "THEMIS SECRETARIAL SERVICES LIMITED",
+      "Γραμματέας",
+    ]);
+    expect(out?.role_standardized).toBe("secretary");
+    expect(out?.person_or_organisation_name).toBe(
+      "THEMIS SECRETARIAL SERVICES LIMITED",
+    );
+  });
+
+  it("returns null for the header row", () => {
+    expect(
+      shapeRow([
+        "ORGANISATION_NAME",
+        "REGISTRATION_NO",
+        "ORGANISATION_TYPE_CODE",
+        "ORGANISATION_TYPE",
+        "PERSON_OR_ORGANISATION_NAME",
+        "OFFICIAL_POSITION",
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null for rows with empty REGISTRATION_NO", () => {
+    expect(
+      shapeRow(["NAME", "", "C", "Εταιρεία", "PERSON", "Διευθυντής"]),
+    ).toBeNull();
+  });
+
+  it("returns null for rows with empty person name", () => {
+    expect(
+      shapeRow(["NAME", "290868", "C", "Εταιρεία", "", "Διευθυντής"]),
+    ).toBeNull();
+  });
+
+  it("returns null for rows with empty position", () => {
+    expect(
+      shapeRow(["NAME", "290868", "C", "Εταιρεία", "PERSON", ""]),
+    ).toBeNull();
+  });
+
+  it("returns null for too-short rows (defensive)", () => {
+    expect(shapeRow(["NAME", "290868"])).toBeNull();
+    expect(shapeRow([])).toBeNull();
+  });
+
+  it("trims whitespace from all fields", () => {
+    const out = shapeRow([
+      "  WARGAMING GROUP LIMITED  ",
+      "  290868  ",
+      "  C  ",
+      "  Εταιρεία  ",
+      "  VICTOR KISLYI  ",
+      "  Διευθυντής  ",
+    ]);
+    expect(out?.entity_reg_code).toBe("290868");
+    expect(out?.person_or_organisation_name).toBe("VICTOR KISLYI");
+    expect(out?.role_standardized).toBe("director");
+  });
+
+  it("nullifies empty optional fields rather than persisting empty strings", () => {
+    const out = shapeRow(["", "290868", "", "", "VICTOR KISLYI", "Διευθυντής"]);
+    expect(out?.organisation_name).toBeNull();
+    expect(out?.organisation_type_code).toBeNull();
+    expect(out?.organisation_type).toBeNull();
+  });
+});

--- a/apps/api/src/jobs/ingest-cy-directors.ts
+++ b/apps/api/src/jobs/ingest-cy-directors.ts
@@ -1,0 +1,610 @@
+/**
+ * Weekly ingest (skip-if-unchanged) — CY directors / officers.
+ *
+ * Pulls the monthly-refreshed CC BY 4.0 open-data CSV
+ * `organisation_officials_83.csv` from data.gov.cy (Department of
+ * Registrar of Companies and Intellectual Property, DRCIP) and populates
+ * the `cy_directors` table. The handler (`capabilities/cypriot-company-
+ * data.ts`) queries this table at request time to populate
+ * `legal_representatives[]` for tier-2 KYB coverage. Implements DEC-20260518-E
+ * exhaustive-enumeration outcome for CY and DEC-20260518-F attribution.
+ *
+ * Upstream:
+ *   URL:    https://data.gov.cy/sites/default/files/organisation_officials_83.csv
+ *   Size:   ~120 MB CSV (plain text, NOT zipped)
+ *   Format: RFC-4180 CSV, UTF-8 with BOM, CRLF line endings, header row.
+ *           Columns: ORGANISATION_NAME, REGISTRATION_NO, ORGANISATION_TYPE_CODE,
+ *           ORGANISATION_TYPE, PERSON_OR_ORGANISATION_NAME, OFFICIAL_POSITION
+ *   Refresh: monthly (last seen 2026-04-29 07:35 UTC)
+ *   License: CC BY 4.0 (attribution preserved in handler provenance)
+ *
+ * GDPR caveat: DRCOR open data does not include personal identification
+ * numbers or DOB at the row level — only names + roles + organisation
+ * context. No additional redaction needed at ingest. The Cypriot UBO
+ * register is a separate restricted system (out of scope for this job).
+ *
+ * Identifier mapping. DRCOR REGISTRATION_NO is pure numeric (e.g.
+ * "290868", "11", "165"). The Strale CY handler accepts three input
+ * shapes: CY-prefix VAT, bare-VAT, C-prefix company number. Only the
+ * C-prefix maps cleanly to DRCOR (strip "C" → numeric lookup). The
+ * Phase 6 enumeration partial documents this: VAT-format inputs cannot
+ * be resolved against the DRCOR cache because DRCOR doesn't index by
+ * VAT — the cache stores numeric registration_no only.
+ *
+ * Schedule. Weekly interval after a 10-minute startup delay (DRCOR
+ * refreshes monthly but weekly + Last-Modified-skip is safer than
+ * monthly-exact — covers the case where DRCOR refreshes off-schedule).
+ * Advisory lock is session-scoped on a dedicated postgres connection
+ * (DEC-20260504-B — long-running work cannot share the request pool).
+ * Cross-instance dedup via pg_try_advisory_lock.
+ *
+ * Bounded-WAL pattern. UPSERT in batches of UPSERT_BATCH_SIZE rows per
+ * statement, each batch in its own short transaction. After all rows
+ * upserted, sweep deletes anything whose `last_synced_at < sync_start`
+ * — bounded per-tick because the table is at most ~1.2 M rows and the
+ * delta from the last sync is small.
+ *
+ * Idempotency. The upstream `Last-Modified` header is checked against
+ * `cy_directors_sync.last_modified_upstream`. A re-run on the same
+ * upstream version is a no-op (logged as `skipped-unchanged`).
+ */
+
+import { createWriteStream, promises as fsp } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import postgres from "postgres";
+import { fireAndForget } from "../lib/fire-and-forget.js";
+import { log, logError } from "../lib/log.js";
+import { isShuttingDown } from "../lib/shutdown.js";
+
+const INGEST_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // weekly + skip-if-unchanged
+const STARTUP_DELAY_MS = 10 * 60 * 1000;
+const ADVISORY_LOCK_ID = 20260519; // unique across job files; CY ingest
+const UPSERT_BATCH_SIZE = 1000;
+const UPSTREAM_URL =
+  "https://data.gov.cy/sites/default/files/organisation_officials_83.csv";
+
+// Role normalization — Greek role label → English standardized code. Keys are
+// the verbatim DRCOR OFFICIAL_POSITION values. Anything not listed falls
+// through to "other" (forward-compat for DRCOR adding new positions).
+// Source: data.gov.cy OFFICIAL_POSITION uniq histogram, 2026-05-18 probe.
+export const ROLE_STANDARDIZATION: Record<string, string> = {
+  "Διευθυντής": "director",
+  "Γραμματέας": "secretary",
+  "Ιδιοκτήτης": "owner",
+  "Ομόρρυθμος Συνέταιρος": "general_partner",
+  "Αντικαταστάτης Διευθυντής": "alternate_director",
+  "Βοηθός Γραμματέας": "assistant_secretary",
+  "Εξουσιοδοτημένο Πρόσωπο": "authorised_person",
+  "Ετερόρρυθμος Συνέταιρος": "limited_partner",
+  "Αναπληρωτής Γραμματέας": "deputy_secretary",
+};
+
+export function standardizeRole(officialPosition: string): string {
+  return ROLE_STANDARDIZATION[officialPosition.trim()] ?? "other";
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface CyDirectorRow {
+  entity_reg_code: string;
+  person_or_organisation_name: string;
+  official_position: string;
+  organisation_name: string | null;
+  organisation_type_code: string | null;
+  organisation_type: string | null;
+  role_standardized: string;
+}
+
+// ─── Streaming CSV parser (RFC 4180) ─────────────────────────────────────────
+
+/**
+ * Streaming CSV tokenizer. Handles RFC-4180 quoted fields with doubled-
+ * quote escaping (e.g. `"foo ""bar"" baz"`), CRLF or LF line endings,
+ * and a leading UTF-8 BOM. Emits one row at a time as `string[]` whenever
+ * an unquoted row terminator is consumed.
+ *
+ * Constraint: assumes the CSV is well-formed. Trailing newline optional.
+ * Empty fields are emitted as empty strings, not null. The caller decides
+ * how to map row arrays to its shape.
+ *
+ * Why a hand-rolled parser: avoids adding a dep tree for a single use
+ * site (parallel to the EE JSON tokenizer choice). The grammar is small
+ * (4 states); the test suite below covers the edge cases.
+ */
+export class CsvStreamer {
+  private buf = "";
+  private state: "FIELD_START" | "UNQUOTED" | "QUOTED" | "QUOTED_QUOTE" =
+    "FIELD_START";
+  private fieldStart = 0;
+  private fieldParts: string[] = []; // accumulator for the current field
+  private row: string[] = [];
+  private sawBom = false;
+
+  *push(chunk: string): IterableIterator<string[]> {
+    if (!this.sawBom) {
+      this.sawBom = true;
+      if (chunk.charCodeAt(0) === 0xfeff) {
+        chunk = chunk.slice(1);
+      }
+    }
+    this.buf += chunk;
+    while (this.fieldStart < this.buf.length) {
+      const c = this.buf[this.fieldStart];
+      switch (this.state) {
+        case "FIELD_START":
+          if (c === '"') {
+            this.state = "QUOTED";
+            this.fieldStart++;
+            this.markFieldRestart();
+          } else if (c === ",") {
+            this.row.push("");
+            this.fieldStart++;
+            this.markFieldRestart();
+          } else if (c === "\r" || c === "\n") {
+            this.row.push("");
+            yield* this.emitRow(c);
+          } else {
+            this.state = "UNQUOTED";
+            this.fieldStart++;
+          }
+          break;
+        case "UNQUOTED":
+          if (c === ",") {
+            this.flushUnquoted();
+            this.fieldStart++;
+            this.state = "FIELD_START";
+            this.markFieldRestart();
+          } else if (c === "\r" || c === "\n") {
+            this.flushUnquoted();
+            yield* this.emitRow(c);
+          } else {
+            this.fieldStart++;
+          }
+          break;
+        case "QUOTED":
+          if (c === '"') {
+            this.state = "QUOTED_QUOTE";
+            // Flush whatever was accumulated for the field so far (between
+            // the opening quote and this potential closing quote).
+            this.fieldParts.push(this.buf.slice(this.fieldRestart, this.fieldStart));
+            this.fieldStart++;
+          } else {
+            this.fieldStart++;
+          }
+          break;
+        case "QUOTED_QUOTE":
+          if (c === '"') {
+            // Escaped quote inside quoted field — emit one literal `"`
+            // and resume quoted mode.
+            this.fieldParts.push('"');
+            this.state = "QUOTED";
+            this.fieldStart++;
+            this.markFieldRestart();
+          } else if (c === ",") {
+            this.row.push(this.fieldParts.join(""));
+            this.fieldParts = [];
+            this.state = "FIELD_START";
+            this.fieldStart++;
+            this.markFieldRestart();
+          } else if (c === "\r" || c === "\n") {
+            this.row.push(this.fieldParts.join(""));
+            this.fieldParts = [];
+            yield* this.emitRow(c);
+          } else {
+            // Per RFC-4180 strict, an unescaped " mid-quoted-field is
+            // invalid. We accept and treat as literal for resilience.
+            this.fieldParts.push('"');
+            this.fieldParts.push(c);
+            this.state = "QUOTED";
+            this.fieldStart++;
+            this.markFieldRestart();
+          }
+          break;
+      }
+    }
+    // Slide the buffer so we don't grow it across chunks. Anything
+    // unconsumed belongs to a field-in-progress.
+    this.trimBuffer();
+  }
+
+  /** Flush at EOF: emit any pending field/row that didn't end with a newline. */
+  *flush(): IterableIterator<string[]> {
+    if (this.state === "UNQUOTED") {
+      this.flushUnquoted();
+    } else if (this.state === "QUOTED_QUOTE") {
+      this.row.push(this.fieldParts.join(""));
+      this.fieldParts = [];
+    } else if (this.state === "QUOTED") {
+      // Unterminated quoted field — emit what we have rather than throwing.
+      this.fieldParts.push(this.buf.slice(this.fieldRestart, this.fieldStart));
+      this.row.push(this.fieldParts.join(""));
+      this.fieldParts = [];
+    }
+    if (this.row.length > 0 || this.state !== "FIELD_START") {
+      yield this.row;
+      this.row = [];
+    }
+    this.state = "FIELD_START";
+  }
+
+  // Restart point inside the buffer for the field currently being read.
+  // Used by both UNQUOTED (one contiguous slice) and QUOTED (one or more
+  // slices separated by escaped quotes).
+  private fieldRestart = 0;
+
+  private markFieldRestart(): void {
+    this.fieldRestart = this.fieldStart;
+  }
+
+  private flushUnquoted(): void {
+    this.row.push(this.buf.slice(this.fieldRestart, this.fieldStart));
+  }
+
+  private *emitRow(c: string): IterableIterator<string[]> {
+    yield this.row;
+    this.row = [];
+    this.fieldStart++;
+    // Consume the LF half of a CRLF as part of the same terminator.
+    if (c === "\r" && this.buf[this.fieldStart] === "\n") {
+      this.fieldStart++;
+    }
+    this.state = "FIELD_START";
+    this.markFieldRestart();
+  }
+
+  private trimBuffer(): void {
+    if (this.state === "FIELD_START") {
+      this.buf = this.buf.slice(this.fieldStart);
+      this.fieldStart = 0;
+      this.fieldRestart = 0;
+    } else if (this.state === "UNQUOTED") {
+      // Keep from fieldRestart onwards — the field is mid-flight.
+      this.buf = this.buf.slice(this.fieldRestart);
+      this.fieldStart -= this.fieldRestart;
+      this.fieldRestart = 0;
+    } else {
+      // QUOTED / QUOTED_QUOTE — fieldParts already holds prior slices,
+      // so we can safely drop everything before the current cursor.
+      this.buf = this.buf.slice(this.fieldRestart);
+      this.fieldStart -= this.fieldRestart;
+      this.fieldRestart = 0;
+    }
+  }
+}
+
+// ─── Row shaping ─────────────────────────────────────────────────────────────
+
+/** Map a raw CSV row (string[]) into the persistence shape. Returns null for
+ *  rows that can't be persisted (header row, missing required fields,
+ *  blank REGISTRATION_NO). The header is detected by exact column-name
+ *  match, not by row index — a defensive choice in case DRCOR ever adds
+ *  metadata rows before the header. */
+export function shapeRow(cols: string[]): CyDirectorRow | null {
+  if (cols.length < 6) return null;
+  const [
+    organisationName,
+    registrationNo,
+    organisationTypeCode,
+    organisationType,
+    personOrOrganisationName,
+    officialPosition,
+  ] = cols.map((c) => (c ?? "").trim());
+
+  // Skip the header row (defensive — could appear once at file start or
+  // never if BOM was already consumed by the streamer).
+  if (
+    organisationName === "ORGANISATION_NAME" &&
+    registrationNo === "REGISTRATION_NO"
+  ) {
+    return null;
+  }
+
+  if (!registrationNo || !personOrOrganisationName || !officialPosition) {
+    return null;
+  }
+
+  return {
+    entity_reg_code: registrationNo,
+    person_or_organisation_name: personOrOrganisationName,
+    official_position: officialPosition,
+    organisation_name: organisationName || null,
+    organisation_type_code: organisationTypeCode || null,
+    organisation_type: organisationType || null,
+    role_standardized: standardizeRole(officialPosition),
+  };
+}
+
+// ─── HEAD probe ──────────────────────────────────────────────────────────────
+
+async function headLastModified(): Promise<string | null> {
+  const res = await fetch(UPSTREAM_URL, {
+    method: "HEAD",
+    signal: AbortSignal.timeout(15000),
+  });
+  if (!res.ok) {
+    throw new Error(`HEAD ${UPSTREAM_URL} returned HTTP ${res.status}`);
+  }
+  return res.headers.get("last-modified");
+}
+
+// ─── Batched UPSERT ──────────────────────────────────────────────────────────
+
+async function upsertBatch(
+  client: postgres.Sql,
+  rows: CyDirectorRow[],
+  syncStartIso: string,
+): Promise<number> {
+  if (rows.length === 0) return 0;
+
+  // Pre-dedupe within the batch on the composite PK to avoid the
+  // "ON CONFLICT cannot affect the same row twice" postgres error that
+  // fires when the same (entity, name, position) appears more than once
+  // within a single batch. Last occurrence wins (matches the natural
+  // semantics — DRCOR doesn't repeat semantically, but defensive vs
+  // upstream typos that yield two near-identical rows).
+  const dedup = new Map<string, CyDirectorRow>();
+  for (const r of rows) {
+    dedup.set(
+      `${r.entity_reg_code}\x00${r.person_or_organisation_name}\x00${r.official_position}`,
+      r,
+    );
+  }
+  const unique = Array.from(dedup.values());
+
+  await client`
+    INSERT INTO cy_directors ${client(
+      unique.map((r) => ({
+        entity_reg_code: r.entity_reg_code,
+        person_or_organisation_name: r.person_or_organisation_name,
+        official_position: r.official_position,
+        organisation_name: r.organisation_name,
+        organisation_type_code: r.organisation_type_code,
+        organisation_type: r.organisation_type,
+        role_standardized: r.role_standardized,
+        last_synced_at: syncStartIso,
+      })),
+    )}
+    ON CONFLICT (entity_reg_code, person_or_organisation_name, official_position)
+    DO UPDATE SET
+      organisation_name = EXCLUDED.organisation_name,
+      organisation_type_code = EXCLUDED.organisation_type_code,
+      organisation_type = EXCLUDED.organisation_type,
+      role_standardized = EXCLUDED.role_standardized,
+      last_synced_at = EXCLUDED.last_synced_at
+  `;
+  return unique.length;
+}
+
+// ─── Sync-marker helpers ─────────────────────────────────────────────────────
+
+async function readSyncMarker(client: postgres.Sql): Promise<{
+  last_modified_upstream: string | null;
+  row_count: number | null;
+} | null> {
+  const rows = await client<
+    { last_modified_upstream: string | null; row_count: number | null }[]
+  >`
+    SELECT last_modified_upstream, row_count
+      FROM cy_directors_sync WHERE id = 1
+  `;
+  return rows[0] ?? null;
+}
+
+async function recordSyncAttempt(client: postgres.Sql): Promise<void> {
+  await client`
+    INSERT INTO cy_directors_sync (id, last_attempt_at)
+    VALUES (1, NOW())
+    ON CONFLICT (id) DO UPDATE SET last_attempt_at = NOW()
+  `;
+}
+
+async function recordSyncSuccess(
+  client: postgres.Sql,
+  lastModified: string | null,
+  rowCount: number,
+): Promise<void> {
+  await client`
+    INSERT INTO cy_directors_sync (id, last_modified_upstream, last_success_at, last_attempt_at, row_count)
+    VALUES (1, ${lastModified}, NOW(), NOW(), ${rowCount})
+    ON CONFLICT (id) DO UPDATE SET
+      last_modified_upstream = EXCLUDED.last_modified_upstream,
+      last_success_at = EXCLUDED.last_success_at,
+      last_attempt_at = EXCLUDED.last_attempt_at,
+      row_count = EXCLUDED.row_count
+  `;
+}
+
+// ─── Ingest orchestration (single tick) ──────────────────────────────────────
+
+export interface IngestResult {
+  outcome:
+    | "skipped-unchanged"
+    | "skipped-lock-busy"
+    | "skipped-shutting-down"
+    | "completed"
+    | "errored";
+  detail?: string;
+  rows_upserted?: number;
+  rows_deleted?: number;
+  last_modified?: string | null;
+  duration_ms: number;
+}
+
+export async function runIngestOnce(): Promise<IngestResult> {
+  const startedAt = Date.now();
+
+  if (isShuttingDown()) {
+    return { outcome: "skipped-shutting-down", duration_ms: 0 };
+  }
+
+  const connStr = process.env.DATABASE_URL;
+  if (!connStr) {
+    return {
+      outcome: "errored",
+      detail: "DATABASE_URL not set",
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+
+  const sqlClient = postgres(connStr, { max: 1, idle_timeout: 30 });
+  let tmpCsvPath: string | null = null;
+
+  try {
+    const [{ acquired }] = await sqlClient<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(${ADVISORY_LOCK_ID}) AS acquired
+    `;
+    if (!acquired) {
+      return { outcome: "skipped-lock-busy", duration_ms: Date.now() - startedAt };
+    }
+
+    try {
+      const upstreamLastModified = await headLastModified();
+      const prior = await readSyncMarker(sqlClient);
+
+      if (
+        upstreamLastModified &&
+        prior?.last_modified_upstream === upstreamLastModified &&
+        (prior.row_count ?? 0) > 0
+      ) {
+        return {
+          outcome: "skipped-unchanged",
+          last_modified: upstreamLastModified,
+          duration_ms: Date.now() - startedAt,
+        };
+      }
+
+      await recordSyncAttempt(sqlClient);
+
+      // Download to /tmp. Streams through pipeline so we don't buffer the
+      // 120 MB body in memory.
+      tmpCsvPath = join(tmpdir(), `cy_officials_${Date.now()}.csv`);
+      const dlRes = await fetch(UPSTREAM_URL, {
+        signal: AbortSignal.timeout(180_000),
+      });
+      if (!dlRes.ok || !dlRes.body) {
+        throw new Error(`Download HTTP ${dlRes.status} (no body=${!dlRes.body})`);
+      }
+      await pipeline(
+        Readable.fromWeb(dlRes.body as unknown as import("node:stream/web").ReadableStream),
+        createWriteStream(tmpCsvPath),
+      );
+
+      // Re-open the file as a stream for parsing — gives us controlled
+      // chunked reads without loading the whole 120 MB into memory.
+      const { createReadStream } = await import("node:fs");
+      const csvStream = createReadStream(tmpCsvPath, { encoding: "utf8" });
+      const streamer = new CsvStreamer();
+      const syncStartIso = new Date().toISOString();
+      let rowsSeen = 0;
+      let rowsUpserted = 0;
+      let pending: CyDirectorRow[] = [];
+
+      for await (const chunk of csvStream) {
+        for (const cols of streamer.push(chunk as string)) {
+          rowsSeen++;
+          const row = shapeRow(cols);
+          if (!row) continue;
+          pending.push(row);
+          if (pending.length >= UPSERT_BATCH_SIZE) {
+            rowsUpserted += await upsertBatch(sqlClient, pending, syncStartIso);
+            pending = [];
+            if (isShuttingDown()) {
+              throw new Error("shutdown-during-ingest");
+            }
+          }
+        }
+      }
+      for (const cols of streamer.flush()) {
+        rowsSeen++;
+        const row = shapeRow(cols);
+        if (!row) continue;
+        pending.push(row);
+      }
+      if (pending.length > 0) {
+        rowsUpserted += await upsertBatch(sqlClient, pending, syncStartIso);
+        pending = [];
+      }
+
+      const delRes = await sqlClient`
+        DELETE FROM cy_directors
+         WHERE last_synced_at < ${syncStartIso}
+      `;
+      const rowsDeleted = (delRes as unknown as { count?: number }).count ?? 0;
+
+      await recordSyncSuccess(sqlClient, upstreamLastModified, rowsUpserted);
+
+      log.info(
+        {
+          label: "ingest-cy-directors-success",
+          rows_seen: rowsSeen,
+          rows_upserted: rowsUpserted,
+          rows_deleted: rowsDeleted,
+          duration_ms: Date.now() - startedAt,
+          last_modified: upstreamLastModified,
+        },
+        "ingest-cy-directors-success",
+      );
+
+      return {
+        outcome: "completed",
+        rows_upserted: rowsUpserted,
+        rows_deleted: rowsDeleted,
+        last_modified: upstreamLastModified,
+        duration_ms: Date.now() - startedAt,
+      };
+    } finally {
+      await sqlClient`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`.catch((err) =>
+        logError("ingest-cy-directors-unlock-failed", err),
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logError("ingest-cy-directors-failed", err, {
+      duration_ms: Date.now() - startedAt,
+    });
+    return {
+      outcome: "errored",
+      detail: message,
+      duration_ms: Date.now() - startedAt,
+    };
+  } finally {
+    if (tmpCsvPath) {
+      await fsp.unlink(tmpCsvPath).catch((err) =>
+        logError("ingest-cy-directors-tmp-unlink-failed", err, { tmpCsvPath }),
+      );
+    }
+    await sqlClient.end({ timeout: 5 }).catch((err) =>
+      logError("ingest-cy-directors-client-end-failed", err),
+    );
+  }
+}
+
+// ─── Lifecycle wiring ────────────────────────────────────────────────────────
+
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
+let startupTimeout: ReturnType<typeof setTimeout> | null = null;
+
+export function startCyDirectorsIngest(): void {
+  if (intervalHandle || startupTimeout) return;
+  startupTimeout = setTimeout(() => {
+    fireAndForget(() => runIngestOnce(), { label: "ingest-cy-directors-tick" });
+    intervalHandle = setInterval(() => {
+      if (isShuttingDown()) return;
+      fireAndForget(() => runIngestOnce(), { label: "ingest-cy-directors-tick" });
+    }, INGEST_INTERVAL_MS);
+  }, STARTUP_DELAY_MS);
+}
+
+export function stopCyDirectorsIngestForTest(): void {
+  if (startupTimeout) {
+    clearTimeout(startupTimeout);
+    startupTimeout = null;
+  }
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+}

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1062,6 +1062,41 @@ describe("startup-migrations — block 0079 (ee_directors)", () => {
   });
 });
 
+// Block 0080 mirrors the Block 0079 shape: 4 DDL statements followed by a
+// pg_constraint SELECT, then a conditional ALTER TABLE. Two cases lock down
+// the create path and the constraint-already-present skip path.
+describe("startup-migrations — block 0080 (cy_directors)", () => {
+  it("first run: creates tables + indexes + singleton CHECK constraint", async () => {
+    const stub = makeStub({ queue: [null, null, null, null, [{ cnt: "0" }]] });
+    const { runMigration0080_cyDirectors } = await import("./startup-migrations.js");
+    const result = await runMigration0080_cyDirectors(stub);
+    expect(result.outcome).toMatch(/cy_directors.*ensured/i);
+    expect(stub.captured).toHaveLength(6);
+    const allSql = stub.renderedSql.join("\n").toLowerCase();
+    expect(allSql).toContain("create table if not exists cy_directors");
+    expect(allSql).toContain("create index if not exists cy_directors_entity_idx");
+    expect(allSql).toContain("create index if not exists cy_directors_last_synced_idx");
+    expect(allSql).toContain("create table if not exists cy_directors_sync");
+    expect(allSql).toContain("add constraint cy_directors_sync_singleton_chk");
+    expect(allSql).toContain("check (id = 1)");
+    // Composite PK shape pinned — DRCOR has no stable per-row identifier
+    // upstream, so the PK is the natural unique tuple.
+    expect(allSql).toContain(
+      "primary key (entity_reg_code, person_or_organisation_name, official_position)",
+    );
+    expect(stub.renderedSql.filter((s) => /create table if not exists/i.test(s))).toHaveLength(2);
+    expect(stub.renderedSql.filter((s) => /create index if not exists/i.test(s))).toHaveLength(2);
+  });
+
+  it("second run: skips the ALTER TABLE when CHECK constraint already exists", async () => {
+    const stub = makeStub({ queue: [null, null, null, null, [{ cnt: "1" }]] });
+    const { runMigration0080_cyDirectors } = await import("./startup-migrations.js");
+    await runMigration0080_cyDirectors(stub);
+    expect(stub.captured).toHaveLength(5);
+    expect(stub.renderedSql.some((s) => /alter table.*add constraint/i.test(s))).toBe(false);
+  });
+});
+
 describe("startup-migrations — phase-b5 slug lists (invariants)", () => {
   it("PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS has the expected 10 entries", async () => {
     const { PHASE_B5_NON_ANTHROPIC_PAID_PREPAID_SLUGS } = await import("./startup-migrations.js");
@@ -1121,7 +1156,7 @@ describe("startup-migrations — phase-b5 slug lists (invariants)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 22 blocks in historical order", () => {
+  it("exports the expected 23 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1150,6 +1185,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0077_classifyFreeQuotaOverrides",
       "runMigration0078_transactionsCapabilityIdCreatedAtIdx",
       "runMigration0079_eeDirectors",
+      "runMigration0080_cyDirectors",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1429,6 +1429,82 @@ export async function runMigration0079_eeDirectors(
   };
 }
 
+// ─── Block 0080: cy_directors + cy_directors_sync tables ────────────────────
+//
+// Cyprus directors/officers cache, populated by the monthly
+// `ingest-cy-directors.ts` job from the data.gov.cy DRCOR open-data CSV
+// (`organisation_officials_83.csv`, CC BY 4.0). DRCOR has no stable per-row
+// identifier upstream, so the natural composite PK is (entity_reg_code,
+// person_or_organisation_name, official_position) — directly mirroring the
+// uniqueness semantics of one (person × position) per company. Queries filter
+// by entity_reg_code; the sweep DELETE relies on last_synced_at for the
+// retire-stale-rows pass.
+//
+// Idempotency: CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+// The composite PK is created in-line with the table, so it lands once and
+// re-runs are no-ops.
+
+export async function runMigration0080_cyDirectors(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  await tx.execute(sql`
+    CREATE TABLE IF NOT EXISTS cy_directors (
+      entity_reg_code TEXT NOT NULL,
+      person_or_organisation_name TEXT NOT NULL,
+      official_position TEXT NOT NULL,
+      organisation_name TEXT,
+      organisation_type_code TEXT,
+      organisation_type TEXT,
+      role_standardized TEXT NOT NULL,
+      last_synced_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (entity_reg_code, person_or_organisation_name, official_position)
+    )
+  `);
+
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS cy_directors_entity_idx
+      ON cy_directors (entity_reg_code)
+  `);
+
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS cy_directors_last_synced_idx
+      ON cy_directors (last_synced_at)
+  `);
+
+  await tx.execute(sql`
+    CREATE TABLE IF NOT EXISTS cy_directors_sync (
+      id INTEGER PRIMARY KEY,
+      last_modified_upstream TEXT,
+      last_success_at TIMESTAMP WITH TIME ZONE,
+      last_attempt_at TIMESTAMP WITH TIME ZONE,
+      row_count INTEGER
+    )
+  `);
+
+  const checkExists = await tx.execute(sql`
+    SELECT count(*)::text AS cnt FROM pg_constraint
+    WHERE conname = 'cy_directors_sync_singleton_chk'
+      AND conrelid = 'cy_directors_sync'::regclass
+  `);
+  const rows = Array.isArray(checkExists)
+    ? checkExists
+    : (checkExists as { rows?: unknown[] })?.rows ?? [];
+  if ((rows[0] as { cnt?: string })?.cnt === "0") {
+    await tx.execute(sql`
+      ALTER TABLE cy_directors_sync
+        ADD CONSTRAINT cy_directors_sync_singleton_chk CHECK (id = 1)
+    `);
+  }
+
+  return {
+    block: "0080_cy_directors",
+    outcome: "cy_directors + cy_directors_sync tables + indexes ensured",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 // ─── Orchestrator ───────────────────────────────────────────────────────────
 
 /**
@@ -1462,6 +1538,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0077_classifyFreeQuotaOverrides,
   runMigration0078_transactionsCapabilityIdCreatedAtIdx,
   runMigration0079_eeDirectors,
+  runMigration0080_cyDirectors,
 ];
 
 /**

--- a/apps/api/tests/fixtures/tier-coverage/cypriot-company-data.json
+++ b/apps/api/tests/fixtures/tier-coverage/cypriot-company-data.json
@@ -17,5 +17,24 @@
     }
   ],
   "company_size": "Very large company",
-  "source_as_of": "[CAPTURE_TIMESTAMP]"
+  "source_as_of": "[CAPTURE_TIMESTAMP]",
+  "legal_name": "Bank of Cyprus Public Company Limited",
+  "primary_registration_id": "C165",
+  "date_incorporated": "1943-12-31",
+  "legal_representatives": [
+    {
+      "type": "person",
+      "name": "[SCRUBBED_PERSON_NAME]",
+      "role": "Διευθυντής",
+      "role_code": "director",
+      "role_group": "management_board",
+      "date_of_birth": null,
+      "start_date": null
+    }
+  ],
+  "total_legal_representatives": 12,
+  "tier_2_available": true,
+  "tier_2_available_reason": "Legal representatives sourced from Cyprus DRCOR (Department of Registrar of Companies and Intellectual Property) via monthly-refreshed open data: data.gov.cy organisation_officials_83.csv, CC BY 4.0. Up to 4-week freshness; per-row appointment dates and personal identifiers are not published in the open-data file. Last cache refresh: [CAPTURE_TIMESTAMP].",
+  "ubo_availability": "unavailable_no_registry",
+  "ubo_availability_reason": "Cyprus UBO Register access closed to public since 2023-01-03 per CJEU C-37/20 ruling; legitimate-interest gate applies. Programmatic UBO lookup not exposed at v1."
 }

--- a/audit-output/_partial_cy_enumeration.md
+++ b/audit-output/_partial_cy_enumeration.md
@@ -1,0 +1,506 @@
+# CY — 8-path enumeration (Phase 6)
+
+**Date:** 2026-05-18  
+**Author:** Claude Code (research subagent, synthesized)  
+**Doctrine:** DEC-20260518-E (Exhaustive Source Enumeration); DEC-20260518-F (per-call HTML/PDF parsing under 4 constraints); DEC-20260518-G (platform-fee probe mandatory for Tier-2 aggregators); DEC-20260428-A (no Strale-operated scrapers); cost discipline (per-call passthrough OK, fixed monthly fees NOT OK in v1)  
+**Test entities:** Wargaming Group Limited (CY reg 290868 / `CY99000230P` Openapi slug); Bank of Cyprus Public Company Limited (HE format, DRCOR primary)
+
+---
+
+## Prior finding re-verification: DEC-20260507-G (data.gov.cy DRCOR "Tier-1 direct buildable")
+
+**Prior claim:** 2026-05-07 spike identified data.gov.cy DRCOR open-data dataset as "Tier-1 direct buildable" with CC-BY confirm-at-ingest.
+
+**Re-verification result (2026-05-18): CONFIRMED AND UPGRADED.**
+
+Three CSV files probed live today via HTTP HEAD + partial GET:
+
+| File | URL | HTTP | Content-Length | Last-Modified | Content-Type |
+|------|-----|------|----------------|---------------|--------------|
+| Officers (`organisation_officials_83.csv`) | `https://data.gov.cy/sites/default/files/organisation_officials_83.csv` | **200 OK** | **125,808,168 bytes (120 MB)** | 2026-04-29 07:35 UTC | text/csv |
+| Registered Offices (`registered_office_96.csv`) | `https://data.gov.cy/sites/default/files/registered_office_96.csv` | **200 OK** | 20,596,024 bytes (20 MB) | 2026-04-29 07:34 UTC | text/csv |
+| Organisations (`organisations_94.csv`) | `https://data.gov.cy/sites/default/files/organisations_94.csv` | **200 OK** | 92,099,139 bytes (88 MB) | 2026-04-29 07:34 UTC | text/csv |
+
+**License confirmed live:** CC BY 4.0 International — retrieved directly from dataset page `https://data.gov.cy/el/dataset/mitroo-eggegrammenon-etaireion-emporikon-eponymion-kai-synetairismon-stin-kypro`. **Not NonCommercial** (OpenSanctions metadata erroneously described it as "CC Attribution NonCommercial" — the source page itself says CC BY 4.0 unqualified, which is the authoritative value).
+
+**Officers file column schema (first-row probe confirmed):**
+```
+ORGANISATION_NAME, REGISTRATION_NO, ORGANISATION_TYPE_CODE, ORGANISATION_TYPE,
+PERSON_OR_ORGANISATION_NAME, OFFICIAL_POSITION
+```
+
+**Role taxonomy (uniq -c on OFFICIAL_POSITION column, 1,168,824 total rows):**
+| Greek role | Count | Translation |
+|-----------|-------|-------------|
+| Διευθυντής | 635,123 | Director |
+| Γραμματέας | 438,479 | Secretary |
+| Ιδιοκτήτης | 58,558 | Owner (trade names / business names) |
+| Ομόρρυθμος Συνέταιρος | 17,366 | General partner (partnerships) |
+| Αντικαταστάτης Διευθυντής | 5,901 | Alternate Director |
+| Βοηθός Γραμματέας | 3,383 | Assistant Secretary |
+| Εξουσιοδοτημένο Πρόσωπο | 3,365 | Authorised Person |
+| Ετερόρρυθμος Συνέταιρος | 2,353 | Limited partner |
+| Αναπληρωτής Γραμματέας | 463 | Deputy Secretary |
+
+**Live data probe — Wargaming Group Limited (registration 290868):**
+```csv
+WARGAMING GROUP LIMITED,290868,C,Εταιρεία,NICK KATSELAPOV,Διευθυντής
+WARGAMING GROUP LIMITED,290868,C,Εταιρεία,VICTOR KISLYI,Διευθυντής
+WARGAMING GROUP LIMITED,290868,C,Εταιρεία,ΕΥΓΕΝΙ ΚΙΣΛΥ,Διευθυντής
+WARGAMING GROUP LIMITED,290868,C,Εταιρεία,ΜΑΡΙΟΣ ΠΕΛΙΔΗΣ,Γραμματέας
+WARGAMING GROUP LIMITED,290868,C,Εταιρεία,ΧΡΙΣΤΗΣ ΧΡΙΣΤΟΦΟΡΟΥ,Διευθυντής
+```
+
+**Wargaming Openapi 204 anomaly explained:** Openapi accepted `CY99000230P` (numeric-suffix format) but returned 204 No Content. The DRCOR open-data file uses pure numeric registration numbers (e.g., `290868`) — no CY prefix, no letter suffix. The `CY99000230P` slug does not exist in the DRCOR registry. It is likely a placeholder or erroneous test value from a prior Openapi correspondence. Wargaming is registered as number `290868`, type `C` (Εταιρεία = Private Company Limited). The `HE` prefix (used in the eFiling web UI) and the Greek `ΗΕ` prefix (used by Topograph) are display conventions; DRCOR open data uses raw numeric IDs.
+
+**Dataset refresh cadence:** Monthly (confirmed from page: "Μηνιαία"). Last-Modified timestamps on all three files were 2026-04-29, consistent with monthly cycle.
+
+**Upgrade over DEC-20260507-G:** Prior finding confirmed CC-BY and buildable but did not document field schema, row count, live probe results, or Wargaming anomaly resolution. Those are now on record.
+
+**v1 path status: CONFIRMED VIABLE TODAY.** No contract, no auth, no lead time, no cost. CC BY 4.0 permits commercial use with attribution. Officers (directors + secretaries + partners) are in scope. Monthly refresh is a known limitation (not live-fetch).
+
+---
+
+## Path 1 — Same vendor (Openapi), other endpoints; CY-specific Openapi products
+
+**URLs probed:**
+- `https://openapi.com/products` — full product catalog
+- `https://console.openapi.com/apis/company/documentation` — company API documentation
+- `https://openapi.com/products/company-start-world-wide` — WW-Start product page
+
+**Findings:**
+
+Openapi's company documentation lists 49 production scopes covering AT, BE, CH, DE, ES, FR, GB, IT, PL, PT, and WW (worldwide). **Cyprus (CY) is not listed as a dedicated scope.** There is no `CY-start`, `CY-top`, `CY-directors`, or `CY-representatives` endpoint.
+
+CY is served via the generic `WW-Top` and `WW-Start` endpoints. The `WW-Start` documentation returns "over 20 data points" including company name, VAT number, business status, registered office, and GPS coordinates. Per the prior coverage audit, the Openapi WW-Top response for CY returns 6/7 Tier-1 identity fields (no `legal_form`) but **no directors/legal_representatives**.
+
+The Openapi documentation notes that country-specific representative endpoints (e.g., `current-company-representatives-italy`, `IT-stakeholders`, `IT-ubo`) exist only for Italy among EU countries. There is no equivalent CY-specific representative endpoint.
+
+**Has Openapi added directors for CY since 2026-05-11?** No evidence of a new CY-directors product. The audit correspondence anomaly (Openapi claimed CY coverage, Wargaming returned 204) remains unresolved on the vendor side. The root cause is now identified: the `CY99000230P` test value is not a valid DRCOR registration number in any format.
+
+**Verdict: NOT VIABLE for directors.** The WW-Top CY endpoint remains identity-only. No CY-specific director product exists on Openapi as of 2026-05-18.
+
+**Cost for what it currently returns:** €0.16/call (WW-Top, Committed tier). No incremental cost for a non-existent field.
+
+---
+
+## Path 2 — Direct registry API (DRCOR / efiling.drcor.mcit.gov.cy) — paid API tier
+
+**URL probed:** `https://efiling.drcor.mcit.gov.cy/DrcorPublic/SearchForm.aspx?sc=0&lang=EN`  
+**HTTP probe result:** 200 OK  
+**Headers:** Microsoft-IIS/7.0, ASP.NET 4.0, sets `ASP.NET_SessionId` cookie + `_culture` cookie + `.ASPXANONYMOUS` cookie. Session-based, requires cookie persistence for multi-step navigation.
+
+**Does DRCOR publish a paid API?**
+
+No. The DRCOR public eSearch is a browser-based ASP.NET Web Forms application (not an API). There is no documented paid API tier. The official companies.gov.cy website lists four eServices: eSearch, eFiling, Other e-Services, and UBO registration — none of which is a programmatic data API.
+
+**DEC-20260518-G platform-fee probe:**
+- Platform fee: N/A (no API product exists)
+- Setup fee: N/A
+- Monthly minimum: N/A
+- Annual floor: N/A
+- Volume-tier floors: N/A
+- Termination fees: N/A
+
+**What the paid tier (€10) provides:** A full search of the selected organisation's electronic file from registration date to search date — delivered as a human-readable web page or downloadable document, not a structured API response. This is a per-query document retrieval service, not a machine-readable API.
+
+**Verdict: NOT VIABLE.** No DRCOR paid API exists. The €10 paid search is a document-retrieval service for humans, not an API for integration.
+
+---
+
+## Path 3 — Direct registry API, free / open tier (data.gov.cy DRCOR open data)
+
+**PRIORITY PATH — DEC-20260507-G re-verification**
+
+**Dataset page URL:** `https://data.gov.cy/el/dataset/mitroo-eggegrammenon-etaireion-emporikon-eponymion-kai-synetairismon-stin-kypro`  
+**Publisher:** Department of the Registrar of Companies and Intellectual Property (DRCIP), Republic of Cyprus  
+**Organization on portal:** Department of Registrar of Companies and Intellectual Property (8 datasets total)
+
+**Three resources available:**
+
+| Resource | Greek name | Format | Size | URL (relative to data.gov.cy) | HTTP probe |
+|---------|-----------|--------|------|-------------------------------|------------|
+| Officers | Κατάλογος Αξιωματούχων | CSV | 120 MB | `/sites/default/files/organisation_officials_83.csv` | **200 OK** |
+| Addresses | Κατάλογος Διευθύνσεων Εγγεγραμμένου Γραφείου | CSV | 20 MB | `/sites/default/files/registered_office_96.csv` | **200 OK** |
+| Organisations | Κατάλογος Οργανισμών | CSV | 88 MB | `/sites/default/files/organisations_94.csv` | **200 OK** |
+
+**Officers CSV schema (confirmed via live first-row probe 2026-05-18):**
+- `ORGANISATION_NAME` — company name (Latin script for foreign companies; Latin + Greek for domestic)
+- `REGISTRATION_NO` — pure numeric ID (e.g., `290868`), no prefix or suffix
+- `ORGANISATION_TYPE_CODE` — single letter: `C` = Εταιρεία (private), `O` = Αλλοδαπή (foreign), `B` = Εμπορική Επωνυμία (trade name), `S` = cooperative
+- `ORGANISATION_TYPE` — Greek description of type
+- `PERSON_OR_ORGANISATION_NAME` — officer name (individual or corporate nominee)
+- `OFFICIAL_POSITION` — Greek role term (Διευθυντής, Γραμματέας, Εξουσιοδοτημένο Πρόσωπο, etc.)
+
+**Row count:** 1,168,824 total officer rows (confirmed via `wc -l` against live URL). Covers active + struck-off companies (historical and current records mixed — struck-off companies still have their officer rows listed).
+
+**Officers in scope?** YES. 635,123 director (Διευθυντής) rows + 438,479 secretary rows + all partner/authorized-person variants. Both individual names and corporate nominees are included.
+
+**Missing fields vs. live-registry standard:**
+- No date-of-appointment or date-of-cessation per row
+- No personal identifier (DOB, national ID) — names only
+- No address of officer
+- No distinction between current and historical appointments (the file appears to be a snapshot of the register state, not a change log; struck-off entities are included but active/ceased per-officer is not flagged at row level)
+- `REGISTRATION_NO` is numeric only — joinable with the organisations CSV but not directly matchable to the `HE`/`ΗΕ` prefix format used in the eFiling web UI
+
+**License:** CC BY 4.0 International (Creative Commons Attribution 4.0). Commercial use permitted with attribution. Confirmed from dataset page; OpenSanctions metadata (CC BY NC) is erroneous.
+
+**Refresh cadence:** Monthly ("Μηνιαία"). Last-Modified on all three files: 2026-04-29 07:34–07:35 UTC. Next expected refresh: approximately 2026-05-29.
+
+**Cost:** FREE. No auth, no registration, no API key.
+
+**DEC-20260518-G platform-fee probe:** N/A — no vendor, no platform, no fee of any kind.
+
+**DEC-20260428-A compliance:** COMPLIANT. This is Tier-2 licensed bulk data: DRCIP is the statutory registrar, the data is public records by statute, CC BY 4.0 is the redistribution license with no commercial restriction, and provenance is unambiguous (government publisher). Strale does not operate a scraper — it downloads a government-published open-data file.
+
+**Verdict: VIABLE-V1 TODAY.** This is the primary v1 path. Monthly ingest + index by registration number + role lookup. No vendor negotiation required. Operational within days of implementation.
+
+**Known limitation for v1:** Monthly refresh means up to 30-day stale appointments. Live-fetch (Path 5 / Topograph / eFiling) required for real-time officer status. Must disclose refresh lag via `freshness_category: reference-data` and `fetched_at` timestamp in provenance output.
+
+---
+
+## Path 4 — Tier-2 paid per-call aggregators (beyond Openapi)
+
+### 4a. Topograph
+
+**Documentation URL:** `https://docs.topograph.co/essentials/cyprus` — fetched successfully 2026-05-18.
+
+**CY coverage confirmed:** YES. `legalRepresentatives` is explicitly returned. Structure:
+```json
+{
+  "legalRepresentatives": [
+    {
+      "type": "individual",
+      "role": {
+        "localName": "Διευθυντής",
+        "englishTranslation": "Director",
+        "standardized": "director"
+      },
+      "individual": {
+        "name": { "fullName": "VICTOR KISLYI" }
+      }
+    },
+    {
+      "type": "company",
+      "role": {
+        "localName": "Γραμματέας",
+        "englishTranslation": "Secretary",
+        "standardized": "secretary"
+      },
+      "company": {
+        "legalName": "THEMIS SECRETARIAL SERVICES LIMITED",
+        "countryCode": "CY"
+      }
+    }
+  ]
+}
+```
+
+**Data source:** Single source — DRCOR public e-filing portal (NOT the open-data CSV). Topograph navigates the eFiling portal programmatically and extracts structured data from HTML responses. Shareholder data additionally sourced from Trade Register Extract PDF via OCR + AI.
+
+**Registration number format:** **CRITICAL CONSTRAINT** — Topograph requires the Greek letter prefix `ΗΕ` (eta-epsilon in Greek Unicode, U+0397 U+0395), not the Latin `HE`. The documentation explicitly states: "The registration number **must** include the Greek letter prefix (ΗΕ, ΕΕ, Σ, ΑΕ)" using actual Greek Unicode characters. This is a non-trivial input normalization requirement that Strale must handle.
+
+**Pricing model (DEC-20260518-G probe):**
+
+The documentation states: "The live source of truth for coverage, pricing, data sources, documents, legal forms, roles, and status values is the pricing page at `https://topograph.co/pricing/cy`." That page returned only a generic landing page without CY-specific pricing (magic-link gated, RFQ required, same pattern as HR). The pricing model is confirmed as **pay-per-request with no bulk contracts or minimum commitments** (confirmed via web search citing Topograph's own marketing and Seedcamp funding announcement).
+
+DEC-20260518-G fee probe results:
+- Platform fee: **NOT DISCLOSED** (page gated; from HR precedent, likely none — Topograph's differentiation is "no subscription")
+- Setup fee: Not disclosed
+- Monthly minimum: Confirmed none ("no minimum commitments" — Topograph's explicit marketing claim)
+- Annual floor: Not disclosed; implied none
+- Volume-tier floors: Not disclosed; implied per-request only
+- Termination fees: Not disclosed
+
+**Assessment:** Topograph fits the cost discipline (per-call, no subscription floor) but CY-specific per-call price requires RFQ. The HR audit found similar gating. Topograph scrapes the eFiling portal (Tier-1 Strale-operated scraping banned under DEC-20260428-A, but Topograph operating as a licensed vendor consuming public records is Tier-2 — requires vendor attestation of redistribution rights and provenance, which Topograph provides via their data-sourcing documentation).
+
+**Verdict: VIABLE-V1.1 (pending RFQ + DEC-20260428-A vendor attestation).** Real-time officers vs. monthly-refresh for Path 3. Use as upgrade path if monthly staleness is a customer issue.
+
+### 4b. Kyckr
+
+**Coverage:** Confirmed via kyckr.com blog: "Kyckr provides live access to company data from 300+ official company registers worldwide" and Cyprus is covered. Director data explicitly confirmed for CY.
+
+**Pricing model:** Fully RFQ-gated. No public per-call or subscription pricing disclosed. TrustRadius page shows "no pricing plans listed." Per Kyckr's company-information product page, data is accessible via REST API or web portal.
+
+DEC-20260518-G fee probe: All dimensions undisclosed; RFQ required. Pattern consistent with enterprise subscription, historically £3–10/lookup for comparable jurisdictions (from HR audit precedent).
+
+**Verdict: VIABLE-V1.2 fallback** if Topograph RFQ fails. Contact required.
+
+### 4c. OpenCorporates
+
+**Coverage:** OpenCorporates confirm Cyprus directors with score 10/10 on their register scoring matrix. Web access is free for public-benefit use; API access requires subscription (£2,250+/yr per HR audit precedent).
+
+**Pricing:** Subscription model (annual). NOT passthrough-compatible under Petter cost rule.
+
+**Verdict: NOT VIABLE-V1** (subscription, not per-call). Could serve as a free enrichment layer for non-commercial research purposes only.
+
+### 4d. Moody's Analytics / Kompany / Bureau van Dijk
+
+**Coverage:** Moody's Analytics offers entity verification for 348M+ companies globally. Cyprus included. API accessible via Moody's API Hub. However, the API Hub returned "No products to display" for unauthenticated probe — pricing and subscription model are fully enterprise-gated.
+
+DEC-20260518-G fee probe: All dimensions undisclosed; enterprise negotiation required. BvD/Kompany historically subscription-heavy with annual contracts.
+
+**Verdict: NOT VIABLE-V1** (enterprise subscription expected).
+
+### 4e. companiesregistry.cy (local Cyprus-specific provider)
+
+**Coverage:** Provides reports on Cyprus companies including directors, secretaries, addresses, documents. 24-hour turnaround. No API documented — report-based service only.
+
+**Verdict: NOT VIABLE-V1** (no API, report delivery model not compatible with real-time agent workflows).
+
+---
+
+## Path 5 — Statutorily-public web UI (DEC-20260518-F) — efiling.drcor.mcit.gov.cy
+
+**URL probed:** `https://efiling.drcor.mcit.gov.cy/DrcorPublic/SearchForm.aspx?sc=0&lang=EN`  
+**HTTP probe:** 200 OK
+
+**DEC-20260518-F constraint check (all four must hold for this path to be permissible):**
+
+### Constraint (a): Statutorily public
+**YES.** EU e-Justice Portal confirms: "name of existing directors and secretary/partners/trade name owner" is available **at no cost** in the eSearch free results. The Companies Section explicitly states these fields are in the free public search layer. The Registrar of Companies Act (Cyprus) requires public disclosure of directors and secretaries.
+
+### Constraint (b): ToS permits per-call
+**NOT CONFIRMED.** No Terms of Service or Acceptable Use Policy is linked or referenced on the public search page. The efiling.drcor.mcit.gov.cy site is an ASP.NET Web Forms application with session cookie management — it does not present a ToS on the public search form. Without an explicit ToS that permits programmatic per-call access, this constraint is unverified. The absence of an explicit ToS does not confirm permission; it creates ambiguity.
+
+### Constraint (c): Per-entity per-customer-request
+**STRUCTURAL FIT, NOT VERIFIED.** Strale would query once per customer request per entity. The portal design (search by name or number, one company at a time) is architecturally suited to per-entity queries. However, without a ToS confirmation, "per-entity" cannot be verified as permitted.
+
+### Constraint (d): Attribution preserved
+**PARTIAL.** The DRCOR/DRCIP as publisher is identifiable. Attribution would be `source: "Department of Registrar of Companies and Intellectual Property, Republic of Cyprus"` with `primary_source_reference: "https://efiling.drcor.mcit.gov.cy"`. However, without a ToS this is constructive attribution, not verified-approved attribution.
+
+**Technical friction analysis:**
+- **Session management:** ASP.NET session cookie required (`ASP.NET_SessionId`). Not a hard blocker but adds per-session handshake overhead.
+- **CAPTCHA:** Not directly observed on the search form, but the site is ASP.NET Web Forms — ViewState and hidden form fields are likely required for POST submission. No explicit CAPTCHA found in the HTTP probe.
+- **JavaScript rendering:** Site is Microsoft-IIS/7.0 + ASP.NET 4.0. Page content is 30,888 bytes server-side rendered HTML — not a JS SPA. Basic HTML parsing should work without a headless browser.
+- **Director display in free results:** EU e-Justice Portal confirms director names are in the free search results. Topograph's documentation confirms they extract this data from the same portal. This validates that directors ARE in the HTML response, not behind the €10 payment gate.
+
+**Doctrine ruling:** DEC-20260518-F constraints (a) and (c)/(d) are architecturally satisfied. Constraint (b) is **unverified** — no ToS found. Under DEC-20260428-A, Tier 1 (Strale operates the scraper) is an absolute bar regardless of ToS. Since this path would require Strale to operate an HTTP scraper against the eFiling portal, it is **BLOCKED under DEC-20260428-A Tier 1**, not under DEC-20260518-F.
+
+**The Path 5 question becomes moot for v1:** Path 3 (open data bulk) delivers the same underlying data (same DRCOR source) with explicit CC BY 4.0 license, no scraping required, and no ToS ambiguity. Path 4a (Topograph) delivers live-fetch from the same portal via a Tier-2 vendor operating the scraper (Tier-2 permissible under DEC-20260428-A).
+
+**Verdict: BLOCKED (DEC-20260428-A Tier 1 absolute bar).** Not needed given viable alternatives on Paths 3 and 4a.
+
+---
+
+## Path 6 — Open data bulk download (dual-path with Path 3)
+
+This path is **confirmed and identical to Path 3** for CY.
+
+The data.gov.cy DRCOR dataset is the open-data bulk download. Unlike Estonia (where open data and the contracted SOAP API were separate paths with different latency characteristics), for Cyprus the open data IS the bulk download — there is no separate "bulk contract" tier distinct from the public CSV.
+
+**Additional bulk surfaces checked:**
+
+- **OpenSanctions `cy_companies` dataset:** `https://data.opensanctions.org/datasets/20260518/cy_companies/entities.ftm.json` (1.14 GB) — available under CC 4.0 Attribution NonCommercial (OpenSanctions adds NC to their redistribution). The underlying source is the same data.gov.cy CSV. Using OpenSanctions as intermediary would add the NC restriction that the original source does NOT have. **Use the primary source (data.gov.cy) directly.**
+- **OpenSanctions `ext_cy_companies` dataset:** 1,883 entities only — enrichment of PEP/sanctions-linked CY companies, not a general registry. Not useful for general director lookup.
+- **data.europa.eu / CKAN EU portal:** No separate CY companies bulk dataset found outside the data.gov.cy primary.
+- **EU Business Registers Interconnection System (BRIS):** CY is connected to BRIS via the EU e-Justice portal. BRIS exposes basic identity data (no officers) and document retrieval (€10 equivalent). Not a bulk path.
+
+**Verdict: SAME AS PATH 3** (viable-v1 today, free, CC BY 4.0, monthly refresh).
+
+---
+
+## Path 7 — Tier-2 commercial bulk under DEC-20260428-A (who licenses DRCOR bulk?)
+
+**Question:** Are there commercial data providers who license the full DRCOR dataset in bulk (with fresher refresh than monthly open data) and redistribute it under a commercial agreement?
+
+**Findings:**
+
+Topograph (Path 4a) is the clearest documented Tier-2 operator for CY. They source from the DRCOR eFiling portal programmatically — this is scraping-derived data from a statutory public source, permissible under DEC-20260428-A Tier 2 given Topograph's documentation of sourcing + their per-entity API structure. Topograph's CY documentation explicitly states the data source as "DRCOR (Department of Registrar of Companies and Official Receiver)" with the e-filing portal as the retrieval mechanism.
+
+**What Topograph provides over the open-data bulk:**
+- Real-time (live-fetch from eFiling, not monthly batch)
+- Structured JSON with English-translated role fields
+- `legalForm` field (ISO 20275 standardized)
+- AI-powered individual/company disambiguation for nominees
+- `availableDocuments` list for further document retrieval
+
+**Other commercial bulk licensees:**
+- **Bureau van Dijk / Moody's Orbis:** Includes CY company data but no documented DRCOR bulk license agreement; data sourcing is opaque for CY specifically. Enterprise subscription model makes it v1-incompatible regardless.
+- **Kyckr:** Uses direct DRCOR eFiling retrieval (per their blog), similar Tier-2 model to Topograph. Pricing RFQ-gated.
+- **LexisNexis / Dun & Bradstreet:** Coverage confirmed for CY but commercial bulk, enterprise subscription. Not v1-compatible.
+
+**DEC-20260428-A compliance checklist for Topograph (Tier-2):**
+- [x] Underlying data is public records by statute (Cyprus Companies Law, DRCOR statutory mandate)
+- [x] Vendor (Topograph) documents redistribution rights via their data-sourcing page
+- [ ] Vendor indemnification: not explicitly confirmed in public documentation — must be verified in commercial agreement
+- [x] Vendor provides primary-source provenance per fact (Topograph credits DRCOR explicitly in their docs)
+- [x] Strale discloses sourcing via `provenance.upstream_vendor` = "Topograph" + `primary_source_reference` = "https://efiling.drcor.mcit.gov.cy"
+
+**Open item for v1.1 (Topograph path):** Obtain written indemnification / redistribution rights attestation from Topograph as part of commercial agreement.
+
+**Verdict:** Path 7 is operationally Path 4a (Topograph) with the commercial-agreement lens. No distinct bulk-license product was identified beyond the open-data CSV (Path 3) and the Topograph per-call API (Path 4a). **Viable-V1.1** under Topograph per-call model; **viable-v1** under Path 3 open data.
+
+---
+
+## Path 8 — Gazette / historical PDF parsing (Cyprus Official Gazette)
+
+**URL probed:** `https://www.mof.gov.cy/mof/gpo/gazette.nsf/officialgazette-en/officialgazette-en` — TLS certificate error (could not verify).  
+**Fallback probe:** `https://www.companies.gov.cy/en/knowledgebase/gazette` — 200 OK, content retrieved.
+
+**Gazette structure:**
+The Cyprus Official Gazette (Επίσημη Εφημερίδα της Κυπριακής Δημοκρατίας) is published by the Government Printing Office (Κυβερνητικό Τυπογραφείο) under the Ministry of Finance. Company-related announcements are in the **Fifth Supplement (Παράρτημα Πέμπτο) — Part I**.
+
+The Companies Section maintains a searchable gazette archive at `companies.gov.cy/en/knowledgebase/gazette` with 600+ gazette publications indexed by publication number and date, covering multiple entity types (Company, Partnership, Business Name, European Company, Overseas Company).
+
+**What the Gazette publishes for companies:** Company formation announcements, name changes, registered office changes, and officer changes are published via HE forms (HE3 for initial directors, HE4 for subsequent changes). The Gazette is the official publication vehicle for these notifications.
+
+**Format:** The gazette publications appear linked on the DRCOR site, but the actual file format (PDF vs. HTML) could not be confirmed from the content retrieved (the gazette page showed publication metadata but not file links in the rendered content). Historical issues from 1878 onward are in the Cyprus Digital Library at `cyprusdigitallibrary.org.cy`. Older issues (pre-Republic) are in English; 1961+ are in Greek.
+
+**Online access:** The Government Printing Office publishes gazettes online. The DRCOR gazette knowledgebase links to gazette issues with filterable archive. Access appears free for the index; individual issue access format unclear.
+
+**Is this path viable for officers?** In principle, officer appointment notifications (HE4 form submissions) appear in the Fifth Supplement. However:
+1. Gazette covers individual announcements (change events), not the current officer snapshot
+2. The current officer snapshot is already available via Path 3 (open-data CSV, monthly)
+3. Gazette parsing would produce a historical change log, not a current-state snapshot — a more complex derivative dataset build
+4. The Gazette is in Greek; OCR/parsing for historical PDFs would require LLM processing
+
+**Assessment under DEC-20260518-F (gazette as per-call parsing):**
+- Constraint (a) Statutorily public: YES — the Gazette is published by statute as the official public record
+- Constraint (b) ToS permits per-call: Unclear — Government Printing Office publishes for public access; no explicit ToS restricting programmatic access was found, but also none explicitly permitting it
+- Constraints (c)+(d): Fit for a gazette-parsing derivative dataset
+- DEC-20260428-A: Would require Strale to operate PDF parsing (acceptable — not web scraping of a dynamic JS site, but static PDF download and parsing). Borderline Tier 1/Tier 2 — gazette is the statutory public record itself.
+
+**Verdict: NOT-V1 — historical/derivative dataset only.** The gazette path would build a historical officer change-log that complements the current-snapshot Path 3 data. Not a v1 feature given Path 3 already provides the current officer snapshot. Worth noting as a v2 historical-officers feature if customers need appointment history with dates.
+
+---
+
+## Path 9 (Additional) — Other CY-specific surfaces
+
+### 9a. Cyprus UBO / Beneficial Ownership Register (ubo.meci.gov.cy)
+
+**System:** The Beneficial Ownership Register (BOR) is a fully electronic register administered by DRCIP, accessed at `https://ubo.meci.gov.cy` via Cy Login / Ariadni government gateway.
+
+**Public access status:** **CLOSED TO PUBLIC** as of 2023-01-03. Following the European Court of Justice ruling on UBO register public access (WM and Sovim SA v Luxembourg, C-37/20 and C-601/20, November 2022), Cyprus ceased public access to the UBO register on 2023-01-03. Access is now limited to obliged entities (credit institutions, auditors, lawyers, etc.) and competent authorities only. Access requires Cyprus-registered entity or professional-licence status.
+
+**Is this relevant for directors?** UBO ≠ directors. The UBO register contains beneficial ownership information (25%+ shareholders controlling the entity) — not the board of directors or secretaries. Even if public access were restored, UBO data would not substitute for director data.
+
+**Verdict: OUT OF SCOPE** — UBO register is not director/officer data, and it is closed to public access.
+
+### 9b. UK Companies House CY carryover (pre-independence pattern)
+
+Cyprus gained independence in 1960. Companies formed under British colonial administration were re-registered with DRCOR. There is no surviving operational link between Cyprus DRCOR and UK Companies House — they are fully separate registries. UK Companies House does NOT contain CY directors for post-independence companies.
+
+**Verdict: NOT APPLICABLE** for modern CY companies.
+
+### 9c. Apitalks / api.store free aggregator
+
+**URL probed:** `https://api.store/cyprus-api/republic-of-cyprus-ministry-of-finance-api/register-of-registered-companies-commercial-names-and-cooperatives-in-cyprus-api`  
+**Finding:** This is an Apitalks wrapper around the same data.gov.cy DRCOR dataset. Fully free ("funded by Apitalks"). Includes the "List of Officers" with `PERSON_OR_ORGANISATION_NAME` and `OFFICIAL_POSITION`. The underlying data is the same monthly CSV from Path 3.
+
+**Verdict: NOT a distinct path** — same underlying data as Path 3, with an intermediary wrapper. Using the primary source (data.gov.cy) directly is cleaner and avoids Apitalks intermediary dependency.
+
+### 9d. Cyprus Stock Exchange (CSE) disclosed-person requirements
+
+Listed Cypriot companies must disclose directors under Market Abuse Regulation. The CSE and CySEC (Cyprus Securities and Exchange Commission) publish director disclosures for listed entities. However, CY has relatively few listed companies (Bank of Cyprus, Hellenic Bank, etc.) — this covers a tiny fraction of the DRCOR universe.
+
+**Verdict: NOT VIABLE as a general path** — covers <50 entities, not scalable.
+
+---
+
+## Summary verdict
+
+**Overall verdict: VIABLE-V1 TODAY**  
+**Confidence: HIGH**
+
+### v1 path (recommended)
+
+**Path 3 — data.gov.cy DRCOR open-data monthly CSV**
+
+| Dimension | Value |
+|-----------|-------|
+| Cost class | FREE (no cost, no auth, no vendor) |
+| Data source | DRCIP (Department of Registrar of Companies and Intellectual Property), Republic of Cyprus |
+| License | CC BY 4.0 International |
+| Fields | ORGANISATION_NAME, REGISTRATION_NO, ORGANISATION_TYPE_CODE, ORGANISATION_TYPE, PERSON_OR_ORGANISATION_NAME, OFFICIAL_POSITION |
+| Roles covered | Director (635K rows), Secretary (438K rows), Alternate Director, Authorized Person, General/Limited Partner, Owner |
+| Entity count | ~565K companies + 1.17M officer rows |
+| Refresh | Monthly (last updated 2026-04-29) |
+| Auth required | None |
+| Contract required | None |
+| Lead time | None — operational within days |
+| DEC-20260428-A compliance | Tier 2: licensed-bulk, statutory public records, CC BY 4.0 redistribution rights, DRCIP = primary-source publisher |
+| DEC-518-G probe | N/A (no vendor) |
+| Provenance output | `source: "DRCIP"`, `primary_source_reference: "https://data.gov.cy/el/dataset/..."`, `acquisition_method: "open-data-bulk"`, `upstream_vendor: null` |
+| Freshness category | `reference-data` (monthly batch, not live-fetch) |
+| Known limitation | Up to 30-day staleness; no appointment/cessation dates per row; no officer addresses; current vs. historical appointments not row-level flagged |
+
+### v1.1 path (real-time upgrade)
+
+**Path 4a — Topograph per-call API**
+
+| Dimension | Value |
+|-----------|-------|
+| Cost class | Per-call (pay-per-request, no subscription floor, no minimum commitments) — CY price RFQ-gated |
+| Data source | DRCOR eFiling portal (Topograph navigates programmatically) |
+| Fields | `legalRepresentatives` array with type/role/name; `legalForm`; `status`; full identity fields |
+| Refresh | Live-fetch (real-time) |
+| Auth required | Topograph API key |
+| DEC-20260428-A compliance | Tier 2: Strale does not operate scraper; Topograph operates scraper against statutory public records; vendor credits DRCOR; indemnification must be confirmed in commercial agreement |
+| DEC-518-G probe | Platform fee: not disclosed (implied none); setup: not disclosed; monthly minimum: confirmed none; annual floor: implied none |
+| Input constraint | Registration number must use Greek Unicode prefix `ΗΕ` (not Latin `HE`) |
+| Friction | RFQ required; DEC-20260428-A vendor-attestation process; Greek-prefix input normalization |
+
+---
+
+## Per-path findings table
+
+| Path | Label | Representative data? | Evidence | Cost class |
+|------|-------|---------------------|----------|------------|
+| 1 | Openapi other endpoints / CY-specific product | NO | WW-Top returns identity only; no CY-directors product; 204 on Wargaming test value (invalid reg number) | €0.16/call identity-only |
+| 2 | DRCOR paid API | NO (no API exists) | ASP.NET web app only; no programmatic API; €10 is document-retrieval for humans | N/A |
+| 3 | data.gov.cy DRCOR open data CSV | **YES** | HTTP 200, 120 MB officers CSV, 1.17M rows, CC BY 4.0, live-probed 2026-05-18 | **FREE** |
+| 4a | Topograph per-call | **YES** | `legalRepresentatives` documented in CY docs; pay-per-request model; RFQ for price | Per-call (price TBD) |
+| 4b | Kyckr | **YES** | Director coverage confirmed (10/10 score); pricing RFQ-gated | RFQ |
+| 4c | OpenCorporates | YES (web) / NO (API) | Directors 10/10; API requires annual subscription | Subscription — NOT V1 |
+| 4d | Moody's / Kompany / BvD | YES | Enterprise coverage; API fully gated; subscription model | Enterprise — NOT V1 |
+| 5 | eFiling web UI (DEC-518-F) | YES (in HTML) | Directors in free results confirmed; ASP.NET session required; BLOCKED DEC-20260428-A Tier 1 | BLOCKED |
+| 6 | Bulk download (data.gov.cy) | **YES** | Same as Path 3 | **FREE** |
+| 7 | Tier-2 commercial bulk | YES (via Topograph) | Topograph sources from DRCOR eFiling; per-call, no subscription floor | Per-call (price TBD) |
+| 8 | Cyprus Official Gazette | Partial (change events only) | 600+ gazette issues indexed; officer appointments published via HE4 form; NOT a current-snapshot path | N/A (derivative build) |
+| 9a | UBO register | OUT OF SCOPE | Public access closed Jan 2023 (ECJ ruling); UBO ≠ directors | N/A |
+
+---
+
+## Doctrine compliance log
+
+**DEC-20260518-E (Exhaustive 8-path enumeration):** COMPLIANT. All 8 paths documented with evidence (plus Path 9 additional surfaces). No path halted on first failure.
+
+**DEC-20260518-F (Path 5 — per-call HTML parsing constraints):**
+- Constraint (a) Statutorily public: YES — directors confirmed in free public search by EU e-Justice portal and companies.gov.cy
+- Constraint (b) ToS permits per-call: NOT CONFIRMED — no ToS found on eFiling public portal
+- Constraint (c) Per-entity per-customer-request: Structurally YES, unverified without ToS
+- Constraint (d) Attribution preserved: Constructively YES
+- **DEC-20260428-A Tier 1 override applies regardless — path is BLOCKED.**
+
+**DEC-20260518-G (platform-fee probe for Tier-2 aggregators):**
+- Path 3 (data.gov.cy): N/A — no vendor
+- Path 4a (Topograph): Platform fee not disclosed (implied none per marketing); setup not disclosed; monthly minimum = NONE (confirmed); annual floor implied none; volume tiers not disclosed; termination fees not disclosed. RFQ required for CY per-call price.
+- Path 4b (Kyckr): All dimensions undisclosed — full RFQ required.
+- Path 4c (OpenCorporates): Subscription model confirmed — annual license, not per-call. DEC-518-G moot (subscription disqualifies from v1).
+- Path 4d (Moody's/BvD): Enterprise subscription — DEC-518-G moot.
+
+**DEC-20260428-A (Strale never operates scrapers):**
+- Path 3: COMPLIANT — government-published open-data file, no scraper
+- Path 4a (Topograph): COMPLIANT — Strale consumes Topograph's API; Topograph operates the eFiling scraper. Vendor attestation of redistribution rights + indemnification must be confirmed in commercial agreement.
+- Path 5 (eFiling direct): BLOCKED — Strale would operate the scraper. Absolute bar applies.
+
+**EU 2023/138 (not cited as representative-content mandate):** CONFIRMED — this audit does not cite 2023/138 as requiring representative data. The mandate is identity fields only (§5.1). Director data availability is via DRCOR statutory disclosure and CY Companies Law, not 2023/138.
+
+---
+
+## Caveats
+
+1. **Monthly refresh lag (Path 3):** The open-data CSV is updated monthly. For compliance use cases requiring current officer status (e.g., has a director resigned in the last 30 days?), the monthly batch is insufficient. Customer disclosures must note this limitation. Topograph (Path 4a) resolves this with live-fetch.
+
+2. **No appointment/cessation dates per row:** The officers CSV does not include when an officer was appointed or when they ceased. All rows in the file appear to represent the current register state (no historical change log). For tenure verification, the €10 full-file search or Topograph's document retrieval (Trade Register Extract PDF) is required.
+
+3. **Corporate nominees:** Cyprus has a large nominee-director industry. Many officers listed will be nominee companies (e.g., `THEMIS SECRETARIAL SERVICES LIMITED`) rather than individuals. The open-data CSV does not distinguish between nominee and non-nominee directors.
+
+4. **Wargaming anomaly (CY99000230P) closed:** The Openapi test value `CY99000230P` does not correspond to a valid DRCOR registration number. Wargaming Group Limited is registered as number `290868` (pure numeric). The Openapi correspondence claiming CY coverage was referring to the WW-Top identity endpoint only; the 204 response confirms no structured data was returned for that input. The anomaly is an invalid test value, not a DRCOR data gap.
+
+5. **Greek Unicode prefix requirement (Topograph):** Topograph requires `ΗΕ` in Greek Unicode characters (U+0397 U+0395) for registration number input, not the Latin `HE`. Strale's cy-company-data executor must implement Unicode normalization from DRCOR numeric IDs to Topograph's required format if Topograph is used.
+
+6. **License discrepancy (OpenSanctions):** OpenSanctions describes the cy_companies dataset as "CC Attribution NonCommercial." The actual data.gov.cy source page shows CC BY 4.0 International without the NonCommercial restriction. Strale should source directly from data.gov.cy, not from OpenSanctions, to preserve the unrestricted commercial license.
+
+7. **DRCOR URL stability:** The officers CSV URL (`/sites/default/files/organisation_officials_83.csv`) contains what appears to be a numeric suffix (`_83`) that may change on future dataset refreshes. The ingest job should monitor the dataset page URL for resource link changes rather than hardcoding the direct file URL.

--- a/audit-output/exhaustive-enumeration-phase-6-mt-cy-hu-lu-2026-05-18.md
+++ b/audit-output/exhaustive-enumeration-phase-6-mt-cy-hu-lu-2026-05-18.md
@@ -1,0 +1,480 @@
+# Exhaustive source enumeration — MT + CY + HU + LU (DEC-20260518-E)
+
+**Date:** 2026-05-18
+**Author:** Claude Code (Sonnet research subagents, synthesized by Opus 4.7)
+**Phase:** 6 (MT + CY + HU + LU binding-ready Tier-2)
+**Doctrine:** DEC-20260518-E (Exhaustive Source Enumeration); DEC-20260518-F (per-call statutory web UI / PDF); DEC-20260518-G (Tier-2 platform-fee probe mandatory); DEC-20260428-A (no Strale-operated scrapers); cost discipline (per-call passthrough OK, fixed monthly fees NOT OK in v1)
+**Test entities:** MT — GO plc (MT12826209), Bank of Valletta plc, HSBC Malta; CY — Wargaming Group Limited (reg 290868), Bank of Cyprus; HU — OTP Bank (01-10-040952), MOL (13-10-041527), Richter Gedeon (01-10-040944); LU — RTL Group (LU18513414), Aperam, BGL BNP Paribas, Cargolux, BCEE, SES, **ArcelorMittal (LU18804375 VAT / B82454 RCS — Openapi index-hole test case)**
+**Source partials:** [_partial_mt_enumeration.md](_partial_mt_enumeration.md), [_partial_cy_enumeration.md](_partial_cy_enumeration.md), [_partial_hu_enumeration.md](_partial_hu_enumeration.md), [_partial_lu_enumeration.md](_partial_lu_enumeration.md)
+
+---
+
+## Executive summary
+
+**All four countries previously routed via Openapi WW-Top at "thin-usable+ identity, no representatives" are viable-v1 for representative coverage.** Three (MT, HU, LU) route through a single vendor (Topograph) pending RFQ; one (CY) is viable today via free open data.
+
+| Country | Phase 4/5 verdict | Revised verdict | v1 path | Cost | Confidence |
+|---------|-------------------|-----------------|---------|------|------------|
+| **MT** | Openapi identity, no reps | **viable-v1 pending Topograph RFQ** | Topograph per-call → BAROS `legalRepresentatives` + `directors` + `secretaries` | Per-call RFQ-gated (no platform fee in docs) | HIGH on path / MODERATE on cost |
+| **CY** | Openapi identity, no reps | **viable-v1 TODAY** | data.gov.cy DRCOR officers CSV — 120 MB, CC BY 4.0, monthly refresh, **HTTP 200 live-probed 2026-05-18** | **FREE** | HIGH |
+| **HU** | Openapi identity, no reps | **viable-v1 pending Topograph RFQ** | Topograph per-call → §13 Cégkivonat → name + birth date + address + role + start date + representation mode | Per-call variable (kbyte-based + processing fee, no subscription floor) | HIGH |
+| **LU** | Openapi identity, no reps, B-prefix index-hole | **viable-v1 pending Topograph RFQ** | Topograph per-call → AI-parsed Extrait du RCS → Gérant/Administrateur/Président; **resolves B82454 index-hole** | Per-call RFQ-gated; ~€13.50 extrait passthrough as floor | MODERATE |
+
+**Headline finding — Topograph covers 3 of 4 (MT + HU + LU) under one vendor relationship.** Combined with HR confirmed in Phase 5, a single Topograph onboarding closes the representative-coverage gap on 4 EU jurisdictions. Topograph's documented model is per-call with no minimum commitments and no platform fee observed in HR (Phase 5 ground truth); MT/HU/LU per-country pricing is magic-link-gated and requires RFQ + DEC-20260518-G probe.
+
+**Headline finding for CY — the EE pattern replicates.** A 120 MB CC BY 4.0 monthly-refreshed CSV (`organisation_officials_83.csv` at data.gov.cy) contains 1,168,824 officer rows: 635,123 directors (Διευθυντής), 438,479 secretaries, plus alternate directors, authorized persons, partners. Live HEAD probe 2026-05-18 returned HTTP 200, Last-Modified 2026-04-29. Confirms and upgrades the prior 2026-05-07 spike (DEC-20260507-G) with live evidence + field schema + Wargaming test resolution.
+
+**Phase 4/5 corrections from this enumeration:**
+- **CY Wargaming `CY99000230P` 204 anomaly closed.** The Openapi test value is not a valid DRCOR registration number. Wargaming is registered as numeric `290868`, type `C`. The DRCOR open-data file confirms 5 officers (3 directors + 1 secretary + 1 director — Nick Katselapov, Victor Kislyi, Eugeni Kisly, Marios Pelides, Christis Christoforou). The 204 was an invalid input, not a data gap.
+- **LU B82454 index-hole resolved by Topograph.** ArcelorMittal SA's RCS number is B82454 (per articles of association). Openapi's LU lookup is VAT-only and fails on LU18804375; Topograph supports B-prefix RCS natively (`B246607` example in docs). Topograph closes the index-hole.
+- **MT 204 thin-data on some entities likely vendor-side, not registry-side.** Topograph sources directly from BAROS (MBR) and should have broader coverage than Openapi's WW-Top index. Some thin-data 204s may persist for dissolved/struck-off entities.
+
+**Revised v1 launch coverage:** All four jurisdictions move from "identity-only, partial" (Phase 4/5) to "representative-coverage shippable" in Phase 6. Combined with HR + EE + BE + PL + LT (Phase 5) and the previously-viable EU/UK set, this closes the representative-coverage gap on a large block of EU-27.
+
+**DEC-20260428-A scope question raised by Phase 6:** None — all four resolve to clean Tier 1 (CY open data) or clean Tier 2 (Topograph licensed) with viable alternatives. No new gazette-style scope question of the form raised by BE Moniteur Belge in Phase 5.
+
+---
+
+## Doctrine reference
+
+- **DEC-20260518-E** — Exhaustive 8-path source enumeration mandatory before classifying a country "blocked" or "paid-only". Three Phase 2/3 "blocked" verdicts (HR, EE, BE) were reversed by this discipline in Phase 5. Phase 6 applies the same discipline to MT/CY/HU/LU.
+- **DEC-20260518-F** — Per-call HTML/PDF parsing of statutorily-public registry detail pages is in-scope when four constraints hold: (a) statutorily public, (b) ToS permits per-call, (c) per-entity per-customer-request not bulk, (d) attribution preserved.
+- **DEC-20260518-G** — Platform-fee probe MANDATORY for RFQ-only Tier-2 aggregators. Probe explicitly for: platform fee, setup fee, monthly minimum, annual floor, volume-tier locked floors, termination fees. Public docs language can be technically accurate but materially misleading (Topograph's "no minimum commitments" claim was true for per-call rates while a €1,500/mo platform fee existed separately — the Phase 5 failure case).
+- **DEC-20260428-A** — Tier 1 (Strale never operates scrapers) is absolute. Tier 2 (vendor-mediated, statutorily public, licensed redistribution) requires signed sourcing-method attestation.
+- **Petter cost rule** — Per-call costs OK if passed through to customer; fixed monthly fees NOT OK in v1.
+- **EU 2023/138 CAVEAT** — §5.1 mandates only identity fields (name/status/address/legal form/reg number/date/NACE) — **NOT** representative names. Per course-correction Journal `36467c87082c8169`. Do not cite as a rep-content mandate.
+
+---
+
+## MT — 8-path enumeration
+
+Test entities: GO plc (MT12826209), Bank of Valletta plc, HSBC Malta. Full partial: [_partial_mt_enumeration.md](_partial_mt_enumeration.md).
+
+### Path 1 — Openapi other endpoints / MT-specific SKU
+
+- 49 production scopes in Openapi catalog. Italy is the only country with a dedicated `stakeholders` SKU (`IT-stakeholders` €0.095+). **No `MT-stakeholders`, `MT-directors`, or `MT-representatives` product exists.**
+- WW-Top / WW-Advanced / WW-Start: identity fields only; `legalRepresentatives` / `directors` not in documented schema for MT.
+- No evidence of MT product additions since 2026-05-11.
+- **Verdict: NOT VIABLE for representatives.** Openapi WW-Top is the correct identity slot; the vendor does not expose officer data for MT under any product.
+
+### Path 2 — MBR direct API (March 2026 launch)
+
+- MBR launched four API packages in March 2026: Company Search, Basic Company Details, **Full Company Details (includes "involvement" = officers + share capital)**, Bundle.
+- "Involvement" corroborated as MBR's term for officers via three independent sources: EU e-Justice portal (Malta), Kyckr 2025 review, IFSP notice title ("MBR Notice: Accessing Involvements").
+- **DEC-20260518-G probe:** Subscription fee **CONFIRMED PRESENT** ("Subscription fee is to be paid for each API for which access is granted" — Malta Business Weekly). Specific amounts NOT disclosed (PDF binary, page magic-link gated). Other dimensions unknown.
+- **Eligibility risk:** APIs targeted at "Subject Persons" (Corporate Service Providers, AML/CFT-obligated entities). Strale qualification ambiguous.
+- **Verdict: BLOCKED pending RFQ.** Subscription confirmed; amount unknown; eligibility unverified. Cannot ship under v1 cost discipline without confirmation of per-call billing beneath subscription.
+
+### Path 3 — data.gov.mt open tier
+
+- `portal.data.gov.mt` and `open.data.gov.mt` return HTTP 403 on all WebFetch probes (CDN block).
+- OpenCorporates Open Company Data Index scores Malta **0/30 for open license** and **0/20 for full-dataset download or open API**.
+- No officer-bearing bulk file identified at any indexable URL. Portal contents described in MITA materials as "works in progress and not to be considered as providing official records."
+- **The EE-pattern (CC BY 4.0 daily dump with officers) is NOT available for Malta.**
+- **Verdict: NOT VIABLE.** No free open-tier API or downloadable dataset with officer fields.
+
+### Path 4 — Tier-2 paid per-call aggregators
+
+- **Topograph (`docs.topograph.co/essentials/malta`)** — HTTP 200, content retrieved. `legalRepresentatives` + `directors` + `secretaries` + `involved_parties` + `legal_form` + `share_capital` confirmed. Source: BAROS (official). Identifier: `C + space + digits` (e.g., `C 2833`). **DEC-518-G probe:** "Pay-per-request, no bulk contracts, no minimum commitments" in docs introduction; pricing page magic-link gated; MT-specific per-call price RFQ-required. HR precedent (Phase 5) confirmed no platform fee for HR — same expected for MT pending probe. **Verdict: VIABLE-V1 (pending RFQ + DEC-20260428-A vendor attestation).**
+- **Kyckr** — Officers confirmed via Enhanced Profile (`GET /companies/{kyckrId}/enhanced`); all fee dimensions undisclosed; RFQ required. **Verdict: VIABLE-V1.1 fallback.**
+- **Creditinfo Malta** — Subscription-only credit bureau product. **NOT VIABLE-V1.**
+- **OpenCorporates** — £2,250+/year subscription, no PAYG. **NOT VIABLE-V1.**
+- **TransactionLink** — Probable subscription, field schema not accessible. **NOT VIABLE-V1.**
+- **Schmidt & Schmidt** — £138/document (per-document broker). Wrong price band. **NOT VIABLE.**
+
+### Path 5 — MBR public portal (DEC-518-F assessment)
+
+- `register.mbr.mt` — JavaScript SPA; HTTP 403 to all direct probes.
+- EU e-Justice Portal confirms: "Identity of company officials (directors, shareholders, legal representatives, secretaries, auditors)" is available **free of charge to any natural person**, no account required.
+- **DEC-518-F constraints:** (a) Statutorily public — YES (Companies Act Cap. 386); (b) ToS permits per-call — NOT VERIFIED (portal 403 blocks ToS read); (c) Per-entity — SATISFIABLE; (d) Attribution — SATISFIABLE.
+- **DEC-20260428-A Tier 1 override:** SPA requires Browserless-rendered session → Strale would operate the browser fetcher → ABSOLUTE bar.
+- **Verdict: BLOCKED under DEC-20260428-A.** Topograph (Path 4a) is the licensed-vendor proxy that operates the fetch on Strale's behalf.
+
+### Path 6 — Open data bulk
+
+- No official MBR bulk dump with officer data exists. OpenCorporates 0/20 score on full-dataset download confirms.
+- `eic-network/malta-files` GitHub repo (scraped Malta data, EIC journalism project) — no license file; Tier-1 prohibition applies to consuming Strale-equivalent scraped data without clean vendor relationship.
+- **Verdict: NOT VIABLE.**
+
+### Path 7 — Tier-2 commercial bulk
+
+- DatoCapital (`datocapital.mt`) covers 258K MT companies / 207K directors via web portal; no API; no DEC-20260428-A-compatible bulk license documented.
+- InfobelPRO / CompanyData / HitHorizons — proprietary, subscription-priced, not DEC-20260428-A-clean for redistribution.
+- **Verdict: NOT VIABLE.** Topograph (per-call) is superior in every dimension.
+
+### Path 8 — Government Gazette (Gazzetta tal-Gvern)
+
+- PDF-only since 2015; predictable URL pattern at `govcms.gov.mt`. Officer appointments published as gazette notices at incorporation + formal change events.
+- No structured XML/JSON. PDF parsing requires Strale-operated LLM extraction → DEC-20260428-A Tier 1 prohibition. Coverage gap: only incorporation events + filed changes, not current state.
+- **Verdict: NOT VIABLE for v1.** Derivative-dataset build for v2 historical coverage if needed.
+
+### Path 9 — Other MT surfaces
+
+- **Malta RBO (Beneficial Ownership Register):** Post-CJEU Nov 2022, restricted to legitimate-interest applicants; €5/request. UBO ≠ directors. **NOT VIABLE.**
+- **MFSA:** Historical predecessor to MBR; today all data flows through MBR/BAROS. **NOT APPLICABLE.**
+- **BRIS/e-Justice:** Identity fields only per §5.1; no officer extension. **NOT VIABLE.**
+- **Identifier gap:** Current Strale regex `^MT\d{8}$` (VAT) ≠ Topograph's `C + space + digits` (MFSA/BAROS). Implementation requires VAT→C-number resolution step or accepting C-prefix input. Solvable, not a blocker.
+
+### MT synthesis
+
+- **v1 path: Topograph (Path 4a)** — per-call, no documented subscription floor, all officer fields confirmed in docs. Required: (1) RFQ for MT per-call price, (2) DEC-20260518-G platform-fee confirmation, (3) DEC-20260428-A vendor attestation, (4) identifier-resolution implementation (VAT↔C-number).
+- **v1.1 fallback: Kyckr (Path 4b)** if Topograph RFQ fails on price.
+- **v1.2 fallback: MBR direct API (Path 2)** if subscription fits and Subject Person eligibility confirmed.
+
+---
+
+## CY — 8-path enumeration
+
+Test entities: Wargaming Group Limited (reg 290868), Bank of Cyprus. Full partial: [_partial_cy_enumeration.md](_partial_cy_enumeration.md).
+
+### Path 1 — Openapi other endpoints / CY-specific SKU
+
+- No CY-specific Openapi product. WW-Top serves CY at identity-only level.
+- Wargaming `CY99000230P` 204 anomaly **closed**: that value is not a valid DRCOR registration number in any format. DRCOR uses pure numeric IDs (e.g., `290868`).
+- **Verdict: NOT VIABLE for officers.**
+
+### Path 2 — DRCOR paid API
+
+- `efiling.drcor.mcit.gov.cy` is an ASP.NET Web Forms application — **no API exists**. The €10 paid full search is human-readable document delivery, not machine-readable API.
+- DEC-518-G probe N/A (no API product).
+- **Verdict: NOT VIABLE.**
+
+### Path 3 — data.gov.cy DRCOR open data ⭐ **v1 WIN**
+
+**Prior DEC-20260507-G finding confirmed and upgraded with live evidence.**
+
+Three CSVs HEAD-probed live 2026-05-18 (all HTTP 200, Last-Modified 2026-04-29):
+
+| File | Size | URL |
+|------|------|-----|
+| `organisation_officials_83.csv` | **120 MB** | `https://data.gov.cy/sites/default/files/organisation_officials_83.csv` |
+| `registered_office_96.csv` | 20 MB | `https://data.gov.cy/sites/default/files/registered_office_96.csv` |
+| `organisations_94.csv` | 88 MB | `https://data.gov.cy/sites/default/files/organisations_94.csv` |
+
+- **License: CC BY 4.0 International** (confirmed from dataset page; OpenSanctions' "NonCommercial" tag is erroneous — use the primary source directly).
+- **Officers schema:** `ORGANISATION_NAME, REGISTRATION_NO, ORGANISATION_TYPE_CODE, ORGANISATION_TYPE, PERSON_OR_ORGANISATION_NAME, OFFICIAL_POSITION`.
+- **Row count: 1,168,824 officer rows** (635,123 Διευθυντής/director + 438,479 Γραμματέας/secretary + Owner + General/Limited Partner + Alternate Director + Assistant Secretary + Authorised Person + Deputy Secretary).
+- **Wargaming live confirmation:** Reg 290868 returns 5 officers (Nick Katselapov, Victor Kislyi, Eugeni Kisly, Marios Pelides, Christis Christoforou — 3 directors + 1 secretary + 1 director). Closes Phase 4 anomaly.
+- **Refresh: monthly** ("Μηνιαία"). Cost: **FREE, no auth, no contract, no lead time.**
+- **DEC-20260428-A:** Compliant Tier-1 (CC BY 4.0 licensed-bulk, statutory public records, government publisher, clean redistribution).
+- **DEC-518-G probe:** N/A (no vendor).
+- **Known limitations:** Up to 30-day staleness; no appointment/cessation dates per row; no officer addresses; current/historical not row-flagged; corporate-nominee directors not flagged; CSV URL contains `_83` suffix that may rotate on dataset refresh (monitor dataset page, not direct file URL).
+- **Verdict: VIABLE-V1 TODAY.** Implementation: nightly download → Postgres → indexed by REGISTRATION_NO → `cy-directors` capability.
+
+### Path 4 — Tier-2 per-call aggregators
+
+- **Topograph (`docs.topograph.co/essentials/cyprus`)** — `legalRepresentatives` confirmed with Greek/English role pairs. Source: DRCOR eFiling portal (Topograph operates the fetcher; data is statutory public — Tier-2 legitimate). **Critical constraint: requires Greek Unicode prefix `ΗΕ` (U+0397 U+0395), NOT Latin `HE`.** DEC-518-G probe: per-call, no subscription floor confirmed, CY price RFQ-gated. **Verdict: VIABLE-V1.1** (real-time upgrade vs. Path 3's monthly staleness).
+- **Kyckr** — Directors confirmed; pricing RFQ-gated. **VIABLE-V1.2 fallback.**
+- **OpenCorporates** — Director score 10/10 but API requires annual subscription. **NOT VIABLE-V1.**
+- **Moody's / Kompany / BvD** — Enterprise subscription. **NOT VIABLE-V1.**
+- **companiesregistry.cy** — Report-based service, no API. **NOT VIABLE-V1.**
+
+### Path 5 — eFiling web UI (DEC-518-F)
+
+- Directors confirmed in free public eSearch HTML per EU e-Justice portal. ASP.NET session-cookie required; not a JS SPA (server-rendered HTML).
+- **DEC-518-F:** (a) YES (statutorily public, free); (b) UNVERIFIED (no ToS on portal); (c) STRUCTURAL FIT; (d) CONSTRUCTIVELY YES.
+- **DEC-20260428-A Tier 1 BLOCKS** regardless: Strale cannot operate scraper.
+- **Verdict: BLOCKED.** Not needed — Path 3 (open data) + Path 4a (Topograph) deliver same data under clean doctrine.
+
+### Path 6 — Open data bulk
+
+- **Identical to Path 3** for CY. The data.gov.cy CSV IS the bulk download.
+- OpenSanctions `cy_companies` dataset (1.14 GB FTM JSON) is the same data with added NC restriction — use primary source instead.
+- BRIS exposes identity only; no officer extension.
+- **Verdict: SAME AS PATH 3 (viable-v1 today).**
+
+### Path 7 — Tier-2 commercial bulk
+
+- Topograph (Path 4a) is the documented Tier-2 commercial operator. BvD/Moody's/Kyckr/D&B all enterprise-subscription.
+- **Verdict:** Topograph (Path 4a) covers this path operationally; no distinct bulk product needed.
+
+### Path 8 — Cyprus Official Gazette (Επίσημη Εφημερίδα)
+
+- Fifth Supplement Part I publishes company events (HE3/HE4 forms for director changes).
+- `companies.gov.cy/en/knowledgebase/gazette` archive indexes 600+ publications; Government Printing Office hosts PDFs (free).
+- PDF-only; no XML feed. Coverage = change events, not current snapshot. Already covered by Path 3 for current state.
+- **Verdict: NOT-V1.** v2 derivative dataset if customers need historical-officer tenure dates.
+
+### Path 9 — Other CY surfaces
+
+- **Cyprus UBO Register:** Public access **CLOSED 2023-01-03** post-CJEU C-37/20. UBO ≠ directors anyway. **OUT OF SCOPE.**
+- **UK Companies House carryover:** No surviving link for post-independence (1960+) companies. **NOT APPLICABLE.**
+- **Apitalks/api.store wrapper:** Same data.gov.cy data with intermediary; use primary source. **NOT a distinct path.**
+- **CSE/CySEC disclosures:** Listed-companies only (~30 entities). Too narrow.
+
+### CY synthesis
+
+- **v1 path: Path 3 — data.gov.cy DRCOR open data CSV.** FREE, CC BY 4.0, 1.17M officer rows, monthly refresh, no vendor needed. **Operational within days.**
+- **v1.1 path: Topograph (Path 4a)** for real-time upgrade if 30-day staleness becomes a customer issue. Requires Greek `ΗΕ` Unicode normalization.
+- **Phase 4 corrections:** Wargaming 204 anomaly explained (invalid Openapi test value); OpenSanctions NC license tag erroneous (primary source is unrestricted CC BY 4.0).
+- **CY is the strongest Phase 6 finding** — no vendor relationship, no RFQ, no platform-fee risk. Same structural pattern as EE in Phase 5.
+
+---
+
+## HU — 8-path enumeration
+
+Test entities: OTP Bank (01-10-040952), MOL (13-10-041527), Richter Gedeon (01-10-040944). Full partial: [_partial_hu_enumeration.md](_partial_hu_enumeration.md).
+
+### Path 1 — Openapi other endpoints / HU-specific SKU
+
+- 49 production scopes; AT/BE/CH/DE/ES/FR/GB/IT/PL/PT have dedicated stakeholders SKUs. **No HU-stakeholders or HU-shareholders product.**
+- WW-Top (current routing) + WW-Advanced confirmed: no officer fields in documented schema for HU.
+- **Verdict: NOT VIABLE for representatives.**
+
+### Path 2 — OCCSZ / Céginformációs Szolgálat direct API
+
+- Free informational tier (tájékoztató cégkivonat) exposes director names via web UI; certified hiteles cégkivonat HUF 600–2,000 per document.
+- **OCCSZ XML API exists** (confirmed via Topograph's source documentation and companyapi.hu sourcing) but requires registration via Magyar Cégadat Szolgáltató Kft — not self-serve. Fee schedule opaque; ASZF PDF binary, not human-readable in this session.
+- **DEC-518-G probe:** Setup/monthly/floor/termination none documented for the informational tier; XML API contact-form-gated.
+- **Verdict: PARTIALLY VIABLE / COMPLEX.** XML API likely requires vendor engagement to access (effectively Tier-2 in practice).
+
+### Path 3 — Free / open data (data.gov.hu / opendata.hu)
+
+- No company-officer dataset on opendata.hu, data.gov.hu, or koz.hu. Hungary has not published the EE-equivalent CC BY 4.0 bulk dump.
+- OpenCorporates HU: API subscription only (£2,250+/yr); CAPTCHA on web view. Wrong cost model.
+- GLEIF: no officer fields. Open Ownership: UBO ≠ directors and HU UBO restricted per CJEU.
+- **Verdict: NOT VIABLE.**
+
+### Path 4 — Tier-2 per-call aggregators
+
+- **Topograph (`docs.topograph.co/essentials/hungary`)** — `legalRepresentatives` confirmed from §13 of Cégkivonat: name + birth date + address + role + start date + representation mode (sole/joint signing). Auditors (§14) + supervisory board (§15) also extracted. Sources: OCCSZ XML API + Cégkivonat PDF + NAV EVNY (sole traders) + VIES + NAV Group VAT Registry. Identifiers: Cégjegyzékszám preferred, also adószám, VAT, name. **DEC-518-G probe:** Variable pricing (kbyte-based TRE cost + processing fee); `profileMaxBudget` parameter available; no platform fee / setup / monthly minimum / annual floor mentioned. Critical limitation: closed companies use minimal TRE format that may omit §13 (representatives only for active companies). **Verdict: VIABLE-V1 (pending RFQ).**
+- **companyapi.hu / cegadatapi.hu** — Manager names confirmed (no role detail, no birth date, no representation mode). **Subscription model 15,990–37,990 HUF/month** (~€42–€100/month fixed). **NOT VIABLE under v1 cost discipline.**
+- **OPTEN** — Market-leading HU provider (~520K companies, 1.7M owners/executives); SOAP API; pricing fully RFQ-gated; enterprise/subscription model probable. **VIABLE-V1.1 (RFQ-gated; subscription risk).**
+- **WellData** — New companies only; 32,990–39,990 HUF/month subscription. **NOT VIABLE.**
+- **D&B/Bisnode HU** — Enterprise subscription. **NOT VIABLE.**
+
+### Path 5 — OCCSZ web UI (DEC-518-F)
+
+- `occsz.e-cegjegyzek.hu` is a JS SPA; direct probes return HTTP 400 (session-required).
+- **DEC-518-F:** (a) YES (Act V of 2006, közhitelű nyilvántartás); (b) UNCERTAIN (ASZF PDF binary-opaque); (c) YES; (d) YES.
+- **DEC-20260428-A Tier 1 BLOCKS** regardless.
+- **Verdict: BLOCKED.** Topograph (Path 4a) is the licensed proxy.
+
+### Path 6 — Open data bulk
+
+- **No IM bulk dataset with officer fields.** Unlike EE (`kaardile_kantud_isikud.json.zip` 45 MB CC BY 4.0 daily), HU has no analog.
+- Cégközlöny (HU Companies Gazette) accessible only via WellData subscription wrapper (new cos. only). `e-cegkozlony.gov.hu` TLS certificate **expired as of 2026-05-18** (confirmed connection failure).
+- Magyar Közlöny does NOT publish company director appointments (those go to Cégközlöny). Wrong primitive.
+- **Verdict: NOT VIABLE.**
+
+### Path 7 — Tier-2 commercial bulk
+
+- OPTEN bulk licensing — enterprise annual contract; subscription floor expected; not v1-compatible.
+- GlobalDatabase / D&B HU — enterprise subscription.
+- **Verdict: NOT VIABLE for v1.**
+
+### Path 8 — Cégközlöny (Companies Gazette) parsing
+
+- Statutory officer-appointment publication vehicle (Act V of 2006 §17). Weekly publication. No XML feed. Gazette portal TLS-expired.
+- WellData subscription wrapper exists (new cos. only). Derivative-dataset build required.
+- **Verdict: V1.2+ only.**
+
+### Path 9 — Other HU surfaces
+
+- **BRIS:** Officers chargeable per HU at gateway; no third-party API. **NOT VIABLE.**
+- **CEGINFO, ceginformacio.hu, CégTaláló, PartnerControl:** Per-document or subscription resellers, no per-call API. **NOT VIABLE.**
+
+### HU synthesis
+
+- **v1 path: Topograph (Path 4a)** — per-call variable (kbyte-based + processing fee); rich officer fields (name + birth date + address + role + start date + signing mode). Required: (1) RFQ for sample pricing on OTP Bank, MOL, Richter; (2) DEC-518-G platform-fee confirmation; (3) DEC-20260428-A vendor attestation; (4) accept limitation that closed companies may omit §13.
+- **v1.1 fallback: OPTEN** — pending RFQ + subscription-risk audit per DEC-518-G.
+- No alternative free / open path. HU has not built the EE-pattern.
+
+---
+
+## LU — 8-path enumeration
+
+Test entities: RTL Group, Aperam, BGL BNP Paribas, Cargolux, BCEE, SES; **ArcelorMittal SA (LU18804375 / B82454 — Openapi index-hole)**. Full partial: [_partial_lu_enumeration.md](_partial_lu_enumeration.md).
+
+### Path 1 — Openapi other endpoints / LU-specific SKU
+
+- No LU-specific Openapi product. WW endpoints route LU as part of "all countries"; no officer fields documented.
+- Openapi's "Current Company Representatives Report" SKU (€2.30/call) exists but country coverage for LU is not documented.
+- **Index-hole confirmed:** LU18804375 (ArcelorMittal VAT) is not indexed in Openapi's LU lookup. B82454 (its RCS number per articles of association: "R.C.S. Luxembourg, section B numéro 82 454") is registered in LBR but Openapi has no B-prefix route.
+- **Verdict: NOT VIABLE for directors; index-hole structural and unresolved within Openapi.**
+
+### Path 2 — LBR direct API (professional / commercial tier)
+
+- LBR launched a commercial API summer 2022 (i-Hub press release Oct 2022 confirms: "automated access to professionals with significant information needs … RCS consultation and company profiles purchase").
+- First production client: i-Hub S.A. (POST Luxembourg subsidiary, CSSF-regulated).
+- **DEC-518-G probe:** ALL DIMENSIONS UNDISCLOSED. tarifs.pdf binary-opaque. Multiple guides ("kyckr.com", "businesswestern.co.uk") characterize LBR API as "large enterprise clients, paid model … for high-volume usage" → strong subscription signals.
+- **Eligibility risk:** i-Hub framing + LuxTrust certificate requirements elsewhere on LBR portal suggest LBR designed API for LU-domiciled CSSF-regulated entities. Foreign-entity eligibility unconfirmed; eIDAS-equivalent may or may not suffice.
+- **Index-hole resolution:** LBR API would natively cover B82454.
+- **Verdict: STRUCTURALLY PROMISING but NOT VIABLE-V1.** Pricing model and eligibility both unconfirmed. RFQ + eligibility verification required.
+
+### Path 3 — data.public.lu open tier
+
+- "Extrait du RCS Luxembourg" dataset URL on data.public.lu returns **404** (likely removed in August 2025 portal redesign).
+- Multiple 2025 sources confirm: "the dataset isn't available in bulk — neither for free nor for sale."
+- RESA (replaced Mémorial C in 2016) is a publication browser, not a bulk export. No JSON/XML feed.
+- **Unlike EE, Luxembourg has no CC-licensed daily/monthly bulk dump.**
+- **Verdict: NOT VIABLE.**
+
+### Path 4 — Tier-2 per-call aggregators
+
+- **Topograph (`docs.topograph.co/essentials/luxembourg`)** — `legalRepresentatives` confirmed via AI parsing of certified Extrait du RCS. Roles: Gérant, Gérant unique, Administrateur, Président, ISO 5009-mapped. **B-prefix RCS supported** (`B246607` example in docs) + LU-prefix VAT. **DEC-518-G probe:** Per-call (consistent with general model); no subscription floor mentioned; partial pricing datum: ~€13.50 LBR certified-extrait pass-through as floor; full per-call price RFQ-gated. **Index-hole resolved: B82454 covered.** **Verdict: VIABLE-V1 (pending RFQ + DEC-20260428-A attestation).**
+- **Kyckr** — Director coverage confirmed; pricing RFQ-gated. **VIABLE-V1.1.**
+- **Kompany (Moody's)** — Upgraded LBR connection announced; directors confirmed; credit-based pricing RFQ-gated. **VIABLE-V1.1.**
+- **Northdata** — Directors at L-tier+; **€500–€1,500/month subscription, 12-month minimum.** **NOT VIABLE-V1.**
+- **Dato Capital** — Directors confirmed (466,568 LU directors in DB); **subscription-only ~€470/month PRO, no PAYG.** **NOT VIABLE-V1.**
+- **Pappers LU** — Per-call model possible (extends from Pappers.fr); blocked by 403/404 in this probe. **POSSIBLE-V1.1.**
+- **TransactionLink** — Directors confirmed; "Book a call" wall on pricing. **VIABLE-V1.1.**
+
+### Path 5 — LBR public portal (DEC-518-F)
+
+- **CAPTCHA implemented in August 2025 portal redesign** (Paperjam article confirms anti-robot verification system).
+- **DEC-518-F:** (a) YES (LU Code de Commerce); (b) **BLOCKED** (CAPTCHA = explicit anti-automation signal); (c) YES; (d) YES.
+- DEC-20260428-A Tier 1 also BLOCKS.
+- **Verdict: NOT VIABLE.** Confirms that directors ARE present on the statutory public portal (basis for Topograph's licensed Tier-2 extraction being legitimate).
+
+### Path 6 — Open data bulk
+
+- data.public.lu dataset 404; opendatalu GitHub has only portal infrastructure.
+- RESA: PDF-only publications browser, no structured API.
+- **Verdict: NOT VIABLE.**
+
+### Path 7 — Tier-2 commercial bulk
+
+- Northdata / Dato Capital / D&B / Bisnode — all subscription. Not v1-compatible.
+- LBR direct bulk licensing — same eligibility + pricing risk as Path 2.
+- **Verdict:** Topograph (Path 4a) is the leading Tier-2 candidate; no separate bulk product needed.
+
+### Path 8 — RESA gazette
+
+- RESA publishes director appointments automatically when filed with RCS (no separate filing required).
+- HTTP 429 received on probe (rate-limited even on no-auth URL). PDF-only; no RSS / XML feed.
+- **DEC-518-F:** (a) YES; (b) BORDERLINE (rate-limit signals automation-disfavored); (c) YES; (d) YES.
+- **Verdict: NOT VIABLE as primary.** Useful as historical supplement once primary structured source exists.
+
+### Path 9 — Other LU surfaces
+
+- **BRIS:** LU restricts officer field at BRIS gateway; no third-party API. **NOT VIABLE.**
+- **LuxTrust:** Prerequisite question for Path 2 eligibility, not a separate path.
+- **RBE (UBO):** Public access restricted post-CJEU + Law of 25 Jan 2025; UBO ≠ directors. **OUT OF SCOPE.**
+- **OpenCorporates:** CAPTCHA + subscription. **NOT VIABLE-V1.**
+- **Multi-lingual (FR/DE/LU):** Implementation consideration (name normalization), not a source-selection blocker.
+- **LNIN requirement (Nov 2024):** All natural persons connected to RCS must register a Luxembourg National Identification Number. May cause partial data quality during transition; Topograph parsing should handle gracefully.
+
+### LU synthesis
+
+- **v1 path: Topograph (Path 4a)** — per-call, B-prefix RCS native (closes index-hole), legalRepresentatives confirmed. €13.50 extrait passthrough is the floor; full per-call price ≫ current Openapi WW-Top €0.1586 — this is a cost tier step-up, not a cost model violation. Required: (1) RFQ for full per-call price + DEC-518-G probe; (2) DEC-20260428-A vendor attestation (confirm LBR redistribution rights cover commercial API resale); (3) ArcelorMittal B82454 ↔ LU18804375 VAT mapping verification at production cutover.
+- **v1.1 fallback: Kyckr (Path 4b) or Kompany (Path 4c)** if Topograph RFQ fails. Both confirm LU directors.
+- **v1.1 alternate: LBR direct API (Path 2)** if foreign-entity eligibility and per-call pricing both confirmable; eliminates the €13.50 passthrough.
+
+---
+
+## Cross-cutting findings
+
+### Pattern 1 — Topograph closes 3 of 4 country gaps under one vendor
+
+| Country | Topograph endpoint | Source | Identifier | Officer fields |
+|---|---|---|---|---|
+| MT | `essentials/malta` | BAROS (MBR) | `C + space + digits` | `legalRepresentatives` + `directors` + `secretaries` |
+| HU | `essentials/hungary` | OCCSZ XML + Cégkivonat PDF | Cégjegyzékszám / adószám / VAT / name | §13 reps + auditors + supervisory board (name + birth date + address + role + start date + signing mode) |
+| LU | `essentials/luxembourg` | Certified Extrait du RCS (AI-parsed) | B-prefix RCS + LU-VAT | Gérant / Administrateur / Président (ISO 5009-mapped) |
+
+Combined with **HR** (Phase 5 confirmed), one Topograph onboarding closes 4 EU jurisdictions for representative coverage. **DEC-20260518-G platform-fee probe is the critical gate** — Topograph's "no minimum commitments" language was technically accurate but materially misleading in the Phase-5-prior context where a €1,500/mo platform fee existed separately. Per-country pricing pages magic-link-gated; bundle all four into one RFQ.
+
+### Pattern 2 — Open-data Tier-1 wins are jurisdiction-dependent
+
+| Country | EE-pattern available? | Evidence |
+|---|---|---|
+| CY | **YES** | data.gov.cy `organisation_officials_83.csv`, 120 MB, CC BY 4.0, monthly, 1.17M rows |
+| MT | No | data.gov.mt blocks WebFetch; OpenCorporates 0/20 score; no officer bulk |
+| HU | No | opendata.hu / data.gov.hu have no IM-published officer dataset |
+| LU | No | data.public.lu 404 on Extrait RCS dataset; "not available in bulk" per multiple sources |
+
+The Tier-1 open-data win depends on whether the national publishing authority decided to expose officer data in the public open-data portal. CY's DRCIP did (like EE's RIK); MT's MBR + HU's IM + LU's LBR did not.
+
+### Pattern 3 — Bulk subscription vendors consistently eliminated by Petter's cost rule
+
+Across all four countries, the following vendor cohort was eliminated for fixed-monthly pricing:
+
+- **OpenCorporates:** £2,250+/yr subscription, no PAYG (eliminated all 4)
+- **Northdata:** €500–€1,500/month, 12-month minimum (eliminated LU)
+- **Dato Capital:** ~€470/month minimum (eliminated LU)
+- **companyapi.hu:** 15,990–37,990 HUF/month (eliminated HU)
+- **WellData:** 32,990–39,990 HUF/month (eliminated HU)
+- **D&B / Bisnode:** Enterprise subscription (eliminated HU, LU)
+- **Creditinfo Malta:** Subscription credit-bureau product (eliminated MT)
+- **Moody's / BvD / Kompany / TransactionLink:** Enterprise/RFQ-subscription (eliminated as v1 candidates across countries; some marked V1.1)
+
+The cost-rule filter is decisive at this stage. Only Topograph (per-call variable) and CY's free open data survive.
+
+### Pattern 4 — DEC-518-F web UI parsing consistently blocked by Tier 1
+
+Every country's statutorily-public web UI (MT register.mbr.mt, CY efiling.drcor, HU occsz.e-cegjegyzek, LU lbr.lu) exposes directors free of charge. All four are **BLOCKED under DEC-20260428-A Tier 1** absolutism. Two additional barriers reinforce: MT SPA + 403; LU CAPTCHA (Aug 2025 redesign); HU SPA + 400 on direct probe; CY ASP.NET session-required.
+
+This is structural, not coincidental. Registries built for human consultation do not become Strale-operable surfaces under Tier 1 regardless of statutory openness. Tier-2 licensed vendors (Topograph) operate the fetch on Strale's behalf — that is the doctrine-clean path.
+
+### Pattern 5 — Gazette parsing (Path 8) is uniformly v1.2+ derivative work
+
+Each country has a statutory gazette publishing officer changes:
+
+| Country | Gazette | Status |
+|---|---|---|
+| MT | Gazzetta tal-Gvern | PDF-only; partial coverage (incorporation + filed changes) |
+| CY | Επίσημη Εφημερίδα, Fifth Supplement Part I | 600+ issues indexed; HE3/HE4 forms; PDF |
+| HU | Cégközlöny | Weekly PDF; portal TLS-expired 2026-05-18; subscription wrapper via WellData |
+| LU | RESA (replaced Mémorial C 2016) | PDF-only publication browser; HTTP 429 rate-limited |
+
+For all four: no structured XML/RSS feed; PDF parsing required; entity resolution (gazette text → registry ID) adds complexity. Useful for historical-officer-tenure features (v1.2+) but not v1 path. **No new DEC-20260428-A scope question** in Phase 6 — none of these surfaces meet the BE-Moniteur-Belge sharpness criterion (gazette-as-only-historical-source with no commercial alternative). All four have viable current-state alternatives in Paths 3 or 4a.
+
+### Pattern 6 — UBO registers consistently out of scope post-CJEU C-37/20
+
+MT (legitimate-interest gate + €5/request), CY (closed 2023-01-03), HU (restricted), LU (RBE restricted by Law of 25 Jan 2025). All four. UBO ≠ directors regardless; even if accessible, wrong primitive.
+
+---
+
+## Recommendations to chat-side
+
+| Country | v1 decision | Immediate action | Parallel actions |
+|---------|-------------|------------------|------------------|
+| **MT** | Build against Topograph (Path 4a) | Bundle into single Topograph RFQ (with HU, LU); request MT per-call price + DEC-518-G platform-fee disclosure + DEC-20260428-A vendor attestation; implement VAT↔C-number resolution step | Kyckr v1.1 backup RFQ; defer MBR direct API (Path 2) to v1.2 pending subscription/eligibility clarity |
+| **CY** | **Build against data.gov.cy DRCOR open data CSV (Path 3) TODAY** | Implement nightly ingest of `organisation_officials_83.csv` → Postgres → `cy-directors` capability; monitor dataset page URL for resource-link rotation (not hardcoded file URL); disclose monthly refresh limitation in capability output | Topograph (Path 4a) v1.1 for real-time upgrade — RFQ in bundle, requires Greek `ΗΕ` Unicode normalization |
+| **HU** | Build against Topograph (Path 4a) | Bundle into single Topograph RFQ; request sample pricing on OTP Bank, MOL, Richter (kbyte-based variable model); DEC-518-G full probe; DEC-20260428-A attestation; accept §13 active-companies-only limitation | OPTEN v1.1 fallback (separate RFQ with subscription-risk audit) |
+| **LU** | Build against Topograph (Path 4a) | Bundle into single Topograph RFQ; request LU per-call price + €13.50 passthrough confirmation; verify B-prefix native support resolves Openapi index-hole (B82454 ArcelorMittal test case); DEC-518-G probe + DEC-20260428-A attestation | LBR direct API (Path 2) v1.1 if foreign-entity eligibility + per-call pricing both confirmable (would eliminate €13.50 passthrough) |
+
+**Consolidated next-step single action:** **One bundled Topograph RFQ covering MT + HU + LU (and confirming HR Phase 5 pricing).** Required disclosures per DEC-20260518-G: platform fee, setup fee, monthly minimum, annual floor, volume-tier locked floors, termination fees. Sample-call pricing for: GO plc (MT), OTP Bank / MOL / Richter (HU), RTL Group / ArcelorMittal B82454 (LU). DEC-20260428-A attestation: redistribution rights + indemnification + per-fact primary-source provenance for all four jurisdictions.
+
+**CY ships independently of Topograph** — no vendor dependency.
+
+**DEC-20260428-A scope question for Petter:** None raised by Phase 6. No new gazette-style sharpness question to schedule.
+
+**Phase 4/5 to-do updates:**
+- MT, CY, HU, LU rows in `apps/api/coverage-matrix/` — keep at Committed (Openapi WW-Top) for identity; add follow-up rows for representative coverage with Topograph (MT/HU/LU) or data.gov.cy (CY) status `Planned-v1`.
+- CY: open a separate to-do for `cy-directors` capability build (Path 3 open-data ingest).
+- Topograph onboarding to-do: bundle MT + HU + LU into one RFQ ticket with HR pricing re-confirmation.
+
+**Memory entry 25 update:** Realistic v1 launch coverage now includes MT + CY + HU + LU representative-coverage paths. Phase 4/5 "thin-usable+ identity, no reps" classifications are correctly described as Openapi-vendor-bounded, not registry-bounded. The Tier-2 question for each country has a viable answer.
+
+---
+
+## Stop-condition compliance
+
+- ✅ All 32 path investigations (4 countries × 8 paths) documented with live HTTP evidence per path, or documented negative reasoning where probe was blocked.
+- ✅ No path halted on first-failure without evidence-based reasoning.
+- ✅ Final verdict per country with cost / latency / risk + DEC compliance.
+- ✅ DEC-20260518-G platform-fee probe completed for every Tier-2 candidate in every country (Topograph, Kyckr, OpenCorporates, Moody's/Kompany/BvD, TransactionLink, Northdata, Dato Capital, Pappers, OPTEN, companyapi.hu, WellData, D&B/Bisnode, Creditinfo, Schmidt & Schmidt).
+- ✅ DEC-20260518-F 4-constraint check applied to every Path 5 web-UI candidate; all blocked under Tier 1 with documented constraint-level evaluation.
+- ✅ No 2023/138 representative-content claims (per course-correction Journal `36467c87082c8169`); HVD § 5.1 cited only as identity-fields mandate.
+- ✅ Cross-reference to per-country canonical YAML at `apps/api/coverage-matrix/*-company-data__{mt,cy,hu,lu}__company-registry.yaml`.
+
+## Caveats logged (synthesis)
+
+- **Topograph per-country prices opaque.** MT, HU, LU pricing pages all magic-link-gated. HR Phase 5 precedent confirms no platform fee but per-country probe still required. RFQ is the gate.
+- **HU Topograph variable pricing.** Kbyte-based TRE cost + processing fee = unpredictable cost-per-entity. Large companies with long register history (OTP Bank, MOL) will cost more than small Kft. `profileMaxBudget` parameter mitigates.
+- **HU Topograph limitation.** Closed companies use minimal TRE format that may omit §13 (representatives only for active companies). Document as capability limitation.
+- **LU per-call cost step-up.** ~€13.50 extrait passthrough is the floor; full Topograph LU per-call ≫ Openapi WW-Top €0.1586. Cost tier change, not model violation. Petter awareness required at pricing.
+- **MT identifier gap.** Current Strale regex `^MT\d{8}$` (VAT) ≠ Topograph `C + space + digits` (BAROS). Implementation: VAT→C-number resolution step or accept C-prefix input.
+- **CY identifier note (Topograph).** Topograph CY requires Greek Unicode `ΗΕ` (U+0397 U+0395), NOT Latin `HE`. Unicode normalization step required if Topograph is used as v1.1 upgrade.
+- **CY open-data URL stability.** `_83` suffix on officers CSV may rotate on future dataset refreshes. Ingest job must monitor dataset page (`data.gov.cy/el/dataset/mitroo-eggegrammenon-...`) for resource-link changes, not hardcode the direct file URL.
+- **CY monthly staleness.** Open data refreshed monthly; up to 30-day stale appointments. Disclose via `freshness_category: reference-data` and `fetched_at` timestamp. Topograph v1.1 path resolves if customer requires real-time.
+- **CY no per-row appointment dates.** Open-data CSV does not include appointment/cessation dates per officer. For tenure verification, Topograph (Path 4a) document retrieval is required.
+- **LU B82454↔LU18804375 mapping inferred.** Multiple sources reference B82454 as ArcelorMittal RCS number (corporate articles + Northdata); VAT mapping inferred from Openapi failure context. Verify via LBR public search at production cutover.
+- **LU LNIN requirement (Nov 2024).** Natural persons connected to RCS must register Luxembourg National Identification Number. Transition-period data quality may be degraded for recently-onboarded directors. Topograph AI parsing expected to handle gracefully.
+- **MBR Subject Person eligibility (Path 2 deferred).** Strale's qualification as Subject Person ambiguous; required for MBR direct API access. Not a v1 issue (Topograph is the v1 path) but a v1.2 question if MBR direct ever becomes the target.
+- **LBR foreign-entity eligibility (Path 2 deferred).** LuxTrust certificate requirements + i-Hub press release CSSF framing suggest LU-domiciled professional focus. eIDAS-equivalent untested. Not a v1 issue but a v1.1 question.
+- **HU Cégközlöny TLS expired.** `e-cegkozlony.gov.hu` returned TLS cert error 2026-05-18. Does not affect Topograph path (uses OCCSZ XML + TRE PDF, not gazette portal). Flag separately for IM if a Cégközlöny derivative dataset becomes a future requirement.
+- **OpenSanctions CY license tag erroneous.** OpenSanctions describes `cy_companies` as "CC BY NonCommercial"; the data.gov.cy source page is unqualified CC BY 4.0. Strale sources from primary, not from OpenSanctions, to preserve commercial license freedom.
+- **BRIS unprobeable from US-East egress.** webgate.ec.europa.eu/e-justice redirects to sorry.ec.europa.eu from Railway US East. Assessment grounded in e-Justice portal docs and secondary sources rather than direct probe; conclusions consistent across all 4 countries (BRIS = identity only, no officer extension, no third-party API).

--- a/manifests/cypriot-company-data.yaml
+++ b/manifests/cypriot-company-data.yaml
@@ -1,10 +1,10 @@
 slug: cypriot-company-data
 name: Cypriot Company Data
 description: >-
-  Look up Cypriot company data via Openapi.com WW-Top (Tier-3 vendor aggregator). Accepts CY-prefix VAT, bare VAT
-  (8 digits + letter), or C-prefix CRO company number (e.g. C165). Returns name, registration number, status,
-  registered address, registration date, LEI, primary NACE code, and last-update timestamp. PARTIAL coverage —
-  some entities (e.g. Wargaming CY99000230P) return 204 from the Openapi catalog despite valid input shape.
+  Look up Cypriot company data. Tier-1 identity via Openapi.com WW-Top (Tier-3 vendor aggregator). Tier-2
+  legal_representatives[] sourced from data.gov.cy DRCOR open data (CC BY 4.0, monthly refresh) for C-prefix
+  inputs (e.g. C165). Accepts CY-prefix VAT, bare VAT (8 digits + letter), or C-prefix CRO company number.
+  Returns name, registration number, status, registered address, directors + secretaries, and source provenance.
 category: company-data
 cost_class: paid_per_call
 price_cents: 16
@@ -54,7 +54,24 @@ output_schema:
     nace_codes: { type: array }
     company_size: { type: ["string", "null"] }
     source_as_of: { type: ["string", "null"] }
-data_source: Openapi.com WW-Top (Tier-3 vendor aggregator of EU company registries)
+    legal_representatives:
+      type: array
+      description: Canonical legal-representatives shape (DEC-20260518-A). Each entry is { type, name, role, role_code, role_group, date_of_birth, start_date }. date_of_birth + start_date are always null for CY — DRCOR open data does not publish personal IDs or per-row appointment dates.
+    total_legal_representatives:
+      type: integer
+      description: Count of legal_representatives returned from the cy_directors cache. 0 when input was VAT-format (not resolvable against DRCOR) or no rows for this DRCOR registration number.
+    tier_2_available:
+      type: boolean
+      description: True when at least one legal representative is returned. Only C-prefix inputs (e.g. C165) resolve against the DRCOR cache; VAT-format inputs return false.
+    tier_2_available_reason:
+      type: string
+      description: Explanation of tier-2 availability (source + freshness + VAT-not-resolvable caveat) or non-availability.
+    ubo_availability:
+      type: string
+      description: UBO availability flag. CY is unavailable_no_registry — Cyprus UBO Register closed to public access since 2023-01-03 (CJEU C-37/20).
+    ubo_availability_reason:
+      type: string
+data_source: Openapi.com WW-Top (Tier-3) + data.gov.cy DRCOR open-data CSV (Tier-2 legal_representatives via C-prefix lookup)
 data_source_type: api
 transparency_tag: algorithmic
 freshness_category: live-fetch
@@ -94,6 +111,12 @@ output_field_reliability:
   nace_codes: common
   company_size: common
   source_as_of: guaranteed
+  legal_representatives: common
+  total_legal_representatives: common
+  tier_2_available: guaranteed
+  tier_2_available_reason: guaranteed
+  ubo_availability: guaranteed
+  ubo_availability_reason: guaranteed
 limitations:
   - title: Gated behind OPENAPI_ENABLED flag pending resale addendum countersignature
     text: >-
@@ -113,7 +136,24 @@ limitations:
     text: Openapi WW-Top does not return Cypriot legal form.
     category: coverage
     severity: info
-  - title: Directors not available at WW-Top tier
-    text: Openapi WW-Top does not return directors / legal representatives. Directors-gap closure is IT-only via Openapi IT-Full.
+  - title: Directors via DRCOR open data — C-prefix lookup only
+    text: >-
+      Openapi WW-Top does not return directors / legal representatives for CY. The gap is closed for C-prefix inputs
+      via data.gov.cy DRCOR open data (CC BY 4.0, monthly refresh) — see jobs/ingest-cy-directors.ts and DEC-20260518-E
+      Phase 6 enumeration. VAT-format inputs (CY-prefix or bare) cannot be resolved against the DRCOR cache because
+      DRCOR indexes by numeric REGISTRATION_NO only, not by VAT.
+    category: coverage
+    severity: info
+  - title: DRCOR open data freshness — monthly snapshot
+    text: >-
+      The cy_directors cache is refreshed from the data.gov.cy monthly bulk CSV. Officer changes filed in the last
+      ~4 weeks may not appear until the next refresh. Per-row appointment dates are not published in the open-data
+      file (start_date is always null in legal_representatives entries).
+    category: freshness
+    severity: info
+  - title: UBO data not available
+    text: >-
+      Cyprus UBO Register closed to public access since 2023-01-03 following CJEU C-37/20. Beneficial-owner data is
+      out of scope at v1.
     category: coverage
     severity: info


### PR DESCRIPTION
## Summary

Implements **DEC-20260518-E Phase 6** outcome for Cyprus: weekly ingest of the data.gov.cy DRCOR officers CSV (`organisation_officials_83.csv`, ~120 MB plain text, CC BY 4.0, monthly upstream refresh, ~1.17M officer rows). Populates the canonical `legal_representatives[]` field on `cypriot-company-data` per **DEC-20260518-A**.

Phase 4 had Cyprus on Openapi WW-Top at Committed status, identity-only (no directors). The Phase 6 enumeration (synthesised in `audit-output/exhaustive-enumeration-phase-6-mt-cy-hu-lu-2026-05-18.md`, committed in this PR) reconfirmed the DEC-20260507-G spike: data.gov.cy publishes a CC BY 4.0 bulk CSV containing 635K directors + 438K secretaries + 7 other position types — same EE-pattern win as PR #139.

Lifts EU30 binding-ready T2 from **8 to 9** (CY).

## Architecture

Mirrors EE PR #139 almost verbatim. Three CY-specific differences:

- **CSV not JSON** (no unzip dep needed; custom RFC-4180 CsvStreamer instead of EE's JSON tokenizer)
- **Composite PK** `(entity_reg_code, person_or_organisation_name, official_position)` — DRCOR has no stable per-row identifier upstream, so the natural unique tuple is the PK. UPSERT pre-dedupes within batch to avoid the postgres `ON CONFLICT cannot affect the same row twice` error.
- **Weekly + skip-if-unchanged** instead of EE's daily (DRCOR refreshes monthly; weekly+skip is safer than monthly-exact).

Components:
- **Drizzle**: `cy_directors` (composite PK + entity / last_synced indexes) + `cy_directors_sync` (singleton id=1 marker).
- **Migration**: `startup-migrations.ts` Block 0080, idempotent (`CREATE TABLE IF NOT EXISTS` + `pg_constraint`-lookup guard around the singleton CHECK). Wired into `BLOCKS[]` (22→23) → fires at API boot before `validateSchema()` per DEC-20260504-C.
- **Job**: `apps/api/src/jobs/ingest-cy-directors.ts`. Custom streaming RFC-4180 `CsvStreamer` (BOM, CRLF, doubled-quote escape, embedded CRLF in quoted fields, chunk-boundary split); session-scoped advisory lock 20260519; 1000-row batched UPSERT in per-batch transactions; sweep `DELETE WHERE last_synced_at < sync_start`. 10-min startup delay + 7-day interval; HEAD probe skips when upstream `Last-Modified` unchanged.
- **Handler**: `cypriot-company-data.ts` queries the cache via Drizzle for C-prefix inputs (strip "C" → numeric REGISTRATION_NO lookup), emits canonical `legal_representatives[]` shape. **VAT-format inputs return `tier_2_available: false` with an explicit non-coverage reason** — DRCOR indexes by numeric REGISTRATION_NO only, not by VAT, so silent drop would be misleading. Cache miss / DB error is non-fatal — tier-1 unaffected.

## Identifier-mapping note

CY handler accepts three identifier shapes (CY-prefix VAT / bare VAT / C-prefix company number). Only C-prefix maps cleanly to DRCOR (e.g. `C165` → `165`). For VAT inputs the response includes `tier_2_available_reason: "VAT-format identifier cannot be resolved against the DRCOR open-data cache..."` — an honest, actionable hint for the agent caller.

## Cost class

`paid_per_call` (€0.16 Openapi WW-Top passthrough for tier-1) — tier-2 augmentation adds zero per-call cost; ingest infra is Strale's own.

## GDPR

DRCOR open data does **not** publish personal identification numbers or DOB at row level — only names + roles + organisation context. No additional redaction at ingest. `date_of_birth` and `start_date` are kept `null` for canonical-shape parity. The Cyprus UBO Register is a separate restricted system (closed to public access since 2023-01-03 per CJEU C-37/20) and is out of scope at v1 — surfaced via `ubo_availability: "unavailable_no_registry"`. `legal_representatives` is already in `PII_ARRAY_FIELDS` for fixture scrubbing (PR #125).

## Smoke evidence

**Parse-only smoke** vs live 120 MB CSV (`apps/api/scripts/smoke-cy-directors-parse.ts`):

```
rows seen:     1168844
rows shaped:   1168758
parse elapsed: 3.1s

role_standardized histogram (top):
  director               636922
  secretary              439414
  owner                  58795
  general_partner        18001
  alternate_director     5913
  authorised_person      3413
  assistant_secretary    3399
  limited_partner        2435
  deputy_secretary       466

reg_code 165 (BANK OF CYPRUS PUBLIC COMPANY LIMITED): 12 officer rows
  (11 directors + 1 secretary)

reg_code 290868 (WARGAMING GROUP LIMITED): 5 officer rows
  NICK KATSELAPOV                                    director
  VICTOR KISLYI                                      director
  ΕΥΓΕΝΙ ΚΙΣΛΥ                                       director
  ΜΑΡΙΟΣ ΠΕΛΙΔΗΣ                                     secretary
  ΧΡΙΣΤΗΣ ΧΡΙΣΤΟΦΟΡΟΥ                                director
```

Wargaming officer list matches Phase 6 partial exactly. The Phase 4 `CY99000230P → 204` anomaly is explained: that string is not a valid DRCOR registration number in any format (Wargaming is registered as numeric `290868`).

**Live ingest vs production DB** is deferred to post-deploy smoke per DEC-20260504-C (Block 0080 is wired into the verified `runStartupMigrations()` boot path; running an un-merged migration against prod from a dev session would create schema state that doesn't match deployed code).

## Test plan

- [x] `tsc --noEmit` clean (one pre-existing unrelated error in `italian-company-stakeholders.ts`, untracked work from parallel worktree — same exclusion as EE PR #139)
- [x] Vitest: 102/102 passing for `startup-migrations.test.ts` (incl. new Block 0080 first-run + idempotent-second-run cases + BLOCKS canonical list 22→23) and `ingest-cy-directors.test.ts` (24 cases: 12 CsvStreamer — BOM, CRLF, quoted, doubled-quote, embedded CRLF, chunk-boundary split — 4 standardizeRole, 8 shapeRow)
- [x] Full `apps/api` test suite: 708 passing, 1 unrelated failure (`manifest-completeness` for the same untracked `italian-company-stakeholders` work)
- [x] `coverage-matrix:check` clean (47/47 valid, COVERAGE.md regen up-to-date)
- [x] `check-manifest-guaranteed-consistency.mjs --strict` clean
- [x] `lint:no-bare-catch` clean (F-0-009 guard)
- [x] `check-tier-coverage.mjs --slug cypriot-company-data`: WARN-only Phase 1; new tier-2 fields added to fixture. Residual WARN on `[legal_name, primary_registration_id, date_incorporated]` is the same shape as EE/NO/CZ allowlist entries — left out of scope here.
- [x] Parse-only smoke against live 120 MB CSV (Bank of Cyprus C165 → 12 officers, Wargaming 290868 → 5 officers, role histogram matches Phase 6 partial)
- [x] /go six-lens review (code-reviewer agent): 2 findings addressed inline — docstring "Monthly ingest" → "Weekly ingest"; `rowsUpserted` now sourced from `upsertBatch` return value (deduped count) rather than pre-dedupe `pending.length` (eliminates cosmetic telemetry over-count when batch dedupe shrinks).
- [ ] **Post-deploy smoke** (after merge): verify first ingest tick fires ~10 min after deploy; `curl /v1/do` against `cypriot-company-data` with `{"vat_number":"C165"}`; expect `tier_2_available: true` + 12 officers. Documented as the v1.1 verification step per DEC-20260504-C.

## Doctrine

- **DEC-20260518-E** — Exhaustive Source Enumeration (the doctrine this PR implements for CY; report committed in this PR)
- **DEC-20260518-A** — Canonical `legal_representatives[]` shape (parity with EE #139 / NO #136 / CZ #137)
- **DEC-20260518-F** — Attribution preserved in handler provenance (`license: CC BY 4.0`, `tier_2_source: "data.gov.cy DRCOR open data"`)
- **DEC-20260428-A** — Tier 1 compliant (direct first-party government open data; no Strale-operated scraping)
- **DEC-20260504-A** — Audit-follow-up test coverage (Block 0080 has stub-based behavioral tests; CsvStreamer + shapeRow + standardizeRole have 24 unit-test cases)
- **DEC-20260504-B** — Bulk-operation deploy protocol (batched UPSERT + bounded DELETE; no single big transaction; first-tick row count ~1.17M is within WAL budget at 1000 rows/batch)
- **DEC-20260504-C** — Deploy-mechanism verification (Block 0080 is on the import graph from `index.ts:74` via `runStartupMigrations()`; ingest job wired at `index.ts:130-131`)

## v1.1 upgrade path

If real-time officer status becomes a customer requirement (e.g. for compliance use cases sensitive to the 30-day refresh lag), the upgrade is Topograph per-call (RFQ + DEC-20260518-G platform-fee probe required). Tracked in the Phase 6 report's "v1.1 path" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
