### PR TITLE
tooling: persistent session marker for accurate /end-session reporting

### DIFF
--- a/.claude/commands/end-session.md
+++ b/.claude/commands/end-session.md
@@ -76,15 +76,31 @@ From the script output + Notion state:
 - Open circuit breakers → is there an alert/task tracking each?
 - Strategy brainstorms raised this session that are sitting un-discussed?
 
-## 7. Final verification report
+## 7. Archive session marker + final verification report
 
-Give the user a structured summary:
+Archive the persistent session marker (written at session start by `scripts/session-state.mjs`). This captures real start/end timestamps + duration + starting/ending commit. Run from the repo root:
+
+```
+node scripts/session-state.mjs end "ended via /end-session"
+```
+
+The script prints a JSON block with `session_started_at`, `ended_at`, `duration_ms`, `starting_commit`, `ending_commit`, `starting_branch`, `ending_branch`, and `archived` (path under `.claude/state/session-archive/`). If the response is `{"action":"no-session-to-end"}`, the marker was never created this session — note "duration unknown" in the report and recommend the user install the SessionStart hook (snippet in the PR that landed this feature).
+
+Then give the user a structured summary:
 
 ```
 === Session close-out ===
 ✓ Green      (N items clean)
 ⚠ Yellow    (N items review)
 ✗ Red       (N items blockers)
+
+Session start:             <ISO from marker> (or "unknown — no marker")
+Session end:               <ISO now>
+Duration:                  <Hh Mm> (or "unknown")
+Starting commit:           <SHA8>
+Ending commit:             <SHA8>
+Branch at end:             <branch>
+Archive:                   <path returned by session-state end>
 
 Handoff file (step 6):     ✓ <path> (written this session)
 Journal entry (step 7):    ✓ <title + URL> (written this session)
@@ -110,3 +126,4 @@ Ready to close? (yes / [which item you want to address first])
 - If Notion MCP tools are unavailable, write the handoff file anyway (filesystem); skip the Journal step and flag loudly — never silently proceed.
 - Distinguish pre-existing issues from new ones honestly. Don't hide issues you introduced; don't take credit for issues you didn't.
 - If the script exits 2 (red findings), default to "don't close yet" unless the user explicitly overrides — but still write the artifacts so the work is recorded.
+- **Always archive the session marker** in step 7, even when the close-check returned red — the archive is a historical record, not a quality gate. The "don't close yet" recommendation is advisory; the archive captures whatever state the session actually ended in.

--- a/apps/api/scripts/session-close-check.ts
+++ b/apps/api/scripts/session-close-check.ts
@@ -5,10 +5,12 @@
  * Only flags state that this session is responsible for — pre-existing drift
  * from other sessions is filtered out.
  *
- * Session scope: work done in the last SESSION_WINDOW_HOURS (default 6).
- * Commits by the current git author within that window, files with mtime
- * in that window, and DB rows whose slugs were touched by those changes.
- * Override with SESSION_WINDOW_HOURS=N.
+ * Session scope: derived from `.claude/state/session-state.json` (written
+ * by scripts/session-state.mjs at session start). If the marker is missing,
+ * falls back to the previous behaviour — last SESSION_WINDOW_HOURS hours
+ * (default 6). Commits by the current git author within the window, files
+ * with mtime in the window, and DB rows whose slugs were touched by those
+ * changes. Override with SESSION_WINDOW_HOURS=N.
  *
  * Checks:
  *   - Git: dangling commits, unpushed work, uncommitted code (all session-scoped)
@@ -28,7 +30,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import postgres from "postgres";
 
@@ -51,8 +53,38 @@ const HANDOFF_DIR = resolve(REPO_ROOT, "handoff/_general/from-code");
 
 const CURRENT_AUTHOR_EMAIL = sh("git config user.email", { cwd: REPO_ROOT, allowFail: true });
 
-const SESSION_WINDOW_HOURS = Number(process.env.SESSION_WINDOW_HOURS ?? 6);
-const SESSION_START_MS = Date.now() - SESSION_WINDOW_HOURS * 3600_000;
+// Prefer the persistent marker (real session start) over a fixed time window.
+// `SESSION_WINDOW_HOURS` (default 6) is the fallback when the marker is missing
+// — e.g. a session that ran without the SessionStart hook installed. Explicit
+// env override always wins, so an operator can force a wider window for audits.
+const FALLBACK_WINDOW_HOURS = Number(process.env.SESSION_WINDOW_HOURS ?? 6);
+const SESSION_MARKER_PATH = resolve(REPO_ROOT, ".claude/state/session-state.json");
+
+function readSessionStartMs(): { startMs: number; source: string } {
+  if (process.env.SESSION_WINDOW_HOURS) {
+    return {
+      startMs: Date.now() - FALLBACK_WINDOW_HOURS * 3600_000,
+      source: `env override (last ${FALLBACK_WINDOW_HOURS}h)`,
+    };
+  }
+  if (existsSync(SESSION_MARKER_PATH)) {
+    try {
+      const marker = JSON.parse(readFileSync(SESSION_MARKER_PATH, "utf-8"));
+      const ms = new Date(marker.session_started_at).getTime();
+      if (Number.isFinite(ms)) {
+        return { startMs: ms, source: `marker (${marker.session_started_at})` };
+      }
+    } catch {
+      // fall through to window fallback
+    }
+  }
+  return {
+    startMs: Date.now() - FALLBACK_WINDOW_HOURS * 3600_000,
+    source: `fallback (last ${FALLBACK_WINDOW_HOURS}h — no marker found)`,
+  };
+}
+
+const { startMs: SESSION_START_MS, source: SESSION_SOURCE } = readSessionStartMs();
 const SESSION_START_SEC = Math.floor(SESSION_START_MS / 1000);
 const SESSION_START_ISO = new Date(SESSION_START_MS).toISOString();
 
@@ -368,7 +400,7 @@ async function checkOpenBreakers(sql: postgres.Sql): Promise<void> {
 // ────────────────────────────────────────────────────────────────
 async function main() {
   console.log("Session close-out check");
-  console.log(`Session window: last ${SESSION_WINDOW_HOURS}h (since ${SESSION_START_ISO})`);
+  console.log(`Session start: ${SESSION_START_ISO}  [source: ${SESSION_SOURCE}]`);
   console.log("=".repeat(60));
 
   checkDanglingCommits();

--- a/scripts/session-state.mjs
+++ b/scripts/session-state.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Strale session-state manager (ported from tilja 2026-05-20).
+ *
+ * Auto-create-if-missing pattern:
+ *   - ensure(): called by a SessionStart hook (or lazily by /end-session).
+ *     Returns the current session-state, creates a fresh one if missing,
+ *     archives + rotates if the existing one is older than STALE_HOURS (12h).
+ *   - end(): archive the current session (called by /end-session command).
+ *   - read(): read-only — does not mutate.
+ *
+ * State files (gitignored — see .gitignore '.claude/state/'):
+ *   - .claude/state/session-state.json    live marker for the current session
+ *   - .claude/state/session-archive/      closed sessions, named by timestamp+SHA
+ *
+ * Why this exists: session-close-check.ts previously used a fixed
+ * "now - 6h" window to scope its checks, which truncated long sessions
+ * and inflated short ones. With a persistent marker, the close-check
+ * filters by the actual session start.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { execSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const STATE_DIR = resolve(REPO_ROOT, ".claude/state");
+const STATE_FILE = resolve(STATE_DIR, "session-state.json");
+const ARCHIVE_DIR = resolve(STATE_DIR, "session-archive");
+const STALE_HOURS = 12;
+
+function gitHead() {
+  return execSync("git rev-parse HEAD", { cwd: REPO_ROOT, encoding: "utf-8" }).trim();
+}
+function gitBranch() {
+  return execSync("git rev-parse --abbrev-ref HEAD", {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+  }).trim();
+}
+function now() {
+  return new Date().toISOString();
+}
+
+function ensureDirs() {
+  if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true });
+  if (!existsSync(ARCHIVE_DIR)) mkdirSync(ARCHIVE_DIR, { recursive: true });
+}
+
+function archiveCurrent(state) {
+  ensureDirs();
+  const archivedAt = now().replace(/[:.]/g, "-");
+  const shortSha = (state.starting_commit ?? "unknown").slice(0, 8);
+  const archivePath = resolve(ARCHIVE_DIR, `${archivedAt}-${shortSha}.json`);
+  state.archived_at = now();
+  writeFileSync(archivePath, JSON.stringify(state, null, 2));
+  return archivePath;
+}
+
+function createNew(notes = "auto-created") {
+  ensureDirs();
+  const state = {
+    session_started_at: now(),
+    starting_commit: gitHead(),
+    starting_branch: gitBranch(),
+    notes,
+  };
+  writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+  return state;
+}
+
+export function ensure() {
+  if (!existsSync(STATE_FILE)) {
+    return { state: createNew(), action: "created" };
+  }
+
+  const existing = JSON.parse(readFileSync(STATE_FILE, "utf-8"));
+  const ageMs = Date.now() - new Date(existing.session_started_at).getTime();
+  const ageHours = ageMs / 1000 / 3600;
+
+  if (ageHours > STALE_HOURS) {
+    const archivePath = archiveCurrent(existing);
+    return {
+      state: createNew(
+        `auto-created after archiving stale session (${archivePath})`,
+      ),
+      action: "rotated",
+      archived: archivePath,
+    };
+  }
+
+  return { state: existing, action: "existing" };
+}
+
+export function end(notes = "manually ended") {
+  if (!existsSync(STATE_FILE)) return { action: "no-session-to-end" };
+
+  const state = JSON.parse(readFileSync(STATE_FILE, "utf-8"));
+  state.ended_at = now();
+  state.end_notes = notes;
+  state.ending_commit = gitHead();
+  state.ending_branch = gitBranch();
+
+  const startMs = new Date(state.session_started_at).getTime();
+  const endMs = new Date(state.ended_at).getTime();
+  state.duration_ms = endMs - startMs;
+
+  const archivePath = archiveCurrent(state);
+  unlinkSync(STATE_FILE);
+  return {
+    action: "ended",
+    archived: archivePath,
+    session_started_at: state.session_started_at,
+    ended_at: state.ended_at,
+    duration_ms: state.duration_ms,
+    starting_commit: state.starting_commit,
+    ending_commit: state.ending_commit,
+    starting_branch: state.starting_branch,
+    ending_branch: state.ending_branch,
+  };
+}
+
+export function read() {
+  if (!existsSync(STATE_FILE)) return null;
+  return JSON.parse(readFileSync(STATE_FILE, "utf-8"));
+}
+
+// CLI entry point: `node scripts/session-state.mjs <ensure|end|read> [notes]`.
+// pathToFileURL normalises Windows paths to the same scheme as
+// import.meta.url ("file:///C:/..."), avoiding a backslash-vs-forward-slash
+// mismatch that would silently skip the CLI block on Windows.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const cmd = process.argv[2];
+  if (cmd === "ensure") {
+    console.log(JSON.stringify(ensure(), null, 2));
+  } else if (cmd === "end") {
+    console.log(JSON.stringify(end(process.argv[3] ?? "manually ended"), null, 2));
+  } else if (cmd === "read") {
+    console.log(JSON.stringify(read(), null, 2));
+  } else {
+    console.error("Usage: node scripts/session-state.mjs <ensure|end|read> [notes]");
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

- Ports the tilja session-state pattern. Replaces `session-close-check.ts`'s fixed `now - 6h` window with a real session-start timestamp read from `.claude/state/session-state.json`.
- `/end-session` now archives the marker and surfaces real **duration**, **starting commit**, and **ending commit** in the final report — fixing the long-session-truncation / short-session-noise problem in today's report.
- Graceful fallback: when the marker is missing (no SessionStart hook, ad-hoc invocation) the close-check uses the previous 6h behaviour. `SESSION_WINDOW_HOURS=N` env override still wins.

## Files touched

- `scripts/session-state.mjs` *(new)* — `ensure` / `end` / `read` CLI. Marker at `.claude/state/session-state.json`, archive at `.claude/state/session-archive/`. Both paths already covered by the `.claude/state/` gitignore entry. 12h stale-rotation matches tilja.
- `apps/api/scripts/session-close-check.ts` — reads marker, falls back to window, logs `[source: marker | env override | fallback]` so the report is honest about which boundary it used.
- `.claude/commands/end-session.md` — step 7 calls `node scripts/session-state.mjs end` and adds duration + commit-range lines to the report block.

## Required follow-up (per-machine, not shippable)

`.claude/settings.json` is gitignored, so the SessionStart hook can't go in the repo. Paste this into your local `.claude/settings.local.json` so the marker is created at true session start (without it, the marker is created lazily when `/end-session` runs and duration shows "unknown"):

```json
{
  "hooks": {
    "SessionStart": [
      {
        "matcher": "*",
        "hooks": [
          { "type": "command", "command": "node scripts/session-state.mjs ensure" }
        ]
      }
    ]
  }
}
```

## Test plan

- [x] `node scripts/session-state.mjs ensure` → creates marker, second call returns `existing` (idempotent).
- [x] `node scripts/session-state.mjs end "test"` → emits JSON with `duration_ms`, `starting_commit`, `ending_commit`, archive path; removes the live marker.
- [x] `npx tsc --project apps/api/tsconfig.json --noEmit` → clean.
- [x] `npx tsx apps/api/scripts/session-close-check.ts` with marker present → header reads `[source: marker (ISO)]`.
- [ ] Manual: install the hook snippet, start a fresh CC session, run `/end-session`, confirm duration block populates.
- [ ] Manual: remove the marker, run the close-check, confirm header shows `[source: fallback (last 6h — no marker found)]` and behaviour matches today.

## Notes

- Parallel CC instances on the same repo would share one marker. Solo-founder usage means this is rarely a problem; if it bites, scope the marker per-worktree (the script already resolves `REPO_ROOT` from its own location, so worktree-scoped install drops in without changes).
- The archive trail in `.claude/state/session-archive/` is local-only (gitignored) — useful for retrospectives, not a governance artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)