### PR TITLE
fix(prompt-optimize): scale max_tokens to input so large prompts don't truncate

### DIFF
--- a/apps/api/src/capabilities/prompt-optimize.ts
+++ b/apps/api/src/capabilities/prompt-optimize.ts
@@ -1,9 +1,28 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import Anthropic from "@anthropic-ai/sdk";
 
+// Output-token ceiling for a single optimization pass. Kept conservatively below
+// the model's maximum output so we never request more than it can return.
+const MAX_OUTPUT_TOKENS = 8000;
+
+// Largest prompt we'll accept. The model echoes the full improved prompt back
+// inside a JSON envelope, so output ≈ input — beyond a certain size the response
+// can't fit in MAX_OUTPUT_TOKENS and the JSON truncates mid-string. This limit is
+// derived from the ceiling so that accepting a prompt implies we can actually
+// optimize it in one pass: ~18000 chars ≈ 4500 input tokens, and the maxTokens
+// formula below then yields ceil(4500*1.6)+800 = 8000 = the ceiling. Reject larger
+// inputs upfront (before the paid API call) with an actionable message.
+const MAX_PROMPT_CHARS = 18000;
+
 registerCapability("prompt-optimize", async (input: CapabilityInput) => {
   const currentPrompt = ((input.current_prompt as string) ?? (input.prompt as string) ?? (input.task as string) ?? "").trim();
   if (!currentPrompt) throw new Error("'current_prompt' is required.");
+  if (currentPrompt.length > MAX_PROMPT_CHARS) {
+    throw new Error(
+      `'current_prompt' is too large to optimize (${currentPrompt.length} chars, max ${MAX_PROMPT_CHARS}). ` +
+        `Trim it to the prompt template itself — strip embedded context, data dumps, or transcripts — and retry.`,
+    );
+  }
 
   const taskDescription = ((input.task_description as string) ?? "").trim();
   const goodExamples = (input.good_examples as string[]) ?? [];
@@ -20,10 +39,19 @@ registerCapability("prompt-optimize", async (input: CapabilityInput) => {
     examplesSection += `\nBad output examples (avoid these):\n${badExamples.map((e, i) => `${i + 1}. ${e}`).join("\n")}`;
   }
 
+  // The response must contain the entire improved prompt (≈ the input size) plus the
+  // analysis envelope. Scale the output budget to the input so large prompts don't
+  // truncate, with a floor for short prompts and a ceiling the model supports.
+  const estimatedInputTokens = Math.ceil(currentPrompt.length / 4);
+  // ×1.6: improved prompt can exceed the original; +800: fixed JSON envelope
+  // (changes_made, scores, issues, techniques). Floor 1500 = old default for
+  // short prompts; ceiling = MAX_OUTPUT_TOKENS (see above).
+  const maxTokens = Math.min(MAX_OUTPUT_TOKENS, Math.max(1500, Math.ceil(estimatedInputTokens * 1.6) + 800));
+
   const client = new Anthropic({ apiKey });
   const r = await client.messages.create({
     model: "claude-haiku-4-5-20251001",
-    max_tokens: 1500,
+    max_tokens: maxTokens,
     messages: [
       {
         role: "user",
@@ -51,12 +79,30 @@ Return JSON:
     ],
   });
 
-  const responseText = r.content[0].type === "text" ? r.content[0].text.trim() : "";
-  const jsonMatch = responseText.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) throw new Error("Failed to optimize prompt.");
+  // If the model hit the output ceiling the JSON is truncated mid-string and
+  // unparseable. Surface that as a clear, actionable error instead of a cryptic
+  // "Unterminated string in JSON" from JSON.parse.
+  if (r.stop_reason === "max_tokens") {
+    throw new Error("'current_prompt' produced output that exceeded the model's output limit. Shorten the prompt and retry.");
+  }
+
+  const block = r.content[0];
+  const responseText = block?.type === "text" ? block.text.trim() : "";
+
+  // Both "no JSON object found" and "JSON.parse threw" are the same failure class
+  // from the caller's view — the optimizer returned unusable output — so surface
+  // one consistent, actionable message rather than two different ones.
+  let output: Record<string, unknown>;
+  try {
+    const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) throw new SyntaxError("no JSON object in response");
+    output = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+  } catch {
+    throw new Error("Failed to optimize prompt: the optimizer returned malformed output. Please retry.");
+  }
 
   return {
-    output: JSON.parse(jsonMatch[0]),
+    output,
     provenance: { source: "claude-haiku", fetched_at: new Date().toISOString() },
   };
 });


### PR DESCRIPTION
## Summary
- `prompt-optimize` hardcoded `max_tokens: 1500`. The capability asks Claude to echo the full improved prompt back inside a JSON envelope, so output ≈ input — any prompt over ~1KB truncated the JSON mid-string and `JSON.parse` threw a cryptic `Unterminated string in JSON`.
- **6 production x402 calls failed this way** (5–8KB nested-JSON prompts from a content-generation pipeline), surfaced via `/activity`.
- Fix: scale `max_tokens` to input size (floor 1500, ceiling 8000); reject inputs >18000 chars upfront before the paid API call; detect `stop_reason === "max_tokens"`; guard content access; unify malformed-output errors.

## Verification
- `tsc --noEmit`: ✅ clean
- `validate-capability --slug prompt-optimize`: ✅ 19/19 checks
- `checkReadiness("prompt-optimize")`: ✅ `ready: true`, 0 issues
- `smoke-test`: structural checks ✅; live-execution step is blocked by the ALLOW_MATRIX (paid caps refuse `internal_test` context to protect vendor credits) — identical on `main`, not a regression. Real execution verified out-of-band:
  - 20000-char input → rejected with `(20000 chars, max 18000)` **before** any API call
  - ~16.7KB prompt (just under the limit) → optimizes in **one pass, no truncation**
  - normal prompt → full parsed JSON (7 fields)

## Reviewer findings
Six-lens review (technical + product). **No HIGH findings.** MEDIUMs addressed in-branch:
- **M1 (correctness):** unguarded `r.content[0]` access → fixed with optional-chaining.
- **MEDIUM-3 (PM):** the original 24000-char guard was inconsistent with the 8000-token ceiling — inputs ~18000–24000 chars were accepted but predictably truncated. Lowered `MAX_PROMPT_CHARS` to 18000 (derived from the ceiling) so *accepted ⟹ handleable in one pass*. Real traffic (5–8KB) is far under this.
- **MEDIUM-1 / LOW-1 (UX):** unified the two malformed-output paths into one consistent message; reworded the truncation error to drop "single pass" jargon.

Deferred (noted, not in scope): a shared `parseJsonEnvelope` helper. The altitude lens found **~80 capabilities inline the same `JSON.parse(match)` pattern** and **8 output-proportional caps carry the identical latent truncation bug** (`translate`, `summarize`, `code-convert`, `pii-redact`, `web-extract`, `pdf-extract`, `image-to-text`, `prompt-compress` — the last already grew the guard by hand). Migrating ~80 sites under a bugfix PR would be scope creep with regression risk; worth a follow-up.

## Test plan
1. Call `prompt-optimize` with a normal prompt → returns `improved_prompt` + analysis fields.
2. Call with a ~10KB prompt (previously failed) → now succeeds.
3. Call with a >18000-char prompt → clean `too large` error, no vendor spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)