### PR TITLE
fix(us-company-data + screenshot-url): retry transient SEC 500s, numeric wait_for, low-confidence match guard

### DIFF
--- a/.claude/wow-core.optout
+++ b/.claude/wow-core.optout
@@ -1,0 +1,2 @@
+Parallel house style — a recorded decision, not an oversight (wow-core README §Consumers).
+Delete this file to let the wow-core suggestion hook prompt for adoption again.

--- a/apps/api/src/capabilities/screenshot-url.test.ts
+++ b/apps/api/src/capabilities/screenshot-url.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression test for the wait_for coercion bug surfaced by 2026-07 x402
+ * traffic. A caller passed `wait_for:"3"` (a numeric string, meaning "wait 3
+ * seconds") to screenshot-url; the executor routed every string into the
+ * `waitForSelector` branch, so "3" was sent to Browserless as a CSS selector.
+ * Browserless rejected it (HTTP 400). Only a real JS `number` ever reached the
+ * intended `waitForTimeout` path.
+ *
+ * Post-fix: numeric strings and numbers both map to waitForTimeout (seconds →
+ * ms, clamped 0..30); only non-numeric strings become selectors.
+ */
+
+import { describe, it, expect } from "vitest";
+import { normalizeWaitFor } from "./screenshot-url.js";
+
+describe("normalizeWaitFor", () => {
+  it('treats a numeric string ("3") as a 3-second timeout, not a selector (the bug case)', () => {
+    expect(normalizeWaitFor("3")).toEqual({ waitForTimeout: 3000 });
+  });
+
+  it("treats a JS number as seconds", () => {
+    expect(normalizeWaitFor(2)).toEqual({ waitForTimeout: 2000 });
+  });
+
+  it("accepts fractional numeric strings", () => {
+    expect(normalizeWaitFor("1.5")).toEqual({ waitForTimeout: 1500 });
+  });
+
+  it("treats a non-numeric string as a CSS selector", () => {
+    expect(normalizeWaitFor("#main")).toEqual({
+      waitForSelector: { selector: "#main", timeout: 10000 },
+    });
+  });
+
+  it("clamps seconds to a 30s ceiling", () => {
+    expect(normalizeWaitFor(120)).toEqual({ waitForTimeout: 30000 });
+  });
+
+  it("clamps negative seconds to 0", () => {
+    expect(normalizeWaitFor(-5)).toEqual({ waitForTimeout: 0 });
+  });
+
+  it("returns null for empty / whitespace / undefined input", () => {
+    expect(normalizeWaitFor(undefined)).toBeNull();
+    expect(normalizeWaitFor("")).toBeNull();
+    expect(normalizeWaitFor("   ")).toBeNull();
+  });
+
+  it("returns null for a non-finite number", () => {
+    expect(normalizeWaitFor(NaN)).toBeNull();
+    expect(normalizeWaitFor(Infinity)).toBeNull();
+  });
+});

--- a/apps/api/src/capabilities/screenshot-url.ts
+++ b/apps/api/src/capabilities/screenshot-url.ts
@@ -3,6 +3,47 @@ import { getBrowserlessConfig } from "./lib/browserless-extract.js";
 import { buildBrowserlessRequestUrl } from "../lib/browserless-launch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
+/**
+ * Normalize the `wait_for` input into a Browserless wait directive.
+ *
+ * A number — or a numeric-looking string such as `"3"` — means "wait N
+ * seconds" and maps to `waitForTimeout` (ms). A non-numeric string is a CSS
+ * selector and maps to `waitForSelector`.
+ *
+ * Bug this guards (observed 2026-07 in x402 traffic): the previous code sent
+ * *any* string down the selector branch, so `wait_for:"3"` became
+ * `waitForSelector{selector:"3"}` — a bogus selector. Best case Browserless
+ * waits the full selector timeout and screenshots nothing extra; at the time
+ * the hosted instance rejected it outright with HTTP 400. Only a real JS
+ * `number` ever reached the intended timeout path.
+ *
+ * Seconds are clamped to [0, 30] (the executor's own abort budget is 40s).
+ */
+export function normalizeWaitFor(
+  raw: unknown,
+): { waitForTimeout: number } | { waitForSelector: { selector: string; timeout: number } } | null {
+  let seconds: number | undefined;
+  let selector: string | undefined;
+
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    seconds = raw;
+  } else if (typeof raw === "string") {
+    const s = raw.trim();
+    if (!s) return null;
+    if (/^\d+(\.\d+)?$/.test(s)) seconds = Number(s);
+    else selector = s;
+  }
+
+  if (seconds !== undefined) {
+    const clamped = Math.min(Math.max(seconds, 0), 30);
+    return { waitForTimeout: Math.round(clamped * 1000) };
+  }
+  if (selector) {
+    return { waitForSelector: { selector, timeout: 10000 } };
+  }
+  return null;
+}
+
 registerCapability("screenshot-url", async (input: CapabilityInput) => {
   const url = ((input.url as string) ?? (input.task as string) ?? "").trim();
   if (!url) throw new Error("'url' is required.");
@@ -10,7 +51,7 @@ registerCapability("screenshot-url", async (input: CapabilityInput) => {
   const fullPage = input.full_page !== false;
   const viewportWidth = (input.viewport_width as number) ?? 1280;
   const viewportHeight = (input.viewport_height as number) ?? 800;
-  const waitFor = (input.wait_for as string | number) ?? undefined;
+  const waitDirective = normalizeWaitFor(input.wait_for);
 
   // F-0-006: Browserless fetches the URL from its own network. validateUrl
   // is the only layer we own — refuse private-IP / bad-scheme before forwarding.
@@ -34,10 +75,8 @@ registerCapability("screenshot-url", async (input: CapabilityInput) => {
     viewport: { width: viewportWidth, height: viewportHeight },
   };
 
-  if (typeof waitFor === "number") {
-    bodyObj.waitForTimeout = waitFor * 1000;
-  } else if (typeof waitFor === "string") {
-    bodyObj.waitForSelector = { selector: waitFor, timeout: 10000 };
+  if (waitDirective) {
+    Object.assign(bodyObj, waitDirective);
   }
 
   const response = await fetch(endpoint, {

--- a/apps/api/src/capabilities/us-company-data.test.ts
+++ b/apps/api/src/capabilities/us-company-data.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression test for the missing-retry bug surfaced by 2026-07 x402 traffic.
+ * A `us-company-data` call for "Stripe Inc" failed with "SEC EDGAR search
+ * returned HTTP 500" while the identical query succeeds on retry — SEC
+ * EFTS/EDGAR intermittently 5xx's and 429's under fair-access throttling. The
+ * previous code surfaced the first 5xx straight to the caller.
+ *
+ * Post-fix: fetchSec delegates to the shared `withRetry` primitive and marks
+ * bare `HTTP 5xx` retryable (the shared default only covers 502/503/504/429,
+ * not the plain 500 seen in prod). Transient 5xx / 429 / network errors retry
+ * once; 4xx (incl. 404) is returned unretried.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { fetchSec } from "./us-company-data.js";
+
+function resp(status: number): Response {
+  return new Response(status === 200 ? "{}" : "", { status });
+}
+
+describe("fetchSec", () => {
+  it("retries a transient 500 and returns the eventual 200 (the bug case)", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(resp(500))
+      .mockResolvedValueOnce(resp(200));
+
+    const r = await fetchSec("https://x", "SEC EDGAR", fetchImpl);
+
+    expect(r.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries 429 throttling", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(resp(429))
+      .mockResolvedValueOnce(resp(200));
+
+    const r = await fetchSec("https://x", "SEC EDGAR", fetchImpl);
+    expect(r.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after the single retry on persistent 500", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(resp(500));
+
+    await expect(fetchSec("https://x", "SEC EDGAR", fetchImpl)).rejects.toThrow(/HTTP 500/);
+    // maxRetries:1 → 2 total attempts.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry a 404 — passes it straight through for the caller to interpret", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(resp(404));
+
+    const r = await fetchSec("https://x", "SEC EDGAR", fetchImpl);
+    expect(r.status).toBe(404);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient network error", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      // "fetch failed" matches withRetry's default retryable network patterns.
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce(resp(200));
+
+    const r = await fetchSec("https://x", "SEC EDGAR", fetchImpl);
+    expect(r.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/capabilities/us-company-data.test.ts
+++ b/apps/api/src/capabilities/us-company-data.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { fetchSec } from "./us-company-data.js";
+import { fetchSec, normalizeCompanyName, classifyNameMatch } from "./us-company-data.js";
 
 function resp(status: number): Response {
   return new Response(status === 200 ? "{}" : "", { status });
@@ -68,5 +68,68 @@ describe("fetchSec", () => {
     const r = await fetchSec("https://x", "SEC EDGAR", fetchImpl);
     expect(r.status).toBe(200);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Regression test for the wrong-company match risk flagged in the PR #148
+ * six-lens review. Name lookups resolve via SEC full-text filing search, which
+ * for a private company (e.g. "Stripe Inc") returns a *different* public filer
+ * that merely mentions the name. classifyNameMatch surfaces that as a low /
+ * non-exact match so callers don't trust a speculative identity.
+ */
+describe("normalizeCompanyName", () => {
+  it("strips corporate suffixes and punctuation so equivalents compare equal", () => {
+    expect(normalizeCompanyName("Apple Inc.")).toBe(normalizeCompanyName("APPLE INCORPORATED"));
+    expect(normalizeCompanyName("Meta Platforms, Inc.")).toBe("meta platforms");
+  });
+});
+
+describe("classifyNameMatch", () => {
+  it("flags exact when normalized names are equal", () => {
+    expect(classifyNameMatch("Apple Inc", "Apple Inc.")).toEqual({
+      match_confidence: "exact",
+      is_exact_match: true,
+    });
+  });
+
+  it("flags LOW when the resolved company is a different filer (the Stripe bug case)", () => {
+    // "Stripe Inc" (private, no filings) resolving to some unrelated public
+    // company that merely mentioned it in a filing.
+    const r = classifyNameMatch("Stripe Inc", "Block, Inc.");
+    expect(r.is_exact_match).toBe(false);
+    expect(r.match_confidence).toBe("low");
+  });
+
+  it("flags high when two multi-token names share most tokens", () => {
+    const r = classifyNameMatch("Berkshire Hathaway", "Berkshire Hathaway Energy");
+    expect(r.match_confidence).toBe("high");
+    expect(r.is_exact_match).toBe(false);
+  });
+
+  it("does NOT let a single-token name reach high against a different longer name", () => {
+    // "Stripe" shares its one token with "Stripe Financial Holdings" (Jaccard
+    // 1/2) but they are different companies — must be low, not a false high.
+    expect(classifyNameMatch("Stripe", "Stripe Financial Holdings").match_confidence).toBe("low");
+    expect(classifyNameMatch("Uber", "Uber Freight LLC").match_confidence).toBe("low");
+  });
+
+  it("flags low when two multi-token names share too few tokens", () => {
+    // Different companies that happen to share one word.
+    expect(classifyNameMatch("Meta Platforms", "Meta Materials").match_confidence).toBe("low");
+  });
+
+  it("errs toward LOW for a correct-but-abbreviated name (safe direction)", () => {
+    // False "low" is acceptable; a false "exact" asserting a wrong identity is not.
+    expect(classifyNameMatch("IBM", "International Business Machines Corp").match_confidence).toBe(
+      "low",
+    );
+  });
+
+  it("returns low, non-exact for an empty resolved name", () => {
+    expect(classifyNameMatch("Anything", "")).toEqual({
+      match_confidence: "low",
+      is_exact_match: false,
+    });
   });
 });

--- a/apps/api/src/capabilities/us-company-data.ts
+++ b/apps/api/src/capabilities/us-company-data.ts
@@ -1,5 +1,11 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { withRetry } from "../lib/retry.js";
+
+const SEC_HEADERS = {
+  "User-Agent": "Strale/1.0 admin@strale.io",
+  Accept: "application/json",
+} as const;
 
 // US company data via SEC EDGAR (free, no auth, requires User-Agent)
 const EDGAR_SEARCH = "https://www.sec.gov/cgi-bin/browse-edgar";
@@ -11,6 +17,49 @@ const CIK_RE = /^\d{1,10}$/;
 function findCik(input: string): string | null {
   const cleaned = input.replace(/[\s.-]/g, "");
   return CIK_RE.test(cleaned) ? cleaned.padStart(10, "0") : null;
+}
+
+/**
+ * Fetch a SEC endpoint, retrying once on transient upstream failure.
+ *
+ * SEC EFTS/EDGAR intermittently returns 5xx and 429 (fair-access throttling,
+ * max 10 req/s) even for well-formed requests (observed 2026-07: a "Stripe Inc"
+ * lookup failed with HTTP 500 while the same query succeeds on retry). We
+ * delegate to the shared `withRetry` primitive — its defaults already retry
+ * 429 / 502 / 503 / 504 and network errors; we add bare `HTTP 5xx` locally
+ * because a plain 500 is the exact case seen and isn't in the shared default
+ * set (widening the shared default would change retry behaviour for every
+ * capability, out of scope here). A 5xx/429 is surfaced as a retryable Error;
+ * 4xx (incl. 404) is returned unretried for the caller to interpret.
+ *
+ * Interaction with the route layer: on the /v1/do path, `executeWithRetry`
+ * (routes/do.ts) already wraps non-deterministic executors in another
+ * `withRetry`. For a bare 500 that layer does NOT re-retry (not in its default
+ * set), so this inner retry is the sole authority — matching the observed bug.
+ * For 429/502/503/504 the two layers stack (~4 attempts worst case); that's
+ * bounded and only on rare persistent failures. This retry is also what covers
+ * the x402 path, which does not go through `executeWithRetry` at all.
+ *
+ * `fetchImpl` is injectable for tests; defaults to global fetch.
+ */
+export function fetchSec(
+  url: string,
+  label: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  return withRetry(
+    async () => {
+      const response = await fetchImpl(url, {
+        headers: SEC_HEADERS,
+        signal: AbortSignal.timeout(10000),
+      });
+      if (response.status >= 500 || response.status === 429) {
+        throw new Error(`${label} returned HTTP ${response.status}`);
+      }
+      return response;
+    },
+    { maxRetries: 1, baseDelayMs: 400, slug: "us-company-data", retryableErrors: [/HTTP 5\d\d/i] },
+  );
 }
 
 async function extractCompanyName(text: string): Promise<string> {
@@ -29,13 +78,7 @@ async function extractCompanyName(text: string): Promise<string> {
 
 async function searchEdgar(name: string): Promise<string> {
   const url = `https://efts.sec.gov/LATEST/search-index?q=%22${encodeURIComponent(name)}%22&forms=10-K,10-Q,8-K&_source=ciks,display_names,biz_locations,inc_states,sics`;
-  const response = await fetch(url, {
-    headers: {
-      "User-Agent": "Strale/1.0 admin@strale.io",
-      Accept: "application/json",
-    },
-    signal: AbortSignal.timeout(10000),
-  });
+  const response = await fetchSec(url, "SEC EDGAR search");
   if (!response.ok) throw new Error(`SEC EDGAR search returned HTTP ${response.status}`);
   const data = (await response.json()) as any;
   const hits = data?.hits?.hits;
@@ -50,13 +93,7 @@ async function searchEdgar(name: string): Promise<string> {
 async function fetchCompany(cik: string): Promise<Record<string, unknown>> {
   const paddedCik = cik.padStart(10, "0");
   const url = `${EDGAR_COMPANY}/CIK${paddedCik}.json`;
-  const response = await fetch(url, {
-    headers: {
-      "User-Agent": "Strale/1.0 admin@strale.io",
-      Accept: "application/json",
-    },
-    signal: AbortSignal.timeout(10000),
-  });
+  const response = await fetchSec(url, "SEC EDGAR");
 
   if (response.status === 404) {
     throw new Error(`US company with CIK ${cik} not found in SEC EDGAR.`);

--- a/apps/api/src/capabilities/us-company-data.ts
+++ b/apps/api/src/capabilities/us-company-data.ts
@@ -19,6 +19,71 @@ function findCik(input: string): string | null {
   return CIK_RE.test(cleaned) ? cleaned.padStart(10, "0") : null;
 }
 
+export type MatchConfidence = "exact" | "high" | "low";
+
+// Common corporate suffixes / stopwords stripped before comparing names, so
+// "Apple Inc" and "Apple Inc." compare equal. Applied as standalone tokens
+// after punctuation has been flattened to spaces.
+const CORP_SUFFIX_RE =
+  /\b(incorporated|inc|corporation|corp|company|co|llc|ltd|limited|lp|plc|holdings?|group|the)\b/gi;
+
+/**
+ * Normalize a company name for fuzzy comparison: lowercase, flatten punctuation
+ * to spaces, drop common corporate suffixes, collapse whitespace.
+ */
+export function normalizeCompanyName(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(CORP_SUFFIX_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Classify how well the name the caller asked for matches the name SEC EDGAR
+ * actually returned for the resolved CIK.
+ *
+ * Why this exists: name lookups resolve via SEC full-text *filing* search
+ * (`searchEdgar`), which returns the top-scoring filing that mentions the query
+ * — not an entity lookup. For a private company with no filings of its own
+ * (e.g. "Stripe Inc" pre-IPO) every hit is a *different* public filer that
+ * merely mentions the name, so the capability would otherwise return someone
+ * else's identity with no signal. This surfaces that risk (per the DEC-
+ * 20260428-B "screening_signal" transparency spirit): callers gate on
+ * `is_exact_match` / `match_confidence` rather than trusting a fuzzy hit.
+ *
+ * Errs toward "low": a correct-but-abbreviated match (e.g. "IBM" vs
+ * "International Business Machines Corp") is flagged low, which is the safe
+ * direction — a false "low" prompts a caller to verify; a false "exact" would
+ * assert a wrong identity.
+ */
+export function classifyNameMatch(
+  searched: string,
+  matched: string,
+): { match_confidence: MatchConfidence; is_exact_match: boolean } {
+  const q = normalizeCompanyName(searched);
+  const m = normalizeCompanyName(matched);
+  if (!q || !m) return { match_confidence: "low", is_exact_match: false };
+  if (q === m) return { match_confidence: "exact", is_exact_match: true };
+
+  const qTokens = new Set(q.split(" "));
+  const mTokens = new Set(m.split(" "));
+  const intersection = [...qTokens].filter((t) => mTokens.has(t)).length;
+  // Both sets are non-empty here (guarded above), so union is too.
+  const jaccard = intersection / new Set([...qTokens, ...mTokens]).size;
+
+  // A partial overlap only counts as "high" when BOTH names carry ≥2 tokens.
+  // A single-token name (Stripe, Uber, Meta) that shares its one token with a
+  // longer, different name ("Stripe Financial Holdings") is not a confident
+  // match and must fall through to "low" — otherwise Jaccard 1/2 would call it
+  // "high", the exact false-confidence this signal exists to prevent.
+  const bothMultiToken = qTokens.size >= 2 && mTokens.size >= 2;
+  return bothMultiToken && jaccard >= 0.5
+    ? { match_confidence: "high", is_exact_match: false }
+    : { match_confidence: "low", is_exact_match: false };
+}
+
 /**
  * Fetch a SEC endpoint, retrying once on transient upstream failure.
  *
@@ -133,12 +198,45 @@ registerCapability("us-company-data", async (input: CapabilityInput) => {
 
   const trimmed = raw.trim();
   let cik = findCik(trimmed);
+  // Null when the caller supplied a CIK directly (an authoritative, exact
+  // lookup with no name-matching ambiguity); set to the resolved name when we
+  // had to search EDGAR for it.
+  let searchedName: string | null = null;
   if (!cik) {
-    const name = await extractCompanyName(trimmed);
-    cik = await searchEdgar(name);
+    searchedName = await extractCompanyName(trimmed);
+    cik = await searchEdgar(searchedName);
   }
 
-  const output = await fetchCompany(cik);
+  const company = await fetchCompany(cik);
+
+  const match =
+    searchedName === null
+      ? { match_confidence: "exact" as MatchConfidence, is_exact_match: true }
+      : classifyNameMatch(searchedName, String(company.company_name ?? ""));
+
+  // Refuse to *assert* a low-confidence identity by default. A name search
+  // resolves via SEC full-text filing search, so a private company with no
+  // filings (e.g. "Stripe Inc") resolves to a different public filer that
+  // merely mentions the name. Returning that identity would let a bundled KYB
+  // solution pipe the wrong company straight into sanctions/PEP screening
+  // (DEC-20260428-B: never assert a fact not in the input). Callers who want
+  // the best-effort match opt in explicitly with allow_low_confidence.
+  const allowLowConfidence = input.allow_low_confidence === true;
+  if (match.match_confidence === "low" && !allowLowConfidence) {
+    const closest = company.company_name ? ` ("${company.company_name}")` : "";
+    throw new Error(
+      `No confident SEC EDGAR match for "${searchedName}". The closest filing belongs to a different entity${closest}, ` +
+        `which is common for private companies with no SEC filings of their own. Supply the company's CIK for an exact ` +
+        `lookup, or pass allow_low_confidence=true to receive the best-effort match with its confidence flags.`,
+    );
+  }
+
+  const output = {
+    ...company,
+    searched_name: searchedName,
+    match_confidence: match.match_confidence,
+    is_exact_match: match.is_exact_match,
+  };
 
   return {
     output,

--- a/manifests/us-company-data.yaml
+++ b/manifests/us-company-data.yaml
@@ -19,6 +19,12 @@ input_schema:
     company:
       type: string
       description: CIK number, ticker symbol, or company name
+    allow_low_confidence:
+      type: boolean
+      description: >-
+        If true, return the best-effort match even when the name could not be confidently resolved
+        (match_confidence "low"). Default false — a low-confidence name lookup errors instead of returning
+        a possibly-wrong company identity, so it can't silently feed downstream screening.
 output_schema:
   type: object
   example:
@@ -34,6 +40,9 @@ output_schema:
     company_name: Apple Hospitality REIT, Inc.
     fiscal_year_end: "1231"
     sic_description: Real Estate Investment Trusts
+    searched_name: null
+    match_confidence: exact
+    is_exact_match: true
   properties:
     status:
       type:
@@ -53,6 +62,21 @@ output_schema:
       type: string
     fiscal_year_end:
       type: string
+    searched_name:
+      type:
+        - string
+        - "null"
+      description: The company name that was resolved and searched; null when a CIK was supplied directly
+    match_confidence:
+      type: string
+      enum:
+        - exact
+        - high
+        - low
+      description: Confidence that the returned entity is the one asked for. "low" means the name search may have matched a different filer that merely mentions the name
+    is_exact_match:
+      type: boolean
+      description: True only when the resolved company name matches the queried name after normalization (or a CIK was supplied directly)
 data_source: SEC EDGAR (US Securities and Exchange Commission)
 data_source_type: api
 transparency_tag: ai_generated
@@ -81,6 +105,9 @@ output_field_reliability:
   sic_code: rare
   company_name: guaranteed
   fiscal_year_end: guaranteed
+  match_confidence: guaranteed
+  is_exact_match: guaranteed
+  searched_name: common
 limitations:
   - title: SEC coverage varies by state — some states have limited registry data
     text: >-
@@ -89,6 +116,20 @@ limitations:
     category: coverage
     severity: warning
     workaround: For states with limited coverage, supplement with the state's Secretary of State website directly
+  - title: Name lookups can return a different company that merely mentions the name
+    text: >-
+      Company-name (and ticker) lookups resolve via SEC full-text *filing* search, which returns the top-scoring
+      filing that mentions the query — not an entity lookup. A private company with no SEC filings of its own (e.g.
+      a pre-IPO firm like Stripe) has no filing to match, so the top hit is a *different* public filer that merely
+      mentions the name. By default a low-confidence name lookup errors rather than returning that wrong identity,
+      so it can't silently feed downstream sanctions/PEP screening; confident matches return normally with
+      match_confidence "exact"/"high".
+    category: accuracy
+    severity: warning
+    workaround: >-
+      Supply the CIK directly for an exact, unambiguous lookup. To receive the best-effort match for an
+      unresolved name anyway, pass allow_low_confidence=true and gate on the returned is_exact_match /
+      match_confidence fields yourself.
   - title: Private company financial data is not included — public filings only
     text: Does not include privately held financial data — only publicly filed information
     category: coverage


### PR DESCRIPTION
## Summary
Three reliability/correctness fixes for capabilities that failed in **production x402 traffic on 2026-07-04** (surfaced via `/activity`), plus a follow-up caught in review:

1. **`screenshot-url`** — `wait_for:"3"` (numeric string = "wait 3 seconds") was routed into the `waitForSelector` branch → bogus CSS selector → **HTTP 400**. `normalizeWaitFor` now maps numbers **and** numeric strings → `waitForTimeout` (clamped 0–30s); only non-numeric strings → selector.
2. **`us-company-data` retry** — a "Stripe Inc" lookup failed hard with `SEC EDGAR returned HTTP 500`. SEC EFTS/EDGAR 5xx/429s transiently; `fetchSec` now delegates to the shared `withRetry` primitive with a local `/HTTP 5\d\d/` pattern (shared default omits bare 500). Also covers the x402 path (bypasses route-level `executeWithRetry`).
3. **`us-company-data` low-confidence guard** (review follow-up) — name lookups resolve via SEC full-text *filing* search, so a private company like "Stripe Inc" resolves to a *different* public filer that merely mentions the name. That wrong identity was flowing straight into the bundled KYB solutions' `sanctions-check`/`pep-check` steps (`solution-executor` maps `$steps[0].company_name` with no gate). Now `classifyNameMatch` scores the resolved name vs the queried name (exact / high / low), and a **low-confidence name lookup errors by default** rather than asserting a wrong identity (DEC-20260428-B). New output fields `match_confidence` / `is_exact_match` / `searched_name`; `allow_low_confidence=true` opts into best-effort. CIK/direct lookups are exact by construction.

## Verification
- `tsc --noEmit` — **pass**
- `vitest` (2 files, **21 tests**) — **pass**; each fails pre-fix / passes post-fix
- `validate-capability` both slugs — **pass**
- CI manifest gates run locally (`check-manifest-guaranteed-consistency --strict`, `check-identity-fixture-shape --strict`) — **exit 0**
- Live-probed the SEC endpoint + Browserless `/screenshot` wait options before writing the fixes

## Reviewer findings (six-lens, all fixes — resolved)
- **HIGH (fix 3, resolved):** low-confidence wrong-company identity flowed into sanctions/PEP screening via the KYB solution chain. Fixed at the source — the capability refuses to assert a low-confidence identity by default.
- **MEDIUM (resolved):** single-token names (Stripe/Uber) could reach a false `high`; now require both names ≥2 tokens before `high`.
- **MEDIUM (fix 2, documented):** executor retry stacks with route-level retry for 429/502/503/504 (the bare-500 case correctly does NOT stack). Bounded, documented in the `fetchSec` docstring.

## Known limitation — DB metadata not backfilled
The new `us-company-data` output/input fields are documented in the manifest but **not yet persisted to the DB** — `onboard --backfill` is blocked by **pre-existing manifest↔DB authority drift** on this capability (the DB's stored `output_schema` claims phantom `jurisdiction`/`vat_number` fields the executor never emits). The runtime fixes work regardless; catalog/audit documentation of the new fields waits on the broader manifest↔DB reconciliation (tracked separately). No CI gate enforces DB-sync.

## Test plan
- Confirm CI green (typecheck + vitest + manifest gates).
- Optional manual: `us-company-data` with `{company:"Apple Inc"}` → exact match; with `{company:"Stripe Inc"}` → errors with the low-confidence message; with `{company:"Stripe Inc", allow_low_confidence:true}` → best-effort match + `match_confidence:"low"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)