### PR TITLE
fix(screenshot-url): speak the Browserless dialect prod actually runs (v1 vs v2 wait keys)

### DIFF
--- a/apps/api/src/capabilities/screenshot-url.test.ts
+++ b/apps/api/src/capabilities/screenshot-url.test.ts
@@ -10,8 +10,17 @@
  * ms, clamped 0..30); only non-numeric strings become selectors.
  */
 
-import { describe, it, expect } from "vitest";
-import { normalizeWaitFor } from "./screenshot-url.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../lib/url-validator.js", () => ({ validateUrl: vi.fn(async () => {}) }));
+
+import {
+  normalizeWaitFor,
+  toV1WaitFor,
+  isWaitKeyRejection,
+  waitDialectByHost,
+} from "./screenshot-url.js";
+import { getDirectExecutor } from "./index.js";
 
 describe("normalizeWaitFor", () => {
   it('treats a numeric string ("3") as a 3-second timeout, not a selector (the bug case)', () => {
@@ -49,5 +58,206 @@ describe("normalizeWaitFor", () => {
   it("returns null for a non-finite number", () => {
     expect(normalizeWaitFor(NaN)).toBeNull();
     expect(normalizeWaitFor(Infinity)).toBeNull();
+  });
+});
+
+/**
+ * Regression tests for the Browserless v1 fallback (2026-08). The production
+ * chromium service is pinned to Browserless v1 (`browserless/chrome:1.61.1`,
+ * apps/api/railway-config.md), which Joi-rejects the v2 keys — first observed
+ * as `"waitForSelector" is not allowed` pre-PR-148, then as
+ * `"waitForTimeout" is not allowed` once PR #148 mapped numeric waits to the
+ * other v2 key. v1 wants a single `waitFor` (number = ms, string = selector).
+ */
+describe("toV1WaitFor", () => {
+  it("maps a v2 timeout directive to waitFor milliseconds", () => {
+    expect(toV1WaitFor({ waitForTimeout: 3000 })).toEqual({ waitFor: 3000 });
+  });
+
+  /**
+   * Security regression (Pass-A H-1). v1's handler branches on typeof: an
+   * OBJECT goes to `page.waitForSelector`, but a bare STRING is interpolated
+   * unescaped into `page.evaluate(...querySelector("<raw>"))` and then run as
+   * `page.evaluate('(<raw>)()')` — caller-supplied JS inside the chromium
+   * container. The object form is the only safe shape, and it also carries
+   * the timeout a bare string has nowhere to put.
+   */
+  it("maps a v2 selector directive to the SAFE v1 object form, never a bare string", () => {
+    const out = toV1WaitFor({ waitForSelector: { selector: "#main", timeout: 10000 } });
+    expect(out).toEqual({ waitFor: { selector: "#main", timeout: 10000 } });
+    expect(typeof out.waitFor).not.toBe("string");
+  });
+
+  it("keeps a JS-injection payload inside the object form (no evaluate path)", () => {
+    const payload = '") || fetch("http://169.254.169.254/latest/meta-data";';
+    const out = toV1WaitFor({ waitForSelector: { selector: payload, timeout: 10000 } });
+    expect(out.waitFor).toEqual({ selector: payload, timeout: 10000 });
+  });
+});
+
+describe("isWaitKeyRejection", () => {
+  it("recognizes the v1 Joi rejection of waitForTimeout (the prod bug case)", () => {
+    const body =
+      '[{"message":"\\"waitForTimeout\\" is not allowed","path":["waitForTimeout"],"type":"object.unknown"}]';
+    expect(isWaitKeyRejection(400, body)).toBe(true);
+  });
+
+  it("recognizes the v1 Joi rejection of waitForSelector", () => {
+    const body = '[{"message":"\\"waitForSelector\\" is not allowed","path":["waitForSelector"]}]';
+    expect(isWaitKeyRejection(400, body)).toBe(true);
+  });
+
+  /**
+   * Captured live from production-sfo.browserless.io (v2) on 2026-08-05 by
+   * POSTing the v1 `waitFor` shape. v2 uses ajv, not Joi, so it does NOT
+   * emit the `"X" is not allowed` phrasing — matching only the Joi form
+   * would strand a process that memoized v1 against a host later upgraded
+   * to v2 (no retry, hard fail on every wait_for call until restart).
+   */
+  it("recognizes the REAL v2 ajv rejection of the v1 waitFor key (symmetry guard)", () => {
+    expect(
+      isWaitKeyRejection(400, "POST Body validation failed: must NOT have additional properties\n"),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated 400s (bad URL, nav timeout)", () => {
+    expect(isWaitKeyRejection(400, "Navigation timeout of 25000 ms exceeded")).toBe(false);
+  });
+
+  it("does not match non-400 statuses", () => {
+    expect(isWaitKeyRejection(500, '"waitForTimeout" is not allowed')).toBe(false);
+  });
+});
+
+describe("executor v1 fallback", () => {
+  const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer;
+  const V1_REJECTION =
+    '[{"message":"\\"waitForTimeout\\" is not allowed","path":["waitForTimeout"],"type":"object.unknown"}]';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env.BROWSERLESS_URL = "http://chromium.test:8080";
+    process.env.BROWSERLESS_API_KEY = "test-token";
+    waitDialectByHost.clear();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const sentBody = (call: number): Record<string, unknown> =>
+    JSON.parse(fetchMock.mock.calls[call][1].body as string);
+
+  it("retries with v1 waitFor when the endpoint rejects waitForTimeout (the prod bug case)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(V1_REJECTION, { status: 400 }))
+      .mockResolvedValueOnce(new Response(PNG, { status: 200 }));
+
+    const exec = getDirectExecutor("screenshot-url")!;
+    const result = await exec({ url: "https://example.com/", wait_for: "3" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(sentBody(0)).toMatchObject({ waitForTimeout: 3000 });
+    expect(sentBody(1)).toMatchObject({ waitFor: 3000 });
+    expect(sentBody(1)).not.toHaveProperty("waitForTimeout");
+    expect((result.output as Record<string, unknown>).size_bytes).toBe(4);
+    expect(waitDialectByHost.get("chromium.test:8080")).toBe("v1");
+  });
+
+  it("skips the probe once the host's dialect is memoized (no wasted roundtrip)", async () => {
+    waitDialectByHost.set("chromium.test:8080", "v1");
+    fetchMock.mockResolvedValueOnce(new Response(PNG, { status: 200 }));
+
+    const exec = getDirectExecutor("screenshot-url")!;
+    await exec({ url: "https://example.com/", wait_for: "3" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sentBody(0)).toMatchObject({ waitFor: 3000 });
+    expect(sentBody(0)).not.toHaveProperty("waitForTimeout");
+  });
+
+  it("memoizes v2 when the first v2-shaped call succeeds", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(PNG, { status: 200 }));
+
+    const exec = getDirectExecutor("screenshot-url")!;
+    await exec({ url: "https://example.com/", wait_for: "3" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sentBody(0)).toMatchObject({ waitForTimeout: 3000 });
+    expect(waitDialectByHost.get("chromium.test:8080")).toBe("v2");
+  });
+
+  it("does not retry on unrelated 400s", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("Navigation timeout of 25000 ms exceeded", { status: 400 }),
+    );
+
+    const exec = getDirectExecutor("screenshot-url")!;
+    await expect(exec({ url: "https://example.com/", wait_for: "3" })).rejects.toThrow(
+      /HTTP 400.*Navigation timeout/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends a selector as the v1 object form on the retry (security regression)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          '[{"message":"\\"waitForSelector\\" is not allowed","path":["waitForSelector"]}]',
+          { status: 400 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(PNG, { status: 200 }));
+
+    const exec = getDirectExecutor("screenshot-url")!;
+    await exec({ url: "https://example.com/", wait_for: "#main" });
+
+    expect(sentBody(1)).toMatchObject({ waitFor: { selector: "#main", timeout: 10000 } });
+    expect(typeof (sentBody(1) as { waitFor: unknown }).waitFor).not.toBe("string");
+  });
+
+  it("surfaces a framed error and does not memoize when both dialects are rejected", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(V1_REJECTION, { status: 400 }))
+      .mockResolvedValueOnce(
+        new Response("POST Body validation failed: must NOT have additional properties", {
+          status: 400,
+        }),
+      );
+
+    const exec = getDirectExecutor("screenshot-url")!;
+    await expect(exec({ url: "https://example.com/", wait_for: "3" })).rejects.toThrow(
+      /rejected both supported wait dialects/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(waitDialectByHost.has("chromium.test:8080")).toBe(false);
+  });
+
+  it("recovers when a memoized dialect goes stale (host upgraded to v2 under a warm process)", async () => {
+    waitDialectByHost.set("chromium.test:8080", "v1");
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response("POST Body validation failed: must NOT have additional properties", {
+          status: 400,
+        }),
+      )
+      .mockResolvedValueOnce(new Response(PNG, { status: 200 }));
+
+    const exec = getDirectExecutor("screenshot-url")!;
+    await exec({ url: "https://example.com/", wait_for: "3" });
+
+    expect(sentBody(0)).toMatchObject({ waitFor: 3000 });
+    expect(sentBody(1)).toMatchObject({ waitForTimeout: 3000 });
+    expect(waitDialectByHost.get("chromium.test:8080")).toBe("v2");
+  });
+
+  it("does not retry when no wait_for was requested", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("boom", { status: 500 }));
+
+    const exec = getDirectExecutor("screenshot-url")!;
+    await expect(exec({ url: "https://example.com/" })).rejects.toThrow(/HTTP 500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/capabilities/screenshot-url.ts
+++ b/apps/api/src/capabilities/screenshot-url.ts
@@ -2,6 +2,7 @@ import { registerCapability, type CapabilityInput } from "./index.js";
 import { getBrowserlessConfig } from "./lib/browserless-extract.js";
 import { buildBrowserlessRequestUrl } from "../lib/browserless-launch.js";
 import { validateUrl } from "../lib/url-validator.js";
+import { logWarn } from "../lib/log.js";
 
 /**
  * Normalize the `wait_for` input into a Browserless wait directive.
@@ -44,6 +45,71 @@ export function normalizeWaitFor(
   return null;
 }
 
+/**
+ * Downgrade a v2 wait directive to the Browserless v1 `waitFor` key.
+ *
+ * The production chromium service is pinned to Browserless v1
+ * (`browserless/chrome:1.61.1`, see apps/api/railway-config.md), whose Joi
+ * schema predates the discrete v2 keys — it rejects both `waitForTimeout`
+ * and `waitForSelector` with HTTP 400 `"...is not allowed"`. v1 takes a
+ * single `waitFor`, overloaded by JS type. The SaaS endpoint used in local
+ * dev speaks v2 and conversely rejects `waitFor`, so the executor probes with
+ * one dialect, retries with the other on the rejection, and memoizes the
+ * winner per host (see waitDialectByHost) so only the first call per process
+ * pays the probe.
+ *
+ * A selector MUST be sent as the object form, never a bare string. v1's
+ * handler (`functions/screenshot.js:144-162` at tag v1.61.1) branches on
+ * typeof: an object destructures to `page.waitForSelector(selector, options)`,
+ * but a *string* is interpolated unescaped into
+ * `page.evaluate('document.createDocumentFragment().querySelector("<raw>")')`
+ * and, if that probe fails, executed as `page.evaluate('(<raw>)()')` — i.e.
+ * caller-supplied JS running inside the chromium container, on Railway's
+ * private network, which is exactly what the validateUrl guard below exists
+ * to prevent. The object form also keeps the selector timeout, which a bare
+ * string has no slot for.
+ */
+export function toV1WaitFor(
+  directive: NonNullable<ReturnType<typeof normalizeWaitFor>>,
+): { waitFor: number | { selector: string; timeout: number } } {
+  if ("waitForTimeout" in directive) return { waitFor: directive.waitForTimeout };
+  return { waitFor: { ...directive.waitForSelector } };
+}
+
+/**
+ * Does this 400 mean "you sent the wrong dialect's wait key"?
+ *
+ * The two versions reject unknown keys with different validators, and both
+ * strings below were captured from live endpoints (2026-08-05) rather than
+ * assumed:
+ *   v1 (Joi)  → `[{"message":"\"waitForTimeout\" is not allowed",...}]`
+ *   v2 (ajv)  → `POST Body validation failed: must NOT have additional properties`
+ *
+ * The v2 string doesn't name the offending key, but every other property this
+ * executor sends (url, gotoOptions, options, viewport) is fixed and accepted
+ * by both versions, so the wait key is the only thing it can be referring to.
+ * Matching only the Joi form would strand a process that had memoized v1
+ * against a host later upgraded to v2: no retry would fire and every
+ * wait_for call would hard-fail until restart.
+ */
+export function isWaitKeyRejection(status: number, errBody: string): boolean {
+  if (status !== 400) return false;
+  // v1: the key sits inside a JSON string value, so its quotes arrive
+  // backslash-escaped in the raw body (`\"waitForTimeout\"`).
+  if (/\\?"waitFor(Timeout|Selector)?\\?" is not allowed/.test(errBody)) return true;
+  // v2: ajv's additionalProperties failure.
+  return /must NOT have additional properties/i.test(errBody);
+}
+
+/**
+ * Which wait dialect each Browserless host speaks, learned from the first
+ * successful wait-carrying call. The dialect is a static property of the
+ * configured endpoint (env-driven, fixed for the process lifetime), so
+ * without this memo the pinned-v1 prod service would pay the probe 400 +
+ * retry on every wait_for call forever. Exported for test reset only.
+ */
+export const waitDialectByHost = new Map<string, "v1" | "v2">();
+
 registerCapability("screenshot-url", async (input: CapabilityInput) => {
   const url = ((input.url as string) ?? (input.task as string) ?? "").trim();
   if (!url) throw new Error("'url' is required.");
@@ -75,20 +141,63 @@ registerCapability("screenshot-url", async (input: CapabilityInput) => {
     viewport: { width: viewportWidth, height: viewportHeight },
   };
 
-  if (waitDirective) {
-    Object.assign(bodyObj, waitDirective);
-  }
+  const shoot = (waitShape: Record<string, unknown> | null) =>
+    fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(waitShape ? { ...bodyObj, ...waitShape } : bodyObj),
+      signal: AbortSignal.timeout(40000),
+    });
 
-  const response = await fetch(endpoint, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(bodyObj),
-    signal: AbortSignal.timeout(40000),
-  });
+  const throwBrowserlessError: (status: number, err: string, note?: string) => never = (
+    status,
+    err,
+    note,
+  ) => {
+    throw new Error(
+      `Browserless screenshot returned HTTP ${status}${note ? ` (${note})` : ""}: ${err.slice(0, 200)}`,
+    );
+  };
+
+  let response: Response;
+  if (waitDirective) {
+    const host = new URL(endpoint).host;
+    const shapeFor = (d: "v1" | "v2") => (d === "v1" ? toV1WaitFor(waitDirective) : waitDirective);
+    let dialect = waitDialectByHost.get(host) ?? "v2";
+
+    response = await shoot(shapeFor(dialect));
+    if (!response.ok) {
+      const err = await response.text().catch(() => "");
+      if (!isWaitKeyRejection(response.status, err)) throwBrowserlessError(response.status, err);
+      // Endpoint speaks the other dialect (see toV1WaitFor) — retry with it.
+      const rejected = dialect;
+      dialect = dialect === "v1" ? "v2" : "v1";
+      // The 2026-07 incident was a *silent* per-call 400 that ran for a month.
+      // Log the flip so a future dialect change leaves a trace before it
+      // becomes a customer-visible failure again.
+      logWarn(
+        "screenshot-wait-dialect-fallback",
+        `Browserless host rejected ${rejected} wait keys — retrying with ${dialect}`,
+        { browserless_host: host, rejected_dialect: rejected, retrying_with: dialect },
+      );
+      response = await shoot(shapeFor(dialect));
+      if (!response.ok) {
+        const retryErr = await response.text().catch(() => "");
+        throwBrowserlessError(
+          response.status,
+          retryErr,
+          "target rejected both supported wait dialects; try omitting wait_for",
+        );
+      }
+    }
+    waitDialectByHost.set(host, dialect);
+  } else {
+    response = await shoot(null);
+  }
 
   if (!response.ok) {
     const err = await response.text().catch(() => "");
-    throw new Error(`Browserless screenshot returned HTTP ${response.status}: ${err.slice(0, 200)}`);
+    throwBrowserlessError(response.status, err);
   }
 
   const buffer = Buffer.from(await response.arrayBuffer());


### PR DESCRIPTION
## Summary

- **`screenshot-url` has been 400-failing on every `wait_for` call in production for a month.** PR #148 fixed the original `wait_for:"3"` bug by mapping to Browserless **v2** keys and verified against the v2 SaaS endpoint — but production's chromium service is pinned to **v1** (`browserless/chrome:1.61.1`, see `apps/api/railway-config.md`), which Joi-rejects `waitForTimeout`. 13 real x402 failures in the last 16 days (surfaced by `/activity`). The manifest's own documented workaround for JS-heavy pages ("use `wait_for` to target a CSS selector") was equally dead, since v1 rejects `waitForSelector` too.
- The executor now sends one dialect, retries once with the other on a wait-key rejection, and **memoizes the winner per endpoint host** so only the first call per process pays the probe.
- **Security fix folded in (found by review, verified against the vendor source):** selectors now go as v1's *object* form, never a bare string.

## The security issue this closes

`browserless/chrome` v1.61.1 `functions/screenshot.js:144-162` branches on `typeof waitFor`:

- **object** → `page.waitForSelector(selector, options)` — safe.
- **string** → interpolated *unescaped* into ``page.evaluate(`document.createDocumentFragment().querySelector("${waitFor}")`)``, and if that probe fails, executed as ``page.evaluate(`(${waitFor})()`)``.

A bare-string selector would therefore have put **caller-supplied JavaScript inside the chromium container on Railway's private network** — defeating the `validateUrl` guard whose own comment says it exists because "Browserless fetches the URL from its own network… validateUrl is the only layer we own." `screenshot-url` is x402-enabled (anonymous, no signup), so this was reachable. v1's Joi schema accepts `{selector, visible, hidden, timeout}`, which routes to the safe branch — and is the only shape with a slot for the selector timeout.

Never shipped: pre-fix, every `wait_for` prod call 400'd, so no string ever reached v1's evaluator. This PR is what would have connected them.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit --project tsconfig.json` (apps/api) | clean |
| `vitest run screenshot-url.test.ts` | 24/24 pass |
| `validate-capability.ts --slug screenshot-url` | all checks pass |
| `smoke-test.ts --slug screenshot-url` | 11/11 steps pass |
| `checkReadiness("screenshot-url")` | `ready: true`, 0 issues |
| Live Browserless probe | both v2 shapes → 200; both v1 shapes → 400 (confirms the fallback trigger is real) |

Both rejection strings are **captured from live endpoints (2026-08-05), not assumed** — v2 uses ajv (`must NOT have additional properties`), *not* Joi's `"X" is not allowed`. Matching only the Joi form would have stranded a warm process that memoized v1 against a host later upgraded to v2: no retry, hard-fail on every `wait_for` call until restart. There is a regression test for that exact stale-memo recovery.

## Reviewer findings

Six-lens review (technical + product passes). **1 HIGH — fixed in this PR** (the `page.evaluate` vector above). MEDIUMs:

- **Dialect knowledge is capability-local.** `waitDialectByHost` / `isWaitKeyRejection` arguably belong beside `buildBrowserlessRequestUrl` in `lib/browserless-launch.ts`. Left local because `screenshot-url` is today the *only* caller sending a version-sensitive wait key — every other Browserless caller sends just `gotoOptions.waitUntil`, which is stable across v1/v2. Flagged as debt for the next caller that needs a wait key.
- **`browserless-launch.ts` docstring says "Build a Browserless **v2** request URL"** while prod is pinned v1. Misleading regardless of this PR; not fixed here to keep the diff to one concern.
- **v1 selector waits are bounded by the object form's `timeout`** (10s), which the bare-string form could not express. This is why the security fix is also the correctness fix.
- **Cold-start default is v2** while the only prod host is v1, so each fresh process burns one fast 400 before memoizing. Self-correcting and negligible; inverting it would just move the cost to dev.
- **No comms possible to affected callers** — x402 is anonymous by design (payment is auth) and charge-on-success means nothing was billed for the failures, but the errors were real.

## Test plan

1. Merge; wait for Railway to report the new SHA at `GET /health`.
2. `POST /v1/do` with `{"capability_slug":"screenshot-url","max_price_cents":50,"inputs":{"url":"https://www.tenex.co/","wait_for":"3"}}` → expect 200 with `base64_png` (this exact call 400s on current prod).
3. Repeat with `"wait_for":"h1"` to exercise the selector path.
4. Check logs for one `screenshot-wait-dialect-fallback` warn on the first call and none after — that's the memo working.