### PR TITLE
fix(product-reviews-extract): refuse ToS-prohibited targets before fetching

### DIFF
--- a/apps/api/src/capabilities/lib/tos-blocklist.test.ts
+++ b/apps/api/src/capabilities/lib/tos-blocklist.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression tests for the ToS blocklist (2026-08-05).
+ *
+ * Origin: `product-reviews-extract` took 31 x402 calls over 2026-07-20 →
+ * 2026-08-05 and failed 28 of them, every one a `trustpilot.com/review/*` URL
+ * returning HTTP 403. The capability was advertising Trustpilot in its own
+ * description and error text while the sibling `trustpilot-score` capability
+ * sat deactivated for that exact ToS reason, so callers were being steered
+ * into a wall and retrying the same URL 3-4 times.
+ *
+ * The deeper defect: deactivating a *named* capability does not stop a
+ * capability that accepts an arbitrary URL from reaching the same host.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  findProhibitedTarget,
+  assertTargetAllowed,
+  PROHIBITED_TARGETS,
+  TOS_REFUSAL_MARKER,
+} from "./tos-blocklist.js";
+import { isUserInputError } from "../../lib/circuit-breaker.js";
+
+describe("findProhibitedTarget", () => {
+  it("blocks the exact URL shape customers were retrying (the bug case)", () => {
+    const hit = findProhibitedTarget("https://www.trustpilot.com/review/majority.co.uk");
+    expect(hit?.site).toBe("Trustpilot");
+  });
+
+  it("blocks country subdomains, which callers also used", () => {
+    // uk.trustpilot.com appeared in the same production window.
+    expect(findProhibitedTarget("https://uk.trustpilot.com/review/imaanactive.co.uk")?.site).toBe(
+      "Trustpilot",
+    );
+  });
+
+  it("blocks a scheme-less host, since the executors prepend https://", () => {
+    expect(findProhibitedTarget("trustpilot.com/review/stripe.com")?.site).toBe("Trustpilot");
+  });
+
+  it("blocks linkedin.com, which tech-stack-detect was fetching successfully", () => {
+    expect(findProhibitedTarget("https://www.linkedin.com")?.site).toBe("LinkedIn");
+    expect(findProhibitedTarget("https://www.linkedin.com/company/hygenco/")?.site).toBe("LinkedIn");
+  });
+
+  it("is case-insensitive on the host", () => {
+    expect(findProhibitedTarget("https://WWW.TrustPilot.COM/review/x")?.site).toBe("Trustpilot");
+  });
+
+  it("does not block the sources that legitimately succeeded in production", () => {
+    // These three completed in the same window and must keep working.
+    expect(findProhibitedTarget("https://www.consumerlab.com/primaforce/")).toBeNull();
+    expect(findProhibitedTarget("https://www.reviews.io/company-reviews/store/unilever")).toBeNull();
+    expect(findProhibitedTarget("https://nutrigardens.tenereteam.com/")).toBeNull();
+  });
+
+  it("does not block a lookalike host that merely contains a blocked name", () => {
+    expect(findProhibitedTarget("https://trustpilot.com.example.org/review/x")).toBeNull();
+    expect(findProhibitedTarget("https://nottrustpilot.com/review/x")).toBeNull();
+    expect(findProhibitedTarget("https://mylinkedin.com")).toBeNull();
+  });
+
+  it("scopes a path-limited rule to that path only", () => {
+    // The ruling covers Google Search, not all of google.com.
+    expect(findProhibitedTarget("https://www.google.com/search?q=shoes")?.site).toBe(
+      "Google Search",
+    );
+    expect(findProhibitedTarget("https://www.google.com/")).toBeNull();
+    expect(findProhibitedTarget("https://patents.google.com/patent/US123")?.site).toBe(
+      "Google Patents",
+    );
+  });
+
+  it("returns null for unparseable input rather than claiming a policy hit", () => {
+    expect(findProhibitedTarget("")).toBeNull();
+    expect(findProhibitedTarget("   ")).toBeNull();
+    expect(findProhibitedTarget("http://")).toBeNull();
+  });
+
+  it("ignores a trailing dot on the hostname (FQDN form)", () => {
+    expect(findProhibitedTarget("https://trustpilot.com./review/x")?.site).toBe("Trustpilot");
+  });
+});
+
+describe("assertTargetAllowed", () => {
+  it("passes an allowed target through silently", () => {
+    expect(() => assertTargetAllowed("https://www.consumerlab.com/primaforce/")).not.toThrow();
+  });
+
+  it("throws an actionable message: what, why, retry won't help, what to use", () => {
+    let message = "";
+    try {
+      assertTargetAllowed("https://www.trustpilot.com/review/stripe.com");
+    } catch (e) {
+      message = (e as Error).message;
+    }
+
+    expect(message).toContain("Trustpilot");
+    expect(message).toContain(TOS_REFUSAL_MARKER);
+    expect(message).toMatch(/retrying .* will not succeed/i);
+    expect(message).toContain("Reviews.io");
+  });
+
+  it("does not leak the internal decision id to callers", () => {
+    let message = "";
+    try {
+      assertTargetAllowed("https://www.trustpilot.com/review/x");
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).not.toMatch(/DEC-\d/);
+  });
+});
+
+describe("blocklist integrity", () => {
+  it("every rule carries a governing decision and an alternative", () => {
+    for (const rule of PROHIBITED_TARGETS) {
+      expect(rule.decision, `${rule.host} missing decision`).toMatch(/^DEC-/);
+      expect(rule.alternatives.length, `${rule.host} missing alternatives`).toBeGreaterThan(0);
+      expect(rule.host).not.toMatch(/^https?:|\//);
+    }
+  });
+
+  it("every thrown message carries the marker the circuit breaker matches on", () => {
+    // If this drifts, a policy refusal starts counting as a capability
+    // failure and a burst of blocked URLs trips the breaker for everyone.
+    for (const rule of PROHIBITED_TARGETS) {
+      const url = `https://${rule.host}${rule.pathPrefix ?? "/"}`;
+      expect(() => assertTargetAllowed(url)).toThrow(TOS_REFUSAL_MARKER);
+    }
+  });
+
+  it("the circuit breaker actually classifies a refusal as user-input, not a fault", () => {
+    // Cross-module guard: circuit-breaker.ts keeps its own copy of the marker
+    // in USER_INPUT_ERROR_PATTERNS. Delete it there and this fails here —
+    // which is the point, because the symptom in production would otherwise
+    // be the capability tripping open for every caller.
+    let message = "";
+    try {
+      assertTargetAllowed("https://www.trustpilot.com/review/stripe.com");
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(isUserInputError(message)).toBe(true);
+  });
+});

--- a/apps/api/src/capabilities/lib/tos-blocklist.ts
+++ b/apps/api/src/capabilities/lib/tos-blocklist.ts
@@ -1,0 +1,174 @@
+/**
+ * Targets Strale will not fetch, because the site's Terms of Service forbid
+ * automated access.
+ *
+ * ## Why this exists
+ *
+ * The platform already decided, site by site, that these hosts are off-limits
+ * — but it enforced those decisions by deactivating the *named* capability
+ * that targeted each one (`trustpilot-score`, `salary-benchmark`,
+ * `employer-review-summary`, `linkedin-url-validate`, `patent-search`; see the
+ * DEACTIVATED map in `../auto-register.ts`, and the trimmed PLATFORMS list in
+ * `../social-profile-check.ts`).
+ *
+ * That is not sufficient. Capabilities which accept an *arbitrary* URL and run
+ * it through Browserless or a direct fetch reach exactly the same targets, so
+ * deactivating the named capability closes the front door and leaves the side
+ * door open. Production bore this out: over 2026-07-20 → 2026-08-05, callers
+ * sent `product-reviews-extract` 28 Trustpilot review URLs (all 403-ed) and
+ * `tech-stack-detect` 19 linkedin.com domains (all *succeeded*) — i.e. the
+ * platform was serving, for money, the precise automated access that
+ * `linkedin-url-validate` had been deactivated for performing.
+ *
+ * Per DEC-20260428-A Tier 1 ("Strale itself never operates scrapers" — stated
+ * as absolute) and DEC-20260420-H (direct connections, full ToS compliance),
+ * the check belongs on the fetch path, not on the capability name. This module
+ * is that single source of truth.
+ *
+ * ## What it is not
+ *
+ * It is not a security control and not an SSRF guard — that is
+ * `lib/url-validator.ts` / `lib/safe-fetch.ts`, which still run. This is a
+ * compliance policy gate, and it is deliberately conservative: it blocks only
+ * hosts the platform has already ruled on. Adding a host here is a policy
+ * decision and needs a corresponding DEC entry.
+ */
+
+export interface ProhibitedTarget {
+  /** Registrable host. Matches this host exactly and any subdomain of it. */
+  host: string;
+  /**
+   * When set, only URLs whose path starts with this prefix are prohibited.
+   * Used where the ruling covers one product rather than a whole domain —
+   * google.com/search is ToS-prohibited for scraping, google.com is not.
+   */
+  pathPrefix?: string;
+  /** Human-readable site name, used in the caller-facing message. */
+  site: string;
+  /** Governing decision. Internal provenance — never sent to callers. */
+  decision: string;
+  /** Caller-facing sentence naming compliant alternatives. */
+  alternatives: string;
+}
+
+export const PROHIBITED_TARGETS: readonly ProhibitedTarget[] = [
+  {
+    host: "trustpilot.com",
+    site: "Trustpilot",
+    decision: "DEC-20260427-H-2",
+    alternatives:
+      "Supported review sources include Reviews.io, Feefo and Yotpo pages, and first-party product pages.",
+  },
+  {
+    host: "glassdoor.com",
+    site: "Glassdoor",
+    decision: "DEC-20260427-H-3 / DEC-20260427-H-4",
+    alternatives:
+      "For salary data try the job-board-search or salary-related capabilities backed by licensed sources.",
+  },
+  {
+    host: "linkedin.com",
+    site: "LinkedIn",
+    decision: "DEC-20260427-H-5",
+    alternatives:
+      "Use the company's own website for company data, or company-enrich for firmographics.",
+  },
+  {
+    host: "patents.google.com",
+    site: "Google Patents",
+    decision: "DEC-20260427-H-1",
+    alternatives: "Compliant patent sources are EPO OPS, USPTO PEDS and Lens.org.",
+  },
+  {
+    host: "google.com",
+    pathPrefix: "/search",
+    site: "Google Search",
+    decision: "DEC-20260427-H-4",
+    alternatives: "Use the google-search capability, which runs on a licensed search API.",
+  },
+  // Removed from social-profile-check's PLATFORMS list under DEC-20260420-H:
+  // these platforms forbid automated access including existence probes.
+  {
+    host: "facebook.com",
+    site: "Facebook",
+    decision: "DEC-20260420-H",
+    alternatives: "Use the organisation's own website instead.",
+  },
+  {
+    host: "instagram.com",
+    site: "Instagram",
+    decision: "DEC-20260420-H",
+    alternatives: "Use the organisation's own website instead.",
+  },
+  {
+    host: "twitter.com",
+    site: "X (Twitter)",
+    decision: "DEC-20260420-H",
+    alternatives: "Use the organisation's own website instead.",
+  },
+  {
+    host: "x.com",
+    site: "X (Twitter)",
+    decision: "DEC-20260420-H",
+    alternatives: "Use the organisation's own website instead.",
+  },
+];
+
+/**
+ * Stable substring of every message {@link assertTargetAllowed} throws.
+ *
+ * `lib/circuit-breaker.ts` matches on this so a policy refusal does not count
+ * as a capability failure — the executor worked correctly and declined a
+ * target it must decline. Without it, a burst of Trustpilot calls would trip
+ * the breaker and take the capability down for everyone.
+ */
+export const TOS_REFUSAL_MARKER = "Terms of Service prohibit automated access";
+
+/** Normalize a possibly scheme-less input the way the executors do. */
+function toUrl(rawUrl: string): URL | null {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed.startsWith("http") ? trimmed : `https://${trimmed}`);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The prohibited-target rule matching this URL, or null if the target is
+ * allowed. An unparseable URL returns null — malformed input is the caller's
+ * own validation problem, not a policy hit.
+ */
+export function findProhibitedTarget(rawUrl: string): ProhibitedTarget | null {
+  const parsed = toUrl(rawUrl);
+  if (!parsed) return null;
+
+  const hostname = parsed.hostname.toLowerCase().replace(/\.$/, "");
+
+  for (const rule of PROHIBITED_TARGETS) {
+    const hostMatches = hostname === rule.host || hostname.endsWith(`.${rule.host}`);
+    if (!hostMatches) continue;
+    if (rule.pathPrefix && !parsed.pathname.startsWith(rule.pathPrefix)) continue;
+    return rule;
+  }
+  return null;
+}
+
+/**
+ * Throw if the URL targets a site whose ToS forbids automated access.
+ *
+ * Call this BEFORE any network work so a prohibited target costs no
+ * Browserless render, no LLM tokens, and no wall-clock — and so the caller
+ * gets a straight answer instead of the target's 403 dressed up as our error.
+ */
+export function assertTargetAllowed(rawUrl: string): void {
+  const rule = findProhibitedTarget(rawUrl);
+  if (!rule) return;
+
+  throw new Error(
+    `${rule.site} is not a supported source: its ${TOS_REFUSAL_MARKER}, so Strale does not fetch it. ` +
+      `This is a policy limit rather than a transient error — retrying the same URL will not succeed. ` +
+      rule.alternatives,
+  );
+}

--- a/apps/api/src/capabilities/product-reviews-extract.test.ts
+++ b/apps/api/src/capabilities/product-reviews-extract.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression tests for the Trustpilot rejection (2026-08-05).
+ *
+ * Production 2026-07-20 → 2026-08-05: 28 of 31 x402 calls to this capability
+ * failed, every one a `trustpilot.com/review/*` URL returning HTTP 403 bot
+ * protection. Each failure had already paid for a Browserless render before
+ * the 403 came back, and the caller got the target's blocking message rather
+ * than a straight answer — so several retried the identical URL 3-4 times.
+ *
+ * The fix rejects prohibited targets before any network work. These tests
+ * assert the *ordering* (no fetch at all), not just the throw, because
+ * throwing after the render would leave the wasted cost in place.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { fetchRenderedHtml } = vi.hoisted(() => ({ fetchRenderedHtml: vi.fn() }));
+vi.mock("./lib/browserless-extract.js", () => ({
+  fetchRenderedHtml,
+  htmlToText: (h: string) => h,
+}));
+
+import { getDirectExecutor } from "./index.js";
+import "./product-reviews-extract.js";
+
+describe("product-reviews-extract ToS rejection", () => {
+  beforeEach(() => {
+    fetchRenderedHtml.mockReset();
+    process.env.ANTHROPIC_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const exec = () => getDirectExecutor("product-reviews-extract")!;
+
+  it("rejects a Trustpilot review URL without rendering it (the bug case)", async () => {
+    await expect(
+      exec()({ url: "https://www.trustpilot.com/review/bemancandles.co.uk" }),
+    ).rejects.toThrow(/Trustpilot is not a supported source/);
+
+    expect(fetchRenderedHtml).not.toHaveBeenCalled();
+  });
+
+  it("rejects the uk. subdomain form callers also sent", async () => {
+    await expect(
+      exec()({ url: "https://uk.trustpilot.com/review/imaanactive.co.uk" }),
+    ).rejects.toThrow(/Terms of Service prohibit automated access/);
+
+    expect(fetchRenderedHtml).not.toHaveBeenCalled();
+  });
+
+  it("tells the caller retrying will not help and names an alternative", async () => {
+    let message = "";
+    try {
+      await exec()({ url: "https://www.trustpilot.com/review/stripe.com" });
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toMatch(/retrying .* will not succeed/i);
+    expect(message).toContain("Reviews.io");
+  });
+
+  it("still fetches an allowed source (no over-blocking)", async () => {
+    // consumerlab.com completed successfully in the same production window.
+    fetchRenderedHtml.mockResolvedValueOnce("<html>reviews</html>");
+
+    // The Anthropic call is not stubbed here, so this rejects *after* the
+    // fetch — which is all this test needs to prove: the guard let it past.
+    await exec()({ url: "https://www.consumerlab.com/primaforce/" }).catch(() => {});
+
+    expect(fetchRenderedHtml).toHaveBeenCalledTimes(1);
+    expect(fetchRenderedHtml).toHaveBeenCalledWith("https://www.consumerlab.com/primaforce/");
+  });
+
+  it("still requires a url, with guidance that no longer names Trustpilot", async () => {
+    let message = "";
+    try {
+      await exec()({});
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toMatch(/'url' or 'product_url' is required/);
+    expect(message).not.toMatch(/Trustpilot/i);
+  });
+});

--- a/apps/api/src/capabilities/product-reviews-extract.test.ts
+++ b/apps/api/src/capabilities/product-reviews-extract.test.ts
@@ -14,10 +14,20 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { fetchRenderedHtml } = vi.hoisted(() => ({ fetchRenderedHtml: vi.fn() }));
+const { fetchRenderedHtml, messagesCreate } = vi.hoisted(() => ({
+  fetchRenderedHtml: vi.fn(),
+  messagesCreate: vi.fn(),
+}));
+
 vi.mock("./lib/browserless-extract.js", () => ({
   fetchRenderedHtml,
   htmlToText: (h: string) => h,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: messagesCreate };
+  },
 }));
 
 import { getDirectExecutor } from "./index.js";
@@ -26,6 +36,7 @@ import "./product-reviews-extract.js";
 describe("product-reviews-extract ToS rejection", () => {
   beforeEach(() => {
     fetchRenderedHtml.mockReset();
+    messagesCreate.mockReset();
     process.env.ANTHROPIC_API_KEY = "test-key";
   });
 
@@ -62,16 +73,23 @@ describe("product-reviews-extract ToS rejection", () => {
     expect(message).toContain("Reviews.io");
   });
 
-  it("still fetches an allowed source (no over-blocking)", async () => {
+  it("still extracts from an allowed source (no over-blocking)", async () => {
     // consumerlab.com completed successfully in the same production window.
     fetchRenderedHtml.mockResolvedValueOnce("<html>reviews</html>");
+    messagesCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: '{"product_name":"Primaforce","average_rating":4.1}' }],
+    });
 
-    // The Anthropic call is not stubbed here, so this rejects *after* the
-    // fetch — which is all this test needs to prove: the guard let it past.
-    await exec()({ url: "https://www.consumerlab.com/primaforce/" }).catch(() => {});
+    const result = await exec()({ url: "https://www.consumerlab.com/primaforce/" });
 
-    expect(fetchRenderedHtml).toHaveBeenCalledTimes(1);
-    expect(fetchRenderedHtml).toHaveBeenCalledWith("https://www.consumerlab.com/primaforce/");
+    expect(fetchRenderedHtml).toHaveBeenCalledExactlyOnceWith(
+      "https://www.consumerlab.com/primaforce/",
+    );
+    expect(result.output).toMatchObject({
+      product_name: "Primaforce",
+      url: "https://www.consumerlab.com/primaforce/",
+    });
+    expect(result.provenance.source).toBe("consumerlab.com");
   });
 
   it("still requires a url, with guidance that no longer names Trustpilot", async () => {

--- a/apps/api/src/capabilities/product-reviews-extract.ts
+++ b/apps/api/src/capabilities/product-reviews-extract.ts
@@ -1,19 +1,26 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { fetchRenderedHtml, htmlToText } from "./lib/browserless-extract.js";
+import { assertTargetAllowed } from "./lib/tos-blocklist.js";
 import Anthropic from "@anthropic-ai/sdk";
 
-// Product review extraction from Amazon, Trustpilot, Google, etc. via Browserless + Claude
+// Product review extraction from review and product pages via Browserless + Claude.
+// Trustpilot is NOT supported — see lib/tos-blocklist.ts.
 
 registerCapability("product-reviews-extract", async (input: CapabilityInput) => {
   const url =
     ((input.url as string) ?? (input.product_url as string) ?? (input.task as string) ?? "").trim();
   if (!url) {
     throw new Error(
-      "'url' or 'product_url' is required. Provide an Amazon, Trustpilot, or other product review page URL.",
+      "'url' or 'product_url' is required. Provide a product or review page URL — for example a first-party product page, or a Reviews.io / Feefo listing.",
     );
   }
 
   const fullUrl = url.startsWith("http") ? url : `https://${url}`;
+
+  // Before any network work: refuse targets whose ToS forbids automated access,
+  // so the caller gets a straight answer instead of the target's 403, and we
+  // burn no Browserless render or LLM tokens on a request we cannot serve.
+  assertTargetAllowed(fullUrl);
 
   // Extract domain for provenance
   let domain: string;

--- a/apps/api/src/lib/circuit-breaker.ts
+++ b/apps/api/src/lib/circuit-breaker.ts
@@ -169,9 +169,16 @@ const USER_INPUT_ERROR_PATTERNS = [
   "This URL points to a PDF",    // url-to-markdown: PDF file
   "This URL points to an image", // url-to-markdown: image file
   "Could not repair JSON",       // json-repair: unrecoverable input
+  // capabilities/lib/tos-blocklist.ts: the caller asked for a site whose ToS
+  // forbids automated access. The executor worked correctly and declined, so
+  // this must not trip the breaker — otherwise a burst of Trustpilot URLs
+  // (28 arrived in 16 days) would take the capability down for everyone.
+  // Kept in sync with TOS_REFUSAL_MARKER by tos-blocklist.test.ts.
+  "Terms of Service prohibit automated access",
 ];
 
-function isUserInputError(reason: string): boolean {
+/** Exported so tests can assert the pattern list stays in sync with its producers. */
+export function isUserInputError(reason: string): boolean {
   return USER_INPUT_ERROR_PATTERNS.some((p) => reason.includes(p));
 }
 

--- a/manifests/product-reviews-extract.yaml
+++ b/manifests/product-reviews-extract.yaml
@@ -4,8 +4,8 @@
 slug: product-reviews-extract
 name: Product Reviews Extract
 description: >-
-  Extract product reviews from Amazon, Trustpilot, or any review page. Returns rating distribution, pros/cons,
-  sentiment.
+  Extract product reviews from a product or review page. Returns rating distribution, pros/cons,
+  sentiment. Trustpilot is not supported (their ToS forbids automated access).
 category: data-extraction
 cost_class: paid_prepaid
 quota_window: none
@@ -18,19 +18,24 @@ input_schema:
   properties:
     url:
       type: string
-      description: Product review page URL
+      description: >-
+        Product or review page URL. Sites whose Terms of Service forbid automated access
+        (Trustpilot, Glassdoor, LinkedIn) are rejected without being fetched.
+# Example reconciled to the DB-canonical value on 2026-08-05 (captured from a
+# real --discover run) so sync-manifest-text-to-db.ts carries only the
+# intentional ToS copy change and does not regress this to a placeholder.
 output_schema:
   type: object
   example:
-    url: https://example.com
-    source: example.com
-    common_cons: []
-    common_pros: []
-    product_name: null
+    url: https://www.amazon.com/dp/B0CHX3QBCH
+    source: amazon.com
+    common_cons: null
+    common_pros: null
+    product_name: Apple iPhone 15 Plus FineWoven Case with MagSafe - Pacific Blue
     review_count: null
     average_rating: null
     recent_reviews: []
-    sentiment_summary: No product review data found on this page
+    sentiment_summary: No customer reviews available on this product page
     rating_distribution:
       1_star: null
       2_star: null
@@ -102,6 +107,17 @@ output_field_reliability:
   average_rating: guaranteed
   rating_distribution: guaranteed
 limitations:
+  - title: Trustpilot, Glassdoor and LinkedIn are not supported — their Terms of Service forbid automated access
+    text: >-
+      Review sites whose Terms of Service prohibit automated access are rejected before any fetch is attempted,
+      and return a policy error rather than review data. This currently covers Trustpilot, Glassdoor, LinkedIn,
+      Google Search and the major social platforms. Retrying will not succeed. Strale will add a source back
+      only under a licensed API agreement.
+    category: coverage
+    severity: warning
+    workaround: >-
+      Use a first-party product page, or a review platform that permits automated access such as Reviews.io,
+      Feefo or Yotpo.
   - title: Extracts visible product page reviews only — hidden, filtered, or paginated reviews may not be captured
     text: >-
       Extracts reviews visible on the product page — filtered/hidden reviews and reviews behind 'load more' may not be


### PR DESCRIPTION
## Summary

- `product-reviews-extract` failed **28 of 31** x402 calls over 2026-07-20 → 2026-08-05. Every failure was a `trustpilot.com/review/*` URL returning HTTP 403 bot protection. Callers retried identical URLs 3-4 times, each attempt paying for a Browserless render before the 403 came back.
- The capability was **advertising the thing it couldn't do**: its description said "Amazon, Trustpilot, or any review page" and its own missing-input error told callers to "Provide an Amazon, Trustpilot, or other product review page URL" — while the sibling `trustpilot-score` capability sat deactivated for exactly that ToS reason.
- Adds `capabilities/lib/tos-blocklist.ts` — a single source of truth for targets Strale will not fetch — and rejects them **before any network work**.

## The underlying defect (why this isn't a one-line Trustpilot check)

The platform enforced its site-by-site ToS rulings by deactivating the *named* capability pointed at each site — `trustpilot-score`, `salary-benchmark`, `employer-review-summary`, `linkedin-url-validate`, `patent-search`, plus a trimmed `PLATFORMS` list in `social-profile-check`. Capabilities that accept an **arbitrary URL** reach the same hosts through the same Browserless path, so deactivation closed the front door and left the side door open.

Production confirms both halves:

| Capability | Prohibited-domain calls | Outcome |
|---|---|---|
| `product-reviews-extract` | 28 × Trustpilot | all **failed** (403) — fails closed |
| `tech-stack-detect` | 19 × linkedin.com | all **completed** — fails open |
| `screenshot-url` | 1 × linkedin.com | failed (unrelated `wait_for` bug, since fixed) |

Per DEC-20260428-A Tier 1 ("Strale itself never operates scrapers", stated as absolute) and DEC-20260420-H, the check belongs on the fetch path, not on the capability name.

## Scope — deliberately not fixed here

`tech-stack-detect` is doing plain GETs against `linkedin.com` and **succeeding**, which is the same automated access `linkedin-url-validate` was deactivated for. That is the more serious of the two (serving prohibited data rather than failing on it), but blocking it removes working, paid customer traffic — a business and legal call, not a refactor. The helper makes it a one-line wire-in whenever you want it. Flagged, not taken.

## Behaviour change

Before — after a full Browserless render:
> `URL returned HTTP 403. The site ([service]) blocks automated access (HTTP 403 Forbidden). This is bot protection on the target site, not a S…`

After — before any fetch:
> `Trustpilot is not a supported source: its Terms of Service prohibit automated access, so Strale does not fetch it. This is a policy limit rather than a transient error — retrying the same URL will not succeed. Supported review sources include Reviews.io, Feefo and Yotpo pages, and first-party product pages.`

No charge either way (charge-on-success), but the new path burns no render, no LLM tokens, and tells the caller what to do instead. The message deliberately does **not** leak the internal DEC id (asserted by test).

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit --project tsconfig.json` | clean |
| Full `vitest run` | **767 passed**, 33 skipped, 0 failed |
| `tos-blocklist.test.ts` | 16/16 |
| `product-reviews-extract.test.ts` | 5/5 |
| `validate-capability.ts --slug product-reviews-extract` | **19/19 checks** |
| `checkReadiness("product-reviews-extract")` | `ready: true`, 0 issues |
| `smoke-test.ts --slug product-reviews-extract` | 10/11 — Step 2 blocked by the **pre-existing** ALLOW_MATRIX paid-cost guard (`internal_test` context). Control capability `pricing-page-extract` fails Step 2 identically on `main`; not a regression. |

Per DEC-20260504-A the cross-module regression test was verified in **both** directions: removing the marker from `circuit-breaker.ts` makes `tos-blocklist.test.ts` fail (`expected false to be true`), restoring it passes.

The executor tests assert **ordering** — `expect(fetchRenderedHtml).not.toHaveBeenCalled()` — not merely that it throws, since throwing after the render would leave the wasted cost in place.

## Circuit-breaker interaction

The refusal message is registered in `USER_INPUT_ERROR_PATTERNS`. Without it, a burst of blocked URLs would read as capability failure and trip the breaker for every caller — the capability is healthy; it is declining a target it must decline. A test asserts the two files stay in sync.

## Follow-up required (not in this PR)

1. **`tech-stack-detect` + `screenshot-url`** — see Scope above. Needs your decision.
2. **~11 other arbitrary-URL capabilities** share the hole (`url-to-markdown`, `structured-scrape`, `pricing-page-extract`, `terms-of-service-extract`, `privacy-policy-analyze`, `return-policy-extract`, `competitor-compare`, `product-search`, `price-compare`, `seo-audit`, `landing-page-roast`, …). A sweep is one import + one call each.
3. **DB catalog text** still advertises Trustpilot. `onboard.ts --backfill` does not write descriptions, so this needs `scripts/sync-manifest-text-to-db.ts product-reviews-extract` (the sanctioned escape hatch — its docstring names "ToS-driven copy change" as the use case). Dry-run verified to carry only description + input_schema; the manifest's `output_schema` example was first reconciled to the DB-canonical value so the sync does not regress it to a placeholder.

## Test plan

1. Merge and deploy.
2. `POST /v1/do` `{"capability_slug":"product-reviews-extract","max_price_cents":50,"inputs":{"url":"https://www.trustpilot.com/review/stripe.com"}}` → expect the policy message, fast (no render latency).
3. Same with `https://www.consumerlab.com/primaforce/` → expect normal extraction (this URL completed in production during the window).
4. Confirm `GET /v1/capabilities` no longer advertises Trustpilot once the text sync in follow-up 3 has run.