### PR TITLE
feat(suggest): bridge search vocabulary so "fx" finds exchange-rate

### DIFF
--- a/apps/api/src/lib/search-aliases.test.ts
+++ b/apps/api/src/lib/search-aliases.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression tests for search-query aliases (2026-08-05).
+ *
+ * Origin: `suggest_log` for 2026-07-20 → 2026-08-05 recorded 17 zero-result
+ * typeahead queries. Some were genuine coverage gaps, but several were pure
+ * vocabulary mismatches — most starkly `fx`, which returned nothing while
+ * `forex` returned forex-history and `currency` returned four capabilities
+ * including exchange-rate. The catalog had the answer; only the word differed.
+ *
+ * These tests pin two things: that the known-bad queries now expand, and —
+ * equally important — that genuine coverage gaps are NOT aliased into false
+ * matches. Sending a caller to a capability that does not do what they asked
+ * is worse than an honest empty result.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  aliasTermsFor,
+  SEARCH_ALIASES,
+  ALIAS_PRIMARY_WEIGHT,
+  ALIAS_SECONDARY_WEIGHT,
+} from "./search-aliases.js";
+import { tokenize } from "./tokenize.js";
+
+describe("aliasTermsFor", () => {
+  it('expands "fx" to the terms the catalog actually uses (the bug case)', () => {
+    const terms = aliasTermsFor(["fx"]);
+    // exchange-rate tokenizes to exchange/rate, so "exchange" is the bridge.
+    expect(terms.has("exchange")).toBe(true);
+    expect(terms.has("forex")).toBe(true);
+    expect(terms.has("currency")).toBe(true);
+  });
+
+  it('expands "visa" to reach work-permit-requirements', () => {
+    expect(aliasTermsFor(["visa"]).has("permit")).toBe(true);
+    expect(aliasTermsFor(["immigration"]).has("permit")).toBe(true);
+    expect(aliasTermsFor(["relocation"]).has("permit")).toBe(true);
+  });
+
+  it('expands "logging" to "log", which prefix matching cannot reach', () => {
+    // The typed word is LONGER than the token, so startsWith() never fires.
+    expect("log".startsWith("logging")).toBe(false);
+    expect(aliasTermsFor(["logging"]).has("log")).toBe(true);
+  });
+
+  it("expands every word of a multi-word query", () => {
+    const terms = aliasTermsFor(["relocation", "visa", "immigration"]);
+    expect(terms.has("permit")).toBe(true);
+  });
+
+  it("does not return a term the user already typed", () => {
+    // "currency" aliases to exchange/forex; typing both must not double-count.
+    const terms = aliasTermsFor(["currency", "forex"]);
+    expect(terms.has("forex")).toBe(false);
+    expect(terms.has("currency")).toBe(false);
+    expect(terms.has("exchange")).toBe(true);
+  });
+
+  it("returns nothing for words with no alias", () => {
+    expect(aliasTermsFor(["email", "validation"]).size).toBe(0);
+    expect(aliasTermsFor([]).size).toBe(0);
+  });
+
+  it("does not alias genuine coverage gaps into false matches", () => {
+    // No capability serves these under any name. An empty result is the
+    // honest answer; these belong on the roadmap, not in the alias map.
+    for (const gap of ["itinerary", "vacation", "reminder", "incident", "rewrite", "africa"]) {
+      expect(aliasTermsFor([gap]).size, `${gap} should not be aliased`).toBe(0);
+    }
+  });
+});
+
+describe("alias map integrity", () => {
+  it("keys and values are single lowercase tokens that survive tokenize()", () => {
+    // A multi-word or punctuated entry would never match, since matching is
+    // done against tokenize() output.
+    for (const [key, values] of Object.entries(SEARCH_ALIASES)) {
+      expect([...tokenize(key)], `key "${key}"`).toEqual([key]);
+      for (const v of values) {
+        expect([...tokenize(v)], `value "${v}" of "${key}"`).toEqual([v]);
+      }
+    }
+  });
+
+  it("no alias maps a word to itself", () => {
+    for (const [key, values] of Object.entries(SEARCH_ALIASES)) {
+      expect(values, `"${key}" maps to itself`).not.toContain(key);
+    }
+  });
+
+  it("alias weights stay below a direct hit so literal matches win", () => {
+    expect(ALIAS_PRIMARY_WEIGHT).toBeLessThan(1);
+    expect(ALIAS_SECONDARY_WEIGHT).toBeLessThan(ALIAS_PRIMARY_WEIGHT);
+    expect(ALIAS_SECONDARY_WEIGHT).toBeGreaterThan(0);
+  });
+
+  it("a name match outranks a description-only mention", () => {
+    // Why the split exists: with one flat weight, "fx" ranked
+    // swift-message-parse (mentions currency in prose) above exchange-rate,
+    // whose name IS the answer.
+    const exchangeRate = ALIAS_PRIMARY_WEIGHT; // "exchange" in the name
+    const swiftParse = ALIAS_SECONDARY_WEIGHT * 2; // currency + exchange in prose
+    expect(exchangeRate).toBeGreaterThan(swiftParse);
+  });
+});

--- a/apps/api/src/lib/search-aliases.ts
+++ b/apps/api/src/lib/search-aliases.ts
@@ -1,0 +1,101 @@
+/**
+ * Query-term aliases for catalog search.
+ *
+ * ## Why
+ *
+ * `typeahead()` matches query words against a token set built from each item's
+ * name, description, category and slug. That is exact-token plus prefix
+ * matching, so a term the catalog never literally uses scores zero however
+ * obviously it maps to something we sell. Production `suggest_log` for
+ * 2026-07-20 → 2026-08-05 shows the failure mode directly: `fx` returned zero
+ * results while `forex` returned `forex-history` and `currency` returned four
+ * capabilities including `exchange-rate`. The intent was unambiguous and the
+ * catalog had the answer; only the vocabulary differed.
+ *
+ * ## What belongs here
+ *
+ * Only vocabulary mappings — a word users type for a thing the catalog
+ * already has under another name. Every entry below is justified by an
+ * observed zero-result query plus a verified catalog item that should have
+ * matched it.
+ *
+ * What does NOT belong here is a coverage gap. `south africa`, `itinerary`,
+ * `vacation planner`, `reminder` and `incident` also returned zero, but no
+ * capability serves them under any name. Aliasing those to adjacent items
+ * would manufacture false matches, which is worse for the caller than an
+ * honest empty result — they would call something that does not do what they
+ * asked. Those belong on the roadmap, not in this file.
+ *
+ * ## Scoring
+ *
+ * An alias hit is worth less than a direct hit (see ALIAS_MATCH_WEIGHT in
+ * suggest.ts), so an item that literally contains the typed word always
+ * outranks one reached by synonym.
+ */
+
+/**
+ * alias term → catalog terms to also search for.
+ *
+ * Keys and values are single lowercase tokens, matched against the same token
+ * set `tokenize()` produces — so hyphenated slugs are already split
+ * (`exchange-rate` yields `exchange` and `rate`).
+ */
+export const SEARCH_ALIASES: Readonly<Record<string, readonly string[]>> = {
+  // Observed: "fx" → 0 results. Catalog has exchange-rate, forex-history,
+  // currency-convert, crypto-price. The single most common finance shorthand.
+  fx: ["forex", "exchange", "currency"],
+  // "forex" matched only forex-history; exchange-rate and currency-convert
+  // are equally valid answers and were invisible.
+  forex: ["exchange", "currency"],
+  currency: ["exchange", "forex"],
+
+  // Observed: "relocation visa immigration" → 0 results, and "visa" alone → 0.
+  // Catalog has work-permit-requirements, whose tokens are work/permit/
+  // requirements — none of which a user searching for visas would type.
+  visa: ["permit"],
+  immigration: ["permit"],
+  relocation: ["permit"],
+
+  // Observed: "logging" → 0 results. Catalog has log-parse, tokenized as
+  // log/parse. Prefix matching does not help because the typed word is
+  // longer than the token.
+  logging: ["log"],
+  logs: ["log"],
+
+  // Observed: "travel" and "trip" → 0 results. flight-status is the only
+  // travel-adjacent capability we have. This is a partial answer to a real
+  // coverage gap (see the module docstring) — it surfaces the one relevant
+  // thing rather than pretending trip planning exists.
+  travel: ["flight"],
+  trip: ["flight"],
+};
+
+/**
+ * Weights for an alias-derived match, relative to 1.0 for a direct hit.
+ *
+ * Split by where the term appears, because merged token sets rank badly here:
+ * with a single weight, "fx" put swift-message-parse (which merely mentions
+ * currency in its description) above exchange-rate, whose *name* is the
+ * answer. Both stay below 1.0 so an item containing the literal typed word
+ * always outranks one reached by synonym.
+ */
+export const ALIAS_PRIMARY_WEIGHT = 0.75; // term appears in the item's name or slug
+export const ALIAS_SECONDARY_WEIGHT = 0.25; // term appears only in description/category
+
+/**
+ * Extra catalog terms to search for, given the user's query words.
+ *
+ * Returns only terms the user did not already type, so an alias never
+ * double-counts a word that would match directly anyway.
+ */
+export function aliasTermsFor(queryWords: readonly string[]): Set<string> {
+  const typed = new Set(queryWords);
+  const extra = new Set<string>();
+
+  for (const word of queryWords) {
+    for (const term of SEARCH_ALIASES[word] ?? []) {
+      if (!typed.has(term)) extra.add(term);
+    }
+  }
+  return extra;
+}

--- a/apps/api/src/lib/suggest.ts
+++ b/apps/api/src/lib/suggest.ts
@@ -8,6 +8,11 @@ import {
 } from "../db/schema.js";
 import { embedQuery, embedDocuments, cosineSimilarity } from "./embeddings.js";
 import { tokenize } from "./tokenize.js";
+import {
+  aliasTermsFor,
+  ALIAS_PRIMARY_WEIGHT,
+  ALIAS_SECONDARY_WEIGHT,
+} from "./search-aliases.js";
 import { determineBadge } from "./trust-helpers.js";
 import { log, logError, logWarn } from "./log.js";
 
@@ -47,6 +52,12 @@ interface CatalogItem {
   embedding: number[];
   embeddingText: string;
   tokens: Set<string>;
+  /**
+   * Tokens from the name and slug only — what the item *is*, as opposed to
+   * everything it mentions. Used to rank alias matches, where a description
+   * mention is much weaker evidence than a name match.
+   */
+  primaryTokens: Set<string>;
   trustSummary?: TrustSummary;
 }
 
@@ -234,6 +245,7 @@ async function loadCatalog(): Promise<CatalogItem[]> {
           embedding: [],
           embeddingText,
           tokens: tokenize(tokenText),
+          primaryTokens: tokenize(`${sol.name} ${sol.slug}`),
         };
       });
 
@@ -277,6 +289,7 @@ async function loadCatalog(): Promise<CatalogItem[]> {
           embedding: [],
           embeddingText,
           tokens: tokenize(tokenText),
+          primaryTokens: tokenize(`${cap.name} ${cap.slug}`),
         };
       });
 
@@ -502,6 +515,10 @@ export async function typeahead(
     return { results: [], total: 0 };
   }
 
+  // Vocabulary bridge: "fx" should reach exchange-rate even though the catalog
+  // never uses the word. Scored below a direct hit so literal matches win.
+  const aliasTerms = aliasTermsFor(qWords);
+
   const scored: Array<{ item: CatalogItem; score: number; snippet?: string; _alsoAvailable?: string[] }> = [];
 
   for (const item of items) {
@@ -513,6 +530,11 @@ export async function typeahead(
     // Token matching: +1 for each query word found in item tokens
     for (const word of qWords) {
       if (item.tokens.has(word)) score++;
+    }
+
+    for (const term of aliasTerms) {
+      if (item.primaryTokens.has(term)) score += ALIAS_PRIMARY_WEIGHT;
+      else if (item.tokens.has(term)) score += ALIAS_SECONDARY_WEIGHT;
     }
 
     // Exact slug match: +2
@@ -893,12 +915,21 @@ function suggestKeyword(
     };
   }
 
+  // Same vocabulary bridge as typeahead — this path runs whenever
+  // VOYAGE_API_KEY is absent, so it must not be blind to synonyms the
+  // typeahead surface understands.
+  const aliasTerms = aliasTermsFor([...queryTokens]);
+
   const scored: Array<{ item: CatalogItem; score: number }> = [];
 
   for (const item of items) {
     let score = 0;
     for (const token of queryTokens) {
       if (item.tokens.has(token)) score++;
+    }
+    for (const term of aliasTerms) {
+      if (item.primaryTokens.has(term)) score += ALIAS_PRIMARY_WEIGHT;
+      else if (item.tokens.has(term)) score += ALIAS_SECONDARY_WEIGHT;
     }
     if (queryTokens.has(item.slug)) score += 2;
     if (item.type === "solution" && score > 0) score += 3;


### PR DESCRIPTION
## Summary

`suggest_log` for 2026-07-20 → 2026-08-05 recorded **17 zero-result typeahead queries**. Some are genuine coverage gaps, but several were pure vocabulary mismatches where the catalog had the answer under a different word. The starkest:

| query | before | after |
|---|---|---|
| `fx` | **0** | 7 — forex-history, currency-convert, **exchange-rate**, … |
| `visa` | **0** | 1 — work-permit-requirements |
| `relocation visa immigration` | **0** | 1 — work-permit-requirements |
| `logging` | **0** | 2 — **log-parse**, release-notes-generate |
| `travel` / `trip` | **0** | 2 — flight-status |

`typeahead()` matches query words against a token set built from each item's name, description, category and slug — exact-token plus prefix matching. A term the catalog never literally uses scores zero no matter how obviously it maps. `fx` returned nothing while `forex` returned forex-history and `currency` returned four capabilities including exchange-rate: same intent, different vocabulary.

Note `logging` → `log-parse` could never work via prefix matching, because the typed word is *longer* than the token (`"log".startsWith("logging")` is false).

## Approach

A data-driven alias map in `lib/search-aliases.ts` — not per-query special cases. Every entry is justified in-file by an observed zero-result query plus a verified catalog item that should have matched it.

Applied to both token-matching paths: `typeahead()` (331 of 336 searches in the window) and `suggestKeyword()` (the no-`VOYAGE_API_KEY` fallback, so it isn't blind to synonyms typeahead understands). The semantic `suggest()` path is untouched — embeddings handle synonyms natively, and only 5 calls in the window used it.

### Ranking

Alias hits score below direct hits, so a literal match always wins. They're further split by *where* the term appears:

- With one flat weight, `fx` ranked `swift-message-parse` (which merely mentions currency in prose) **above** `exchange-rate`, whose name is the answer.
- Added a `primaryTokens` set (name + slug only). Primary alias hit = 0.75, description-only = 0.25. `exchange-rate` now ranks 3rd on `fx`, above swift-message-parse.
- `primaryTokens` is used **only** for alias scoring — direct matching is byte-for-byte unchanged.

## Deliberately NOT aliased — these are roadmap items, not search bugs

`south africa`, `itinerary`, `vacation planner organizer`, `reminder`, `incident`, `rewrite`, `engine`. Nothing in the catalog serves these under any name. Aliasing them to adjacent items would manufacture false matches, which is worse for the caller than an honest empty result — they'd call something that doesn't do what they asked. A test asserts these stay unaliased.

Detail in the report accompanying this PR; the notable ones are a **South Africa company-data gap** and a **travel/trip-planning gap** (we have only `flight-status`, now surfaced as a partial answer).

## Verification

- **Live catalog, before/after** for all 17 zero-result queries — table above; all six genuine gaps still correctly return 0.
- **Through the real route handler** (`app.request()` against `/v1/suggest/typeahead`, exercising middleware and param parsing, not just the function): `fx` → HTTP 200, total=7.
- **Regression probe on the 19 most frequent real queries** from the log (`email validation`, `iban validation`, `invoice compliance validation`, `trade`, `kyb`, …): **0 returned fewer results** than logged. None of them contain an alias key, so impact is confined to the intended queries.
- `tsc --noEmit` clean; `search-aliases.test.ts` 11/11.

### Note on the local full-suite run

9 test files (SSRF buckets, admin/internal routes, health-deep) fail locally with `Test timed out in 10000ms` while importing `app.ts` → `auto-register.ts` (310 dynamic imports). **This is pre-existing and not from this change** — I verified by stashing the diff and re-running: the same 9 files fail on clean `main`. They pass with `--testTimeout=60000`. CI has been green on these files for the last two PRs. Worth a separate look at whether the default timeout is too tight for that import graph.

## Test plan

1. Merge and deploy.
2. `GET /v1/suggest/typeahead?q=fx&type=capability` → expect exchange-rate, forex-history, currency-convert.
3. `GET /v1/suggest/typeahead?q=logging` → expect log-parse first.
4. `GET /v1/suggest/typeahead?q=itinerary` → expect **0 results** (still a real gap; must not have been aliased into a false match).
5. Spot-check a high-traffic query (`?q=email%20validation`) is unchanged.