### PR TITLE
fix(sanitize): stop the hostname stripper eating vendor names we authored

### DIFF
--- a/apps/api/src/lib/sanitize.test.ts
+++ b/apps/api/src/lib/sanitize.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression tests for failure-reason sanitization (2026-08-05).
+ *
+ * Origin: the ToS refusal shipped in PR #151 points callers at compliant
+ * review platforms. Verified against production, the message came back as
+ * "Supported review sources include [service], Feefo and Yotpo pages" — the
+ * hostname stripper had eaten "Reviews.io", turning actionable guidance into
+ * advice that names nothing.
+ *
+ * The stripper is doing its job (internal hostnames must not leak); it simply
+ * cannot distinguish infrastructure from a vendor name we deliberately wrote.
+ * Hence an explicit allowlist, and these tests pin both directions: authored
+ * vendor names survive, real hostnames still get stripped.
+ */
+
+import { describe, it, expect } from "vitest";
+import { sanitizeFailureReason } from "./sanitize.js";
+
+describe("sanitizeFailureReason — allowlisted vendor names", () => {
+  it("keeps Reviews.io in the ToS refusal message (the bug case)", () => {
+    const refusal =
+      "Trustpilot is not a supported source: its Terms of Service prohibit automated access, " +
+      "so Strale does not fetch it. Supported review sources include Reviews.io, Feefo and " +
+      "Yotpo pages, and first-party product pages.";
+
+    const out = sanitizeFailureReason(refusal);
+
+    expect(out).toContain("Reviews.io");
+    expect(out).not.toContain("[service]");
+  });
+
+  it("keeps the blocked site's own name so the caller knows what was refused", () => {
+    expect(sanitizeFailureReason("trustpilot.com is not supported")).toContain("trustpilot.com");
+    expect(sanitizeFailureReason("linkedin.com is not supported")).toContain("linkedin.com");
+  });
+
+  it("is case-insensitive about allowlisted names", () => {
+    expect(sanitizeFailureReason("See REVIEWS.IO for details")).toContain("REVIEWS.IO");
+  });
+});
+
+describe("sanitizeFailureReason — still strips what it should", () => {
+  it("strips an internal infrastructure hostname", () => {
+    const out = sanitizeFailureReason("connect ECONNREFUSED chromium.railway.internal:8080");
+    expect(out).not.toContain("chromium.railway.internal");
+  });
+
+  it("strips an arbitrary third-party hostname that is not allowlisted", () => {
+    const out = sanitizeFailureReason("failed to reach api.some-vendor.example");
+    expect(out).toContain("[service]");
+    expect(out).not.toContain("api.some-vendor.example");
+  });
+
+  it("strips full URLs", () => {
+    const out = sanitizeFailureReason("GET https://internal.example.com/secret?token=abc failed");
+    expect(out).not.toContain("internal.example.com");
+    expect(out).not.toContain("token=abc");
+  });
+
+  it("still keeps the pre-existing code-ish exemptions", () => {
+    expect(sanitizeFailureReason("cannot read error.message")).toContain("error.message");
+  });
+
+  it("handles null and empty input", () => {
+    expect(sanitizeFailureReason(null)).toBe("Unknown error");
+    expect(sanitizeFailureReason("")).toBe("Unknown error");
+  });
+});

--- a/apps/api/src/lib/sanitize.ts
+++ b/apps/api/src/lib/sanitize.ts
@@ -25,6 +25,31 @@ const PROVIDER_NAMES = [
   /\bip-api\.com\b/gi,
 ];
 
+/**
+ * Hostname-shaped strings that must survive sanitization.
+ *
+ * The stripper exists to stop internal infrastructure hostnames leaking into
+ * customer-facing errors, but it cannot tell those from a vendor name we
+ * deliberately wrote into guidance. It ate one: the ToS refusal in
+ * capabilities/lib/tos-blocklist.ts points callers at compliant review
+ * platforms, and "Reviews.io" reached production as "[service]" — advice that
+ * names nothing. Entries here are public product names appearing in authored
+ * copy, never infrastructure.
+ *
+ * Matched case-insensitively as substrings of a hostname-shaped token.
+ */
+const HOSTNAME_ALLOWLIST = [
+  "error.message",
+  "error.code",
+  "schema.org",
+  // Compliant alternatives named by the ToS blocklist refusal messages.
+  "reviews.io",
+  "trustpilot.com",
+  "glassdoor.com",
+  "linkedin.com",
+  "patents.google.com",
+];
+
 export function sanitizeFailureReason(raw: string | null): string {
   if (!raw) return "Unknown error";
 
@@ -63,9 +88,7 @@ export function sanitizeFailureReason(raw: string | null): string {
   // Strip raw hostnames (but preserve common words that match the pattern)
   // Only strip if it looks like a real hostname (has dots, not just "error.message")
   msg = msg.replace(HOSTNAME_PATTERN, (match) => {
-    // Keep common words that happen to match hostname pattern
-    const keepPatterns = ["error.message", "error.code", "schema.org"];
-    if (keepPatterns.some((p) => match.includes(p))) return match;
+    if (HOSTNAME_ALLOWLIST.some((p) => match.toLowerCase().includes(p))) return match;
     return "[service]";
   });
 


### PR DESCRIPTION
## Summary

Post-deploy verification of #151 caught this. The ToS refusal reached a real caller as:

> Supported review sources include **[service]**, Feefo and Yotpo pages, and first-party product pages.

`sanitizeFailureReason()` strips hostname-shaped tokens so internal infrastructure names can't leak into customer errors. It can't distinguish those from a vendor name deliberately written into guidance, so it ate `Reviews.io` — turning the one actionable part of the message into advice that names nothing.

## Fix

An explicit `HOSTNAME_ALLOWLIST` for public product names cited by the blocklist refusals, plus the blocked site's own name so the caller can see *what* was refused (`trustpilot.com is not supported` reading as `[service] is not supported` has the same problem).

Also folded the pre-existing inline `keepPatterns` array into the same named constant — it was doing the identical job two lines below, and matching is now case-insensitive.

## Why an allowlist and not looser stripping

The stripper is load-bearing: `chromium.railway.internal:8080` must never reach a customer. The risk in this change is an allowlist that's too broad, so the tests pin **both** directions — authored vendor names survive, and internal hosts, unknown third-party hosts, and full URLs (with query strings) are still stripped.

## Verification

- `sanitize.test.ts` — 8/8, new file (there was no coverage on this function before).
- `tsc --noEmit` clean.
- Live reproduction of the bug is quoted above, from transaction `b34db6eb-bf89-4a6f-ad3a-3ae2ae18d94d` on prod.

## Test plan

1. Merge and deploy.
2. `POST /v1/do` `{"capability_slug":"product-reviews-extract","max_price_cents":50,"inputs":{"url":"https://www.trustpilot.com/review/bemancandles.co.uk"}}`
3. Expect the refusal to name **Reviews.io** rather than `[service]`, and to still take well under a second (no fetch).