### PR TITLE
fix(domain-contact-extract): stop inventing phone numbers

### DIFF
--- a/apps/api/src/capabilities/domain-contact-extract.test.ts
+++ b/apps/api/src/capabilities/domain-contact-extract.test.ts
@@ -1,127 +1,154 @@
 /**
- * ReDoS regression tests for `domain-contact-extract`.
+ * Regression tests for `domain-contact-extract`.
  *
- * Both regexes below were remotely triggerable denial-of-service: this
- * capability fetches an arbitrary caller-supplied domain and parses up to
- * MAX_BODY_BYTES (300KB) per page across two pages, so the input is fully
- * attacker-controlled. Both patterns are synchronous, and Node is
- * single-threaded — while one runs, nothing else in the process makes
- * progress. The `executeWithHardTimeout` guard in routes/do.ts cannot rescue
- * this: it is a Promise.race against a setTimeout, and that timer cannot fire
- * while the event loop is blocked.
+ * ## ReDoS (EMAIL_RE)
  *
- * Measured on the pre-fix implementations (Node 24):
+ * This capability fetches an arbitrary caller-supplied domain and parses up
+ * to MAX_BODY_BYTES (300KB) per page across two pages, so its input is fully
+ * attacker-controlled. The pre-fix pattern
  *
- *   EMAIL_RE   /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g
- *     2KB 28ms | 8KB 479ms | 16KB 1.9s | 32KB 7.9s        (quadratic)
+ *     /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g
  *
- *   tag strip  /<(?:[^>"']|"[^"]*"|'[^']*')*>/g
- *     16K 0.39s | 64K 10.9s | 300K 243s                   (catastrophic)
+ * backtracked quadratically because its domain class contained the `.` that
+ * the following `\.` also had to match. Measured on Node 24:
+ * 2KB 28ms | 8KB 479ms | 16KB 1.9s | 32KB 7.9s.
  *
- * Per DEC-20260504-A these assertions fail against the un-applied fix and
- * pass against the applied fix — the pre-fix code exceeds every threshold
- * below by more than two orders of magnitude, so the timing bounds are
- * generous enough not to flake on a loaded CI box while still being nowhere
- * near the broken behaviour.
+ * That is a remote DoS, not merely a slow path: the regex is synchronous and
+ * Node is single-threaded, and `executeWithHardTimeout` in routes/do.ts is a
+ * Promise.race against a setTimeout — a timer that cannot fire while the
+ * event loop is blocked.
  *
- * If you are tempted to "simplify" stripTags back into a regex: that is the
- * bug. Read the comment on the function first.
+ * Per DEC-20260504-A these assertions fail against the un-applied fix. Ran
+ * the pre-fix regex against the thresholds below: 1956ms vs the 500ms limit.
+ * Two orders of magnitude of headroom, so a loaded CI box will not flake it.
+ *
+ * ## Phone extraction
+ *
+ * `extractPhones` used to fall back to a visible-text digit heuristic when a
+ * page had no `tel:` links. It shipped fabricated numbers on its first real
+ * production call (see the note in the function). The fallback is gone; only
+ * authoritative markup is trusted. These tests pin that boundary so it does
+ * not get "helpfully" restored.
+ *
+ * A previous version of this file also tested a `stripTags` scanner that had
+ * its own catastrophic-backtracking bug. That code existed only to feed the
+ * text heuristic and was deleted along with it — a vulnerability in code that
+ * no longer exists needs no regression test.
  */
 
 import { describe, it, expect } from "vitest";
-import { stripTags, EMAIL_RE } from "./domain-contact-extract.js";
+import { EMAIL_RE, extractPhones } from "./domain-contact-extract.js";
 
-/** Wall-clock a synchronous fn, in milliseconds. */
 function timeSync(fn: () => unknown): number {
   const t0 = process.hrtime.bigint();
   fn();
   return Number(process.hrtime.bigint() - t0) / 1e6;
 }
 
-describe("stripTags — ReDoS regression", () => {
-  it("handles a 300KB run of unclosed '<' in linear time (was 243s)", () => {
-    const hostile = "<".repeat(300_000);
-    const ms = timeSync(() => stripTags(hostile));
-    expect(ms).toBeLessThan(1000);
-  });
-
-  it("handles 64K of '<\"' pairs quickly (was 6.3s)", () => {
-    const hostile = '<"'.repeat(32_000);
-    const ms = timeSync(() => stripTags(hostile));
-    expect(ms).toBeLessThan(1000);
-  });
-
-  it("scales roughly linearly, not quadratically", () => {
-    // The broken regex grew ~4x per doubling. Linear code grows ~2x. Assert
-    // well inside that gap so normal timing jitter can't trip it.
-    const small = timeSync(() => stripTags("<".repeat(50_000)));
-    const large = timeSync(() => stripTags("<".repeat(200_000)));
-    // 4x the input. Quadratic would be ~16x; allow up to 8x for jitter.
-    expect(large).toBeLessThan(Math.max(small, 1) * 8);
-  });
-});
-
-describe("stripTags — behavioural parity with the regex it replaced", () => {
-  const strip = (s: string) => stripTags(s).replace(/\s+/g, " ").trim();
-
-  it("treats a '>' inside a quoted attribute value as attribute content", () => {
-    // A naive /<[^>]+>/ closes the tag at the '>' inside the value and leaks
-    // the remainder as visible text.
-    expect(strip(`<div style="width:calc(100%>50px)">HELLO</div>`)).toBe("HELLO");
-  });
-
-  it("does not leak data-URI SVG path data as visible text", () => {
-    // This is the original defect: dense path coordinates were being read as
-    // phone numbers by the text-fallback extractor.
-    const html =
-      `<i style="background:url('data:image/svg+xml,<svg><path d=M12.5 3.7L9 2z/></svg>')">VISIBLE</i>`;
-    expect(strip(html)).toBe("VISIBLE");
-  });
-
-  it("handles single-quoted attribute values containing '>'", () => {
-    expect(strip(`<a href='x>y'>LINK</a>`)).toBe("LINK");
-  });
-
-  it("keeps prose after a stray '<' that is not a tag", () => {
-    // Regression guard on the fix itself: an early version dropped everything
-    // after an unterminated '<', which would silently lose contact details in
-    // text like this.
-    expect(strip("5 < 10, call 555-123-4567 now")).toBe("5 < 10, call 555-123-4567 now");
-  });
-
-  it("strips ordinary tags and keeps their text", () => {
-    expect(strip(`<p class="a">Text</p><br/><a href="mailto:x@y.com">x@y.com</a>`)).toBe(
-      "Text x@y.com",
-    );
-  });
-});
+const fresh = () => new RegExp(EMAIL_RE.source, EMAIL_RE.flags);
 
 describe("EMAIL_RE — ReDoS regression", () => {
-  it("handles a 32KB no-match adversarial body quickly (was 7.9s)", () => {
-    // The classic shape: a long local-part run, an '@', then a long dot-free
-    // domain run that never satisfies the trailing \. — maximal backtracking.
+  it("handles a 32KB no-match adversarial body quickly (pre-fix: 7.9s)", () => {
+    // Long local-part run, an '@', then a long dot-free domain run that never
+    // satisfies the trailing \. — maximal backtracking for the old pattern.
     const hostile = "a".repeat(16_000) + "@" + "b".repeat(16_000);
-    const ms = timeSync(() => hostile.match(new RegExp(EMAIL_RE.source, EMAIL_RE.flags)));
-    expect(ms).toBeLessThan(500);
+    expect(timeSync(() => hostile.match(fresh()))).toBeLessThan(500);
   });
 
   it("stays fast at 300KB, the real per-page parse cap", () => {
     const hostile = "a".repeat(150_000) + "@" + "b".repeat(150_000);
-    const ms = timeSync(() => hostile.match(new RegExp(EMAIL_RE.source, EMAIL_RE.flags)));
-    expect(ms).toBeLessThan(1000);
+    expect(timeSync(() => hostile.match(fresh()))).toBeLessThan(1000);
+  });
+
+  it("scales linearly, not quadratically", () => {
+    const small = timeSync(() => ("a".repeat(25_000) + "@" + "b".repeat(25_000)).match(fresh()));
+    const large = timeSync(() => ("a".repeat(100_000) + "@" + "b".repeat(100_000)).match(fresh()));
+    // 4x the input. Quadratic would be ~16x; allow 8x for timing jitter.
+    expect(large).toBeLessThan(Math.max(small, 1) * 8);
   });
 
   it("still matches the addresses it is supposed to find", () => {
     const sample =
       `Contact <a href="mailto:sales@stripe.com">sales@stripe.com</a> ` +
       `or jane.doe@sub.example.co.uk or x@a.io`;
-    const found = sample.match(new RegExp(EMAIL_RE.source, EMAIL_RE.flags)) ?? [];
+    const found = sample.match(fresh()) ?? [];
     expect(found).toContain("sales@stripe.com");
     expect(found).toContain("jane.doe@sub.example.co.uk");
     expect(found).toContain("x@a.io");
   });
 
-  it("does not match a bare '@' run with no dotted domain", () => {
-    expect("aaaa@bbbb".match(new RegExp(EMAIL_RE.source, EMAIL_RE.flags))).toBeNull();
+  it("does not match an '@' run with no dotted domain", () => {
+    expect("aaaa@bbbb".match(fresh())).toBeNull();
+  });
+});
+
+describe("extractPhones — authoritative markup only", () => {
+  it("extracts tel: links", () => {
+    const html = `<a href="tel:+46812345678">Call us</a>`;
+    expect(extractPhones(html)).toEqual(["+46812345678"]);
+  });
+
+  it("URL-decodes and dedupes tel: links", () => {
+    const html = `<a href="tel:%2B46%20812%20345%20678">a</a><a href="tel:%2B46%20812%20345%20678">b</a>`;
+    expect(extractPhones(html)).toEqual(["+46 812 345 678"]);
+  });
+
+  it("extracts schema.org telephone from JSON-LD", () => {
+    const html = `<script type="application/ld+json">
+      {"@type":"Organization","name":"Acme","telephone":"+1-555-123-4567"}
+    </script>`;
+    expect(extractPhones(html)).toContain("+1-555-123-4567");
+  });
+
+  it("finds telephone nested inside JSON-LD sub-objects", () => {
+    const html = `<script type="application/ld+json">
+      {"@type":"Organization","contactPoint":{"@type":"ContactPoint","telephone":"+44 20 7946 0958"}}
+    </script>`;
+    expect(extractPhones(html)).toContain("+44 20 7946 0958");
+  });
+
+  it("extracts microdata telephone in both element and meta form", () => {
+    expect(extractPhones(`<span itemprop="telephone">+61 2 9374 4000</span>`)).toContain(
+      "+61 2 9374 4000",
+    );
+    expect(extractPhones(`<meta itemprop="telephone" content="+81 3 6367 6000">`)).toContain(
+      "+81 3 6367 6000",
+    );
+  });
+
+  it("survives malformed JSON-LD without throwing", () => {
+    const html = `<script type="application/ld+json">{ not valid json </script>
+                  <a href="tel:+15551234567">x</a>`;
+    expect(extractPhones(html)).toEqual(["+15551234567"]);
+  });
+
+  it("rejects values outside the ITU-T E.164 7-15 digit range", () => {
+    expect(extractPhones(`<a href="tel:12345">x</a>`)).toEqual([]);
+    expect(extractPhones(`<a href="tel:+1234567890123456789">x</a>`)).toEqual([]);
+  });
+
+  // The regression that motivated removing the heuristic. Every case below is
+  // digit noise of the kind that reaches this function after a bot-served,
+  // mid-document-truncated page — and every one was previously returned as a
+  // phone number.
+  describe("returns nothing rather than inventing numbers", () => {
+    const noise: Array<[string, string]> = [
+      ["the exact prod false positives", "<p>72-9098-2766 and 24155-3298-4</p>"],
+      ["SVG path coordinates", `<p>M12.5 3.7 L9 2 24155 3298 4</p>`],
+      ["a decimal-looking number", "<p>41056.391</p>"],
+      ["an order/tracking id", "<p>Order 1234567890123</p>"],
+      ["hyphenated non-phone digits", "<p>2024-08-09-114523</p>"],
+      ["plain visible text digits", "<p>Call 555 123 4567 today</p>"],
+    ];
+    for (const [label, html] of noise) {
+      it(label, () => {
+        expect(extractPhones(html)).toEqual([]);
+      });
+    }
+  });
+
+  it("still returns tel: links even when digit noise is present alongside", () => {
+    const html = `<p>72-9098-2766</p><a href="tel:+46812345678">real</a>`;
+    expect(extractPhones(html)).toEqual(["+46812345678"]);
   });
 });

--- a/apps/api/src/capabilities/domain-contact-extract.ts
+++ b/apps/api/src/capabilities/domain-contact-extract.ts
@@ -97,123 +97,14 @@ async function readCapped(resp: Response, maxBytes = MAX_BODY_BYTES): Promise<st
 }
 
 /**
- * `readCapped` truncates the response body at MAX_BODY_BYTES, and that cut
- * can land mid-block — e.g. inside an `<svg>...</svg>` icon sprite, leaving
- * an opening tag with no matching close anywhere in the truncated string.
- * The close-tag-based strip below can't remove a block it never finds the
- * end of, so the dangling fragment (dense SVG path-coordinate digits, in
- * practice) leaks through as if it were visible text. Drop everything from
- * the last unclosed script/style/svg open tag onward before stripping —
- * we can't safely parse past a truncation boundary anyway.
- */
-function dropTrailingUnclosedBlock(html: string, tag: string): string {
-  const openRe = new RegExp(`<${tag}[\\s>]`, "gi");
-  let lastOpenIdx = -1;
-  let m: RegExpExecArray | null;
-  while ((m = openRe.exec(html))) lastOpenIdx = m.index;
-  if (lastOpenIdx === -1) return html;
-  const closeRe = new RegExp(`</${tag}>`, "i");
-  const hasCloseAfter = closeRe.test(html.slice(lastOpenIdx));
-  return hasCloseAfter ? html : html.slice(0, lastOpenIdx);
-}
-
-/**
- * Strip script/style/svg blocks, comments, and all remaining tags to get a
- * plain-text view of the page. Inline SVG `<path d="M59.6 14.2 ...">` data
- * is the dominant false-positive source for a raw-HTML phone regex — it is
- * dense with digit/space/dash/dot sequences that pass any digit-count
- * heuristic. Restricting the text-fallback regex to visible text (never
- * attribute values) eliminates that class of noise entirely.
- */
-function stripToVisibleText(html: string): string {
-  let cleaned = html;
-  for (const tag of ["script", "style", "svg"]) {
-    cleaned = dropTrailingUnclosedBlock(cleaned, tag);
-  }
-  return stripTags(
-    cleaned
-      .replace(/<script[\s\S]*?<\/script>/gi, " ")
-      .replace(/<style[\s\S]*?<\/style>/gi, " ")
-      .replace(/<svg[\s\S]*?<\/svg>/gi, " ")
-      .replace(/<!--[\s\S]*?-->/g, " ")
-      .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, " "),
-  );
-}
-
-/**
- * Strip HTML tags in a single linear pass.
+ * Phone-number extraction from AUTHORITATIVE MARKUP ONLY.
  *
- * This deliberately is NOT a regex. The previous implementation was
- *   /<(?:[^>"']|"[^"]*"|'[^']*')*>/g
- * which handled the real requirement correctly — a naive `<[^>]+>` breaks on
- * tags whose attribute VALUE contains a literal "<" or ">" (e.g. a data-URI
- * SVG inside a `style` attribute), leaking raw SVG path digits into what
- * should be visible text, which is what made phone extraction hallucinate
- * numbers. But it was catastrophically backtracking: `[^>"']` can itself
- * match "<", so on a run of unclosed "<" the engine re-explores the
- * alternation from every offset. Measured on a run of "<" characters:
- *   16K → 0.39s, 64K → 10.9s, 300K → 243s.
- * MAX_BODY_BYTES is 300_000 and we parse up to two pages, so an attacker
- * serving a page of "<"*300000 from their own domain could block the Node
- * event loop for minutes on a single 5-cent call. The hard-timeout guard in
- * routes/do.ts cannot save us — its setTimeout can't fire while the loop is
- * blocked.
- *
- * A hand-written scanner has no backtracking at all: one pass, O(n), with
- * the same quote-awareness the regex provided. Measured at 300KB of the
- * pathological input: sub-millisecond.
+ * Two sources, both of which are the page author explicitly declaring "this
+ * string is a phone number": `tel:` links, and schema.org `telephone` in
+ * JSON-LD or microdata. There is no free-text fallback — see the long note
+ * inside the function for why one cannot work here.
  */
-export function stripTags(html: string): string {
-  let out = "";
-  let i = 0;
-  const n = html.length;
-  while (i < n) {
-    const lt = html.indexOf("<", i);
-    if (lt === -1) {
-      out += html.slice(i);
-      break;
-    }
-    out += html.slice(i, lt);
-    // Walk to the matching ">", treating quoted attribute values as opaque
-    // so an embedded ">" inside them doesn't close the tag early.
-    let j = lt + 1;
-    let quote: string | null = null;
-    while (j < n) {
-      const ch = html[j];
-      if (quote) {
-        if (ch === quote) quote = null;
-      } else if (ch === '"' || ch === "'") {
-        quote = ch;
-      } else if (ch === ">") {
-        break;
-      }
-      j++;
-    }
-    if (j >= n) {
-      // No closing ">" anywhere — this "<" is not a tag at all, it is literal
-      // text (e.g. prose containing "5 < 10, call 555-1234"). Emit the
-      // remainder verbatim and stop. This matches the old regex, which simply
-      // failed to match here and left the text in place; dropping it instead
-      // would silently lose any contact details appearing after a stray "<".
-      out += html.slice(lt);
-      break;
-    }
-    out += " ";
-    i = j + 1;
-  }
-  return out;
-}
-
-/**
- * Phone-number extraction. Prefers `tel:` links (unambiguous — the page
- * author marked it as a phone number). Falls back to a text heuristic only
- * when no tel: links exist, scoped to visible text only (see
- * stripToVisibleText), and requires real phone-like structure (a leading
- * "+" or at least two separator characters) to avoid matching decimal-
- * looking numbers, prices, and tracking IDs that happen to fall in the
- * 7-15 digit range.
- */
-function extractPhones(html: string): string[] {
+export function extractPhones(html: string): string[] {
   const results: string[] = [];
   const seen = new Set<string>();
 
@@ -225,29 +116,92 @@ function extractPhones(html: string): string[] {
     seen.add(num);
     results.push(num);
   }
-  if (results.length > 0) return results.slice(0, 10);
-
-  const visibleText = stripToVisibleText(html);
-  // "." deliberately excluded from the allowed character class: decimal
-  // numbers, prices, and version strings vastly outnumber dot-formatted
-  // phone numbers on real pages and were the single biggest false-positive
-  // source observed during onboarding (e.g. "41056.391").
-  const candidates = visibleText.match(/\+?[\d][\d\s()-]{6,18}\d/g) || [];
-  for (const raw of candidates) {
-    const trimmed = raw.trim().replace(/\s+/g, " ");
-    const digits = trimmed.replace(/[^\d]/g, "");
-    // Real phone numbers are 7-15 digits (ITU-T E.164 max).
+  // Second authoritative source: schema.org `telephone`, in JSON-LD or
+  // microdata. Like a tel: link, this is the site author explicitly declaring
+  // "this string is a phone number" — not us inferring it from shape.
+  for (const num of extractSchemaTelephones(html)) {
+    const digits = num.replace(/[^\d]/g, "");
     if (digits.length < 7 || digits.length > 15) continue;
-    const startsWithPlus = trimmed.startsWith("+");
-    const separatorCount = (trimmed.match(/[\s()-]/g) || []).length;
-    // Bare digit blobs are the other dominant false-positive shape —
-    // require a leading "+" or >=2 separators.
-    if (!startsWithPlus && separatorCount < 2) continue;
-    if (seen.has(trimmed)) continue;
-    seen.add(trimmed);
-    results.push(trimmed);
+    if (seen.has(num)) continue;
+    seen.add(num);
+    results.push(num);
   }
+
+  // DELIBERATELY NO FREE-TEXT FALLBACK.
+  //
+  // There used to be one: it scanned visible text for digit runs that looked
+  // phone-shaped (7-15 digits, plus a leading "+" or >=2 separators). It was
+  // tightened twice during onboarding — first to exclude "." so decimals and
+  // version strings stopped matching, then to require real separator
+  // structure — and it still shipped false positives to production on its
+  // first real call. Against stripe.com it returned "72-9098-2766" and
+  // "24155-3298-4"; neither digit sequence appears anywhere on the page.
+  //
+  // The mechanism: under our bot User-Agent the site serves different markup
+  // than a browser, `readCapped` truncates it at MAX_BODY_BYTES mid-document,
+  // and the heuristic reads the resulting fragment as numbers. No amount of
+  // additional shape-tightening fixes that, because the input itself is
+  // garbage — the heuristic is being asked to distinguish a phone number from
+  // arbitrary truncated markup using only digit grouping, which is not
+  // decidable.
+  //
+  // Returning invented contact details is strictly worse than returning none:
+  // an empty `phones` array is honest and the caller can act on it, whereas a
+  // plausible-looking wrong number is acted on and fails silently. On a
+  // platform selling verified data, that trade is not close. If a site
+  // publishes a phone number without tel: markup or schema.org, we report
+  // nothing and say so in the manifest limitations.
   return results.slice(0, 10);
+}
+
+/**
+ * Pull `telephone` values out of schema.org markup — JSON-LD blocks first,
+ * then microdata attributes. Mirrors extractPostalAddress's approach.
+ */
+function extractSchemaTelephones(html: string): string[] {
+  const found: string[] = [];
+
+  const jsonLdBlocks = html.matchAll(
+    /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
+  );
+  for (const block of jsonLdBlocks) {
+    try {
+      collectTelephoneNodes(JSON.parse(block[1]), found);
+    } catch {
+      // Malformed JSON-LD on the page — skip, not our job to fix their markup.
+    }
+  }
+
+  for (const m of html.matchAll(/itemprop=["']telephone["'][^>]*>([^<]+)</gi)) {
+    const v = m[1]?.trim();
+    if (v) found.push(v);
+  }
+  // Also the attribute form: <meta itemprop="telephone" content="...">
+  for (const m of html.matchAll(
+    /itemprop=["']telephone["'][^>]*content=["']([^"']+)["']/gi,
+  )) {
+    const v = m[1]?.trim();
+    if (v) found.push(v);
+  }
+
+  return found;
+}
+
+/** Recursively collect schema.org `telephone` string values. */
+function collectTelephoneNodes(node: unknown, out: string[], depth = 0): void {
+  if (depth > 4 || node == null || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const item of node) collectTelephoneNodes(item, out, depth + 1);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  if (typeof obj.telephone === "string" && obj.telephone.trim()) {
+    out.push(obj.telephone.trim());
+  }
+  for (const key of Object.keys(obj)) {
+    const val = obj[key];
+    if (val && typeof val === "object") collectTelephoneNodes(val, out, depth + 1);
+  }
 }
 
 /** Recursively search parsed JSON-LD for a schema.org PostalAddress node. */

--- a/manifests/domain-contact-extract.yaml
+++ b/manifests/domain-contact-extract.yaml
@@ -118,11 +118,19 @@ limitations:
       show has_contact_page: false even if a contact page exists.
     category: coverage
     severity: info
-  - title: Phone and address extraction are heuristic, not validated
+  - title: Phone numbers come only from explicit markup — plain-text numbers are not extracted
     text: >-
-      Phone numbers are matched by digit-count heuristics (7-15 digits) and can include false positives from tracking
-      IDs, prices, or other digit strings that happen to look phone-shaped. Postal address relies on the page publishing
-      schema.org JSON-LD or microdata markup; sites without structured markup return postal_address: null even if an
-      address is visible in plain text on the page.
-    category: accuracy
+      A phone number is returned only when the site declares it as one: a tel: link, or a schema.org telephone value in
+      JSON-LD or microdata. A number that appears only as visible text is NOT extracted, so phones can be empty on a
+      page a human would say clearly shows a phone number. This is deliberate. An earlier version inferred numbers from
+      digit shape and returned fabricated values in production (digit sequences that appeared nowhere on the page),
+      because sites serve different markup to bots and the response is truncated at 300KB mid-document. An empty result
+      you can act on is worth more than a plausible wrong number you cannot detect.
+    category: coverage
+    severity: warning
+  - title: Postal address requires structured markup
+    text: >-
+      Postal address relies on the page publishing schema.org JSON-LD or microdata markup; sites without structured
+      markup return postal_address: null even if an address is visible in plain text on the page.
+    category: coverage
     severity: info


### PR DESCRIPTION
## Summary

`domain-contact-extract` returned **fabricated phone numbers** on its first real production call. Asked for `stripe.com`, it answered `phones: ["72-9098-2766", "24155-3298-4"]`. Neither digit sequence appears anywhere on that page. It was deactivated within minutes of the finding; the only calls in the exposure window were my own verification.

This PR removes the mechanism that invented them.

## Cause

When a page had no `tel:` links, `extractPhones` fell back to scanning visible text for phone-shaped digit runs. Two things made that unworkable:

- Sites serve **different markup to our bot User-Agent** than to a browser. The page a browser gets and the page we parse are not the same document.
- `readCapped` truncates at `MAX_BODY_BYTES` (300KB) **mid-document**. Stripe's contact page is 685KB.

So the heuristic was handed an arbitrary fragment of bot-served markup and asked to distinguish phone numbers from digit noise using only grouping. That is not decidable — which is why it had already been tightened twice during onboarding (first to exclude `.` so decimals stopped matching, then to require real separator structure) and still shipped false positives.

## Fix

Phone numbers now come only from markup where **the site itself declares the value is a phone number**:

- `tel:` links (already supported)
- schema.org `telephone` in JSON-LD or microdata (**new** — recovers most of the coverage the fallback existed to provide, honestly)

No free-text inference. Verified live against `stripe.com`, `github.com`, `mozilla.org`: all now return `phones: []` instead of fabricated numbers, with `role_emails`, social links and contact-page discovery unaffected (`sales@stripe.com` still found, `has_contact_page: true`).

An empty array is worth more than a plausible wrong number. A caller can act on "we found none"; they cannot detect a fabricated one. The manifest limitation now states this plainly, upgraded to `severity: warning`, instead of describing the heuristic that no longer exists.

## Dead code removed

`stripToVisibleText`, `stripTags`, and `dropTrailingUnclosedBlock` existed **only** to feed the deleted heuristic and now have no callers.

That also permanently removes the catastrophic-backtracking surface in `stripTags` — 300KB of `<` characters took **243 seconds** pre-fix, remotely triggerable for five cents. A vulnerability in deleted code needs no regression test, so its tests are removed with it. This is a deeper fix than the scanner rewrite it supersedes: the code can't be slow if it doesn't exist.

The `EMAIL_RE` ReDoS tests **remain** — that regex is still live.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit` | pass |
| `vitest` (domain-contact-extract) | 19/19 |
| `validate-capability` | 19/19 |
| `smoke-test` | pass |
| `check-ssrf-inventory.mjs` (F-0-006) | pass |
| Live: stripe.com / github.com / mozilla.org | `phones: []`, other fields intact |

New tests pin the boundary so the heuristic cannot be "helpfully" restored: the exact production false positives, SVG path coordinates, decimals, tracking IDs, and plain visible-text digits all assert `[]`, while `tel:` and schema.org values assert extraction — including when digit noise sits alongside a real `tel:` link.

## Deployment

`domain-contact-extract` is currently `lifecycle_state=validating, visible=false, x402_enabled=false`. After merge and deploy, I will verify a real production call returns `phones: []` for `stripe.com` **before** reactivating — same order as last time, since that ordering is what caught this.

`email-validate-bulk` and `keyword-rank-check` are unaffected and remain live.

## Test plan

1. Merge, confirm the deployed commit on `GET /health`.
2. `POST /v1/do` `domain-contact-extract` with `{"domain":"stripe.com"}` — expect `phones: []`, `role_emails: ["sales@stripe.com"]`, `has_contact_page: true`.
3. Confirm `{"domain":"trustpilot.com"}` still refuses on ToS policy without charging.
4. Only then reactivate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
