### PR TITLE
fix(domain-contact-extract): decode JSON unicode escapes before extraction

### DIFF
--- a/apps/api/src/capabilities/domain-contact-extract.test.ts
+++ b/apps/api/src/capabilities/domain-contact-extract.test.ts
@@ -37,7 +37,17 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { EMAIL_RE, extractPhones } from "./domain-contact-extract.js";
+import { EMAIL_RE, extractPhones, decodeJsonUnicodeEscapes } from "./domain-contact-extract.js";
+
+// Built from char codes so nothing in the toolchain can silently interpret the
+// escape sequences this module exists to handle.
+const BACKSLASH = String.fromCharCode(92);
+const ESCAPED_GT = BACKSLASH + "u003e";
+const ESCAPED_LT = BACKSLASH + "u003c";
+const ESCAPED_NUL = BACKSLASH + "u0000";
+const ESCAPED_EMOJI = BACKSLASH + "ud83d" + BACKSLASH + "ude00";
+const EMOJI = String.fromCharCode(0xd83d, 0xde00);
+
 
 function timeSync(fn: () => unknown): number {
   const t0 = process.hrtime.bigint();
@@ -150,5 +160,44 @@ describe("extractPhones — authoritative markup only", () => {
   it("still returns tel: links even when digit noise is present alongside", () => {
     const html = `<p>72-9098-2766</p><a href="tel:+46812345678">real</a>`;
     expect(extractPhones(html)).toEqual(["+46812345678"]);
+  });
+});
+
+describe("decodeJsonUnicodeEscapes", () => {
+  const emails = (s: string) => s.match(new RegExp(EMAIL_RE.source, EMAIL_RE.flags)) ?? [];
+
+  it("fixes the exact production failure", () => {
+    // Railway (US East) is served the escaped form immediately before the
+    // address; the same URL fetched from Sweden has a literal ">".
+    const html = "<p>" + ESCAPED_GT + "sales@stripe.com</p>";
+
+    // Without decoding, the bug reproduces — this is what shipped to prod.
+    expect(emails(html)).toEqual(["u003esales@stripe.com"]);
+
+    // With decoding, the address is clean.
+    expect(emails(decodeJsonUnicodeEscapes(html))).toEqual(["sales@stripe.com"]);
+  });
+
+  it("is a no-op on content with no escapes", () => {
+    const plain = '<a href="mailto:sales@stripe.com">sales@stripe.com</a>';
+    expect(decodeJsonUnicodeEscapes(plain)).toBe(plain);
+  });
+
+  it("decodes several escapes in one pass", () => {
+    const html = ESCAPED_LT + "div" + ESCAPED_GT + "hi" + ESCAPED_LT + "/div" + ESCAPED_GT;
+    expect(decodeJsonUnicodeEscapes(html)).toBe("<div>hi</div>");
+  });
+
+  it("leaves C0 control escapes encoded", () => {
+    expect(decodeJsonUnicodeEscapes(ESCAPED_NUL)).toBe(ESCAPED_NUL);
+  });
+
+  it("decodes surrogate pairs back into the original character", () => {
+    expect(decodeJsonUnicodeEscapes(ESCAPED_EMOJI)).toBe(EMOJI);
+  });
+
+  it("ignores malformed escapes", () => {
+    const malformed = BACKSLASH + "u12";
+    expect(decodeJsonUnicodeEscapes(malformed)).toBe(malformed);
   });
 });

--- a/apps/api/src/capabilities/domain-contact-extract.ts
+++ b/apps/api/src/capabilities/domain-contact-extract.ts
@@ -68,6 +68,40 @@ const SOCIAL_PATTERNS: Record<string, RegExp> = {
 };
 
 /**
+ * Decode JSON `\uXXXX` escape sequences into the characters they represent.
+ *
+ * Modern sites embed markup inside JSON payloads (Next.js flight data, inlined
+ * state, script-tag JSON). In that form a `>` is not a `>` — it is the six
+ * literal characters backslash, u, 0, 0, 3, e. That escaped text sits in the
+ * HTML we parse, and none of our extractors understand it.
+ *
+ * The concrete failure: a production call for stripe.com returned
+ * `role_emails: ["u003esales@stripe.com"]`. The page contained the escaped
+ * form immediately before the address. EMAIL_RE's local-part class accepts
+ * letters and digits but not backslashes, so the match began at the `u` of the
+ * escape and swallowed `u003e` into the local part.
+ *
+ * This is region-dependent and was invisible locally: Railway (US East) is
+ * served the escaped variant, while the same URL fetched from Sweden returns a
+ * literal `>`. Decoding here — once, at the single point where fetched bytes
+ * enter the capability — means every downstream extractor sees the same text
+ * the browser would, regardless of which variant the origin served.
+ *
+ * Linear, no backtracking. Surrogate pairs decode correctly because each half
+ * is converted independently and concatenated.
+ */
+export function decodeJsonUnicodeEscapes(s: string): string {
+  if (!s.includes("\\u")) return s;
+  return s.replace(/\\u([0-9a-fA-F]{4})/g, (whole, hex: string) => {
+    const code = parseInt(hex, 16);
+    // Leave C0 controls encoded — decoding them would inject raw control
+    // characters into text we hand back to callers, and nothing we extract
+    // needs them.
+    return code < 0x20 ? whole : String.fromCharCode(code);
+  });
+}
+
+/**
  * Read a fetch Response body capped at `maxBytes`, streaming so an
  * oversized response never gets fully buffered in memory first.
  */
@@ -309,7 +343,9 @@ registerCapability("domain-contact-extract", async (input: CapabilityInput) => {
     if (!resp.ok) {
       throw new Error(`domain-contact-extract: ${hostname} returned HTTP ${resp.status}`);
     }
-    homepageHtml = await readCapped(resp);
+    // Decode at the boundary so every extractor below sees one canonical
+    // form, whichever variant the origin served this region.
+    homepageHtml = decodeJsonUnicodeEscapes(await readCapped(resp));
     fetchedUrls.push(homepageUrl);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -341,7 +377,7 @@ registerCapability("domain-contact-extract", async (input: CapabilityInput) => {
         timeoutMs: FETCH_TIMEOUT_MS,
       });
       if (resp.ok) {
-        contactHtml = await readCapped(resp);
+        contactHtml = decodeJsonUnicodeEscapes(await readCapped(resp));
         fetchedUrls.push(contactPageUrl);
       }
     } catch {


### PR DESCRIPTION
## Summary

Production returned `role_emails: ["u003esales@stripe.com"]` for `stripe.com`. This is the last known defect blocking `domain-contact-extract` from reactivation.

Modern sites embed markup inside JSON payloads (Next.js flight data, inlined state, script-tag JSON). In that form a `>` is not a `>` — it is the six literal characters backslash, u, 0, 0, 3, e. `EMAIL_RE`'s local-part class accepts letters and digits but not backslashes, so the match began at the `u` of the escape and swallowed `u003e` into the address.

Decoding now happens **once, at the single point where fetched bytes enter the capability**, so every downstream extractor (emails, personal addresses, contact-link discovery, social links, `tel:` hrefs) sees the same text a browser would, regardless of which variant the origin served. C0 control escapes are deliberately left encoded — decoding those would inject raw control characters into strings handed back to callers, and nothing here needs them.

## Why this reached production

It is **region-dependent**. Railway in US East is served the escaped variant; the same URL fetched from Sweden returns a literal `>`.

Every local gate passed: 19/19 structural validation, 11/11 smoke test, clean local execution. None of them parsed the bytes the production runtime actually receives.

This is the **third** defect in this capability with that same shape, after the two fabricated-phone-number cases in #157. The pattern is now well established and worth stating plainly: for a capability whose input is third-party web content, local verification demonstrates very little, because origins vary their response by region and by User-Agent. Verification has to mean a real production call, with the output values read rather than just the status code.

## Tests

The regression test does **not** depend on the network. It builds the escape sequence from char codes (so no layer of tooling can silently interpret it — which happened twice while writing this) and asserts both directions:

- without decoding, `["u003esales@stripe.com"]` — the bug, reproduced
- with decoding, `["sales@stripe.com"]` — fixed

Plus: no-op on unescaped content, multiple escapes in one pass, C0 controls left alone, surrogate pairs round-tripped, malformed escapes ignored.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit` | pass |
| `vitest` (domain-contact-extract) | 25/25 |
| `validate-capability` | 19/19 |
| `smoke-test` | pass |
| `check-ssrf-inventory.mjs` (F-0-006) | pass |

## Deployment

`domain-contact-extract` is currently `lifecycle_state=validating, visible=false, x402_enabled=false`.

After merge, I will wait for `GET /health` to report this commit, then make a **real production call** and read the actual output before reactivating — because a local call structurally cannot confirm this fix. `email-validate-bulk` and `keyword-rank-check` are unaffected and remain live.

## Test plan

1. Merge; poll `GET /health` until the deployed commit matches.
2. `POST /v1/do` `domain-contact-extract` `{"domain":"stripe.com"}` — expect `role_emails: ["sales@stripe.com"]` (no `u003e` prefix), `phones: []`, `has_contact_page: true`.
3. Confirm `{"domain":"trustpilot.com"}` still refuses on ToS policy without charging.
4. Only then reactivate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
