### PR TITLE
fix(serper): validate language, widen country aliases, fix iso-country-lookup reliability

### DIFF
--- a/apps/api/src/capabilities/google-search.ts
+++ b/apps/api/src/capabilities/google-search.ts
@@ -1,5 +1,6 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { resolveCountryOrThrow } from "./lib/iso-3166.js";
+import { resolveLanguageOrThrow } from "./lib/language-tag.js";
 
 // Uses Serper.dev API (free tier: 2,500 queries/month, no CAPTCHA issues)
 // Requires SERPER_API_KEY env var
@@ -9,7 +10,9 @@ registerCapability("google-search", async (input: CapabilityInput) => {
   if (query.length < 2) throw new Error("'query' must be at least 2 characters.");
 
   const numResults = Math.min((input.num_results as number) ?? 10, 20);
-  const language = ((input.language as string) ?? "").trim();
+  // Same silent-ignore behaviour as `country` below — Google drops an
+  // unrecognised `hl` and bills the call anyway.
+  const language = resolveLanguageOrThrow(input.language);
 
   // Validate before spending a Serper call. An unresolvable country used to be
   // forwarded verbatim as `gl`, which Serper ignores — the caller paid for a

--- a/apps/api/src/capabilities/keyword-rank-check.ts
+++ b/apps/api/src/capabilities/keyword-rank-check.ts
@@ -1,5 +1,6 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { resolveCountryOrThrow } from "./lib/iso-3166.js";
+import { resolveLanguageOrThrow } from "./lib/language-tag.js";
 
 registerCapability("keyword-rank-check", async (input: CapabilityInput) => {
   const rawDomain = (
@@ -63,7 +64,7 @@ registerCapability("keyword-rank-check", async (input: CapabilityInput) => {
   // search while the response echoed the caller's bogus value back — and here
   // that also means the reported rank is for the wrong market.
   const country = resolveCountryOrThrow(input.country, { fallback: "us" }).toLowerCase();
-  const language = ((input.language as string) ?? "en").trim().toLowerCase();
+  const language = resolveLanguageOrThrow(input.language, { fallback: "en" });
 
   let depth = 10;
   if (input.depth !== undefined && input.depth !== null) {

--- a/apps/api/src/capabilities/lib/iso-3166.test.ts
+++ b/apps/api/src/capabilities/lib/iso-3166.test.ts
@@ -215,3 +215,47 @@ describe("resolveCountryOrThrow", () => {
     expect(() => resolveCountryOrThrow("墨西")).toThrow(/墨西/);
   });
 });
+
+describe("resolveCountryAlpha2 — accent and alias handling", () => {
+  it("resolves accented names typed without their accents", () => {
+    expect(resolveCountryAlpha2("Cote d'Ivoire")).toBe("CI");
+    expect(resolveCountryAlpha2("Côte d'Ivoire")).toBe("CI");
+    expect(resolveCountryAlpha2("Aland Islands")).toBe("AX");
+    expect(resolveCountryAlpha2("Åland Islands")).toBe("AX");
+    expect(resolveCountryAlpha2("Saint Barthelemy")).toBe("BL");
+  });
+
+  it("resolves real-world names ISO does not use", () => {
+    expect(resolveCountryAlpha2("Czechia")).toBe("CZ");
+    expect(resolveCountryAlpha2("Türkiye")).toBe("TR");
+    expect(resolveCountryAlpha2("Turkiye")).toBe("TR");
+    expect(resolveCountryAlpha2("UAE")).toBe("AE");
+    expect(resolveCountryAlpha2("Holland")).toBe("NL");
+    expect(resolveCountryAlpha2("Ivory Coast")).toBe("CI");
+    expect(resolveCountryAlpha2("Cape Verde")).toBe("CV");
+    expect(resolveCountryAlpha2("Swaziland")).toBe("SZ");
+    expect(resolveCountryAlpha2("Burma")).toBe("MM");
+    expect(resolveCountryAlpha2("Macedonia")).toBe("MK");
+    expect(resolveCountryAlpha2("Vatican")).toBe("VA");
+  });
+
+  it("maps the UK's constituent countries to GB, which is what gl accepts", () => {
+    for (const name of ["England", "Scotland", "Wales", "Northern Ireland", "Britain", "Great Britain"]) {
+      expect(resolveCountryAlpha2(name), name).toBe("GB");
+    }
+  });
+
+  it("still refuses names that need a guess", () => {
+    // Adding aliases must not quietly widen into ambiguity.
+    expect(resolveCountryAlpha2("Korea")).toBeNull();
+    expect(resolveCountryAlpha2("Congo")).toBeNull();
+    expect(resolveCountryAlpha2("America")).toBeNull();
+  });
+
+  it("lets a real ISO code win over any alias key", () => {
+    // Precedence guard: code lookup runs before the alias map, so a future
+    // alias whose key collides with an assigned code cannot shadow it.
+    expect(resolveCountryAlpha2("CD")).toBe("CD");
+    expect(resolveCountryAlpha2("VA")).toBe("VA");
+  });
+});

--- a/apps/api/src/capabilities/lib/iso-3166.ts
+++ b/apps/api/src/capabilities/lib/iso-3166.ts
@@ -352,40 +352,91 @@ const resolveAlpha2 = new Map<string, string>();
 const resolveAlpha3 = new Map<string, string>();
 const resolveNumeric = new Map<string, string>();
 const resolveName = new Map<string, string>();
+
+/**
+ * Fold a country name to a comparison key: lowercase, diacritics stripped.
+ *
+ * Callers type "Cote d'Ivoire", "Aland Islands" and "Saint Barthelemy" without
+ * the accents far more often than with them, and an LLM emitting JSON may drop
+ * them entirely. Folding both sides once here is better than carrying one
+ * alias per accented character.
+ */
+function foldName(name: string): string {
+  return name
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim();
+}
+
 for (const c of ALL_ISO_IDENTIFIERS) {
   resolveAlpha2.set(c.alpha_2, c.alpha_2);
   resolveAlpha3.set(c.alpha_3, c.alpha_2);
   resolveNumeric.set(c.numeric, c.alpha_2);
-  resolveName.set(c.name.toLowerCase(), c.alpha_2);
+  resolveName.set(foldName(c.name), c.alpha_2);
 }
 
 // ─── Strict resolver for upstream-API country parameters ────────────────────
 
 /**
- * Non-ISO codes that callers pass often enough to be worth accepting. `uk` is
- * the big one: it is not ISO 3166-1 (the code is `GB`) but Google's own `gl`
- * parameter accepts it, so rejecting it would break callers who are otherwise
- * doing nothing wrong.
+ * Names and codes callers pass that ISO does not list, keyed by folded name.
+ *
+ * The traffic here is LLM-authored, so the common failure is not a typo — it
+ * is a real-world name the standard happens not to use: the endonym
+ * ("Türkiye"), the renamed state ("Czechia", "Swaziland"), the constituent
+ * country ("Scotland"), the colloquial ("Holland"), or the abbreviation
+ * ("UAE"). Each of these is a call we would otherwise reject and bill nothing
+ * for, but which the caller meant unambiguously.
+ *
+ * `uk` earns its place for a different reason: it is not ISO 3166-1 (the code
+ * is `GB`) but Google's own `gl` accepts it, so rejecting it would break
+ * callers doing nothing wrong.
+ *
+ * Deliberately absent: "Korea" (North or South?), "America" (the US, or the
+ * continents?), "Congo" (two countries). Anything that needs a guess belongs
+ * in the error message, not in this map — silently picking one is the failure
+ * mode this whole module exists to prevent.
  */
 const ALIASES: Record<string, string> = {
-  UK: "GB",
+  uk: "GB",
+  britain: "GB",
+  "great britain": "GB",
+  england: "GB",
+  scotland: "GB",
+  wales: "GB",
+  "northern ireland": "GB",
+  czechia: "CZ",
+  turkiye: "TR", // folded form of "Türkiye"
+  uae: "AE",
+  holland: "NL",
+  "ivory coast": "CI",
+  "cape verde": "CV",
+  swaziland: "SZ",
+  burma: "MM",
+  macedonia: "MK",
+  vatican: "VA",
+  "u.s.": "US",
+  "u.s.a.": "US",
+  "congo-kinshasa": "CD",
+  drc: "CD",
+  "congo-brazzaville": "CG",
 };
 
 /**
  * Resolve a caller-supplied country to a canonical ISO 3166-1 alpha-2 code,
  * or `null` if it cannot be resolved unambiguously.
  *
- * Accepts alpha-2, alpha-3, numeric, an exact country name (case-insensitive),
- * and the aliases above. Unlike `searchCountries` this deliberately does NOT
- * do substring name matching — "Guinea" matches four different countries, and
- * silently picking one to hand to an upstream API is worse than refusing.
+ * Accepts alpha-2, alpha-3, numeric, a country name (case- and accent-
+ * insensitive), and the aliases above. Unlike `searchCountries` this
+ * deliberately does NOT do substring name matching — "Guinea" matches four
+ * different countries, and silently picking one to hand to an upstream API is
+ * worse than refusing.
  */
 export function resolveCountryAlpha2(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) return null;
 
   const upper = trimmed.toUpperCase();
-  if (ALIASES[upper]) return ALIASES[upper];
 
   // Numeric codes are canonically three digits. Accepting shorter input and
   // zero-padding it would silently turn a caller's dialling code into an
@@ -396,7 +447,8 @@ export function resolveCountryAlpha2(raw: string): string | null {
     (/^\d{3}$/.test(upper) ? resolveNumeric.get(upper) : undefined);
   if (byCode) return byCode;
 
-  return resolveName.get(trimmed.toLowerCase()) ?? null;
+  const folded = foldName(trimmed);
+  return resolveName.get(folded) ?? ALIASES[folded] ?? null;
 }
 
 /**

--- a/apps/api/src/capabilities/lib/language-tag.test.ts
+++ b/apps/api/src/capabilities/lib/language-tag.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for `resolveLanguageOrThrow`.
+ *
+ * `hl` has the same silent-ignore behaviour as `gl`: Google drops an
+ * unrecognised value and bills the call anyway, so an unvalidated `language`
+ * buys a search in the wrong language with no signal. Same failure class as
+ * the 2026-08-09 `country: "墨西"` incident.
+ *
+ * These pin the deliberate asymmetry with the country resolver: this one
+ * validates SHAPE, not membership, so it can never reject a real language it
+ * has not heard of. The "knowingly accepted" case below documents the residue
+ * that choice leaves behind — it is a trade, not an oversight.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveLanguageOrThrow } from "./language-tag.js";
+
+describe("resolveLanguageOrThrow — accepts", () => {
+  it("plain two-letter codes, normalising case", () => {
+    expect(resolveLanguageOrThrow("en")).toBe("en");
+    expect(resolveLanguageOrThrow("EN")).toBe("en");
+    expect(resolveLanguageOrThrow("  sv  ")).toBe("sv");
+  });
+
+  it("three-letter primary subtags", () => {
+    expect(resolveLanguageOrThrow("fil")).toBe("fil");
+  });
+
+  it("region and script subtags", () => {
+    expect(resolveLanguageOrThrow("pt-BR")).toBe("pt-br");
+    expect(resolveLanguageOrThrow("zh-CN")).toBe("zh-cn");
+    expect(resolveLanguageOrThrow("zh-Hant")).toBe("zh-hant");
+    expect(resolveLanguageOrThrow("zh-Hant-TW")).toBe("zh-hant-tw");
+  });
+
+  it("the fallback when nothing is supplied", () => {
+    expect(resolveLanguageOrThrow("", { fallback: "en" })).toBe("en");
+    expect(resolveLanguageOrThrow(undefined, { fallback: "en" })).toBe("en");
+    expect(resolveLanguageOrThrow(null, { fallback: "en" })).toBe("en");
+  });
+
+  it("returns null when nothing is supplied and no fallback is given", () => {
+    expect(resolveLanguageOrThrow(undefined)).toBeNull();
+    expect(resolveLanguageOrThrow("   ")).toBeNull();
+  });
+});
+
+describe("resolveLanguageOrThrow — rejects", () => {
+  it("non-Latin script, the shape the incident actually took", () => {
+    expect(() => resolveLanguageOrThrow("中文")).toThrow(/must be a two-letter ISO 639-1 code/);
+    expect(() => resolveLanguageOrThrow("墨西")).toThrow(/must be a two-letter/);
+  });
+
+  it("full language names rather than codes", () => {
+    expect(() => resolveLanguageOrThrow("English")).toThrow(/must be a two-letter/);
+    expect(() => resolveLanguageOrThrow("Spanish")).toThrow(/must be a two-letter/);
+  });
+
+  it("an unresolvable value even when a fallback exists", () => {
+    // The fallback covers "absent", not "present but wrong".
+    expect(() => resolveLanguageOrThrow("中文", { fallback: "en" })).toThrow(/must be a two-letter/);
+  });
+
+  it("non-string types", () => {
+    expect(() => resolveLanguageOrThrow(42)).toThrow(/must be a string/);
+    expect(() => resolveLanguageOrThrow({ language: "en" })).toThrow(/must be a string/);
+  });
+
+  it("truncates an oversized value rather than reflecting it whole", () => {
+    try {
+      resolveLanguageOrThrow("x".repeat(5000));
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect((e as Error).message.length).toBeLessThan(400);
+      expect((e as Error).message).toContain("…");
+    }
+  });
+});
+
+describe("resolveLanguageOrThrow — knowingly accepted residue", () => {
+  it("lets a well-formed but non-existent tag through", () => {
+    // Documented trade: catching this would require a membership list, and an
+    // incomplete membership list hard-rejects real languages. Google ignores
+    // "xy" the same way it ignored "墨西" — but the shape check cannot tell
+    // them apart, and rejecting real callers is the worse error.
+    expect(resolveLanguageOrThrow("xy")).toBe("xy");
+  });
+});

--- a/apps/api/src/capabilities/lib/language-tag.ts
+++ b/apps/api/src/capabilities/lib/language-tag.ts
@@ -1,0 +1,60 @@
+// ─── Language-tag validation for upstream-API parameters ────────────────────
+//
+// Google's `hl` behaves exactly like `gl`: an unrecognised value is silently
+// ignored, so a caller is billed for a search that quietly ran in the wrong
+// language with the bogus value echoed back. Same failure class as the
+// `country` incident of 2026-08-09.
+//
+// This validates SHAPE, not membership — deliberately unlike the country
+// resolver, which checks against the full ISO 3166-1 set.
+//
+// The reason for the difference is what the two lists cost to get wrong. The
+// country table already existed in-repo and was near-complete, so finishing it
+// was a bounded, verifiable job. An ISO 639-1 table would have to be authored
+// from scratch, and any code missing from it becomes a hard rejection of a
+// caller who did nothing wrong — precisely the trap the country table set when
+// its 45 missing entries turned from a lookup gap into a paid-traffic gate.
+// Shape validation has no completeness cliff: it cannot reject a valid tag it
+// has never heard of.
+//
+// What it does catch is the failure that actually happened: a non-Latin string
+// ("中文"), a full language name ("English"), or a country name in the language
+// field. What it does NOT catch is a well-formed tag that simply isn't a real
+// language ("xy"). That residue is accepted knowingly — the alternative is a
+// list that rejects real languages, which is worse.
+
+/**
+ * Simplified BCP 47: a 2–3 letter primary subtag, optionally followed by
+ * script/region/variant subtags. Covers "en", "pt-BR", "zh-Hant", "zh-Hant-TW".
+ */
+const LANGUAGE_TAG = /^[a-z]{2,3}(-[a-z0-9]{2,8})*$/i;
+
+/**
+ * Validate and normalise a caller-supplied language tag.
+ *
+ * Returns the lowercased tag, or `null` when nothing was supplied and no
+ * `fallback` was given. Throws when a value is present but not tag-shaped.
+ */
+export function resolveLanguageOrThrow(raw: unknown, opts: { fallback: string }): string;
+export function resolveLanguageOrThrow(raw: unknown, opts?: { fallback?: string }): string | null;
+export function resolveLanguageOrThrow(
+  raw: unknown,
+  opts: { fallback?: string } = {},
+): string | null {
+  if (raw !== undefined && raw !== null && typeof raw !== "string") {
+    throw new Error(`'language' must be a string. Received ${typeof raw}.`);
+  }
+
+  const supplied = (raw ?? "").trim() || (opts.fallback ?? "");
+  if (!supplied) return null;
+
+  if (!LANGUAGE_TAG.test(supplied)) {
+    const shown = supplied.length > 64 ? `${supplied.slice(0, 64)}…` : supplied;
+    throw new Error(
+      `'language' must be a two-letter ISO 639-1 code ("en"), optionally with a region ("pt-BR"). ` +
+        `Received: ${JSON.stringify(shown)}. If unsure, use the two-letter code.`,
+    );
+  }
+
+  return supplied.toLowerCase();
+}

--- a/apps/api/src/capabilities/serp-analyze.ts
+++ b/apps/api/src/capabilities/serp-analyze.ts
@@ -1,5 +1,6 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { resolveCountryOrThrow } from "./lib/iso-3166.js";
+import { resolveLanguageOrThrow } from "./lib/language-tag.js";
 
 registerCapability("serp-analyze", async (input: CapabilityInput) => {
   const keyword = (
@@ -15,7 +16,7 @@ registerCapability("serp-analyze", async (input: CapabilityInput) => {
   // unrecognised `gl`, so an unresolvable country used to buy an unscoped
   // search while the response echoed the caller's bogus value back.
   const country = resolveCountryOrThrow(input.country, { fallback: "us" }).toLowerCase();
-  const language = ((input.language as string) ?? "en").trim().toLowerCase();
+  const language = resolveLanguageOrThrow(input.language, { fallback: "en" });
 
   const serperKey = process.env.SERPER_API_KEY;
   if (!serperKey) throw new Error("SERPER_API_KEY is required.");

--- a/apps/api/src/capabilities/serper-input-validation.test.ts
+++ b/apps/api/src/capabilities/serper-input-validation.test.ts
@@ -1,6 +1,6 @@
 /**
- * Cross-capability regression test for country validation on the three
- * Serper-backed capabilities.
+ * Cross-capability regression tests for caller-input validation on the three
+ * Serper-backed capabilities (country and language).
  *
  * Incident: on 2026-08-09 an x402 caller sent 50 consecutive `google-search`
  * calls with `country: "墨西"`. Serper silently ignores an unrecognised `gl`,
@@ -153,6 +153,53 @@ describe("gl parameter", () => {
     async ({ slug, baseInput }) => {
       const body = await captureRequestBody(getExecutor(slug), baseInput);
       expect(body.gl).toBe("us");
+    },
+  );
+});
+
+describe("language validation", () => {
+  const REJECTED_LANGUAGES = ["中文", "English", "墨西", "e", "en_US!"];
+
+  describe.each(CAPABILITIES)("$slug", ({ slug, baseInput }) => {
+    it.each(REJECTED_LANGUAGES)("rejects %j without spending a Serper call", async (language) => {
+      const run = getExecutor(slug)!;
+
+      await expect(
+        run({ ...baseInput, language }, {} as never),
+      ).rejects.toThrow(/'language' must be a two-letter ISO 639-1 code/);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("sends a valid tag through to hl, lowercased", async () => {
+      const run = getExecutor(slug)!;
+      await expect(
+        run({ ...baseInput, language: "pt-BR" }, {} as never),
+      ).rejects.toThrow(/fetch called/);
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+      expect(body.hl).toBe("pt-br");
+    });
+  });
+
+  it("google-search omits hl entirely when no language is given", async () => {
+    const run = getExecutor("google-search")!;
+    await expect(
+      run({ query: "phone contact" }, {} as never),
+    ).rejects.toThrow(/fetch called/);
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body).not.toHaveProperty("hl");
+  });
+
+  it.each(CAPABILITIES.filter((c) => c.slug !== "google-search"))(
+    "$slug defaults to hl=en when no language is given",
+    async ({ slug, baseInput }) => {
+      const run = getExecutor(slug)!;
+      await expect(run(baseInput, {} as never)).rejects.toThrow(/fetch called/);
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+      expect(body.hl).toBe("en");
     },
   );
 });

--- a/manifests/google-search.yaml
+++ b/manifests/google-search.yaml
@@ -25,6 +25,9 @@ input_schema:
         search runs rather than silently ignored. Omit for unscoped global results.
     language:
       type: string
+      description: >-
+        Language for results, as an ISO 639-1 code ("en"), optionally with a region ("pt-BR"). Validated for shape and
+        rejected before the search runs if malformed, rather than silently ignored. Omit for Google's default.
     num_results:
       type: integer
       description: Number of results (default 10, max 20)

--- a/manifests/iso-country-lookup.yaml
+++ b/manifests/iso-country-lookup.yaml
@@ -64,13 +64,16 @@ test_fixtures:
         reliability: common
   health_check_input:
     query: land
+# Top-level response fields only. `name`, `alpha_2`, `region` etc. are NOT
+# top-level — the executor nests them inside `match` (single hit) or inside
+# each element of `matches` (zero or several hits). Declaring them here made
+# the smoke test assert not-null on fields that never appear at the top level,
+# so step 3 failed on every run.
 output_field_reliability:
-  name: guaranteed
-  region: guaranteed
-  alpha_2: guaranteed
-  alpha_3: guaranteed
-  schengen: guaranteed
-  eu_member: guaranteed
+  query: guaranteed
+  match: common
+  matches: common
+  total_matches: common
 limitations:
   - title: Country data is based on ISO 3166-1 — newly created or renamed countries may not yet be reflected
     text: Country data based on ISO 3166-1 standard — newly created or renamed countries may take time to be reflected

--- a/manifests/keyword-rank-check.yaml
+++ b/manifests/keyword-rank-check.yaml
@@ -28,7 +28,9 @@ input_schema:
         search runs rather than silently ignored. Sent to Google as the gl parameter. Defaults to "us".
     language:
       type: string
-      description: Google language code (hl parameter). Defaults to "en".
+      description: >-
+        Language for results, as an ISO 639-1 code ("en"), optionally with a region ("pt-BR"). Validated for shape and
+        rejected before the search runs if malformed, rather than silently ignored. Sent to Google as the hl parameter. Defaults to "en".
     depth:
       type: integer
       description: Number of results to scan (Serper "num" parameter). Defaults to 10, max 100.

--- a/manifests/serp-analyze.yaml
+++ b/manifests/serp-analyze.yaml
@@ -26,6 +26,9 @@ input_schema:
       type: string
     language:
       type: string
+      description: >-
+        Language for results, as an ISO 639-1 code ("en"), optionally with a region ("pt-BR"). Validated for shape and
+        rejected before the search runs if malformed, rather than silently ignored. Defaults to "en".
 output_schema:
   type: object
   example:


### PR DESCRIPTION
## Summary

Three follow-ups to #160, all the same incident class: a caller-supplied value forwarded to Google, silently ignored when unrecognised, and billed anyway.

### 1. `language` / `hl`

Google drops an unrecognised `hl` exactly as it dropped `gl`, so `language: "中文"` bought a search in the wrong language with the bogus value echoed back. Now validated before the paid call in all three capabilities.

**This validates shape, not membership — deliberately unlike the country resolver.** An ISO 639-1 table would have to be authored from scratch, and anything missing from it becomes a hard rejection of a caller who did nothing wrong. That is precisely the trap the country table set in #160, where 45 missing entries turned from a harmless lookup gap into a gate on paid traffic the moment the same table started rejecting calls. Shape validation has no completeness cliff — it cannot reject a real language it has never heard of.

The residue: `"xy"` is well-formed but not a language, and passes. That is a knowing trade, and there is a test named `knowingly accepted residue` that says so, so the next reader doesn't mistake it for an oversight.

### 2. Country aliases

The traffic is LLM-authored, so the common miss isn't a typo — it's a real-world name ISO doesn't use. All of these were rejected before and are accepted now: `Czechia`, `Türkiye`, `UAE`, `Holland`, `England`/`Scotland`/`Wales`/`Northern Ireland`/`Britain`, `Ivory Coast`, `Cape Verde`, `Swaziland`, `Burma`, `Macedonia`, `Vatican`, `DRC`.

Accents are handled by **folding both sides once** rather than one alias per accented character, which also fixes `Cote d'Ivoire`, `Aland Islands` and `Saint Barthelemy` for free.

Names that need a guess — `Korea`, `Congo`, `America` — are still refused, and a test pins that so future alias additions can't quietly widen into ambiguity. A second test pins that a real ISO code always beats an alias key, so an alias can never shadow an assigned code.

### 3. `iso-country-lookup` field reliability

The manifest declared `name`, `alpha_2`, `region`, `alpha_3`, `schengen`, `eu_member` as top-level guaranteed fields. The executor nests them under `match` (single hit) or inside each element of `matches` (zero or several). Smoke-test step 3 had been failing on **every** run as a result — on `main` too, long before this work. Corrected to the actual top-level shape (`query`, `match`, `matches`, `total_matches`).

## Verification

| Gate | Result |
|---|---|
| All 11 runnable CI gates | pass (incl. `lint:no-bare-catch`, which #160 initially tripped) |
| `vitest run src/capabilities/` | 15 files, **270 tests pass** |
| `validate-capability.ts` × 4 slugs | 19/19 each |
| `sync-manifest-canonical-to-db.ts iso-country-lookup --dry-run` | drift is exactly `output_field_reliability`, nothing else |

## Post-merge step

`iso-country-lookup`'s smoke-test step 3 will keep failing until the DB is synced — the smoke test reads reliability from the **DB**, not the YAML:

```
npx tsx scripts/sync-manifest-canonical-to-db.ts iso-country-lookup
```

Same for the three new `language` descriptions (`google-search`, `serp-analyze`, `keyword-rank-check`). Dry-run confirmed the only drift in each case is the intended field.

## Still open after this

- **`/v1/do` returns 500 for caller-input errors** while x402 returns 400 — the one remaining piece of this incident class, and a platform-wide error-shape change rather than a capability fix.
- **`iso-country-lookup`'s rich table is still 204 entries.** Completing it needs authoritative source data for capital / currency / calling-code / language per country; inventing those would ship fabricated data to customers.

## Test plan

1. `cd apps/api && npx vitest run src/capabilities/lib/ src/capabilities/serper-input-validation.test.ts`
2. Confirm `language: "中文"` errors with no Serper call; `language: "pt-BR"` reaches the wire as `hl=pt-br`.
3. Confirm `country: "Czechia"` → `gl=cz`, and `country: "Korea"` still rejects.
