### PR TITLE
fix(scripts): compare manifest drift by value, not by JSON key order

### DIFF
--- a/apps/api/scripts/sync-manifest-canonical-to-db.ts
+++ b/apps/api/scripts/sync-manifest-canonical-to-db.ts
@@ -88,9 +88,31 @@ if (before.length === 0) {
 const dbRow = before[0];
 const drifts: string[] = [];
 
+/**
+ * Serialise with object keys in a stable order, at every depth.
+ *
+ * Postgres `jsonb` does not preserve insertion order — it stores keys sorted
+ * by length then bytewise. A plain `JSON.stringify` comparison therefore
+ * reports drift forever for any object whose manifest key order differs from
+ * jsonb's, even immediately after a successful write.
+ *
+ * That phantom drift is not cosmetic. This script pushes ALL manifest-canonical
+ * fields in one shot, so a field that always looks dirty is an standing
+ * invitation to re-run it — and a re-run happily overwrites a *genuinely*
+ * newer prod value with a stale manifest one. That near-miss is exactly what
+ * happened with google-search's output_schema during the #160 sync.
+ */
+function canonical(value: unknown): string {
+  return JSON.stringify(value, (_key, v) =>
+    v && typeof v === "object" && !Array.isArray(v)
+      ? Object.fromEntries(Object.entries(v as Record<string, unknown>).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)))
+      : v,
+  );
+}
+
 function compare(field: string, dbVal: unknown, manifestVal: unknown) {
-  const a = JSON.stringify(dbVal);
-  const b = JSON.stringify(manifestVal);
+  const a = canonical(dbVal);
+  const b = canonical(manifestVal);
   if (a !== b) {
     drifts.push(field);
     console.log(`\n--- ${field} drift ---`);


### PR DESCRIPTION
## Summary

Postgres `jsonb` does not preserve insertion order — it stores keys sorted by length then bytewise. The drift check in `sync-manifest-canonical-to-db.ts` compared raw `JSON.stringify` output, so any object whose manifest key order differed from jsonb's was reported as drifting **forever**, including immediately after a successful write.

Reproduced during the #163 sync: `iso-country-lookup` and `keyword-rank-check` both reported drift, were synced ("Updated 1 row(s)"), and still reported the same drift on the next dry-run. The stored values were correct — only the key order differed.

## Why this is worth fixing rather than tolerating

This script pushes **all** manifest-canonical fields in one shot. A field that always looks dirty is a standing invitation to re-run it, and a re-run overwrites a genuinely newer prod value with a stale manifest one.

That is not hypothetical. During the #160 sync, `google-search`'s `output_schema` showed real drift pointing the wrong way — prod held a captured Stripe example, the manifest still held the original speedtest placeholder. It was caught only because the drift was inspected field-by-field before running the write. Phantom drift makes that inspection habit harder to sustain, because most of what it flags is noise.

## The fix

Comparison is now key-order-insensitive at every depth, via a `JSON.stringify` replacer that sorts object entries. Arrays are untouched, so array order still counts as a difference.

## Verification

Behaviour table, verified directly:

| Case | Treated as equal | Correct |
|---|---|---|
| top-level key order only | yes | ✓ |
| nested key order only | yes | ✓ |
| different value | no | ✓ |
| missing key | no | ✓ |
| array reordered | no | ✓ |
| nested real difference | no | ✓ |

Before/after against prod, all four slugs touched by #160/#163:

```
before:  google-search  clean · serp-analyze  clean · keyword-rank-check  DRIFT · iso-country-lookup  DRIFT
after:   all four → "No drift — DB already matches manifest."
```

`npm run typecheck` passes.

## Test plan

1. `cd apps/api && npx tsx scripts/sync-manifest-canonical-to-db.ts iso-country-lookup --dry-run` → "No drift".
2. Change one reliability value in `manifests/iso-country-lookup.yaml`, re-run → drift is still reported. Revert.
