### PR TITLE
docs(handoff): backfill 14 untracked session records (May–Aug 2026)

### DIFF
--- a/handoff/_general/from-code/2026-05-15-v1-launch-readiness-sweep.md
+++ b/handoff/_general/from-code/2026-05-15-v1-launch-readiness-sweep.md
@@ -1,0 +1,132 @@
+# Session handoff — v1 launch readiness sweep — 2026-05-15
+
+**Intent:** Run the full empirical v1 launch readiness sweep across the 20 EU+UK+NO+CH+SG identity capabilities (Phase 1 audit), surface and triage every operational concern that audit uncovered, scout US v1 viability (Phase 3), probe SI Openapi WW-Top integration (Phase 2), and bundle the customer-DX schema-cleanup PR. End with a defensible v1 launch picture and concrete pre-launch work queue.
+
+---
+
+## What shipped
+
+### Phase 1 — Identity field-coverage audit (20 of 20 countries, Phase 1 COMPLETE)
+
+Branch: `docs/identity-field-coverage-2026-05-15`. Final commit: `8eb8c0e`.
+
+- **Batch 1** (`2f991d2`): SE, UK, DE, SI, SG — 5 countries, surfaced DE quota exhaustion (OpenRegister 50/month free tier) and SI structural source gap (data.gov.si lacks status/regdate/NACE/directors/VAT/LEI). UK `vat_number` 0/3 mismatch identified.
+- **Batch 2** (`ffc109c`): NO, DK, FR, BE, CZ — surfaced DK quota exhaustion (cvrapi.dk 50/day). **FR is the only country with empirical directors (3/3, capped at 3, true counts 15–20).** BE `industry` 0/3 mismatch flagged.
+- **Batch 3** (`ec73c9d`): FI, IE, EE, PL, LV — **CKAN-thinness hypothesis REFUTED** (IE + LV both rich). 5 new schema mismatches (IE/EE/LV vat_number, PL address + regdate). 5 new free-path director-build candidates queued.
+- **Batch 4** (`9a5ba15`): CH, GR, HR, LT, SK — 3 of 5 hit outage-class failures during the audit's 15-concurrent burst (CH Zefix, HR Sudreg, LT data.gov.lt Spinta). **SK is the second country with empirical full directors** (3/3 uncapped, free CC-BY 4.0 source). GR memory entry vs manifest mismatch surfaced (memory referenced HELLENiQ via PR #116 but manifest fixture is NBG branch).
+- Final picture: **17 v1-ready as certified, 2 quota-managed (DE/DK), 3 transient/outage-class but now empirically working post-triage.**
+
+### FR directors truncation — investigation + fix + ship
+
+- Investigation doc on audit branch (`042589b`): root cause is Strale-side `.slice(0, 3)` at `french-company-data.ts:56`; upstream returns full array; the slice was kept by the 2026-05-09 doctrine sweep as "defensible payload management" but never benchmarked.
+- **PR #119 merged** (commit `96ddb40` on main): raises cap to `DIRECTORS_CAP = 50`. Post-deploy verification confirms TotalEnergies SE (`542051180`) now returns 15 directors with `directors_truncated: false`. Wallet cost €0.30 (verification probes).
+
+### LT/CH/HR outage triage — RETRACTS "do not ship LT in v1" flag
+
+Triage doc on audit branch (`dd40aa7`). All three capabilities verified working end-to-end at session end. Root cause: clustered transient incident driven by the audit's 15-concurrent-call pattern saturating Strale's egress pool, compounded by upstream blips on Zefix (~2h) and Sudreg (~30 min). Three different upstream architectures (CKAN Spinta, REST+Basic auth, REST+OAuth2) — failures architecturally independent, shared variable was Strale's egress. **All three ship in v1.** Two operational caveats logged for v1.1+ (capability_health gateway-failure blind spot + parallel-call amplification pattern).
+
+### capability_health blind-spot burst probe — verdict ACADEMIC for v1
+
+Burst-probe doc on audit branch (`335c59c`). Tier 1 (5 concurrent × 3 runs, 15/15 success) + Tier 2 (10 concurrent × 2 runs, 20/20 success) + Tier 3 (15 concurrent, 9/15 + 5 Strale rate-limit 429s + 1 application 500). **The 5 pre-execution 429s did NOT update `capability_health`** — same blind-spot class as the audit's 502s (different visible symptom, same architectural cause: pre-execution failures bypass the executor-level update path). **Verdict: blind spot is academic at production-realistic load. P1 To-do stays P1 as v1.1+ work, NOT v1-launch-gate.** Wallet spend €2.20 (44 successful calls).
+
+### Rate-limit + CA orchestration concurrency verdict
+
+Verdict doc on audit branch (`7862a00`). **NO PRE-V1 ACTION REQUIRED.** Three findings: (a) 10 req/sec per API key is a deliberate production setting per DEC-21, not stale dev default; (b) CA-style orchestration internalises capability fan-out inside a single HTTP request via solution-executor's `Promise.all` — rate-limit gates HTTP request count, NOT internal parallelism; (c) 429s ARE logged structurally via `request-complete` Pino log line, just not metricized. Optional pre-v1 10-min win: add rate-limit-specific log emit in `lib/rate-limit.ts`.
+
+### US Topograph 14-state scout — Phase 3
+
+New branch `docs/us-topograph-scout-2026-05-15` (commit `34036a0`). 14 states + SAM.gov classified:
+- **Free API (2):** NY (Socrata SODA), SAM.gov (free key, 1-4w lead time).
+- **Free bulk download (4):** CO, FL (Sunbiz SFTP), MA, WA (CCFS CSV).
+- **Mixed (1):** TX (free Comptroller API + paid SOSDirect).
+- **Paid signup required (8):** DE, GA, IL, MN, NV, NJ, PA, WY.
+
+**Total Tier 1 direct candidates: 7 of 15. Tier 2 via Cobalt: 8 of 15.** Critical: DE is the most-incorporated US state — Cobalt's DE coverage must be verified before v1 sign-off. SAM.gov key registration takes 1-4 weeks — start NOW if v1 <4w away.
+
+### SI Openapi WW-Top probe — Phase 2
+
+Verdict doc on audit branch (`8eb8c0e`). **Openapi does NOT close the SI directors gap.** Response schema for the 2 SI entities Openapi has (Petrol + Mercator) lacks directors/officers/representatives/shareholders fields. SI catalog coverage is partial — 5 of 7 well-known SI VATs returned 204 No Content, including Krka (canonical fixture). UTF-8 mojibake on `nativeCompanyName`. 10× slower than CKAN (~6.6s). **Verdict: KEEP CKAN as Tier-1; consider Openapi as Tier-2 enrichment for non-directors fields only (LEI, NACE, balance sheets, status, regdate).** Env var is `OPENAPI_COM_API_TOKEN_PROD` + `OPENAPI_COM_EMAIL` (not `OPENAPI_API_KEY` as prompt assumed); auth uses OAuth scope-exchange via `oauth.openapi.it/token`.
+
+### Schema cleanup — PR #120 (awaiting chat review)
+
+Branch `fix/schema-cleanup-eu-audit-2026-05-15`. **7 of 10 audit mismatches fixed in PR; 2 non-issues; 1 deferred:**
+- UK / IE / EE `vat_number` — manifest-remove (c). Companies House / CRO / Äriregister don't return VAT.
+- LV `vat_number` — added `deriveVatLV` helper, populate from regcode. `LV` + 11-digit.
+- EE `business_type` — extended legalForms map to handle legacy code `"1"` = AS (audit caught Bolt + Tallink returning numeric `"1"` while Pipedrive returned label).
+- PL `address` + `registration_date` — reliability downgrade `guaranteed → common` (manifest example itself shows null, was lying about reliability).
+- FI manifest additive — declare `vat_number` + `website` + `industry_description` (handler returned more than manifest declared).
+- BE `industry` — non-issue, already declared `rare`.
+- FI "undercount" — non-issue, inverted (handler returned more); fixed via additive.
+- SK `vat_number` (DIČ) — deferred (RPO `identifiers` array shape needs upstream investigation).
+
+`npx tsc --noEmit` passes. `npx vitest run` = 665 passed, 33 skipped, 0 failed. No self-merge per Rule 16 carve-out — chat reviews customer-facing schema PR.
+
+---
+
+## What's open / next session priorities
+
+1. **Chat review + merge PR #120** (schema cleanup). Post-merge verify LV Air Baltic returns `vat_number: "LV40003245752"` and EE Bolt returns `business_type: "AS (Public limited company)"`.
+2. **SK DIČ surfacing** — separate prompt. Needs RPO `identifiers` array shape investigation (does it have a type field?). Pre-fix probe confirms gap exists.
+3. **Notion follow-ups across 4 docs:**
+   - Capability × Country Coverage Matrix — update 6 country rows for schema-cleanup, plus FR directors-cap status, plus US Topograph state classifications.
+   - Active Vendor Stack — add Openapi as Tier-2 enrichment with partial-SI-coverage caveat; add SAM.gov / state SOS sources for US.
+   - Internals → incident retrospective — log the parallel-call amplification pattern for future audits.
+   - GR fixture/memory mismatch reconciliation.
+4. **DEC-20260513-F supersession input:** all three deferred verdict docs (LT/CH/HR triage + burst probe + rate-limit) feed chat's drafting of a successor DEC. Empirically defensible "17 + 2 quota + 3 transient = 22/20 ship-able" picture.
+5. **SAM.gov API key registration** — start NOW if v1 launch is <4 weeks away (1-4 week approval lead time).
+6. **DE OpenRegister quota triage** — pull the May 2026 call log to determine whether the 50/month was burned by customer traffic vs health probes. DK cvrapi.dk same question (daily reset = lower stakes).
+7. **PL `address` + `registration_date` picker rewrite** — moderate-scope follow-up to restore reliability to `guaranteed`. Out of scope for v1 launch.
+
+---
+
+## Non-obvious learnings
+
+- **The 24h canary green-rate that DEC-20260513-F's v1-ready verdict rests on is trustworthy at production-realistic load** (proven by burst probe Tier 1 + Tier 2). The capability_health blind spot only fires at 15+ concurrent — not a real customer pattern.
+- **Internal capability fan-out inside `/v1/solutions/.../execute` does NOT consume rate-limit budget.** The rate-limit middleware gates HTTP request count, not internal `Promise.all` parallelism. This single architectural fact closes the entire "CA orchestration concurrency" concern.
+- **Manifest authoring needs a "honest reliability" pass.** PL was the canary — example output itself showed null for `address`/`registration_date` while the manifest declared `guaranteed`. Manifest was self-contradictory and shipped. Worth a coordinated reliability audit across all 290+ capabilities at some point.
+- **Openapi WW-Top SI coverage is partial.** Krka — Slovenia's largest pharma, publicly traded — is NOT in their catalog. Don't assume vendor coverage matches catalog claims; probe specific entities before committing.
+- **Auth schemes vary per Openapi product.** Their unified API uses OAuth scope-exchange (basic auth on `oauth.openapi.it/token` → scoped Bearer for the actual API). The env var naming we had (`OPENAPI_COM_API_TOKEN_PROD` + `OPENAPI_COM_EMAIL`) was correct; the prompt's `OPENAPI_API_KEY` assumption was wrong.
+- **Memory drift is a real risk after PRs.** GR fixture memory entry referenced HELLENiQ via PR #116, but the actual manifest fixture is NBG branch. Treat manifests as authoritative over memory for capability-fixture questions.
+- **The "free public API for US state SOS" framing was too narrow.** Reality is 4 categories (free API / free bulk / paid signup / mixed). 7 of 15 states are Tier-1-shippable, but only 2 via "free API" — 4 more via "free bulk download" require an ingest-and-index pattern (similar to LV/SI CKAN).
+
+---
+
+## Cost
+
+- Phase 1 audit Batches 1-4: **€2.30** (46 successful calls)
+- FR truncation verification probes: **€0.30** (6 calls during deploy poll loop — note: future fix prompts should use non-charging health endpoints to avoid this)
+- LT/CH/HR triage re-probes: **€0.15** (3 calls)
+- capability_health burst probe: **€2.20** (44 successful calls)
+- SI Openapi WW-Top: **~€0.24-€1.08 Openapi-side** (depends on whether 204s are billed); €0 Strale-side
+- US Topograph scout: **€0** (direct HTTP, no Strale calls)
+- Rate-limit verdict: **€0** (read-only code investigation)
+- Schema cleanup PR: **€0.05** (1 SK pre-fix probe)
+
+**Total Strale wallet spend: ~€5.00. Total Openapi spend: ~€1.08 max.** Wallet at start: €33.99. Wallet at end: ~€29.
+
+---
+
+## Artifacts produced
+
+8 docs on `docs/identity-field-coverage-2026-05-15`:
+1. `apps/api/docs/identity-field-coverage-2026-05-15.md` — Phase 1 audit (4 batches)
+2. `apps/api/docs/fr-directors-truncation-2026-05-15.md` — FR fix investigation
+3. `apps/api/docs/lt-ch-hr-outage-triage-2026-05-15.md`
+4. `apps/api/docs/burst-probe-capability-health-blind-spot-2026-05-15.md`
+5. `apps/api/docs/rate-limit-and-ca-orchestration-concurrency-2026-05-15.md`
+6. `apps/api/docs/si-openapi-wwtop-probe-2026-05-15.md`
+
+1 doc on `docs/us-topograph-scout-2026-05-15`:
+7. `apps/api/docs/us-topograph-state-scout-2026-05-15.md`
+
+1 doc on `fix/schema-cleanup-eu-audit-2026-05-15`:
+8. `apps/api/docs/schema-cleanup-2026-05-15.md`
+
+2 PRs:
+- PR #119 (FR directors cap fix) — **MERGED** at `96ddb40`
+- PR #120 (schema cleanup, 7 fixes) — **OPEN**, awaiting chat review
+
+3 branches awaiting chat decision on merge timing:
+- `docs/identity-field-coverage-2026-05-15` (6 docs)
+- `docs/us-topograph-scout-2026-05-15` (1 doc)
+- `fix/schema-cleanup-eu-audit-2026-05-15` (1 PR open)

--- a/handoff/_general/from-code/2026-05-18-phase-4-se-dk-source-enumeration.md
+++ b/handoff/_general/from-code/2026-05-18-phase-4-se-dk-source-enumeration.md
@@ -1,0 +1,43 @@
+Intent: Run Phase 4 exhaustive source enumeration for SE + DK director coverage (8 paths × 2 countries) per DEC-20260518-E, applying the platform-fee probe discipline learned from the HR Topograph correction (Journal 35967c87082c8177). Research-only — no main-repo code touched.
+
+## What shipped
+
+- Single research report covering 16 path investigations: `audit-output/exhaustive-enumeration-se-dk-2026-05-18.md` (590 lines).
+- Committed on isolated worktree branch `worktree-agent-a9020b4c2f1bd73cd` at commit `3bbb79d`. Not on `main`; not pushed. Worktree path: `c:\Users\pette\Projects\strale\.claude\worktrees\agent-a9020b4c2f1bd73cd`.
+
+## Top-line verdicts
+
+- **SE — Viable v1 today (two candidate paths):**
+  - **Path 5a (Bolagsverket `foretradare_historik.csv`)** — CC BY 2.5 SE, monthly refresh, free, no auth, clean Tier 1. Open question that must be resolved before committing to the build: does the CSV contain named-individual rows per org number (usable as a director lookup) or only aggregate statistics? Field-description XLSX at `bolagsverket.se/polopoly_fs/1.14117!/beskrivning-av-foretradare-csv-fil.xlsx` resolves this — open it from an EU egress / browser before locking the path.
+  - **Path 4a (Topograph SE)** — per-call, "no minimum commitments" in public docs, sources from Bolagsverket Företagsinformation API v4, officer coverage confirmed (VD, ordförande, ledamöter, suppleanter). Same platform-fee discipline as HR applies — treat as v1.1 until written attestation received.
+
+- **DK — Viable v1.1 today (may already be unblocked):**
+  - **Path 1b (Erhvervsstyrelsen CVR S2S ElasticSearch)** returns `LEDELSESORGAN` (directors, board, signing rules) free post-contract. Existing handler notes the application to `cvrselvbetjening@erst.dk` went ~3 weeks ago; normal processing is ~3 weeks. **Immediate action: check that mailbox** — credentials may already be in the inbox.
+  - **Bridge path: Topograph DK** per-call (RFQ) draws from the same CVR source.
+
+## Open
+
+- Did the user open the Bolagsverket field-description XLSX to confirm `foretradare_historik.csv` row granularity? Decision is gated on this.
+- Has the Virk S2S contract reply arrived in the cvrselvbetjening@erst.dk thread? Need to check the inbox.
+- Topograph SE/DK platform-fee attestation not received — both are v1.1 until written confirmation matches HR pattern.
+- Research worktree branch `worktree-agent-a9020b4c2f1bd73cd` not merged to main. Either cherry-pick the audit-output file or `git merge` the branch in main; the worktree is otherwise transient.
+
+## Non-obvious learnings
+
+- Bolagsverket's web surface served CAPTCHA to every WebFetch probe from Railway US-East egress. ToS verification for Path 6, CSV field structure, and Företagsinformation API v4 contract terms all rest on search snippets and third-party docs, not direct probes. Worth re-confirming from EU egress before committing — same access-egress gotcha noted in the HR/EE/BE work (BRIS sorry.ec.europa.eu redirect from US-East).
+- Creditsafe confirmed an enterprise annual contract fee on both SE and DK — disqualified by v1 cost discipline; treat as DQ on future country sweeps without re-probing.
+- UC AB, Bisnode SE, Risika DK, Retrify DK are all unknown-RFQ-gated. No smoking-gun platform fee surfaced, but none cleared either. Apply HR Topograph pattern: classify v1.1 until written attestation.
+- The "DK might already be unblocked" finding is the kind of thing that lives in operational state (an email inbox), not in the codebase — close-check scripts won't surface it. Worth a project-memory entry to remind future sessions to look there.
+
+## Cost
+
+- Zero external API spend (research-only).
+- ~16 minutes Sonnet subagent duration; 145 tool calls. Cap was 4 hours; came in well under.
+
+## Cross-references
+
+- HR/EE/BE enumeration report: `audit-output/exhaustive-enumeration-hr-ee-be-2026-05-18.md` (same template).
+- HR Topograph platform-fee learning: Notion Journal entry `35967c87082c8177`.
+- DEC-20260518-E (Exhaustive Source Enumeration).
+- DEC-20260518-F (Path 6 4-constraint test).
+- DEC-20260428-A (Strale-operated scrapers prohibition).

--- a/handoff/_general/from-code/2026-05-18-pii-fixture-audit-legal-representatives.md
+++ b/handoff/_general/from-code/2026-05-18-pii-fixture-audit-legal-representatives.md
@@ -1,0 +1,36 @@
+Intent: Sweep apps/api/tests/fixtures/tier-coverage/ for unredacted PII in legal_representatives + the full PII_ARRAY_FIELDS set following the 2026-05-18 CZ pre-commit near-miss (7 Skoda board members caught before PR #137 landed). Verify capture-tier-fixtures.ts scrubber covers the field and that git history never leaked real PII through the directory.
+
+## Outcome
+
+- **All clean within scope.** 33 tier-coverage fixtures swept. 8 carry PII_ARRAY_FIELDS keys (br/cz/fr/gr/it/jp/no/sk); all show `"[REDACTED]"`, `null`, or `[]`. Other 25 carry no PII-array keys.
+- **Git history clean.** Zero commits ever pushed unredacted PII through `apps/api/tests/fixtures/tier-coverage/`. The PR #125/#136/#137 inline pattern (add field to PII_ARRAY_FIELDS during the capture that surfaced it) caught the GDPR exposure pre-commit.
+- **PR opened.** https://github.com/strale-io/strale/pull/138 (chore/pii-fixture-audit-legal-representatives). Single-file diff: the audit report at `audit-output/pii-fixture-audit-legal-representatives-2026-05-18.md`.
+
+## Open
+
+- **PR #138 awaits Petter review/merge** — audit-only, no code changes.
+- **Notion to-do `36467c87-082c-8117-8053-cb47e30a2c9f`** — close after merge.
+- **Out-of-scope follow-up surfaced by /go six-lens review (the substantive finding):** two manifest `output_schema.example` blocks carry real natural-person names — same class of PII the CZ near-miss surfaced:
+  - `manifests/french-company-data.yaml:30-33` — three real TotalEnergies SE board members (JACQUES ANDRE ASCHENBROICH, MARIE CHRISTINE COISNE, LISE CROTEAU) in `directors`.
+  - `manifests/brazilian-company-data.yaml:30-32` — one real partner (CLAUDIA KICH DA SILVA, 16-Presidente) in `partners`.
+  - These were never passed through `scrubFixture()` — manifests are hand-authored and `PII_ARRAY_FIELDS` only runs at capture time on executor output. Flagged in PR #138 body; recommend a separate remediation to-do.
+
+## Non-obvious learnings
+
+- **Scrubber is shallow + type-lying.** `scrubFixture()` iterates `Object.entries(output)` — top-level keys only. Nested PII arrays (e.g. `{ company: { directors: [...] } }`) would not be scrubbed. Also: the scrubber replaces a populated `T[]` with the literal string `"[REDACTED]"`, which `check-tier-coverage.mjs` accepts as populated but any future fixture-typed consumer (replay harness, type generator) must skip or cast for PII_ARRAY_FIELDS keys. Pre-existing design trade-off, now documented in the audit doc's Step 1 caveats.
+- **Audit methodology gap (worth knowing for future PII sweeps):** the git-history grep `git log -p --all ... | grep '^\+'` only catches additions, not removals. An added-then-reverted commit would be invisible. Conclusion still defensible for the CZ incident because the pre-commit catch meant the unredacted fixture never reached `git commit` — there's no SHA where it landed.
+- **Audit-scope discipline matters.** The audit's narrow scope (tier-coverage fixtures) intentionally excluded `manifests/` and similar PII-bearing surfaces. The /go six-lens reviewer surfacing the manifest exposure is exactly the gain pattern documented in `feedback_session_end_review_gate` — a second pass catches what the scoped sweep was structurally blind to.
+- **Working-tree hygiene:** branch started in detached HEAD on stale commit (f618870) with three handoff files marked untracked but already tracked-identical in origin/main. Resolved by removing the conflicting untracked copies (hash-verified identical to origin/main blobs) before checking out a fresh branch off origin/main. The `.agents/`, `AGENTS.md`, prior `audit-output/` files, and three handoff files remain untracked and pre-existed this session — none staged into PR #138.
+
+## Cost
+
+Trivial. Single Sonnet review subagent x2 parallel + Opus orchestrator. No external API calls; no fixture re-captures.
+
+## References
+
+- PR: https://github.com/strale-io/strale/pull/138
+- Audit doc: `audit-output/pii-fixture-audit-legal-representatives-2026-05-18.md`
+- Capture script: `apps/api/scripts/capture-tier-fixtures.ts:81-120`
+- Tier-coverage gate: `apps/api/scripts/check-tier-coverage.mjs`
+- Trigger PRs: #136 (NO `legal_representatives`), #137 (CZ `legal_representatives`)
+- Six-lens precedent: PR #125 (`/go` skill caught a similar PII pattern 2026-05-17)

--- a/handoff/_general/from-code/2026-05-18-registry-source-research-directors-exposure.md
+++ b/handoff/_general/from-code/2026-05-18-registry-source-research-directors-exposure.md
@@ -1,0 +1,49 @@
+Intent: Run the source-side counterpart to the handler-side directors-verification audit — research what each EU30 + UK + CH + SG + US-Cobalt + EU BRIS business registry source publicly claims to expose for directors / officers / legal representatives, with citation URLs and canonical field names, to feed the four-way diagnostic matrix (source-yes-handler-yes = Class A audit bug; source-yes-handler-no = Class B real gap; source-no = Class C honest gap; AML-gated = Class D).
+
+## Outcome
+
+Report written to [audit-output/registry-source-research-2026-05-18.md](audit-output/registry-source-research-2026-05-18.md). Coverage: 33 sources researched in 6 parallel general-purpose research-agent batches (Nordics+UK+IE; Western Europe; Southern Europe+Iberia; CEE+Baltics; Openapi product matrix; SG+US-Cobalt+BRIS).
+
+Headline source-side findings:
+- **13 free + structured API sources** for directors: SE, NO, DK, UK, FR, BE, CH, PL, CZ, SK, EE, LV, HR
+- **11 sources expose directors only via paid / PDF / web-UI / contract-gated channels**: DE (free PDF only post-DiRUG Aug 2022), LU (free PDF), GR/MT/CY/HU (free HTML), IE (partial open data), NL/AT/IT/ES/PT/RO (paid), BG (paid SOAP), FI (paid Virre — free v3 API does NOT expose vastuuhenkilöt)
+- **0 true Class C cases for directors** — every registry exposes directors at some tier; the question is always which tier
+- **0 Class D cases for directors** — Class D applies only to UBO registries (LU RBE, AT WiEReG, PT RCBE, IT TE), not director registers
+- **Openapi.com is Italy-only for directors** — public catalog has no AT/BG/CY/HU/LU/MT/NL/PT/RO/ES product exposing director data; only IT-Stakeholders and the Current Company Representatives Report (Italy) do
+- **SG free data.gov.sg is structurally name-blind** (officer count only); paid BizFile EIQ required for director names
+- **US-Cobalt** officers covered in ~28 of 50 states; CA/NY/DE explicitly redacted at source
+- **EU BRIS** is identity-only — not a useful director feed; per-MS variable
+
+Canonical field names captured per source (verbatim, with citation): Funktionärer (SE), Roller (NO), Deltagere (DK), Vastuuhenkilöt (FI), Officers (UK/IE/MT/CY), Représentants légaux/Dirigeants (FR), Vertretungsberechtigte/Geschäftsführer/Vorstand (DE/AT), Functionarissen/Bestuurders (NL), Fonctions/Functies (BE), Verwaltungsrat/Personen/Zeichnungsberechtigte (CH), Dirigeants/gérant/administrateur (LU), Administradores/Cargos (ES), Membros dos órgãos sociais/Gerentes/Administradores (PT), Cariche/Amministratori (IT), Διοίκηση/Διοικητικό Συμβούλιο/Διαχειριστές/Εκπρόσωποι (GR), Reprezentacja/Skład organu (PL), Statutární orgán/Jednatel (CZ), Štatutárny orgán/Konajúce osoby (SK), Vezető tisztségviselő/Képviselő (HU), Juhatuse liikmed/Esindusõigus (EE), Amatpersonas/Valdes loceklis (LV), Vadovas/Valdymo organas (LT), Osobe ovlaštene za zastupanje (HR), Zastopniki/Člani uprave (SI), Управители/Представители/Съвет на директорите (BG), Administratori/Reprezentanți legali (RO), Position Holders (SG paid).
+
+## Cross-reference
+
+Class A vs B determination is mechanical once the parallel handler-side audit (Prompt 1, `handler-directors-verification-2026-05-18.md`) lands. Report's matrix has all source-side columns pre-filled; handler-side audit fills columns 7-8.
+
+## Open
+
+- IE: could not verify whether the bulk Company Records dataset on opendata.cro.ie includes structured director rows. CRO Open Services REST API documentation enumerates only company-level fields. Follow-up: direct fetch of CSV header / dataset schema.
+- Openapi: full WW-Top JSON response schema is behind console login; possibly includes undocumented director fields for some countries. Follow-up: logged-in fetch of `company.openapi.json` OAS.
+
+## Non-obvious learnings
+
+- Belgium's KBO is free + structured but returns only **current** functions with **no DOB, no residence, no historic-director records**. Reverse-lookup (director → company) is blocked. Less PII than Germany's free post-DiRUG Aktueller Ausdruck.
+- France's INSEE Sirene Open Data explicitly **excludes** représentants légaux per Art. R 123-232 Code de commerce. Director data flows only via INPI RNE (free with auth) or the free recherche-entreprises.api.gouv.fr aggregator. `diffusibilité` flag MUST be honored — non-diffusible records cannot be redistributed.
+- Poland's KRS JSON anonymizes director names (`"nazwisko": "L******"`, PESEL first digit only) per GDPR carve-out, but the **PDF** returned by the same free API contains full names. Implication: for KYB use, parse the PDF.
+- Germany's DiRUG reform (1 Aug 2022) made directors free — but no JSON API was built. Every consumer parses the AD-PDF or uses a scraping wrapper.
+- Singapore stripped officer names from data.gov.sg under Companies Act s.12(2A). The `no_of_officers` column is a count, not a list. A free SG capability is structurally name-blind.
+- All true Class D (AML-obliged-only) cases discovered are UBO registries, not director registries — directors remain broadly accessible in the EU by statute, though often paid or PDF-only.
+
+## Cost
+
+Zero — research only, no executions billed. Time: ~5 minutes of wall-clock for 6 parallel research agents.
+
+## Followups for chat
+
+Chat reads this report alongside Prompt 1's handler-side findings. Intersection determines per-country action:
+- Class A (audit bug only) → labeling fix to use canonical source terms
+- Class B (extraction gap) → feeds legal-representatives extraction sweep v1.1 to-do
+- Class C (honest gap, FI on free tier) → reflect in v1 launch DEC honestly
+- Class D (AML-gated) → potentially closeable v1.1 if Strale's customer profile includes obliged entities (but this set has 0 director-side cases)
+
+No code changes, no DB mutations, no Decisions DB entries authored. No /go gate required (research-only).

--- a/handoff/_general/from-code/2026-05-18-uk-ubo-smoke-eu30-reaudit-directors-verification.md
+++ b/handoff/_general/from-code/2026-05-18-uk-ubo-smoke-eu30-reaudit-directors-verification.md
@@ -1,0 +1,82 @@
+Intent: validate PR #132's UK UBO GREEN verdict against live production, re-audit EU30 coverage post-PR-131 + post-PR-132 against the Evidence Tier and Use-case Tier frameworks, and verify the re-audit's "only 2 of 30 binding-ready T2" claim via multi-language handler-source grep + production smoke tests.
+
+# Outcome
+
+Three read-only audits completed, three audit-output files written, **zero code changes, zero commits**. All three feed chat-side decisions about v1 launch tier-claim shape.
+
+## Artifact 1 — UK UBO live smoke test
+
+Path: `audit-output/uk-ubo-smoke-test-2026-05-18.md` (in strale-work worktree)
+
+Verdict: **GREEN-VERIFIED**. PR #132's UK UBO activation works end-to-end against real Companies House behavior. Two production calls against Monzo (CH no. 09446231) confirmed:
+
+- `uk-company-data` returns `ubo_availability: "available"` with customer-friendly reason
+- `beneficial-ownership-lookup` returns populated `beneficial_owners[]` with name, type, ownership_level 75-100%, natures_of_control, notified_on
+
+First test entity (BP P.L.C., CH no. 00006245) returned `beneficial_owners: []` — correct PSC-exempt behavior for listed PLCs. Switched to Monzo per the prompt's stop-condition guidance. No code changes. UK UBO is v1-launch-ready.
+
+## Artifact 2 — EU30 coverage re-audit
+
+Path: `audit-output/eu-coverage-use-case-tier-audit-2026-05-18.md` (in strale-work worktree)
+
+Top-line verdicts:
+- **T1 Continuity: 29 of 30** EU30 countries deliverable (CH excluded under strict canonical-key reading)
+- **T2 Onboarding: 19 of 30** framework-compliant (declared with reason); **2 of 30 binding-ready within EU30** (DE + GR with populated representative arrays)
+- **T3 EDD: 0 of 30** — `ongoing-monitoring.ts` confirmed absent, universally blocked
+
+Findings:
+- PR #131 + PR #132 closed the CRITICAL `ubo_availability` + `tier_2_available` silent-omission gap on 31 of 32 handlers. The 32nd (`swiss-company-data`) remains a throw-stub + chain-provider framework violation (PR #131 explicitly scoped it out).
+- DK was correctly flipped from `available` → `unavailable_no_registry` by PR #132 (the integration was never wired; the flag was lying).
+- The 2-of-30 binding-ready T2 number is the most material datapoint for the v1 launch DEC — see Artifact 3 for the correction.
+
+## Artifact 3 — Handler-side directors verification
+
+Path: `audit-output/handler-directors-verification-2026-05-18.md` (in strale-research worktree)
+
+**Re-audit miss found.** Multi-language grep across all 32 patched handlers + 22 director-equivalent language variants + 9 production smoke tests revealed:
+
+| Country | Verdict | Evidence |
+|---|---|---|
+| FR | **CONFIRMED MISS** | `french-company-data.ts:62-82` emits `directors` from INSEE `dirigeants`. Smoke test on Renault SIREN 441639465 returned 18 directors (Senard, Provost, et al.). |
+| SK | **CONFIRMED MISS** | `slovak-company-data.ts:170-188` emits `directors` from `entity.statutoryBodies` with active-only filter. Smoke test on Slovnaft ICO 31322832 returned 8 directors. |
+| SE | YAML DRIFT | YAML claims "directors via Bolagsverket" but handler does not emit; live smoke confirms 0. |
+| UK | SLUG-BUNDLING | `uk-company-data` doesn't emit directors; a separate live capability `uk-companies-house-officers` exists and consumes the Officers API. |
+| 23 others | REAL GAP | Handler-grep + live smoke confirm no director-equivalent field. Re-audit correct. |
+
+**Updated EU30 binding-ready T2 count after the audit-bug fix:**
+- 2 (DE, GR) — original re-audit baseline
+- **4 (DE, FR, GR, SK)** — after flipping `tier_2_available: true` on FR + SK and updating their reason strings
+- 5 — if UK bundles `uk-companies-house-officers` extraction into `uk-company-data.ts`
+
+No git-history regressions: FR has emitted `dirigeants`→`directors` since the initial 22-capability addition (`094a597`); SK since `1d67bf2`. The labeling sweep (PR #131) wrote the wrong reason string from the start — pure audit-bug, no code regression.
+
+# Open / loose threads for next session
+
+1. **Audit-bug fix PR for FR + SK** (chat-side prompt pending). Flip `tier_2_available: true`, update reason strings, optionally add `legal_representatives` canonical alias mapped to `directors`. ~10 lines of code total across two files.
+2. **SE YAML annotation correction.** Either remove "directors via Bolagsverket" from `swedish-company-data__se__company-registry.yaml` or open a separate ticket for the Bolagsverket directors-endpoint integration.
+3. **UK slug-bundling decision.** Either bundle `uk-companies-house-officers` into `uk-company-data.ts` (lifts UK to binding-ready T2) or clarify the YAML annotation. Chat call.
+4. **v1 launch tier-claim DEC.** Pick the T2 definition the launch claim uses: framework-compliant (19/30) vs binding-ready (4/30 after the FR+SK fix, 5/30 after UK bundling). The 2026-05-18 re-audit's Section 7 names this as the central question for the launch DEC.
+5. **Per-country T1 populated-field probe.** Re-audit assumed direct-API handlers reach 6/6 populated; not verified per country. A one-call-per-country probe would lock the populated-T1 count as ground truth before launch.
+6. **Swiss handler framework compliance** (still open from PR #131 scope-out). Either extend the labeling sweep to `providers/swiss-company-data.ts` or accept CH as the lone framework-non-compliant row.
+
+# Non-obvious learnings
+
+- The `/v1/counterparty-assurance` endpoint in the smoke-test prompt is fictional — the real surface is `POST /v1/do` with `capability_slug` and `inputs` (plural). The prompt-spec'd shape produced HTTP 400s until corrected. Spec-vs-reality drift in prompt authoring is a recurring failure mode for one-shot prompts that posit endpoint shapes; verifying against `app.ts` route mounts is cheap.
+- BP P.L.C. (CH no. 00006245) is **PSC-exempt as a listed PLC** — the handler returns HTTP 200 + `beneficial_owners: []` correctly. Don't smoke-test UBO integrations on listed PLCs; use private Ltd entities (Monzo CH no. 09446231 is a good standby).
+- The prompt's `/v1/do` body uses `inputs` (plural) not `input` (singular). Helpfully, the API returns a structured error when the singular form is sent — but Python-style `body.input` mental defaults will burn a request roundtrip.
+- Per-handler input-key names are **not uniform**: BE wants `enterprise_number`, IE wants `cro_number`, FI wants `business_id`, NO/SE want `org_number`, SK/CZ want `ico`, FR wants `siren`, PL wants `krs_number`. The error message at HTTP 400 names the expected fields — don't guess; read the error.
+- The 2026-05-18 re-audit's "only 2 of 30 binding-ready T2" verdict was bug-prone because the alias resolver only matched fixed English names. Multi-language grep + live smoke tests is the only reliable way to verify handler-emission claims across a multi-country surface — `tier_2_available: false` is a self-reported flag that does NOT correspond to what the handler actually returns. The labeling sweep wrote the same boilerplate reason ("handler does not currently extract legal representatives from upstream registry") for FR and SK despite both extracting directors — boilerplate reason-string templates are dangerous in coverage audits.
+- Strale-research worktree was at `e1c2105` (pre-PR-131) at session start — a stop condition. `git checkout 2126de0` cleanly carried the local `.gitignore` `audit-output/` addition forward (no diff between commits). For future audits, double-check worktree HEAD before relying on it.
+
+# Cost
+
+Production wallet on `test2@strale.io`: ~125 cents total across ~14 production `/v1/do` calls (3 UK smoke + 11 directors verification). Final balance: 2789 cents.
+
+# Git state
+
+- No commits this session
+- Three audit-output files written, all in `audit-output/` (gitignored locally on strale-research; not gitignored globally)
+- strale-research worktree HEAD: `2126de0` (post-PR-132 main)
+- strale-work worktree HEAD: `2126de0` (main)
+- strale primary worktree HEAD: `f618870` (detached, unrelated to this session)
+- Pre-existing dirty state preserved: strale-research has local `.gitignore` mod adding `audit-output/`; strale has 3 unrelated unstaged handoff files + 2 unrelated AGENTS.md/.agents/ untracked items — none from this session

--- a/handoff/_general/from-code/2026-06-17-prompt-optimize-truncation-fix.md
+++ b/handoff/_general/from-code/2026-06-17-prompt-optimize-truncation-fix.md
@@ -1,0 +1,39 @@
+# Handoff — prompt-optimize truncation fix
+
+**Intent:** Fix the `prompt-optimize` capability bug surfaced by `/activity` (6 production x402 failures) and ship it.
+
+**Date:** 2026-06-17
+**Mode:** Quick (single-capability bug fix)
+**Branch / PR:** `fix/prompt-optimize-truncation` → [PR #145](https://github.com/strale-io/strale/pull/145)
+
+## What happened
+
+Ran `/activity since-last` (window 2026-06-08 → 2026-06-17): 525 external calls, mostly an x402 catalog sweep. Two real signals:
+1. **`prompt-optimize` failing in production** — 6 calls from a "Jobright" content-generation pipeline (Agent1→Agent2 lanes) erroring with `Unterminated string in JSON`.
+2. The 17 `no_matching_capability` logs were **not real gaps** — almost all from a competitor agent-marketplace experiment ("Arbor" / `tryarbor.vercel.app` / repo `Imhaohao/miyohacks`, pinging from `agentdex.dev`) forwarding generic LLM "bid request" prompts at `/v1/do`. Only genuine signals: no flight-search capability exists, and the keyword matcher is brittle when a real task (USD→CHF conversion) is buried in a large context envelope. Both backlog-only, not urgent.
+
+## The fix (PR #145)
+
+Root cause: `prompt-optimize` asks Claude to echo the full improved prompt back inside a JSON envelope (output ≈ input), but `max_tokens` was hardcoded at 1500 → any prompt over ~1KB truncated mid-string → `JSON.parse` crashed.
+
+Changes to `apps/api/src/capabilities/prompt-optimize.ts`:
+- Scale `max_tokens` to estimated input size (floor 1500, ceiling `MAX_OUTPUT_TOKENS = 8000`).
+- Reject inputs > `MAX_PROMPT_CHARS = 18000` upfront, before the paid API call. Limit is *derived from* the 8000-token ceiling so accepting a prompt implies it can be optimized in one pass (no silent truncation at the top of the range).
+- Detect `stop_reason === "max_tokens"` → actionable error instead of a parser crash.
+- Guard `r.content[0]` access; unify the two malformed-output paths into one consistent retryable message.
+
+## Verification
+
+- tsc clean; `validate-capability` 19/19; `checkReadiness` → `ready: true`, 0 issues.
+- smoke-test: structural pass; live step blocked by ALLOW_MATRIX (paid cap from `internal_test`) — same on `main`, not a regression. Verified live execution out-of-band: 20000-char input rejects pre-call; ~16.7KB prompt optimizes in one pass; normal prompt returns full JSON.
+- `/go` six-lens review: 0 HIGH. 4 MEDIUM all fixed in-branch (unsafe content access; char-limit↔ceiling inconsistency; unified error messages; reworded truncation error).
+
+## Follow-ups (deferred, not in this PR)
+
+- **Shared `parseJsonEnvelope` helper.** Altitude lens found ~80 caps inline the same `JSON.parse(match)` pattern, and **8 output-proportional caps carry the identical latent truncation bug**: `translate`, `summarize`, `code-convert`, `pii-redact`, `web-extract`, `pdf-extract`, `image-to-text`, `prompt-compress` (the last already grew the guard by hand). A shared helper that checks `stop_reason`, extracts `{...}`, and try/catches the parse would retire the bug fleet-wide. Migrating ~80 sites is its own PR.
+- **Matcher robustness** — real tasks buried in large context envelopes return `no_matching_capability` (Arbor traffic). Low priority unless that traffic grows.
+- **Flight search/comparison** — unserved capability (only `flight-status` exists). Bot-protected scraping territory; backlog.
+
+## State at handoff
+
+PR #145 open against `main`; merging on green CI. Once merged, Railway auto-deploys from `main` and the fix goes live.

--- a/handoff/_general/from-code/2026-06-24-llm-json-truncation-fix.md
+++ b/handoff/_general/from-code/2026-06-24-llm-json-truncation-fix.md
@@ -1,0 +1,45 @@
+# Handoff — readme-generate / price-compare LLM-JSON truncation fix
+
+**Intent:** Fix the `readme-generate` (and related `price-compare`) production 500s surfaced by `/activity`, where the model's JSON output was truncated or followed by trailing prose and the naive parse crashed. Ship it.
+
+**Date:** 2026-06-24
+**Mode:** Quick (two-capability bug fix, same family as #145)
+**Branch / PR:** `fix/llm-json-truncation` → [PR #146](https://github.com/strale-io/strale/pull/146)
+
+## What happened
+
+`/activity since-last` (window 2026-06-17→24) flagged two real capability bugs under an x402 catalog sweep:
+- **`readme-generate`** failed 3/3: "Unterminated string in JSON at position ~7800". A comprehensive README exceeds the hardcoded `max_tokens: 3000`, so the JSON truncated mid-string and `JSON.parse` threw a raw `SyntaxError` → 500.
+- **`price-compare`** failed 3/3: "Unexpected non-whitespace character after JSON". The greedy `/\{[\s\S]*\}/` regex over-captured trailing prose that contained a `}`, so `JSON.parse` choked after the first object.
+
+Both are the failure family PR #145 fixed for `prompt-optimize`.
+
+## The fix (PR #146)
+
+New shared helper `apps/api/src/capabilities/lib/llm-json.ts`:
+- `parseLlmJsonObject(response, label)` — reports `stop_reason === "max_tokens"` truncation as an actionable (output-neutral) error, extracts the first **balanced** top-level object, and returns a clean error (never a raw `SyntaxError`; attaches the parse error as `{ cause }` for logs).
+- `extractFirstJsonObject(text)` — single-pass, **string-literal-aware** brace scanner (ignores braces inside JSON strings, respects escapes), so trailing prose is dropped.
+
+Call-site changes:
+- `readme-generate.ts`: `max_tokens` 3000 → **8000** (output size is driven by the generated README, NOT the input — so a fixed generous ceiling, not input-scaled like #145). Parse via helper.
+- `price-compare.ts`: `max_tokens` 2000 → **4000** (long offer lists). Parse via helper.
+
+Both ceilings are well under Haiku 4.5's 64K output limit and the ~16K non-streaming HTTP-timeout threshold (confirmed via the `claude-api` skill).
+
+Regression test `llm-json.test.ts` (14 cases) covers both prod failure shapes + brace-in-string, truncated-mid-string-with-braces (exact prod shape), empty/non-text content, and preamble-unbalanced-brace degradation.
+
+## Verification
+
+- tsc clean; `validate-capability` 19/19 (both); `checkReadiness` ready:true 0 issues (both); 14/14 unit tests; `lint:no-bare-catch` clean.
+- smoke-test: structural + non-paid steps pass; paid live step blocked by ALLOW_MATRIX (`paid_prepaid` from `internal_test`) — expected, same on `main`, not a regression (same as the #145 handoff noted).
+- **Live execution verified out-of-band** (direct executor call, bypassing the cost-guard): both prod repro inputs now succeed — ~12KB READMEs (22/17 sections) where it previously truncated 3/3.
+- Six-lens `/go` review: 0 HIGH remaining. Applied: output-neutral truncation message, `{ cause }` on the malformed-JSON rethrow, JSDoc single-block note + a degradation test.
+
+## Follow-ups (deferred, not in this PR)
+
+- **Fleet-wide migration onto `parseLlmJsonObject`.** ~80 capabilities still inline the greedy-regex parse, **including `prompt-optimize.ts` itself** (which has the truncation guard but is still vulnerable to the trailing-prose over-capture). The #145 handoff already flagged this as its own PR; this PR only fixed the two caps with confirmed production failures.
+- **`readme-generate` silent input truncation.** `project_description` is silently `.slice(0, 4000)`'d with no caller signal — pre-existing, unrelated to this JSON bug. Candidate for the migration PR (mirror `prompt-optimize`'s explicit-reject pattern).
+
+## State at handoff
+
+PR #146 open against `main`; merge on green CI. Railway auto-deploys from `main` on merge; the fix goes live then. Pre-existing untracked working-tree files (`.agents/`, `AGENTS.md`, `audit-output/`, `handoff/_general/from-code/*`) were left untouched — only the four fix files were staged.

--- a/handoff/_general/from-code/2026-07-02-railway-outage-recovery.md
+++ b/handoff/_general/from-code/2026-07-02-railway-outage-recovery.md
@@ -1,0 +1,19 @@
+# 2026-07-02 — Railway production outage recovery
+
+Intent: Check status of the Strale Railway deployment and restore it if down.
+
+## What happened
+- Production API (strale-production.up.railway.app) was returning 502 "Application failed to respond".
+- Root cause chain:
+  1. Postgres on Railway had a severe I/O degradation episode ~08:30–09:00 UTC today — one checkpoint took 20 minutes (`total=1205s`, normally <30s), client authentications hit `canceling authentication due to timeout`.
+  2. The API crash-looped at startup on `CONNECT_TIMEOUT postgres.railway.internal:5432` (fatal in `startup-migrations-begin`), exhausted `restartPolicyMaxRetries: 10`, and Railway stopped restarting it → service stuck in CRASHED.
+  3. Postgres recovered on its own (direct connection: 771ms, `pg_stat_activity` empty, volume at 8GB/100GB — NOT a repeat of the 2026-05-04 disk-full incident), but nothing restarted the app.
+- Fix: `railway redeploy --service strale` → deployment `51642542` SUCCESS at 21:30 CET. Verified: `/health` 200 (commit af580be), `/v1/capabilities` 200 in 0.67s (DB-backed, proves Postgres connectivity).
+
+## Estimated downtime
+~11 hours (approx. 08:30 UTC → 19:32 UTC). No alerting fired.
+
+## Loose threads (flagged, not fixed)
+1. **No alerting caught this.** `BETTER_STACK_SOURCE_TOKEN` is unset in production ("log shipping disabled" at startup). No external uptime monitor exists. An 11-hour outage went unnoticed. Spawn-task chip created for adding uptime monitoring + alerting.
+2. **Startup hard-fails on transient DB unavailability.** `runStartupMigrations()` treats a DB connect timeout as fatal; combined with `restartPolicyMaxRetries: 10` + `ON_FAILURE`, any DB blip longer than ~10 restart cycles permanently kills the service until a human redeploys. Consider: retry-with-backoff around startup DB connection, and/or Railway restart policy change, and/or a healthcheck-based restart.
+3. The Postgres I/O degradation cause is unknown (transient Railway host issue suspected). Worth watching for recurrence.

--- a/handoff/_general/from-code/2026-07-02-startup-db-retry-alerting.md
+++ b/handoff/_general/from-code/2026-07-02-startup-db-retry-alerting.md
@@ -1,0 +1,46 @@
+# 2026-07-02 — Outage follow-up: startup DB retry + alerting gaps
+
+Intent: Close the three alerting/resilience gaps from the 2026-07-02 ~11h outage (see `2026-07-02-railway-outage-recovery.md` for the incident itself).
+
+## Done this session
+
+### 1. Startup DB retry + fatal-startup email alert (PR #147)
+- https://github.com/strale-io/strale/pull/147 — awaiting Petter's merge.
+- Transient DB connectivity errors at boot (the exact incident shape) now retry in-process with backoff under a shared per-boot budget (default 10 min, `STARTUP_DB_RETRY_BUDGET_MS`). Combined with Railway's 10 restarts this tolerates hours of DB downtime instead of minutes.
+- Fatal startup errors now send a critical email via Resend before exit (prod only). **This works TODAY** — `RESEND_API_KEY` + `ALERT_RECIPIENTS` are already set on Railway. Had it existed on 2026-07-02, the page would have fired at ~08:30 UTC instead of silence.
+- Six-lens review ran (/go); 1 HIGH + 2 MEDIUM findings fixed pre-PR; full suite green (721 passed).
+
+### 2 & 3. Better Stack log shipping + external uptime monitor — BLOCKED on Petter (~10 min)
+Could not complete: no Better Stack account/session exists (checked the browser — not signed in), and account creation/sign-in is an action Claude is prohibited from doing on your behalf. Everything else is prepped. Runbook:
+
+#### A. Create the account (once)
+1. Go to https://betterstack.com → Sign up (free plan: 10 monitors, 3-min checks, email alerts — sufficient).
+2. Use petter@strale.io so alert routing is consistent.
+
+#### B. Uptime monitor (~3 min)
+1. Better Stack → Uptime → Monitors → Create monitor.
+2. URL: `https://strale-production.up.railway.app/health/deep`
+   - **Use /health/deep, not /health** — it exercises the Postgres write path (insert+delete probe row), so it would have caught the 08:30 DB degradation itself, hours before the crash. Verified working today: 200 in 0.23s, `write_path: ok`, 6ms.
+   - Optionally add a second monitor on plain `/health` (process-alive signal) to distinguish "DB degraded" from "app dead".
+3. Check frequency: 3 min (free tier max). Expect "200" status. Request timeout: 30s (deep check does a DB write; give it headroom during degradation).
+4. Alerting: email to petter@strale.io (default). Add phone/push via the Better Stack mobile app if wanted — voice calls are free-tier unlimited.
+
+#### C. Log shipping source (~3 min)
+1. Better Stack → Telemetry (Logs) → Sources → Connect source → platform "JavaScript • Node.js" (Logtail/pino).
+2. Copy the **source token**.
+3. Then run (or paste the token to Claude Code and it will run):
+   ```
+   railway variables --set BETTER_STACK_SOURCE_TOKEN=<token> --service strale
+   railway redeploy --service strale
+   ```
+4. Verify after deploy: startup logs should NO LONGER print `alerting.no-log-sink` ("BETTER_STACK_SOURCE_TOKEN unset"). Live logs should appear in the Better Stack Logs UI within a minute.
+5. Optional but recommended: in Better Stack Logs, create an alert on `label:"startup-db-retry-exhausted"` OR `severity:"critical"` → email. That pages on the new retry-exhaustion path even if email via Resend also fails.
+
+#### Why Better Stack over UptimeRobot
+One vendor covers both gaps (uptime + log sink), the codebase is already wired for it (`@logtail/pino` transport in `lib/log.ts` activates on the env var alone — zero code change), and `lib/alerting.ts` docs already reference it.
+
+## Notes / loose ends
+- **Railway project was renamed**: CLAUDE.md and memory say project "desirable-serenity", but `railway status` reports the project name is now **"Strale"** (id `16920e2f-8258-47db-86c0-60ec9d7edc13`). Memory updated this session; CLAUDE.md still says desirable-serenity in two places — cleanup candidate.
+- Railway service has `healthcheckPath: null` — no deploy-time HTTP probe. With the in-process retry shipped, adding a Railway healthcheck on `/health` is optional; revisit if deploys ever go live with a broken boot.
+- The Postgres I/O degradation root cause remains unknown (suspected transient Railway host issue). The `/health/deep` monitor is the recurrence tripwire.
+- Post-merge verification for PR #147 (per DEC-20260504-C): after deploy, confirm boot logs show `startup-migrations-complete` and `GET /health/version`-equivalent (`/health` commit field) shows the new SHA.

--- a/handoff/_general/from-code/2026-07-05-screenshot-waitfor-edgar-retry.md
+++ b/handoff/_general/from-code/2026-07-05-screenshot-waitfor-edgar-retry.md
@@ -1,0 +1,30 @@
+# Handoff — 2026-07-05 — screenshot-url + us-company-data reliability fixes
+
+**Intent:** Ran `/activity since-last`, dug into two failures it surfaced in production x402 traffic, fixed both, shipped via `/go` → PR #148.
+
+## What the activity check showed (window 2026-07-02 21:42 → 2026-07-05 02:47 CET)
+- 15 external calls, all x402, single exploratory user testing the catalog against `stripe.com` / `vercel.com`. 1 signup (throwaway-looking, no spend).
+- 3 failures, two of them real signal:
+  - `screenshot-url` HTTP 400 on `wait_for:"3"`.
+  - `us-company-data` HTTP 500 on `{"company_name":"Stripe Inc"}` (+ one wrong-param `{"query":"STRI"}`).
+
+## Fixes (PR #148 — branch `fix/screenshot-waitfor-edgar-retry`, off `main`)
+1. **screenshot-url** — `wait_for:"3"` (numeric string = "wait 3s") was routed into the `waitForSelector` branch → bogus CSS selector → Browserless 400. Added `normalizeWaitFor()`: numbers **and** numeric strings → `waitForTimeout` (seconds, clamped 0–30); non-numeric strings → selector. Confirmed live against Browserless that `waitForTimeout:3000` returns 200.
+2. **us-company-data** — SEC EDGAR 500 was **transient** (endpoint returns 200 consistently on re-test; "Stripe Inc" even returns hits). Root cause = no retry. Replaced a first-draft hand-rolled retry loop with the shared `withRetry` primitive (`lib/retry.ts`) via new `fetchSec()`, adding a local `/HTTP 5\d\d/` pattern because the shared default omits bare 500. Also covers the x402 path (bypasses route-level `executeWithRetry`).
+
+Both carry regression tests (13 total, fail pre-fix / pass post-fix).
+
+3. **us-company-data low-confidence guard** (added after the six-lens review flagged it as a follow-up, then folded into PR #148). Name lookups resolve via SEC full-text *filing* search → a private company ("Stripe Inc") resolves to a different public filer that merely mentions the name. Pass B review found this wrong identity was flowing into the bundled KYB solutions' `sanctions-check`/`pep-check` steps ungated — a real DEC-20260428-B harm. Fix: `classifyNameMatch` (exact/high/low, both names must be ≥2 tokens for high), and a **low-confidence name lookup now errors by default** instead of asserting a wrong identity; `allow_low_confidence=true` opts into best-effort. New output fields `match_confidence`/`is_exact_match`/`searched_name`. Manifest limitation reframed. 21 tests total now.
+
+## Verification
+tsc clean · vitest 13/13 · validate-capability both pass · smoke: screenshot-url full pass, us-company-data blocked only by pre-existing ALLOW_MATRIX paid-cost guard (`internal_test`), not a regression · readiness: screenshot-url `ready=true`; us-company-data `ready=false` **pre-existing platform-wide manifest drift** (control cap `email-validate` fails identically) — unrelated to this diff.
+
+## Review (six-lens, both passes — no HIGH)
+- MEDIUM: executor retry stacks with route-level retry for 429/502/503/504 (~4 attempts; bare-500 case correctly does NOT stack). Bounded, documented in the `fetchSec` docstring, kept because it's what covers x402.
+- MEDIUM (out of scope, follow-up spawned `task_694ae016`): `searchEdgar` takes `hits[0]` → private/ambiguous names (e.g. "Stripe Inc") can resolve to the **wrong** public filer. Needs a match-confidence signal.
+
+## Open threads / next
+- **PR #148** awaiting CI + merge.
+- **Follow-up task** `task_694ae016` — us-company-data wrong-CIK match risk.
+- **Pre-existing, not mine:** the `checkReadiness` "missing output_field_reliability" gate mis-fires platform-wide (email-validate, us-company-data, likely many more flag output fields absent from their manifest `output_field_reliability` map). Worth a dedicated sweep — it makes the readiness gate noisy/untrustworthy.
+- Branch `fix/startup-db-retry-alerting` (PR #147, unrelated) was checked out when this session started; my fixes were deliberately branched off `main` to avoid bundling.

--- a/handoff/_general/from-code/2026-08-05-activity-followups-tos-and-search.md
+++ b/handoff/_general/from-code/2026-08-05-activity-followups-tos-and-search.md
@@ -1,0 +1,95 @@
+# Handoff — 2026-08-05 — activity follow-ups: ToS blocklist + search aliases
+
+> **Frontend threads continued and closed on 2026-08-06** — see
+> [2026-08-06-frontend-ci-signal-and-audit-drift.md](2026-08-06-frontend-ci-signal-and-audit-drift.md).
+> The PR #12 / #13 sections below record their in-progress state as of this
+> session; both are now merged and verified on `main`.
+
+**Intent:** Continuation of the same session as [2026-08-05-screenshot-waitfor-browserless-v1.md](2026-08-05-screenshot-waitfor-browserless-v1.md). Worked the two remaining follow-ups that `/activity since-last` surfaced: the `product-reviews-extract` Trustpilot wall and the search typeahead gaps.
+
+## PR #151 — ToS blocklist (merged, `87b84db`)
+
+**Symptom:** 28 of 31 x402 calls to `product-reviews-extract` failed over 16 days, every one a `trustpilot.com/review/*` URL returning 403. Callers retried identical URLs 3-4×, each attempt paying for a Browserless render first.
+
+**Root cause was one level deeper than the symptom.** The capability was *advertising* Trustpilot — both its DB description ("Amazon, Trustpilot, or any review page") and its own missing-input error told callers to use it — while sibling `trustpilot-score` sat deactivated for exactly that ToS reason. More structurally: the platform enforced its site-by-site ToS rulings by deactivating the **named** capability pointed at each site. Capabilities taking an *arbitrary* URL reach the same hosts through the same Browserless path, so deactivation closed the front door and left the side door open.
+
+Added `apps/api/src/capabilities/lib/tos-blocklist.ts` as one source of truth (Trustpilot, Glassdoor, LinkedIn, Google Patents, Google Search, FB/IG/X — all previously scattered across the auto-register DEACTIVATED map and a comment in `social-profile-check`). Rejection happens before any network work: no render, no LLM tokens, and the caller gets a message naming the constraint, saying retry won't help, and pointing at Reviews.io/Feefo/Yotpo.
+
+Registered the refusal string in circuit-breaker `USER_INPUT_ERROR_PATTERNS` — otherwise a burst of blocked URLs reads as capability failure and trips the breaker for everyone. Cross-module test verified in both directions per DEC-20260504-A.
+
+**Deliberately not fixed — needs Petter's call (task chip `task_475e2c5a`):** `tech-stack-detect` completed **19 calls against linkedin.com** in the same window, and `screenshot-url` has one. That's the same automated access `linkedin-url-validate` was deactivated for, and it fails *open* (serving prohibited data) rather than closed. Blocking it is a one-line wire-in but removes working paid traffic — a business/legal decision, not a refactor. ~11 further arbitrary-URL capabilities share the gap.
+
+## PR #152 — search vocabulary aliases (open at time of writing)
+
+17 zero-result typeahead queries in `suggest_log`. Split them into vocabulary mismatches (fixable) and coverage gaps (not).
+
+Fixed via a data-driven alias map (`apps/api/src/lib/search-aliases.ts`): `fx` 0→7 results (exchange-rate 3rd), `visa`/`relocation visa immigration` 0→1 (work-permit-requirements), `logging` 0→2 (log-parse first — prefix matching could never reach it, the typed word is longer than the token), `travel`/`trip` 0→2 (flight-status).
+
+Ranking needed a second pass: with one flat alias weight, `fx` put `swift-message-parse` (mentions currency in prose) above `exchange-rate` (whose *name* is the answer). Added a `primaryTokens` set (name + slug), used **only** for alias scoring, so direct matching is unchanged.
+
+**Left unaliased on purpose:** south africa, itinerary, vacation, reminder, incident, rewrite, engine. Nothing serves them under any name; aliasing to adjacent items would manufacture false matches. A test pins this.
+
+Verified: live catalog before/after, through the real route handler via `app.request()`, plus a regression probe of the 19 most frequent real queries — 0 returned fewer results.
+
+## PR #153 — sanitizer allowlist (found by post-deploy verification)
+
+Verifying #151 against production caught a defect in my own shipped message. The refusal came back as *"Supported review sources include **[service]**, Feefo and Yotpo pages"* — `sanitizeFailureReason()` strips hostname-shaped tokens to stop internal infrastructure names leaking, and it can't tell those from a vendor name deliberately written into guidance, so it ate `Reviews.io`. The one actionable part of the message named nothing.
+
+Added an explicit `HOSTNAME_ALLOWLIST` (public product names cited by the refusals, plus the blocked site's own name so callers can see *what* was refused), folded the pre-existing inline `keepPatterns` into it, and made matching case-insensitive. Tests pin **both** directions, since a too-broad allowlist is the more dangerous failure — `chromium.railway.internal` must still never reach a customer. `sanitize.ts` had no test coverage before this.
+
+Worth noting for the future: this only surfaced because the post-deploy check read the actual response body rather than just asserting a non-200 came back.
+
+## strale-frontend PR #12 — AuditRecord.quality drift (open, needs your call on CI)
+
+`check-shape-contracts.mjs` flagged the frontend declaring `quality: { sqs, label, pass_rate }` that the backend stopped shipping when the SQS engine was deleted (DEC-20260503-B, 2026-05-05).
+
+**It was user-visible, not just a type mismatch.** Two live consumers read it — the audit page's § 6 "Quality at Time of Transaction" and the downloadable PDF. Both use optional chaining so nothing threw; instead **every audit record and every generated PDF rendered "—" for SQS Score and Test pass rate for three months.** On a compliance document that reads as "unavailable for this transaction" rather than "permanently gone", which is worse than a crash.
+
+Removed the field and the two dead cells, kept schema validation (the one cell still backed by real fields). Did not restore backend-side: SQS was retired deliberately and the frontend's own CLAUDE.md says "SQS is dead — do not reintroduce it". Left a comment so nobody re-adds it without a real source. Shape check now passes 25/25 both sides.
+
+**Not merged.** The `build-and-test` job is red — 47 pre-existing lint errors (`no-explicit-any` etc.), **zero of them in my files**, mostly in vendored `src/components/ui/` primitives the repo's rules say not to drive-by-edit. Frontend `main` has been red on this job since the CI workflow was added 2026-07-03. Cloudflare Pages (the actual deploy) passed. Merging publishes to the live site, so that's your call, not mine.
+
+**Related: the frontend CI signal is effectively dead** — a job that has been red for a month gets ignored, which is how the next real failure will slip through.
+
+## strale-frontend PR #13 — lint, partial by design (open)
+
+`build-and-test` has been red on frontend `main` since the CI workflow landed 2026-07-03, so every PR inherits a failing check and the signal is dead.
+
+**It could not be taken to green, and the reason matters.** Of 47 errors, only **7** were safe to touch:
+
+- **21** sit in files the in-flight work is **deleting** (`ZoneBReliability`, `StepQualityTable`, `ZoneCCompliance`, `api.contract.test.ts`) — fixing them is wasted; they vanish when that work lands.
+- **19** sit in files with **uncommitted edits**, including `src/lib/api.ts` alone at 14. Staging any of those would have committed your work-in-progress along with a lint fix.
+
+Four of those files — `api.ts`, `Security.tsx`, `learnGuides.ts`, `generate-sitemap.ts` — had been modified **within 30 minutes** of my starting. The tree is actively in use, so I built the branch in a separate `git worktree` off `origin/main` and never touched the working tree. Verified afterwards: all 60 WIP files still present and unmodified.
+
+Fixed: eslint override scoping two rules off `src/components/ui/**` (vendored shadcn — both rules fire on how upstream ships them, not on defects); deleted two dead exports in `quality-indicators.ts`; tailwind `require()` → ESM import; one `any` in `run-site-tests.ts`. **54 problems → 40, all 7 warnings gone.** tsc clean, build succeeds, 23/23 tests.
+
+Two things worth knowing:
+- The `quality-indicators.ts` deletions were the same pattern as the AuditRecord drift — the `any` casts were hiding that both functions read step fields that don't exist on the type, so one could only ever return `null` and the other counted every step as "live". They were never called, so nothing changes behaviourally.
+- The tailwind swap was verified past "it built": `animate-in`/`fade-in`/`zoom-in` are present in the emitted CSS, and those are plugin-generated. An ESM default-import swap can silently no-op.
+
+**Then, on your call, made it non-blocking — and CI is now GREEN.** Second commit on the same PR.
+
+**The bigger finding came out of this.** `Lint` ran *first* in the workflow, and a failed step halts the job. Verified against a real run: `Lint failure → Test skipped → Build skipped`. So **Test and Build have been skipped on every CI run for a month** — the frontend has had no automated test or build verification in CI at all, and a broken build would only have surfaced at deploy time. Reordering Test and Build ahead of Lint is the fix that actually mattered; the lint noise was the smaller half.
+
+For lint itself I did **not** use `continue-on-error` — it unblocks the job by making new errors fail nothing, which is the same dead signal by another route. Instead `scripts/lint-ratchet.mjs` compares against a per-file baseline of the 40 accepted errors: known backlog passes, new offender or a file exceeding its allowance fails by name.
+
+Per-file rather than a single total, because a total lets a new problem hide behind an unrelated improvement — verified exactly that: with a 9-error file deleted and one fresh error added the total drops 40 → 32 (under a total threshold) and the ratchet still fails. All five branches were exercised, including that improvements *pass* with a "tighten the baseline" note, since an improvement turning CI red is the trap that created this mess.
+
+**When your WIP lands, ~21 errors vanish with the deleted files — run `node scripts/lint-ratchet.mjs --update` to tighten the ledger.**
+
+Both commits were built in throwaway `git worktree`s off origin; the live tree was never touched (verified: 60 WIP files present and unmodified, still on your branch, before and after).
+
+## Things found along the way that are NOT mine
+
+1. **`apps/api/src/routes/wallet.ts` has an uncommitted local change** — Stripe redirect URLs moved from `/?topup=success` to `/topup?status=success`. It appears in no commit and no branch, and was not in the session-start git status. I did not author it, did not stage it, and left it untouched per the git working-copy safety rule. **Someone should confirm whether it's wanted** — it looks like deliberate work-in-progress matching a frontend `/topup` route, but it's currently unversioned and one `git checkout` away from being lost.
+
+2. **`AuditRecord.quality` frontend/backend drift** (task chip `task_c17a28f8`) — `check-shape-contracts.mjs` reports the frontend declares `quality: { sqs, label, pass_rate }` which the backend no longer ships. Almost certainly SQS-deletion fallout (DEC-20260503-B). It passes in GitHub CI only because the frontend repo isn't checked out there, so the comparison silently skips — worth making a skipped check say so rather than look green.
+
+3. **9 test files fail locally on `main`** (SSRF buckets, admin/internal routes, health-deep) with `Test timed out in 10000ms` importing `app.ts` → `auto-register.ts` (310 dynamic imports). Verified pre-existing by stashing my diff and re-running clean. They pass with `--testTimeout=60000`. CI is green on them. The default timeout looks too tight for that import graph on a loaded machine.
+
+## Open threads
+
+- **PR #152** awaiting CI/merge at time of writing.
+- **Capability gaps from search demand** (task chip `task_6dc8cf31`): South Africa company data; travel/trip planning; reminder/scheduling; incident logging. Plus the cheapest one — **a text-rewrite capability**, since `summarize`, `translate`, `classify-text` and `email-draft` already exist as neighbours and "rewrite" returned zero.
+- The `railway-config.md` Browserless v1 pin revisit date was **2026-08-06** — tomorrow relative to this session.

--- a/handoff/_general/from-code/2026-08-05-screenshot-waitfor-browserless-v1.md
+++ b/handoff/_general/from-code/2026-08-05-screenshot-waitfor-browserless-v1.md
@@ -1,0 +1,51 @@
+# Handoff — 2026-08-05 — screenshot-url Browserless v1/v2 dialect fix
+
+**Intent:** Ran `/activity since-last`, found `screenshot-url` still failing in prod despite a month-old fix sitting unmerged. Merged that branch (PR #148), discovered it didn't actually fix prod, diagnosed the real cause, shipped PR #150.
+
+## What `/activity since-last` showed (2026-07-20 → 2026-08-05)
+
+854 external calls, 711 completed / 143 failed. 97% x402, only 4 unique users — a few heavy agents, not broad usage. Top caps: tech-stack-detect 175, keyword-suggest 102, serp-analyze 61, email-validate 61, google-search 52. 6 signups, notably `simon@pavebank.com` (Pave Bank) who ran sanctions-check on Monzo Bank + pep-check on Monzo's co-founder — real KYB ICP evaluation.
+
+Two failure clusters:
+- `screenshot-url` — 13 × HTTP 400 `waitForSelector is not allowed`.
+- `product-reviews-extract` — 28 of 31 calls failed, all Trustpilot HTTP 403 bot-protection. **Still open.**
+
+## The bug chain
+
+1. **PR #148 (2026-07-05) was never merged.** Branch `fix/screenshot-waitfor-edgar-retry` sat open for a month while its bugs failed live paying traffic. Merged this session as `df4d8ff`.
+2. **Merging it did not fix prod.** Post-deploy verification against `/v1/do` returned a *new* 400: `"waitForTimeout" is not allowed`. PR #148 was verified against the **v2 SaaS** endpoint (`production-sfo.browserless.io`, what local `.env` points at), but production's chromium service is pinned to **Browserless v1** (`browserless/chrome:1.61.1`, `railway-config.md:51`). v1 rejects both v2 wait keys. PR #148 swapped one rejected key for another.
+3. The manifest's own documented workaround for JS-heavy pages ("use `wait_for` to target a CSS selector") was equally dead on v1.
+
+## PR #150 — what shipped
+
+Executor sends one dialect, retries once with the other on a wait-key rejection, memoizes the winner per endpoint host (module-level Map) so only the first call per process pays the probe.
+
+**Security fix folded in (review Pass A HIGH, verified by me against the vendor source):** v1's `functions/screenshot.js:144-162` branches on `typeof waitFor`. An **object** → `page.waitForSelector` (safe). A **string** → interpolated *unescaped* into `page.evaluate('...querySelector("<raw>")')`, and any non-selector string executed as `page.evaluate('(<raw>)()')`. Sending a bare-string selector would have put caller-supplied JS inside the chromium container on Railway's private network — defeating the `validateUrl` guard that exists precisely because Browserless fetches from its own network. `screenshot-url` is x402-enabled (anonymous). Never shipped: pre-fix every `wait_for` call 400'd, so no string ever reached the evaluator. Now sends v1's object form, which is also the only shape with a slot for the selector timeout.
+
+**Empirical catch that changed the code:** I probed both endpoints rather than trusting the symmetry assumption. v2 rejects with ajv's `must NOT have additional properties` — **not** Joi's `"X" is not allowed`. Matching only the Joi form would have stranded a warm process that memoized v1 against a host later upgraded to v2 (no retry, hard-fail until restart). Both strings are now matched, with a regression test for stale-memo recovery.
+
+## Verification
+
+tsc clean · vitest 24/24 · validate-capability pass · smoke-test 11/11 · `checkReadiness` **ready=true, 0 issues** · CI green.
+
+Post-deploy against prod (`dfc122cace72`), all previously-failing:
+- `wait_for:"3"` on tenex.co → 200, 8.4s
+- `wait_for:"h1"` (selector path) → 200, 1.29MB PNG
+- **Original customer input** `arkm.com/explorer/address/TAJH8...` `wait_for:"8"` → 200, 10.9s
+
+## Reviewer findings carried forward (MEDIUM, in PR body)
+
+- Dialect knowledge is capability-local; arguably belongs beside `buildBrowserlessRequestUrl` in `lib/browserless-launch.ts`. Left local — `screenshot-url` is today the only caller sending a version-sensitive wait key. Debt for the next one.
+- `browserless-launch.ts` docstring says "Build a Browserless **v2** request URL" while prod is pinned v1. Misleading regardless of this PR; not fixed here to keep the diff to one concern.
+- Cold-start default is v2 while the only prod host is v1 → one wasted fast-400 per process restart. Self-correcting; inverting just moves the cost to dev.
+
+## Open threads
+
+- **`product-reviews-extract` Trustpilot 403** — 28 failures/16 days, users retrying the same URL 3-4×. Needs a working path, an upfront rejection with a real limitation, or routing to `trustpilot-score`. Note `trustpilot-score` is in the auto-register DEACTIVATED list ("Trustpilot scraping prohibited by ToS, DEC-20260420-H"), so the honest answer is probably documented rejection.
+- **Search typeahead gaps** (from `suggest_log`): `"fx"` returns zero results though `exchange-rate` exists — cheap alias fix. Also zero-result: travel/itinerary cluster, `"relocation visa immigration"`, `"south africa"` (no ZA company data).
+- **`railway-config.md` v1 pin revisit date was 2026-08-06** — i.e. tomorrow. Whoever handles it should know the dialect fallback now self-heals a v1→v2 migration on cold start, but a warm process needs a restart to re-probe.
+- PR #148's own open thread (`task_694ae016`, us-company-data wrong-CIK match risk) — that landed with the merge; the low-confidence guard is in.
+
+## Note for next session
+
+The deploy-mechanism lesson from DEC-20260504-C repeated itself in a new shape: PR #148 verified the *code* against a real endpoint, but not against **the endpoint prod actually uses**. Local `.env` points at the v2 SaaS; prod points at the pinned v1 container. Any Browserless-touching change needs verification against the v1 container, not just local.

--- a/handoff/_general/from-code/2026-08-06-frontend-ci-signal-and-audit-drift.md
+++ b/handoff/_general/from-code/2026-08-06-frontend-ci-signal-and-audit-drift.md
@@ -1,0 +1,67 @@
+# Handoff — 2026-08-06 — frontend CI signal restored + AuditRecord drift closed
+
+**Intent:** Close out the two strale-frontend threads opened late on 2026-08-05 — the `AuditRecord.quality` shape drift and the month-dead CI signal — and get both merged and verified on `main`.
+
+Continues [2026-08-05-activity-followups-tos-and-search.md](2026-08-05-activity-followups-tos-and-search.md), which covers the backend half of the same session (PRs #150–#153) and the in-progress state of these two.
+
+## Shipped
+
+**strale-frontend#13** → `e8ac837` (2026-08-05 22:09) — CI signal restoration.
+**strale-frontend#12** → `38d11c6` (2026-08-06 06:55) — AuditRecord drift fix, rebased onto #13.
+
+## The finding that mattered most
+
+The brief was "lint is noisy, make it non-blocking." Investigating the workflow turned up something larger: `Lint` ran **first**, and a failed step halts a GitHub Actions job. Verified against a real run:
+
+```
+success  Install dependencies
+failure  Lint
+skipped  Test
+skipped  Build
+```
+
+**Test and Build had been skipped on every CI run since 2026-07-03.** The frontend had no automated test or build verification in CI for a month — a broken build would only have surfaced at deploy time, post-merge, via Cloudflare Pages. Reordering Test and Build ahead of Lint is the fix that actually mattered; the lint noise was the smaller half.
+
+## Why not `continue-on-error`
+
+That was the obvious implementation of "non-blocking" and the wrong one: it unblocks the job by making new errors fail *nothing* — the same dead signal by another route. Instead `scripts/lint-ratchet.mjs` compares against a per-file baseline (`.lint-baseline.json`) of the 40 accepted errors. Known backlog passes; a new offender, or a baselined file exceeding its allowance, fails by name.
+
+**Per-file, not a single total**, because a total lets a new problem hide behind an unrelated improvement. Verified exactly that: delete a 9-error file and add one fresh error → total drops 40 → 32, under any total-based threshold, and the ratchet still fails on the new offender.
+
+All five branches were exercised rather than just the happy path: baseline passes; new file fails; total-falls-with-new-offender fails; regression inside a baselined file fails naming its allowance; and **improvements pass** with a "tighten the baseline" note — an improvement turning CI red is the trap that produced this situation.
+
+## AuditRecord.quality (#12)
+
+`check-shape-contracts.mjs` flagged the frontend declaring `quality: { sqs, label, pass_rate }` that the backend dropped when the SQS engine was deleted (DEC-20260503-B, 2026-05-05).
+
+It was user-visible, not just a type mismatch. Two live consumers — the audit page §6 and the downloadable PDF — read it behind optional chaining, so nothing threw; instead **every audit record and every generated PDF rendered "—" in both cells for three months.** On a compliance document that reads as "unavailable for this transaction" rather than "permanently gone", which is worse than a crash.
+
+Removed the field and the two dead cells, kept schema validation (the one cell still backed by real fields). Not restored backend-side: SQS was retired deliberately and the frontend's own CLAUDE.md says "SQS is dead — do not reintroduce it". Left a comment so nobody re-adds it without a real source.
+
+## Verification
+
+- CI on `main` after both merges: **green**, with `Test`, `Build`, `Lint (new errors only)` all `success` — the first genuinely passing run since 2026-07-03, and the first time in a month Test and Build actually executed on main.
+- Deploy health check: `success`; strale.dev returns HTTP 200.
+- Before force-pushing the #12 rebase, ran the full CI sequence locally on the rebased commit (23/23 tests, build OK, ratchet clean) rather than pushing and waiting.
+
+## Working-tree safety (worth repeating next time)
+
+The frontend tree had ~60 uncommitted WIP files throughout, and four of them — including `src/lib/api.ts`, the single biggest lint offender at 14 errors — were modified **within 30 minutes** of my starting. Someone was actively working in it.
+
+So every commit was authored in a throwaway `git worktree` off `origin`, never in the live tree; the #12 rebase used a **detached** worktree (the branch was checked out in the live tree, so it couldn't be checked out twice) and force-pushed with `--force-with-lease` pinned to the old SHA. Verified before and after: 60 WIP files present and unmodified, same branch, same HEAD.
+
+This is also why the lint fix was deliberately partial — only **7 of 47** errors were in files with no uncommitted changes. Staging any of the rest would have committed someone else's work.
+
+## Open
+
+1. **Backend `fix/topup-redirect-target` is unpushed with no upstream.** Commit `76dca76` (2026-08-06 06:56) — the Stripe `/topup` redirect change I'd flagged as an unversioned working-tree edit. Now properly committed, but not pushed and has no PR. Its frontend counterpart (`src/pages/TopUp.tsx`) is still untracked in strale-frontend.
+2. **Lint baseline is tightenable.** The frontend WIP deletes files accounting for ~21 of the 40 baselined errors (`ZoneBReliability`, `StepQualityTable`, `ZoneCCompliance`, `api.contract.test.ts`). When it lands: `node scripts/lint-ratchet.mjs --update`. CI passes either way, but a loose ledger lets a future regression hide under the old allowance.
+3. **Local `fix/audit-record-quality-drift` is stale.** Deleted on origin by the #12 merge; the live tree is still on it at the pre-rebase commit with the 60 WIP files. Harmless, but **`git reset --hard` would destroy that WIP** — commit or stash first.
+4. **`check-shape-contracts.mjs` skips silently in PR CI** because the frontend repo isn't checked out there; it only does the real cross-repo comparison in the weekly drift cron or locally. A skipped check currently looks identical to a passing one. Worth making it log "skipped — frontend not checked out".
+5. **Residual SQS content in the frontend** beyond what #12 touched — `Security.tsx` still describes the dual-profile QP/RP matrix and `min_sqs`, `learnGuides.ts` references `min_sqs`, `sqs-display.ts` still exists. The repo's own CLAUDE.md says SQS is dead. The in-flight WIP appears to be deleting some of this; worth confirming it covers the copy as well as the components.
+
+## Non-obvious learnings
+
+- **A red check is worse than no check.** A month of red trained everyone to ignore the job, and the real damage (Test/Build never running) hid behind the noise everyone had stopped reading. When a signal goes red and stays red, the question isn't "how do we silence it" but "what else is it now hiding".
+- **"Make it non-blocking" is usually a request for a working signal, not for silence.** Taking it literally would have satisfied the words and defeated the purpose.
+- **`any` casts in this codebase have twice been load-bearing lies.** Both `AuditRecord.quality` and the two deleted `quality-indicators` functions used casts to read fields that didn't exist on the type. In both cases the cast was the only thing standing between a silent wrong answer and a compile error.

--- a/handoff/_general/from-code/2026-08-09-usage-analysis-capability-buildout.md
+++ b/handoff/_general/from-code/2026-08-09-usage-analysis-capability-buildout.md
@@ -1,0 +1,439 @@
+# 2026-08-09 — 90-day usage analysis → neighbouring-capability buildout
+
+**Intent:** Fix the free-tier count drift, run a 90-day usage analysis, and implement the
+zero-marginal-cost neighbouring capabilities it surfaced (email cluster first), with each
+capability tested and validated.
+
+**Mode:** Full (new capabilities → Capability Onboarding Protocol DEC-20260320-B applies).
+
+---
+
+## 1. Free-tier drift fix (shipped)
+
+`CLAUDE.md`, `AGENTS.md`, and `MEMORY.md` all claimed **5** free-tier capabilities. The live
+`is_free_tier = true` set is **11** — the original five plus six crypto address validators
+(btc/eth/sol/tron/doge/xrp), of which five have `x402_enabled = false` (free-path only).
+
+All three surfaces corrected and repointed at the canonical source
+(`is_free_tier` column → `GET /v1/platform/facts` → `free_tier_slugs`) rather than restating a
+count that goes stale. `check-platform-facts-drift.ts` clean across 159 surface files, both repos.
+
+Worth noting the drift guard did **not** catch this — it scans for hardcoded values in surface
+files, and prose in CLAUDE.md/AGENTS.md isn't in its surface set.
+
+---
+
+## 2. 90-day usage analysis (2026-05-10 → 2026-08-08)
+
+~3,700 external calls, ~€239 revenue. Key structural findings:
+
+- **A large slice of the long tail is not demand.** 150+ capabilities with 2–3 calls each, all
+  timestamped 2026-06-13 → 06-18, are a single catalogue-enumeration sweep. Any future analysis
+  that ranks by raw call count without excluding that window will draw wrong conclusions.
+- **Email/lead verification is the only month-over-month growing cluster**
+  (email-validate 14→94→154→175/mo). `lead-email-verify` is the #1 solution by revenue.
+- **`google-search` is the #1 revenue capability** (€33.10); `company-enrich` has the best unit
+  economics (€0.50/call).
+- **The compliance wedge is inverted**: "company" is the #1 website search (37×) while the EU
+  registry capabilities are the worst-performing group in the catalogue
+  (danish 0/11, swiss 0/5, estonian 0/2, finnish 2/9). Shopped-for but undeliverable.
+- **Schema-guess failures are pure lost revenue**: agents pass a free-text `query` field to
+  typed-input capabilities (tech-stack-detect 40 fails, us-company-data 14, danish 11).
+
+Twelve to-dos filed in the Notion To-do DB from this analysis.
+
+---
+
+## 3. Capabilities built
+
+All four land at `lifecycle_state=validating`, `visible=false`, `x402_enabled=false`.
+**Nothing was activated.** Activation is a separate, explicit go/no-go.
+
+| Slug | Verified | State |
+|---|---|---|
+| `email-validate-bulk` | 19/19 validate, 11/11 smoke, tsc | ready to activate |
+| `domain-contact-extract` | 19/19, 11/11, readiness ready:true | ready to activate |
+| `email-finder` | 19/19, 11/11, tsc | **hold — value problem, see below** |
+| `keyword-rank-check` | 19/19, tsc; logic mocked only | **hold — never live-tested** |
+
+### email-validate-bulk
+Batch of ≤100, per-domain MX cache + bounded concurrency (10), aliases `emails` /
+`email_addresses` / `text`. Shared `validateOneEmail()` extracted from `email-validate.ts`.
+
+**Regression risk handled:** `email-validate` is live with 437 calls/90d. Diff reviewed
+line-by-line and re-smoke-tested post-refactor — 11/11 pass, live execution returns exactly 9
+fields, matching the original valid-path shape. The subtle `provenance.source` branch
+(`algorithmic` for format-failures vs `algorithmic+dns` otherwise), which the original produced
+via two separate return paths, is preserved.
+
+### domain-contact-extract
+Organisation-level contact channels only. Three real bugs found and fixed during onboarding:
+phone-regex false positives from decimals (`41056.391`), SVG path coordinates leaking as fake
+phone numbers through a naive tag-stripper, and the 300KB read cap severing an `<svg>` block
+mid-element. SSRF guard confirmed (`169.254.169.254` blocked, `localhost` rejected pre-fetch).
+
+### email-finder — built, but do not activate yet
+Guardrails held: no SMTP callback probing, no field named `verified`, evidence-linked confidence,
+`safeFetch`, `processes_personal_data: true`, categories `[name, email]`.
+
+**Independent testing found a value problem the pipeline did not.** Tested against two real
+domains drawn from our own traffic (`lampin.com`, `markforged.com`): **both returned zero
+published addresses**, so the evidence branch never fires, confidence is always `low`, and
+ranking degenerates to a generic convention list. It also **mis-ranks `lampin.com`** — proposes
+`keith.slowik@` when the real pattern is `keithslowik@`, corroborated by 12 addresses in our own
+90-day transaction logs.
+
+Root cause: modern corporate sites publish contact forms, not addresses. Vendors like Hunter rely
+on a large harvested address corpus, which Strale does not have.
+
+**Do not use our own transaction history as that corpus.** Addresses submitted for validation
+cannot be repurposed for discovery — that is a GDPR purpose-limitation violation, and it is the
+precise failure mode CNIL fined Kaspr €240k for in Dec 2023.
+
+### keyword-rank-check — built, never live-tested
+Two independent blockers: root `.env` has no `SERPER_API_KEY`, and `guardedExecute`'s
+`ALLOW_MATRIX` refuses all `paid_prepaid` capabilities from `internal_test` context. Ranking
+logic verified against mocked Serper responses only (subdomain match, first-match-wins,
+`competitors_above`, not-found path, depth clamp at 100). Serper credits consumed: 0.
+**Requires one real call in a key-bearing environment before activation.**
+
+---
+
+## 4. Systemic findings (filed as to-dos)
+
+1. **The onboarding pipeline cannot live-verify any `paid_prepaid` capability.** `ALLOW_MATRIX`
+   unconditionally refuses `paid_prepaid` from `internal_test`, and both `onboard.ts --discover`
+   and `smoke-test.ts` invoke exclusively through that context. Confirmed reproducible against the
+   already-active `serp-analyze`, so **every paid capability in the catalogue has shipped without
+   live fixture verification.** The gate itself is correct and test-covered
+   (`guarded-executor.test.ts`, 60 tests pass) — the pipeline is what needs a sanctioned,
+   budget-capped verification path. Do not simply widen the matrix.
+
+2. **CLAUDE.md's documented one-command onboarding flow does not work for new capabilities.**
+   (a) `--discover` on a new slug throws `CapabilityNotClassifiedError` because discovery executes
+   before the DB row carrying `cost_class` exists; requires a second `--backfill --discover --force`
+   pass. (b) readiness requires `avg_latency_ms`, but that field is DB-canonical per
+   `capability-field-authority.ts` and is stripped from manifests on backfill, so it cannot be set
+   through the documented path at all — every agent this session had to fall back to a direct
+   `UPDATE`. Either fix the pipeline or correct the docs to describe the real two-pass flow.
+
+3. **`personal_data_categories: contact_details` is not in the canonical `PII_CATEGORY_ENUM`.**
+   Two agents independently hit this and substituted honest canonical values
+   (`[name, email]`, `[email, phone, address]`). Worth confirming the enum covers what authors
+   reach for.
+
+---
+
+## 5. Not built, and why
+
+- **`us-trademark-search`** — blocked on a *free but registration-gated* key. Probed:
+  `api.uspto.gov` 403 (`Missing Authentication Token`), `tsdrapi.uspto.gov` 401 with an explicit
+  register-for-a-key notice, `tmsearch.uspto.gov` serves an AWS WAF bot challenge (scraping it
+  would violate Tier 1 DEC-20260428-A *and* the bot-detection prohibition). Register at
+  `account.uspto.gov/api-manager` → `USPTO_ODP_API_KEY`. Executor is a one-session build after
+  that. Precedent: `indian-company-data` / `DATA_GOV_IN_API_KEY`.
+- **`brand-name-check` solution** — blocked behind `us-trademark-search`.
+- **`keyword-metrics`** (search volume/difficulty) — requires a paid vendor (DataForSEO or
+  similar). Needs a Tier-2 doctrine check and economics decision first.
+
+---
+
+## 6. State at handoff
+
+- Modified: `CLAUDE.md`, `AGENTS.md`, `apps/api/src/capabilities/email-validate.ts`
+- Added: 4 executors + 4 manifests
+- `npx tsc --noEmit` clean; 60/60 tests pass; drift sweep clean
+- **`/go` has NOT been run.** No commit, no PR, no branch. Per the CLAUDE.md code-review gate,
+  `/go` must run on this before `/end-session` or any ship.
+- **No capability activated.** Four sit at `validating`/`visible=false`/`x402` off.
+
+## 7. Open decisions for Petter
+
+1. Activate `email-validate-bulk` and `domain-contact-extract`? (Both clean.)
+2. `email-finder`: ship as an honest-but-weak permutation generator, invest in a lawful evidence
+   source, or shelve?
+3. `keyword-rank-check`: run one live Serper call to verify, then activate?
+4. Register the free USPTO key to unblock `us-trademark-search`?
+
+---
+
+## 8. Post-report actions (same session, after Petter's decisions)
+
+**Activated** (`lifecycle_state=active`, `visible=true`, `x402_enabled=true`):
+- `email-validate-bulk`
+- `domain-contact-extract`
+
+x402 was enabled on both alongside visibility. Rationale: 217 of the last 227 external calls
+came through x402, so activating without it would have made them effectively unreachable.
+Single-column `UPDATE` to reverse if that wasn't wanted.
+
+**Shelved** — `email-finder`. Added to the `DEACTIVATED` map in `auto-register.ts` with full
+rationale, DB set to `lifecycle_state=deactivated`. Executor and manifest retained in-repo.
+Confirmed skipped at registration (`skipped_deactivated` 11 → 12). The map comment carries the
+explicit warning not to "fix" it by mining the transactions table for addresses.
+
+**USPTO key provisioned — but does not unlock what we assumed.** Petter registered and set
+`USPTO_ODP_API_KEY` in local `.env`. 19 endpoint/method/header combinations probed. Exactly one
+returns 200:
+
+```
+GET https://tsdrapi.uspto.gov/ts/cd/casestatus/sn{serial}/info.json
+Header: USPTO-API-KEY   (NOT X-API-KEY — that 401s on this host)
+```
+
+Verified live against Stripe's STRIPE wordmark (sn87285790 → reg 6389494). But this is TSDR:
+**status lookup by serial/registration number**, requiring the caller to already know the
+identifier. No endpoint on `api.uspto.gov`, `tsdrapi.uspto.gov`, or the now-non-resolving
+assignment host accepts a mark *name* and returns matches. Corroborated by a third-party OpenAPI
+extraction which states trademark search has no public API.
+
+`us-trademark-search` therefore remains blocked, and `brand-name-check` with it. Four options
+open: (a) build the narrower `us-trademark-status-lookup`, (b) ingest USPTO bulk trademark data
+from `bulkdata.uspto.gov` (Tier-3-preferred licensed bulk, but a DEC-20260428-B-grade build),
+(c) licensed vendor, (d) drop US trademark coverage.
+
+**Railway — blocked, not done.** CLI authenticates as `petterlindstrom@hotmail.com`, but
+`railway list` shows no projects under that account and `railway status` returns Unauthorized on
+the linked project. Wrong account. Needs `railway logout && railway login` with the account that
+owns the Strale project. Consequently:
+- `USPTO_ODP_API_KEY` is NOT set in Railway (local `.env` only)
+- `SERPER_API_KEY` could not be checked or copied to `.env`, so `keyword-rank-check` remains
+  unverifiable locally
+
+**Still unreviewed:** `/go` has not run. Changed files now also include
+`apps/api/src/capabilities/auto-register.ts`.
+
+---
+
+## 9. Code review, two production incidents, and what actually shipped
+
+Everything above §8 predates the `/go` review. The review changed the outcome
+materially, so read this section as authoritative where the two conflict.
+
+### Shipped and live (verified by real production calls, not DB rows)
+
+| Capability | State | Verified by |
+|---|---|---|
+| `email-validate-bulk` | **live** | prod `POST /v1/do` → 200, 15ms, correct verdicts |
+| `keyword-rank-check` | **live** | prod → `stripe.com` #1 for "payment processing api" |
+| `domain-contact-extract` | **parked** | see incident 2 |
+| `email-finder` | **shelved** | deliberate, unchanged |
+
+PRs: [#156](https://github.com/strale-io/strale/pull/156) (buildout + tests),
+[#157](https://github.com/strale-io/strale/pull/157) (phone fix).
+
+### The review found three HIGH ship-blockers
+
+1. **ReDoS in `EMAIL_RE`** — the domain class contained the `.` the following
+   `\.` also had to match. Quadratic: 7.9s on 32KB, against a 300KB×2 parse
+   budget. Synchronous, so it blocks the whole event loop, and
+   `executeWithHardTimeout` cannot fire while blocked — a 5-cent x402 call
+   against an attacker's own homepage would have stalled the API. Fixed.
+2. **Second ReDoS in the tag stripper** — 243 SECONDS on 300KB of `<`.
+   Initially fixed with a linear scanner; later **deleted entirely** in #157
+   when the code that called it was removed. Deleted code cannot be slow.
+3. **F-0-006 CI guard was already red** on the branch and I had not run it.
+
+Plus five MEDIUMs fixed: the bulk path could blow the 15s wallet-transaction
+budget (50s worst case); MX timeouts silently marked deliverable addresses
+invalid; `blog.stripe.com` matched `stripe.com` results; `domain: "com"`
+returned a confident fake #1; and `domain-contact-extract` bypassed the ToS
+blocklist that commit `87b84db` had explicitly flagged as an open side door.
+
+### Incident 1 — capabilities advertised before the code existed
+
+I set `visible=true, x402_enabled=true` in the **production** DB while the
+executors were still uncommitted in my working tree. The catalogue is
+DB-driven, so prod advertised and priced three slugs it had no handlers for.
+Caught by the review's operational note (`git rev-list` showed the branch 0
+commits ahead of main). Zero calls in the window; no customer impact.
+
+This is exactly DEC-20260504-C. The lesson is the ordering, and it is not
+negotiable: **merge → deploy → verify the deployed artifact → activate.**
+`GET /health` returns the deployed commit; use it.
+
+### Incident 2 — `domain-contact-extract` returned fabricated phone numbers
+
+First real production call for `stripe.com` returned
+`phones: ["72-9098-2766", "24155-3298-4"]`. Neither digit sequence appears
+anywhere on that page. Deactivated within minutes; 7 calls total, all mine.
+
+Cause: with no `tel:` links, the extractor fell back to scanning visible text
+for phone-shaped digit runs. Sites serve different markup to our bot UA than
+to a browser, and `readCapped` truncates at 300KB mid-document, so the
+heuristic was handed arbitrary markup fragments. Not decidable by digit
+grouping — which is why it had already been tightened twice and still failed.
+
+Fixed in #157: authoritative markup only (`tel:` links + schema.org
+`telephone`). Verified live: `phones: []` on stripe.com, github.com,
+mozilla.org.
+
+### Still open on `domain-contact-extract` — the reason it is parked
+
+Verifying #157 in prod surfaced a THIRD defect:
+`role_emails: ["u003esales@stripe.com"]`.
+
+The page Railway receives in **US East** contains JSON-escaped markup
+(`\u003e`); the page served to Sweden has a literal `>`. `EMAIL_RE`'s
+local-part class accepts letters and digits, so the match starts at `u003e`.
+
+**Fix:** decode `\uXXXX` sequences in the fetched HTML before email
+extraction (applies to `role_emails` and `published_personal_addresses`).
+Small — roughly one normalisation step.
+
+**Verify it against a US-served page.** This is the important part: a Swedish
+local test structurally CANNOT reproduce it. Both this bug and the phone bug
+have the same root cause — origin-served content differs by region and by
+User-Agent, so local verification of this capability proves very little.
+Verify in prod or not at all.
+
+### Test coverage added
+
+`domain-contact-extract.test.ts` (19) and `email-validate.test.ts` (14).
+Per DEC-20260504-A the ReDoS assertions were proven to fail against the
+un-applied fix: 1956ms vs a 500ms limit, 4212ms vs 1000ms, 26.7x growth vs 8x
+allowed. The phone tests assert `[]` for the exact production false positives,
+SVG coordinates, decimals and tracking IDs, so the heuristic cannot be quietly
+restored.
+
+Known flake: `ssrf-bucket-a.test.ts` can be starved during collection when run
+alongside a typecheck in the same command — reports as a file-level failure
+with its tests skipped, not as an assertion failure. Two clean re-runs after.
+
+### Recommended order next session
+
+1. `domain-contact-extract` unicode-escape fix + **prod** verification (~20 min).
+2. The `ALLOW_MATRIX` sweep — every paid capability has shipped without live
+   fixture verification. Not theoretical: the first live check on `serp-analyze`
+   immediately found a broken fixture (`featured_snippet` annotated
+   `guaranteed` on a majority-null field), fixed this session.
+3. EU registries (P0) — "company" is the #1 site search while danish is 0/11.
+4. Park US trademark. The ODP key unlocks TSDR status-lookup-by-serial only,
+   not name search; `brand-name-check` stays blocked.
+
+---
+
+## 10. Closed out — all four capabilities resolved
+
+`domain-contact-extract`'s unicode-escape defect is fixed and the capability
+is live. [PR #158](https://github.com/strale-io/strale/pull/158), deployed as
+`9d748f5`, verified by real production calls before reactivation.
+
+`decodeJsonUnicodeEscapes()` runs once at the point fetched bytes enter the
+capability, so every downstream extractor sees one canonical form regardless
+of which variant the origin served. C0 control escapes stay encoded.
+
+Production verification (not local):
+
+| domain | role_emails | phones | contact page |
+|---|---|---|---|
+| stripe.com | `["sales@stripe.com"]` — no `u003e` prefix | `[]` | yes |
+| github.com | `[]` | `[]` | no |
+| mozilla.org | `[]` | `[]` | yes |
+| trustpilot.com | ToS refusal, not charged | — | — |
+
+### Final state
+
+| Capability | State |
+|---|---|
+| `email-validate-bulk` | **live** — active, visible, x402 |
+| `keyword-rank-check` | **live** — active, visible, x402 |
+| `domain-contact-extract` | **live** — active, visible, x402 |
+| `email-finder` | **shelved** — DEACTIVATED, deliberate |
+
+All three live capabilities confirmed present in prod `GET /v1/capabilities`.
+
+### Next session, in order
+
+1. **The `ALLOW_MATRIX` sweep** — every paid capability has shipped without
+   live fixture verification. The first live check run this session (on
+   `serp-analyze`) immediately found a broken fixture. Widest blast radius of
+   anything open.
+2. **EU registries (P0)** — "company" is the #1 site search while danish is
+   0/11, swiss 0/5, estonian 0/2.
+3. **Free-text `query` resolution** (P1) — converts ~57 logged agent failures
+   into paid calls.
+4. **`pdf-extract` 0/5** (P1), **PII retention tier** (P1, needs the
+   DEC-20260504-B deploy protocol).
+5. Park US trademark.
+
+### The one thing to carry forward
+
+Three defects in `domain-contact-extract` — two fabricated-phone cases and
+this one — all passed 19/19 structural validation, 11/11 smoke tests, and
+clean local execution. Every one was caught only by a real production call
+reading actual output values.
+
+The cause is not weak tests. Origins serve different bytes by region and by
+User-Agent, so a Sweden-based local run and the Railway US East runtime parse
+different documents. For any capability whose input is third-party web
+content, local verification demonstrates very little. Verify in prod, and read
+the values, not the status code.
+
+---
+
+## 11. ALLOW_MATRIX sweep — the systemic gap, closed
+
+[PR #159](https://github.com/strale-io/strale/pull/159).
+
+`ALLOW_MATRIX` refuses `paid_prepaid`/`paid_subscription` from `internal_test`,
+`ci` and `health_probe`. Both `onboard.ts --discover` and `smoke-test.ts`
+invoke only through `internal_test` — so **no paid capability had ever had its
+`known_answer` fixture checked against live output.** 92 capabilities.
+
+### The fix is a supervised path, not a weaker gate
+
+`apps/api/scripts/sweep-paid-fixtures.ts` — one deliberate operator call per
+capability, checked against its declared assertions, classified as
+pass / fixture-fail / upstream-error / env-blocked / no-executor / skipped so a
+missing local key is never mistaken for a broken fixture.
+
+The gate was deliberately **not** widened. It is correct: widening it lets the
+test scheduler burn vendor credits, which is the 2026-05-11 OpenRegister
+incident documented in `guarded-executor.ts`.
+
+It costs money, so metered/expensive vendors are denylisted and reported rather
+than called: Cobalt (€2.00/call), `us-ein-match`, `us-sec-filings-extended`,
+eSortcode CoP, and the three Dilisense capabilities (informal Starter-tier
+grace — don't spend that quota on fixtures). Extend the denylist, never empty it.
+
+### First run: 85 swept, 79 pass, 2 real defects
+
+**`eu-trademark-search`** — the `known_answer` input was
+`SELECT * FROM users WHERE active = true LIMIT 10`, a SQL-injection probe
+miscategorised as the correctness fixture. EUIPO legitimately returns nothing
+for it, so the test asserted against an empty result set and could never have
+caught a regression. Now `Nike`; `total_results` → `common` (null on empty
+result sets — the same class that broke 8 EU registries and that we fixed on
+`serp-analyze` earlier the same day).
+
+**`product-reviews-extract`** — returned `status: completed` with every review
+field null, its own `sentiment_summary` reading "No review data available on
+the provided page text", and billed 25¢. The prompt tells the model to use null
+for anything it can't determine, so a client-rendered page or bot interstitial
+produces a well-formed empty object that reads as success. Now throws when no
+review signal was found at all, so DEC-14 refunds it.
+
+Post-fix: **79 pass, 0 fixture failures.**
+
+### Filed, not fixed
+
+- 5 stale/hostile fixtures: `image-to-text` (dead URL), `invoice-extract`
+  (503), `return-policy-extract` + `product-reviews-extract` (both point at
+  Amazon, which 403s bots — and `amazon-price` is already DEACTIVATED for
+  exactly that), `us-company-data` (searches "Google"; closest EDGAR match is
+  "Teads Holding Co.").
+- `price-compare` intermittently emits malformed JSON — failed run 1, passed
+  run 2 on identical input. Repo precedent: the 2026-06-24 LLM-JSON-truncation
+  handoff.
+- `uk-company-data` is `ENV_BLOCKED` locally; `COMPANIES_HOUSE_API_KEY` is
+  Railway-only.
+
+### Run it
+
+```
+cd apps/api && npx tsx scripts/sweep-paid-fixtures.ts
+```
+
+After changing any paid capability, and periodically. It is the only thing that
+verifies a paid fixture against live output.


### PR DESCRIPTION
## Summary

Backfills 14 session handoff records that accumulated on disk between 2026-05-15 and 2026-08-09 and were never committed.

`session-close-check.ts` warns on uncommitted handoff files, so every new session inherited a growing pile of warnings about *other* sessions' records — and the records themselves existed only on one machine. Docs only: no code, no manifests, no behaviour change.

## Files

| Date | Record |
|---|---|
| 05-15 | v1 launch readiness sweep |
| 05-18 | phase-4 SE/DK source enumeration |
| 05-18 | PII fixture audit — legal representatives |
| 05-18 | registry source research — directors exposure |
| 05-18 | UK UBO smoke, EU30 re-audit, directors verification |
| 06-17 | prompt-optimize truncation fix |
| 06-24 | LLM JSON truncation fix |
| 07-02 | Railway outage recovery |
| 07-02 | startup DB retry alerting |
| 07-05 | screenshot waitFor / EDGAR retry |
| 08-05 | activity follow-ups — ToS and search |
| 08-05 | screenshot waitFor / Browserless v1 |
| 08-06 | frontend CI signal and audit drift |
| 08-09 | usage analysis capability buildout |

## Review before staging

These were written by other sessions, so they were read rather than added blind:

- **Credential scan** — clean across all 14 (`sk_live`/`sk_test`/`ghp_`/`github_pat`/bearer tokens/connection strings/PEM blocks/long hex).
- **Personal data** — one file, `2026-05-18-pii-fixture-audit-legal-representatives.md`, names four real individuals (three TotalEnergies board members and one Brazilian partner). It names them *because it is the audit that flagged them*. Those same names are already tracked in `manifests/french-company-data.yaml:30-33` and `manifests/brazilian-company-data.yaml:30-32`, so committing this file adds no exposure that isn't already in git history.

## Finding worth separate attention

The manifest exposure above is **still unremediated**. The 2026-05-18 audit flagged it as an out-of-scope follow-up and recommended a remediation to-do; ~3 months on, `manifests/french-company-data.yaml` still carries three real board members by name in `output_schema.example.directors`, and `manifests/brazilian-company-data.yaml` one real partner.

Worth noting these are hand-authored manifests, so `scrubFixture()` / `PII_ARRAY_FIELDS` never touch them — that machinery only runs at capture time on executor output. Not fixed here because it's a manifest content change with GDPR implications, not a docs backfill.

## Test plan

Read the files. CI runs for form only.
