### PR TITLE
fix(manifests): remove real people's names from output examples, gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,14 @@ jobs:
       # time, and with onboard.ts verifyFixtures which fires at manifest
       # authoring time.
       - run: node apps/api/scripts/check-manifest-guaranteed-consistency.mjs --strict
+      # Manifest PII guard. scrubFixture()/PII_ARRAY_FIELDS run at CAPTURE time
+      # on executor output; manifests are hand-authored, so an example pasted
+      # from a live response ships real people's names and no machinery ever
+      # looks at it. That is how five manifests came to carry real board
+      # members and partners for ~3 months after the 2026-05-18 fixture audit
+      # flagged two of them. Enforces that PII-bearing arrays in manifest
+      # examples are empty, null, or explicitly synthetic.
+      - run: node apps/api/scripts/check-manifest-pii.mjs --strict
       # Phase 1 tier-coverage gate (WARN-ONLY). For each manifest with a
       # captured response fixture at apps/api/tests/fixtures/tier-coverage/
       # <slug>.json, compares empirical wire-shape against manifest

--- a/apps/api/scripts/check-manifest-pii.mjs
+++ b/apps/api/scripts/check-manifest-pii.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Manifest PII guard — no real natural-person names in manifest examples.
+ *
+ * Background: the 2026-05-18 fixture audit
+ * (`handoff/_general/from-code/2026-05-18-pii-fixture-audit-legal-representatives.md`)
+ * swept `apps/api/tests/fixtures/tier-coverage/` and found it clean, then
+ * surfaced an out-of-scope finding it could not fix: `manifests/*.yaml`
+ * carried real board members and partners by name in
+ * `output_schema.example`. Five manifests were affected — the audit spotted
+ * two. It stayed unremediated for ~3 months.
+ *
+ * The root cause is structural, not a lapse. `scrubFixture()` and
+ * `PII_ARRAY_FIELDS` in `capture-tier-fixtures.ts` run at CAPTURE time on
+ * executor output. Manifests are hand-authored: an author pastes a real
+ * response into `output_schema.example` to document the shape, and no
+ * machinery ever looks at it. Fixing the five files does nothing about the
+ * sixth.
+ *
+ * So this gate enforces the rule at authoring time: any PII-bearing array in
+ * a manifest example must be empty, null, or carry an obviously-synthetic
+ * placeholder. It deliberately does NOT try to decide whether a given string
+ * "looks like a real person" — that is not decidable, and a heuristic that
+ * guesses would either miss real names or block legitimate edits. Requiring
+ * an explicit synthetic marker is checkable and unambiguous.
+ *
+ * Usage:
+ *   node apps/api/scripts/check-manifest-pii.mjs           # report, exit 0
+ *   node apps/api/scripts/check-manifest-pii.mjs --strict   # exit 1 on any finding
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+
+const strict = process.argv.includes("--strict");
+const MANIFEST_DIR = join(dirname(fileURLToPath(import.meta.url)), "../../../manifests");
+
+/**
+ * Keys whose values are natural persons. Mirrors PII_ARRAY_FIELDS in
+ * capture-tier-fixtures.ts — keep the two in step.
+ */
+const PII_FIELDS = new Set([
+  "directors",
+  "partners",
+  "legal_representatives",
+  "officers",
+  "former_officers",
+  "beneficial_owners",
+  "shareholders",
+  "board_members",
+  "ubos",
+  "representatives",
+  "managers",
+  "signatories",
+]);
+
+/**
+ * A value is acceptable if it is unmistakably not a real person. Placeholder
+ * markers are matched in the languages the affected registries actually use,
+ * so an author can keep the example in its native format.
+ */
+const SYNTHETIC = /\[REDACTED\]|\bEXAMPLE\b|\bEXEMPLE\b|\bEXEMPLO\b|\bEXEMPEL\b|\bESIMERKKI\b|\bBEISPIEL\b|\bPLACEHOLDER\b|\bJOHN DOE\b|\bJANE DOE\b|\bTEST\b/i;
+
+/** Pull the human-readable name out of either a bare string or a {name} object. */
+function nameOf(entry) {
+  if (typeof entry === "string") return entry;
+  if (entry && typeof entry === "object" && typeof entry.name === "string") return entry.name;
+  return null;
+}
+
+/** Walk any nested structure, reporting populated PII arrays. */
+function walk(node, path, out) {
+  if (!node || typeof node !== "object") return;
+
+  if (Array.isArray(node)) {
+    node.forEach((v, i) => walk(v, `${path}[${i}]`, out));
+    return;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    const here = path ? `${path}.${key}` : key;
+
+    if (PII_FIELDS.has(key) && Array.isArray(value) && value.length > 0) {
+      for (const entry of value) {
+        const name = nameOf(entry);
+        // A non-string entry carries no name we can check; a shape-only entry
+        // (e.g. {type, role}) is fine.
+        if (name && !SYNTHETIC.test(name)) {
+          out.push({ path: here, name });
+        }
+      }
+    }
+
+    walk(value, here, out);
+  }
+}
+
+const findings = [];
+
+for (const file of readdirSync(MANIFEST_DIR).filter((f) => f.endsWith(".yaml"))) {
+  let doc;
+  try {
+    doc = yaml.load(readFileSync(join(MANIFEST_DIR, file), "utf8"));
+  } catch {
+    continue; // malformed YAML is another gate's problem
+  }
+  if (!doc || typeof doc !== "object") continue;
+
+  const found = [];
+  // Only example/fixture surfaces carry values. `properties` blocks are type
+  // declarations and never contain a person.
+  walk(doc.output_schema?.example, "output_schema.example", found);
+  walk(doc.test_fixtures, "test_fixtures", found);
+
+  for (const f of found) findings.push({ slug: basename(file, ".yaml"), ...f });
+}
+
+if (findings.length === 0) {
+  console.log("Manifest PII guard: clean — no unredacted person names in manifest examples.");
+  process.exit(0);
+}
+
+console.log(
+  `Manifest PII guard: ${findings.length} entr${findings.length === 1 ? "y" : "ies"} in a PII field look like real names.\n` +
+    `Manifests are hand-authored and never pass through scrubFixture(), so an example pasted from a\n` +
+    `live response ships real people's data. Replace with a placeholder that keeps the shape, e.g.\n` +
+    `"EXEMPLE PREMIER DIRIGEANT (Administrateur)". Offenders:\n`,
+);
+for (const f of findings) {
+  console.log(`  ${f.slug}: ${f.path} → ${JSON.stringify(f.name)}`);
+}
+
+process.exit(strict ? 1 : 0);

--- a/manifests/annual-report-extract.yaml
+++ b/manifests/annual-report-extract.yaml
@@ -35,8 +35,11 @@ output_schema:
     revenue_sek: 108131545000
     company_name: Spotify AB
     dividend_sek: null
+    # Placeholder name. The live capability returns real board members; this
+    # example must not, since manifests are hand-authored and never pass
+    # through the fixture scrubber. Format preserved: Name (Roll).
     board_members:
-      - Carl Peter Christian Luiga (Ordförande)
+      - Exempel Förste Ledamot (Ordförande)
     total_assets_sek: 91250324000
     number_of_employees: 1397
     operating_profit_sek: null

--- a/manifests/brazilian-company-data.yaml
+++ b/manifests/brazilian-company-data.yaml
@@ -27,8 +27,11 @@ output_schema:
     type: MATRIZ
     status: ATIVA
     address: R GARIBALDI, 070, VILA RICA, 95.760-000 SAO SEBASTIAO DO CAI, RS
+    # Placeholder name. The live capability returns real partners; this example
+    # must not, since manifests are hand-authored and never pass through the
+    # fixture scrubber. Shape preserved: { name, role }.
     partners:
-      - name: CLAUDIA KICH DA SILVA
+      - name: EXEMPLO PRIMEIRO SOCIO
         role: 16-Presidente
     trade_name: CAIXA ESCOLA DA ESCOLA ESTADUAL DE ENSINO FUNDAMENTAL J
     company_name: CAIXA ESCOLAR DA ESCOLA ESTADUAL DE ENSINO FUNDAMENTAL JOSEFINA JACQUES NORONHA

--- a/manifests/business-license-check-se.yaml
+++ b/manifests/business-license-check-se.yaml
@@ -25,8 +25,11 @@ output_schema:
     org_number: 556703-7485
     company_name: Spotify AB
     company_type: AB
+    # Placeholder name. The live capability returns real board members; this
+    # example must not, since manifests are hand-authored and never pass
+    # through the fixture scrubber.
     board_members:
-      - Carl Peter Christian Luiga
+      - Exempel Förste Ledamot
     moms_registered: true
     registered_date: "2006-05-10"
     registered_address: Regeringsgatan 19 5tr, 111 53 Stockholm

--- a/manifests/credit-report-summary.yaml
+++ b/manifests/credit-report-summary.yaml
@@ -28,8 +28,11 @@ output_schema:
     fiscal_year: 2024-12
     revenue_sek: 108131545
     company_name: Spotify AB
+    # Placeholder name. The live capability returns real board members; this
+    # example must not, since manifests are hand-authored and never pass
+    # through the fixture scrubber.
     board_members:
-      - Carl Peter Christian Luiga
+      - Exempel Förste Ledamot
     credit_rating: null
     risk_indicator: null
     credit_limit_sek: null

--- a/manifests/french-company-data.yaml
+++ b/manifests/french-company-data.yaml
@@ -27,10 +27,13 @@ output_schema:
     siret: "54205118000066"
     status: active
     address: LA DEFENSE 6 2 PLACE JEAN MILLIER 92400 COURBEVOIE
+    # Placeholder names. The live capability returns real directors; this
+    # example must not, since manifests are hand-authored and never pass
+    # through the fixture scrubber. Format preserved: NAME (Role).
     directors:
-      - JACQUES ANDRE ASCHENBROICH (Administrateur)
-      - MARIE CHRISTINE COISNE (Administrateur)
-      - LISE CROTEAU (Administrateur)
+      - EXEMPLE PREMIER DIRIGEANT (Administrateur)
+      - EXEMPLE DEUXIEME DIRIGEANT (Administrateur)
+      - EXEMPLE TROISIEME DIRIGEANT (Administrateur)
     postal_code: "92400"
     company_name: TOTALENERGIES SE (TOTALENERGIE SE)
     activity_code: 70.10Z


### PR DESCRIPTION
## Summary

Five manifests carried real natural persons by name in `output_schema.example`:

| Manifest | Names |
|---|---|
| `french-company-data` | 3 TotalEnergies board members |
| `brazilian-company-data` | 1 partner |
| `annual-report-extract` | 1 Swedish board member |
| `business-license-check-se` | same person again |
| `credit-report-summary` | same person again |

Replaced with placeholders that keep the exact local format — `NAME (Role)`, casing, nested `{name, role}` — so the examples still document the shape they exist to document.

The 2026-05-18 fixture audit flagged **two** of these as an out-of-scope finding and recommended a remediation to-do. Three months on it was still open, and the sweep for this fix found **three more** the audit hadn't seen (its scope was `directors`/`partners`; the Nordic manifests use `board_members`).

## Why the file edits alone would not have held

The cause is structural, not a lapse. `scrubFixture()` and `PII_ARRAY_FIELDS` in `capture-tier-fixtures.ts` run at **capture** time on executor output. Manifests are **hand-authored**: an author pastes a real response into `output_schema.example` to document the shape, and no machinery ever looks at it. The sixth manifest repeats the incident.

So the rule is now enforced at authoring time by `check-manifest-pii.mjs`, wired into CI next to the other manifest gates.

**It deliberately does not try to judge whether a string "looks like a real person."** That isn't decidable, and a guessing heuristic would both miss real names and block legitimate edits. Instead it requires PII-bearing arrays in examples to be empty, null, or *explicitly synthetic* — which is checkable and unambiguous. Placeholder markers are recognised in the languages the affected registries actually use (`EXEMPLE`, `EXEMPLO`, `EXEMPEL`, `BEISPIEL`, …), so an example can stay in its native format.

`PII_FIELDS` in the gate mirrors `PII_ARRAY_FIELDS` in the capture script; they're commented to be kept in step.

## Verification

**Regression direction verified both ways** — the gate exits **1** against the pre-fix content and names all three FR directors, exits **0** after:

```
pre-fix   → 3 entries ... french-company-data: output_schema.example.directors → "JACQUES ANDRE ..."  (exit 1)
post-fix  → clean — no unredacted person names in manifest examples             (exit 0)
```

All other gates pass: `typecheck`, `check-manifest-guaranteed-consistency --strict`, `check-tier-coverage`, `check-identity-fixture-shape --strict`, `lint:no-bare-catch`, `check-shape-contracts`.

`validate-capability` on the five touched slugs reports the **same failure counts as `origin/main`** (verified by stashing the manifest edits and re-running) — those are pre-existing and unrelated: an unregistered-executor harness artifact on three, and two pre-existing Gate 5 fixture-coverage gaps.

`processes_personal_data: true` was already correct on all five, so the GDPR classification never needed changing — only the illustrative values.

## Deliberately not included

**`pep-check`'s example names Angela Merkel.** A PEP-screening example can't demonstrate itself without naming a PEP, and a head of government's political exposure is the public fact the capability exists to report. Different in kind from a private company's board roster. Raising it here rather than folding it in silently — say the word if you want it placeholdered too, though I'd argue the example is less useful then.

**`fake-data-generate` and `api-mock-response`** contain invented names by design; untouched, and the gate doesn't flag them (they don't use PII field names).

## Test plan

1. `node apps/api/scripts/check-manifest-pii.mjs --strict` → clean.
2. Paste a real-looking name into any `directors:` example, re-run → exits 1 and names it. Revert.
3. Confirm the five examples still show the shape a consumer needs (role in parens, nested `{name, role}`).
