### PR TITLE
fix(norwegian-company-data): let the route accept company_name

### DIFF
--- a/manifests/norwegian-company-data.yaml
+++ b/manifests/norwegian-company-data.yaml
@@ -13,12 +13,27 @@ price_cents: 5
 is_free_tier: false
 input_schema:
   type: object
-  required:
-    - org_number
+  # No field is individually required: an org number OR a company name is
+  # enough, and the executor enforces that ("at least one of") itself with a
+  # message naming every accepted alias. Listing org_number as `required` made
+  # the ROUTE reject {"company_name": "Telenor"} with
+  # "Missing required input fields: org_number" before the executor ever ran —
+  # so the capability's own name-resolution path was unreachable from the API
+  # even after the executor was fixed. Danish and Finnish already use required: [].
+  required: []
   properties:
     org_number:
       type: string
-      description: Norwegian org number (9 digits) or company name
+      description: Norwegian org number, 9 digits (e.g. 923609016)
+    company_name:
+      type: string
+      description: >-
+        Company name (e.g. "Telenor"). Resolved against Brønnøysundregistrene and
+        accepted only on a confident name match — an ambiguous name is refused
+        rather than resolved to the wrong legal entity.
+    company_number:
+      type: string
+      description: Alias for org_number
 output_schema:
   type: object
   example:


### PR DESCRIPTION
## Summary

Follow-up to #161. The executor learned company-name resolution there, but production still rejected `{"company_name": "Telenor"}` with `Missing required input fields: org_number`.

The route validates against the capability's `input_schema` **before** the executor runs, and that schema declared `org_number` as required and didn't list `company_name` as a property at all. So the name-resolution path stayed unreachable from the API even after the code was correct.

No field is individually required: an org number **or** a company name is enough, and the executor already enforces that itself with an error naming every accepted alias. `danish` and `finnish` already use `required: []` — which is exactly why Finnish worked in production immediately and Norwegian didn't.

Applied to the DB too, since that is what the route reads at request time.

## Verified in production

| Input | Result |
|---|---|
| `{company_name: "Telenor"}` | **TELENOR ASA** (982463718) — was `NITO TELENOR` |
| `{company_name: "Norsk Hydro"}` | **Norsk Hydro ASA** (914778271) — was `NORSK HYDROGENBILFORENING` |
| `{company_name: "Statoil"}` | refused, not charged — correct, renamed to Equinor |
| `{org_number: "923609016"}` | EQUINOR ASA — unchanged |

## Test plan

Re-run the four calls above against production; confirm `finnish-company-data` `{"company_name": "Nokia"}` still returns Nokia Oyj `0112038-9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)