### PR TITLE
chore(security): scrub two committed credentials from tracked files

### DIFF
--- a/archive/growth-ops/upload-graphics.sh
+++ b/archive/growth-ops/upload-graphics.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-TYPEFULLY_MCP="https://mcp.typefully.com/mcp?TYPEFULLY_API_KEY=dced9NYbgoQdgbqrADTF70g7AuwYWCJz"
+# 2026-08-10: the live Typefully API key was committed here in plaintext on
+# 2026-04-18. Read it from the environment instead. NOTE: redacting this line
+# does not undo the exposure — the value is in git history permanently, so the
+# key must be rotated in Typefully. Track that separately from this edit.
+TYPEFULLY_MCP="https://mcp.typefully.com/mcp?TYPEFULLY_API_KEY=${TYPEFULLY_API_KEY:?set TYPEFULLY_API_KEY}"
 GRAPHICS_DIR="/c/Users/pette/Projects/strale/growth-plan/graphics"
 
 upload_and_attach() {

--- a/handoff/_general/from-code/2026-02-27-admin-stats-webhooks.md
+++ b/handoff/_general/from-code/2026-02-27-admin-stats-webhooks.md
@@ -26,13 +26,20 @@ Intent: Add admin stats endpoint, signup webhook, and transaction milestone aler
 **Set ADMIN_SECRET on Railway:**
 The env var needs to be set via the Railway dashboard (CLI wasn't authenticated).
 
+> **2026-08-10:** this section originally contained the live `ADMIN_SECRET`
+> value in plaintext, and it sat in a tracked file for ~5.5 months. The
+> secret was rotated on 2026-08-10 (old value verified rejected with 401,
+> new value 200), so the committed string is now worthless — but it remains
+> in git history permanently, which is why rotation rather than redaction is
+> the actual fix. Never paste a live credential into a handoff file.
+
 ```
-ADMIN_SECRET=7e95e1cdce0931e4c43295819ac3664ddde614064d6c9d364735a2be8a48cfe4
+ADMIN_SECRET=<generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))">
 ```
 
 Once set, test with:
 ```
-curl -H "Authorization: Bearer 7e95e1cdce0931e4c43295819ac3664ddde614064d6c9d364735a2be8a48cfe4" \
+curl -H "Authorization: Bearer $ADMIN_SECRET" \
   https://api.strale.io/v1/admin/stats
 ```
 


### PR DESCRIPTION
## Summary

A repo-wide secret sweep (prompted by the `ADMIN_SECRET` rotation) found **two live credentials in plaintext in tracked files**:

| Credential | File | Committed | Grants |
|---|---|---|---|
| `ADMIN_SECRET` | `handoff/_general/from-code/2026-02-27-admin-stats-webhooks.md` | 2026-02-27 (~5.5 months) | all of `/v1/internal/*` |
| `TYPEFULLY_API_KEY` | `archive/growth-ops/upload-graphics.sh` | 2026-04-18 | Typefully account (social scheduling) |

## Status

**`ADMIN_SECRET` — rotated 2026-08-10, before this edit.** Verified end to end: old value now returns **401**, new value returns **200**, local `.env` updated and confirmed matching. The committed string is worthless.

**`TYPEFULLY_API_KEY` — NOT yet rotated.** This PR only stops the script carrying the value. The key is still valid in Typefully and still in git history. **Rotating it is outstanding and does not happen as a side effect of merging this.**

## Redaction is not the fix

Both values are in git history permanently and no file edit removes them. Rotation is what makes them worthless. These edits are hygiene — they stop the values being copy-pasted onward and stop future scans re-flagging them. The handoff file carries an explicit note saying exactly that, so the next reader doesn't mistake a redacted file for a closed incident.

## Sweep coverage

Patterns checked across all tracked files: Stripe (`sk_live_`/`sk_test_`), Anthropic (`sk-ant-`), GitHub (`ghp_`/`github_pat_`), AWS (`AKIA`), Slack (`xox[baprs]-`), Google (`AIza`), bearer tokens ≥30 chars, `SECRET`/`TOKEN`/`API_KEY`/`PASSWORD` assignments with ≥24-char values, Postgres/MySQL/Redis connection strings with embedded passwords, PEM private-key blocks, and Slack/Discord webhook URLs.

Post-scrub re-sweep is clean.

**Deliberately left:** `apps/api/docs/v1-identity-coverage-matrix-2026-05-13.md:5` carries `sk_live_0d56f39c…` — a truncated 8-char prefix with an ellipsis. Per DEC-20 the `key_prefix` is stored in the DB for lookup, so a prefix is not a credential.

## Recommended follow-up (not in this PR)

Two credentials reaching `main` in plaintext suggests the gap is preventive, not remedial. Rather than hand-rolling a third bespoke CI gate, I'd suggest enabling **GitHub secret scanning + push protection** on the repo — it blocks the commit at push time and recognises vendor key formats natively. That's a repo-settings decision rather than a code change, so it's yours to make.

## Test plan

1. `bash -n archive/growth-ops/upload-graphics.sh` → syntax OK (verified).
2. Confirm neither literal value appears in the working tree.
3. Confirm the script now fails loudly with `set TYPEFULLY_API_KEY` if the env var is absent, rather than silently using a dead key.
