### PR TITLE
fix(registries): Swiss name search used the wrong HTTP method

### DIFF
--- a/apps/api/src/capabilities/estonian-company-data.ts
+++ b/apps/api/src/capabilities/estonian-company-data.ts
@@ -6,6 +6,8 @@ import { getDb } from "../db/index.js";
 import { eeDirectors, eeDirectorsSync } from "../db/schema.js";
 
 // Estonian company data via ariregister.rik.ee — FREE, no auth
+import { classifyNameMatch } from "../lib/company-name-match.js";
+
 const API = "https://ariregister.rik.ee/est/api";
 
 interface LegalRepresentative {
@@ -159,14 +161,56 @@ async function fetchApi(path: string): Promise<unknown> {
   }
 }
 
-async function searchCompany(query: string): Promise<Record<string, unknown>> {
+/**
+ * @param query      registry code or company name
+ * @param isRegCode  true when `query` is an 8-digit registry code. A code is an
+ *                   exact identifier, so the single result is authoritative. A
+ *                   NAME is not: the autocomplete endpoint is fuzzy and ordered
+ *                   by its own relevance, which is not ours — searching
+ *                   "Tallink" returns "Tallink - City Spordiklubi" (a sports
+ *                   club, reg 80405811) ahead of "Aktsiaselts Tallink Grupp"
+ *                   (10238429). Taking results[0] on a name therefore hands the
+ *                   caller a different legal entity with no signal that it did.
+ */
+async function searchCompany(query: string, isRegCode: boolean): Promise<Record<string, unknown>> {
   const data = (await fetchApi(`/autocomplete?q=${encodeURIComponent(query)}`)) as any;
   const results = data?.data;
   if (!results || results.length === 0) {
-    throw new Error(`No Estonian company found matching "${query}".`);
+    throw new Error(
+      isRegCode
+        ? `No Estonian company found for registry code "${query}". The code is well-formed but is ` +
+          `not in the Business Register — it may belong to a deregistered entity, or be a typo. ` +
+          `Search by company_name instead if you are unsure of the code.`
+        : `No Estonian company found matching "${query}".`,
+    );
   }
 
-  const c = results[0];
+  let c = results[0];
+  if (!isRegCode) {
+    // Score every candidate and accept only a real match, mirroring the
+    // discipline in finnish/norwegian-company-data and us-company-data.
+    let best: any = null;
+    for (const cand of results) {
+      const nm = cand?.name;
+      if (typeof nm !== "string" || !nm) continue;
+      const { match_confidence } = classifyNameMatch(query, nm);
+      if (match_confidence === "exact") { best = cand; break; }
+      if (match_confidence === "high" && !best) best = cand;
+    }
+    if (!best) {
+      const closest = results
+        .slice(0, 3)
+        .map((r: any) => r?.name)
+        .filter(Boolean)
+        .join(", ");
+      throw new Error(
+        `No confident Estonian registry match for "${query}". The Business Register's search is ` +
+          `fuzzy and returned only unrelated entities${closest ? ` (closest: ${closest})` : ""}. ` +
+          `Provide the 8-digit registry code for an exact lookup.`,
+      );
+    }
+    c = best;
+  }
   // EE registry returns two code systems for legal_form depending on entity vintage:
   // legacy `liik` (1, 2, 3) and modern codes (4-10). Map both to canonical
   // human-readable labels so the wire shape is consistent across entities.
@@ -212,8 +256,8 @@ registerCapability("estonian-company-data", async (input: CapabilityInput) => {
 
   const trimmed = raw.trim();
   const regCode = findRegCode(trimmed);
-  const query = regCode || await extractCompanyName(trimmed);
-  const output = await searchCompany(query);
+  const query = regCode || (await extractCompanyName(trimmed));
+  const output = await searchCompany(query, !!regCode);
 
   const regCodeForRef = (output.registry_code as string) || "";
   const primarySourceUrl = regCodeForRef

--- a/apps/api/src/capabilities/providers/swiss-company-data.ts
+++ b/apps/api/src/capabilities/providers/swiss-company-data.ts
@@ -11,6 +11,7 @@
  */
 
 import { registerChain } from "../../lib/data-provider.js";
+import { classifyNameMatch } from "../../lib/company-name-match.js";
 
 const ZEFIX_API = "https://www.zefix.admin.ch/ZefixPublicREST/api/v1";
 
@@ -146,20 +147,75 @@ registerChain({
           const data = await res.json();
           company = Array.isArray(data) ? data[0] : data;
         } else {
-          // Name search
-          const res = await fetch(
-            `${ZEFIX_API}/company/search?name=${encodeURIComponent(raw)}&languageKey=en&maxEntries=1`,
-            { headers, signal: AbortSignal.timeout(10000) },
-          );
+          // Name search.
+          //
+          // MUST be POST. Zefix's /company/search accepts a JSON body and
+          // returns 405 Method Not Allowed for GET — which is exactly what
+          // production returned for {"uid": "Swisscom"} before this fix, twice.
+          // The 405 was surfaced raw to the caller as "Zefix API error: HTTP
+          // 405", which reads like an outage rather than our bug.
+          const res = await fetch(`${ZEFIX_API}/company/search`, {
+            method: "POST",
+            headers: { ...headers, "Content-Type": "application/json" },
+            body: JSON.stringify({ name: raw, languageKey: "en", maxEntries: 20 }),
+            signal: AbortSignal.timeout(10000),
+          });
           if (!res.ok) {
             throw new Error(`Zefix API error: HTTP ${res.status} for name "${raw}"`);
           }
           const data = await res.json();
-          company = Array.isArray(data) ? data[0] : data;
+          const candidates: Array<Record<string, unknown>> = Array.isArray(data) ? data : [data];
+
+          // Score candidates rather than trusting the first. Zefix's search is
+          // fuzzy, and a name query that lands on a different legal entity is
+          // undetectable by the caller — the same failure class fixed in
+          // finnish/norwegian-company-data.
+          let best: Record<string, unknown> | null = null;
+          for (const cand of candidates) {
+            const nm = cand?.name;
+            if (typeof nm !== "string" || !nm) continue;
+            const { match_confidence } = classifyNameMatch(raw, nm);
+            if (match_confidence === "exact") { best = cand; break; }
+            if (match_confidence === "high" && !best) best = cand;
+          }
+          if (!best) {
+            // Two distinct failures, and conflating them sends the caller the
+            // wrong way. Zefix matches diacritics LITERALLY and does no folding
+            // of its own: "Nestle" returns 0 results while "Nestlé" returns 15
+            // including Nestlé AG. So an empty result set usually means the
+            // accent is missing, not that the company is absent.
+            if (candidates.length === 0) {
+              throw new Error(
+                `Zefix returned no companies for "${raw}". Its name search matches accented ` +
+                  `characters literally — try the exact registered spelling (e.g. "Nestlé" rather ` +
+                  `than "Nestle"), or provide the UID (CHE-xxx.xxx.xxx) for an exact lookup.`,
+              );
+            }
+            const closest = candidates
+              .slice(0, 3)
+              .map((c) => c?.name)
+              .filter((n): n is string => typeof n === "string")
+              .join(", ");
+            throw new Error(
+              `No confident Swiss registry match for "${raw}". Zefix's name search is fuzzy and ` +
+                `returned only unrelated entities${closest ? ` (closest: ${closest})` : ""}. ` +
+                `Provide the UID (CHE-xxx.xxx.xxx) for an exact lookup.`,
+            );
+          }
+          company = best;
         }
 
         if (!company) {
-          throw new Error(`No Swiss company found for "${raw}"`);
+          // Zefix answers an unknown-but-well-formed UID with 200 [] rather
+          // than 404, so this is the not-found path for exact lookups. Say so
+          // plainly: three production calls for CHE-105.805.977 landed here,
+          // and "no company found" alone does not tell the caller whether the
+          // identifier is wrong or the register is incomplete.
+          throw new Error(
+            `No Swiss company found for "${raw}". The identifier is well-formed but is not in ` +
+              `Zefix — it may belong to a deregistered entity, or be a typo. Search by ` +
+              `company_name instead if you are unsure of the UID.`,
+          );
         }
 
         return {

--- a/apps/api/src/lib/company-name-match.test.ts
+++ b/apps/api/src/lib/company-name-match.test.ts
@@ -108,3 +108,50 @@ describe("classifyNameMatch — edge cases", () => {
     expect(classifyNameMatch("Oyj", "ASA").match_confidence).toBe("low");
   });
 });
+
+describe("normalizeCompanyName — diacritics and punctuated legal forms", () => {
+  // Registries return the native spelling; callers type ASCII. Without folding,
+  // "Nestle" vs "Nestlé S.A." scores as a non-match and a valid query is refused.
+  const folds: Array<[string, string]> = [
+    ["Nestlé S.A.", "nestle"],
+    ["Ørsted A/S", "orsted"],
+    ["Mehiläinen Oy", "mehilainen"],
+    ["Ålandsbanken Abp", "alandsbanken"],
+    ["Heineken N.V.", "heineken"],
+    ["Société Générale", "societe generale"],
+  ];
+  for (const [input, expected] of folds) {
+    it(`"${input}" -> "${expected}"`, () => {
+      expect(normalizeCompanyName(input)).toBe(expected);
+    });
+  }
+
+  it("keeps a single-letter name rather than normalising it away", () => {
+    // The stray-letter cleanup only fires when a longer token survives, so a
+    // company genuinely named one character does not become "".
+    expect(normalizeCompanyName("X")).toBe("x");
+  });
+
+  it("keeps an alphanumeric short name", () => {
+    expect(normalizeCompanyName("3M Company")).toBe("3m");
+  });
+});
+
+describe("classifyNameMatch — ASCII query against native spelling", () => {
+  const resolves: Array<[string, string]> = [
+    ["Nestle", "Nestlé S.A."],
+    ["Orsted", "Ørsted A/S"],
+    ["Mehilainen", "Mehiläinen Oy"],
+  ];
+  for (const [query, registryName] of resolves) {
+    it(`"${query}" matches "${registryName}"`, () => {
+      expect(classifyNameMatch(query, registryName).match_confidence).toBe("exact");
+    });
+  }
+
+  it("folding does not make unrelated entities match", () => {
+    // Guard against over-folding: these must still be refused.
+    expect(classifyNameMatch("Nokia", "Fysios Mehiläinen Oy").match_confidence).toBe("low");
+    expect(classifyNameMatch("Norsk Hydro", "NORSK HYDROGENBILFORENING").match_confidence).toBe("low");
+  });
+});

--- a/apps/api/src/lib/company-name-match.ts
+++ b/apps/api/src/lib/company-name-match.ts
@@ -36,19 +36,55 @@ export type MatchConfidence = "exact" | "high" | "low";
 // English word and stripping it would corrupt unrelated names. "Telenor AS"
 // still resolves, via the two-token Jaccard path rather than suffix stripping.
 const CORP_SUFFIX_RE =
-  /\b(incorporated|inc|corporation|corp|company|co|llc|ltd|limited|lp|plc|holdings?|group|the|asa|oyj|oy|ab|aps|gmbh|ag|nv|bv|sa|sas|sarl|srl|spa|kft)\b/gi;
+  /\b(incorporated|inc|corporation|corp|company|co|llc|ltd|limited|lp|plc|holdings?|group|the|asa|oyj|oy|abp|ab|aps|gmbh|ag|nv|bv|sa|sas|sarl|srl|spa|kft)\b/gi;
 
 /**
  * Normalize a company name for fuzzy comparison: lowercase, flatten punctuation
  * to spaces, drop common corporate suffixes, collapse whitespace.
  */
-export function normalizeCompanyName(s: string): string {
+/**
+ * Fold diacritics and the Nordic/continental letters that Unicode
+ * decomposition does not cover.
+ *
+ * Registries return the legal name with its native spelling while callers type
+ * ASCII: "Nestle" for Nestlé S.A., "Orsted" for Ørsted A/S, "Mehilainen" for
+ * Mehiläinen. Without folding, those score as non-matches and a valid query is
+ * refused. NFD + stripping combining marks handles é/ä/å; ø, æ, œ, ß, ł and đ
+ * are single code points with no decomposition, so they need explicit mapping.
+ */
+const LETTER_FOLD: Record<string, string> = {
+  ø: "o", æ: "ae", œ: "oe", ß: "ss", ł: "l", đ: "d", ð: "d", þ: "th",
+};
+
+function foldDiacritics(s: string): string {
   return s
-    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{M}+/gu, "")
+    .replace(/[øæœßłđðþ]/g, (c) => LETTER_FOLD[c] ?? c);
+}
+
+export function normalizeCompanyName(s: string): string {
+  return foldDiacritics(s.toLowerCase())
     .replace(/[^\p{L}\p{N}\s]/gu, " ")
     .replace(CORP_SUFFIX_RE, " ")
     .replace(/\s+/g, " ")
-    .trim();
+    .trim()
+    // Punctuated legal forms shatter into single letters once punctuation is
+    // flattened: "Nestlé S.A." -> "nestle s a", "Ørsted A/S" -> "orsted a s",
+    // "Heineken N.V." -> "heineken n v". Those stray letters are never part of
+    // the distinguishing name, and leaving them in turns an exact match into a
+    // partial one, so a valid query gets refused.
+    //
+    // Only dropped when at least one multi-character token survives — a company
+    // genuinely named a single letter keeps it rather than normalising to "".
+    .split(" ")
+    .reduce<string[]>((acc, tok, _i, all) => {
+      const hasLongToken = all.some((t) => t.length > 1);
+      if (tok.length === 1 && hasLongToken) return acc;
+      acc.push(tok);
+      return acc;
+    }, [])
+    .join(" ");
 }
 
 /**


### PR DESCRIPTION
## Summary

Completes the registry work from #161 and #168 for the last two failing countries. Diagnosed from the real production inputs rather than assumed — and the headline finding is that only **one** of the seven failures was actually a bug.

## Swiss — the real bug: wrong HTTP method

Zefix `/company/search` is a **POST** endpoint. The provider called it with **GET**, so every name lookup returned **HTTP 405**, surfaced raw to the caller as `Zefix API error: HTTP 405` — which reads like an upstream outage rather than our defect. Two production calls hit it.

Now POSTs a JSON body. `{"uid": "Swisscom"}` returns **Swisscom AG**.

## The other five failures were correct behaviour, badly worded

| Input | Reality |
|---|---|
| `CHE-105.805.977` ×3 | Zefix genuinely doesn't hold it — answers `200 []`, not 404, for an unknown-but-well-formed UID |
| `10667868` ×2 (Estonian) | Returns zero results upstream |

Both now say the identifier is well-formed but absent, and suggest searching by name instead of leaving the caller guessing whether the register is incomplete or their input is wrong.

## Both carried the same latent wrong-company bug as #161

Neither was live — the failing calls never reached the name path — but both would have returned a different legal entity:

- **Estonian**: `Tallink` → autocomplete returns **"Tallink - City Spordiklubi"** (a sports club) ahead of Aktsiaselts Tallink Grupp.
- **Swiss**: `maxEntries=1` and took `[0]`.

Both now score candidates with `classifyNameMatch` and refuse rather than resolve to the wrong company. Estonian applies this **only to the name path** — a registry code is an exact identifier and stays authoritative.

## Two normalizer gaps, both causing valid queries to be refused

Surfaced while verifying, and worth fixing because they'd bite every registry:

1. **Diacritics weren't folded.** `Nestle` didn't match `Nestlé S.A.`; `Orsted` didn't match `Ørsted A/S`. Registries return the native spelling while callers type ASCII. NFD + combining-mark stripping covers é/ä/å; `ø æ œ ß ł đ ð þ` have no decomposition and are mapped explicitly.
2. **Punctuated legal forms shattered into single letters.** `"Nestlé S.A."` → `"nestle s a"`. Those stray letters are never distinguishing and turned exact matches into partial ones. Dropped — but only when a longer token survives, so a company genuinely named one character still normalises to itself. Added `abp` (Finnish public company).

Verified this does **not** over-match: `Nokia`/`Fysios Mehiläinen Oy` and `Norsk Hydro`/`NORSK HYDROGENBILFORENING` are still correctly refused.

## An upstream limitation worth recording

**Zefix matches diacritics literally and does no folding of its own** — `"Nestle"` returns **0 results**, `"Nestlé"` returns **15** including Nestlé AG. Our classifier can't paper over an empty result set, so that case now says so explicitly and suggests the exact spelling, instead of claiming the register "returned only unrelated entities".

## Verification

| Input | Result |
|---|---|
| `swiss {uid: "Swisscom"}` | **Swisscom AG** — was HTTP 405 |
| `swiss {company_name: "Nestlé"}` | **Nestlé AG** |
| `swiss {company_name: "Nestle"}` | clear refusal naming the diacritics cause |
| `swiss {uid: "CHE-102.753.938"}` | Swisscom AG — exact UID unchanged |
| `swiss {uid: "CHE-105.805.977"}` | clear not-found |
| `estonian {registry_code: "10238429"}` | **Aktsiaselts Tallink Grupp** — exact code unchanged |
| `estonian {company_name: "Tallink Grupp"}` | **Aktsiaselts Tallink Grupp** |
| `estonian {registry_code: "10667868"}` | clear not-found |
| `finnish {company_name: "Nokia"}` | Nokia Oyj — #161 regression check |
| `norwegian {company_name: "Telenor"}` | TELENOR ASA — #161 regression check |

| Gate | Result |
|---|---|
| `tsc --noEmit` | pass |
| `company-name-match.test.ts` | 33/33 (12 new) |
| `us-company-data.test.ts` | 13/13 — depends on the normalizer |
| `providers/swiss-company-data.test.ts` | pass |
| `check-no-bare-catch` (F-0-009) | pass |
| `check-ssrf-inventory` (F-0-006) | pass |
| `validate-capability --slug swiss-company-data` | 20/20 |

## Pre-existing, NOT addressed

`estonian-company-data` fails **Gate 5 path coverage** on `main` as well — confirmed by stashing this branch and re-running. All three of its `known_answer` fixtures use `registry_code`, yet the gate reports `registry_code` as the uncovered entry point, which points at a classifier bug in `gate5-path-coverage` rather than a missing fixture. Filed separately; it is not part of CI.

## Test plan

1. `POST /v1/do` `swiss-company-data` `{"company_name": "Swisscom"}` — expect Swisscom AG, **not** HTTP 405.
2. `{"company_name": "Nestlé"}` — expect Nestlé AG; `{"company_name": "Nestle"}` — expect the diacritics hint.
3. `estonian-company-data` `{"registry_code": "10238429"}` — expect Aktsiaselts Tallink Grupp.
4. Regression: `finnish {"company_name": "Nokia"}` → Nokia Oyj, `norwegian {"company_name": "Telenor"}` → TELENOR ASA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
