### PR TITLE
fix(registries): let the route accept company_name for Swiss and Estonian

### DIFF
--- a/manifests/estonian-company-data.yaml
+++ b/manifests/estonian-company-data.yaml
@@ -8,12 +8,22 @@ price_cents: 5
 is_free_tier: false
 input_schema:
   type: object
-  required:
-    - registry_code
+  # No field is individually required: an identifier OR a company name is
+  # enough, and the executor enforces that itself. Listing the identifier as
+  # `required` made the ROUTE reject a company_name call with "Missing required
+  # input fields" before the executor ran, leaving the name path unreachable
+  # from the API. Same defect fixed for norwegian-company-data in PR #168.
+  required: []
   properties:
     registry_code:
       type: string
-      description: Estonian registry code (8 digits) or company name
+      description: Estonian registry code, 8 digits (e.g. 10238429)
+    company_name:
+      type: string
+      description: >-
+        Company name. Resolved against the Business Register and accepted only on a
+        confident name match — an ambiguous name is refused rather than resolved to
+        the wrong legal entity.
 output_schema:
   type: object
   example:

--- a/manifests/swiss-company-data.yaml
+++ b/manifests/swiss-company-data.yaml
@@ -10,12 +10,21 @@ price_cents: 5
 is_free_tier: false
 input_schema:
   type: object
-  required:
-    - uid
+  # No field is individually required: an identifier OR a company name is
+  # enough, and the executor enforces that itself. Listing the identifier as
+  # `required` made the ROUTE reject a company_name call with "Missing required
+  # input fields" before the executor ran, leaving the name path unreachable
+  # from the API. Same defect fixed for norwegian-company-data in PR #168.
+  required: []
   properties:
     uid:
       type: string
-      description: Swiss UID (e.g. CHE-101.602.521), EHRAID, or company name
+      description: Swiss UID (CHE-xxx.xxx.xxx) or EHRAID
+    company_name:
+      type: string
+      description: >-
+        Company name. Zefix matches diacritics literally, so use the exact registered
+        spelling (e.g. "Nestlé"). Accepted only on a confident name match.
 output_schema:
   type: object
   example:


### PR DESCRIPTION
## Summary

Same defect fixed for Norway in #168. The route validates against the capability's **DB `input_schema` before the executor runs**, and both of these declared their identifier as `required` with no `company_name` property at all.

So after #172 fixed the Swiss GET/POST bug, production *still* answered `{"company_name": "Swisscom"}` with `Missing required input fields: uid`. The code was correct and unreachable.

Neither field is individually required — an identifier **or** a name is enough, and both executors enforce that themselves. Applied to the DB too, since that is what the route reads at request time.

## Verified in production

| Input | Result |
|---|---|
| `swiss {company_name: "Swisscom"}` | **Swisscom AG** `CHE102753938` |
| `swiss {company_name: "Nestlé"}` | **Nestlé AG** `CHE105909036` |
| `swiss {company_name: "Nestle"}` | diacritics hint, not a bare not-found |
| `swiss {uid: "CHE-102.753.938"}` | Swisscom AG — unchanged |
| `estonian {company_name: "Tallink Grupp"}` | **Aktsiaselts Tallink Grupp** `10238429` |
| `estonian {registry_code: "10238429"}` | unchanged |

## This is not confined to these two

Auditing every active `*-company-data` schema found **nine more** with `required: [<identifier>]` and no name property, so a `company_name` call cannot reach their executors regardless of what those executors support:

`au` · `brazilian` · `canadian` · `croatian` · `cz` · `japanese` · `polish` · `slovak` · `swedish`

`swedish` is the notable one — DEC-20260225-P-m5n6 states it accepts fuzzy natural-language input, which its current schema forbids.

**Deliberately not changed here.** Each needs its executor checked first: opening a schema for a capability that cannot actually resolve names would trade a clear "missing field" error for a confusing downstream failure, or worse, a wrong-company answer. Filed separately with the full audit table.

## Test plan

1. `POST /v1/do` `swiss-company-data` `{"company_name": "Swisscom"}` — expect Swisscom AG.
2. `estonian-company-data` `{"company_name": "Tallink Grupp"}` — expect Aktsiaselts Tallink Grupp.
3. Identifier paths unchanged: `{"uid": "CHE-102.753.938"}`, `{"registry_code": "10238429"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)