### PR TITLE
feat(retention): redact PII columns at 90 days, not 1095

### DIFF
--- a/apps/api/src/lib/data-retention.test.ts
+++ b/apps/api/src/lib/data-retention.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression tests for the retention sweep, and specifically for the PII tier
+ * added 2026-08-12.
+ *
+ * Two hazards this file exists to catch, both drawn from real incidents:
+ *
+ * 1. BIND-PARAMETER SHAPE (DEC-20260504-A). PR #43 shipped a Date straight
+ *    into a `sql` template; postgres-js's encoder cannot serialise one, and
+ *    every affected call 500'd silently for four days. The cert-audit batch
+ *    that introduced it shipped a structurally identical bug in this very
+ *    file. So: walk the query and assert no Date, Buffer or object reaches
+ *    the driver — the cutoff must already be an ISO string.
+ *
+ * 2. SELECTION SCOPE. The PII sweep runs on a much shorter window than the
+ *    compliance sweep, so a WHERE clause that is too broad silently destroys
+ *    data early, and one that is too narrow silently keeps personal data past
+ *    its window. Neither failure is visible in the summary log, which only
+ *    reports counts.
+ *
+ * These are unit tests over the emitted SQL rather than integration tests: the
+ * repo has no Postgres-backed harness for retention, and per the CLAUDE.md
+ * test-harness exemption a structural test that captures the shape of the bug
+ * is the sanctioned substitute. The accumulated-workload audit required by
+ * DEC-20260504-B was run against production before merge and is recorded in
+ * the PR body and in the comment on purgePiiTransactions.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/** Recorded `sql` template invocations from a fake db.execute. */
+interface Captured {
+  strings: readonly string[];
+  params: unknown[];
+}
+
+const captured: Captured[] = [];
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({
+    execute: (query: unknown) => {
+      // Drizzle's sql`` object exposes its chunks; capture whatever the
+      // driver would receive so we can assert on the shapes.
+      // Drizzle splits a sql`` template into StringChunk objects (literal SQL,
+      // whose `.value` is a string array) and RAW PRIMITIVES for the bind
+      // parameters. Getting this backwards makes the shape assertions below
+      // inspect an empty list and pass vacuously, so classify explicitly:
+      // a StringChunk is text, anything else is a parameter.
+      const q = query as { queryChunks?: unknown[] };
+      const params: unknown[] = [];
+      const strings: string[] = [];
+      for (const chunk of q.queryChunks ?? []) {
+        const isStringChunk =
+          chunk !== null &&
+          typeof chunk === "object" &&
+          Array.isArray((chunk as { value?: unknown }).value) &&
+          ((chunk as { value: unknown[] }).value).every((x) => typeof x === "string");
+        if (isStringChunk) {
+          strings.push(((chunk as { value: string[] }).value).join(""));
+        } else {
+          params.push(chunk);
+        }
+      }
+      captured.push({ strings, params });
+      // rowCount 0 ends the batching loop on the first pass.
+      return Promise.resolve({ rowCount: 0 });
+    },
+  }),
+}));
+
+vi.mock("./log.js", () => ({ log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+const { cleanupOldTestData, PII_RETENTION_DAYS, TRANSACTION_RETENTION_DAYS } = await import(
+  "./data-retention.js"
+);
+
+beforeEach(() => {
+  captured.length = 0;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Every SQL string emitted during a sweep, concatenated per statement. */
+function statements(): string[] {
+  return captured.map((c) => c.strings.join(" ").replace(/\s+/g, " "));
+}
+
+describe("retention windows", () => {
+  it("redacts PII strictly earlier than the compliance skeleton", () => {
+    // If these ever invert, PII would outlive the record it belongs to and the
+    // sweep could never reach it.
+    expect(PII_RETENTION_DAYS).toBeLessThan(TRANSACTION_RETENTION_DAYS);
+  });
+
+  it("keeps the compliance window at the Colorado AI Act minimum", () => {
+    expect(TRANSACTION_RETENTION_DAYS).toBe(1095);
+  });
+});
+
+describe("bind-parameter shapes (DEC-20260504-A)", () => {
+  it("passes no Date, Buffer or plain object to the driver", async () => {
+    await cleanupOldTestData();
+    expect(captured.length).toBeGreaterThan(0);
+    // Guard against a vacuous pass: if the mock ever stops classifying bind
+    // parameters correctly, this assertion fires instead of the loop below
+    // silently inspecting nothing.
+    expect(captured.flatMap((c) => c.params).length).toBeGreaterThan(0);
+
+    for (const { params } of captured) {
+      for (const p of params) {
+        expect(p).not.toBeInstanceOf(Date);
+        expect(p).not.toBeInstanceOf(Buffer);
+        if (p !== null && typeof p === "object") {
+          // Arrays/objects would mean a cutoff or id list leaked through
+          // unserialised — the PR-43 failure mode.
+          expect(Array.isArray(p)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("passes cutoffs as ISO strings", async () => {
+    await cleanupOldTestData();
+    const isoLike = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+    const stringParams = captured
+      .flatMap((c) => c.params)
+      .filter((p): p is string => typeof p === "string");
+    // Every sweep passes at least one cutoff; all of them must be ISO.
+    const cutoffs = stringParams.filter((p) => isoLike.test(p));
+    expect(cutoffs.length).toBeGreaterThan(0);
+    for (const c of cutoffs) expect(new Date(c).toString()).not.toBe("Invalid Date");
+  });
+});
+
+describe("PII sweep selection scope", () => {
+  it("restricts to capabilities flagged processes_personal_data", async () => {
+    await cleanupOldTestData();
+    const pii = statements().find((s) => s.includes("pii_retention_purge"));
+    expect(pii, "PII sweep statement was not emitted").toBeDefined();
+    expect(pii).toContain("processes_personal_data");
+    expect(pii).toContain("JOIN capabilities");
+  });
+
+  it("never touches rows on legal hold", async () => {
+    await cleanupOldTestData();
+    for (const s of statements().filter((x) => x.includes("deletion_reason"))) {
+      expect(s).toContain("legal_hold = false");
+    }
+  });
+
+  it("skips already-redacted rows so a re-run is a no-op", async () => {
+    await cleanupOldTestData();
+    for (const s of statements().filter((x) => x.includes("deletion_reason"))) {
+      expect(s).toContain("deleted_at IS NULL");
+    }
+  });
+
+  it("self-throttles with a LIMIT rather than one unbounded statement", async () => {
+    // DEC-20260504-B: the first run after introducing a window is a
+    // workload-resumption event. The LIMIT is what bounds it.
+    await cleanupOldTestData();
+    const pii = statements().find((s) => s.includes("pii_retention_purge"));
+    expect(pii).toContain("LIMIT");
+  });
+
+  it("marks PII redactions distinguishably from the 3-year sweep", async () => {
+    // Operators must be able to tell why a row was redacted; the two windows
+    // have different justifications and different review consequences.
+    await cleanupOldTestData();
+    const all = statements().join(" | ");
+    expect(all).toContain("pii_retention_purge");
+    expect(all).toContain("retention_purge");
+  });
+
+  it("zeroes every PII column, not just input", async () => {
+    await cleanupOldTestData();
+    const pii = statements().find((s) => s.includes("pii_retention_purge"))!;
+    for (const col of ["input", "output", "error", "audit_trail", "provenance", "idempotency_key"]) {
+      expect(pii).toContain(col);
+    }
+  });
+
+  it("preserves the chain and the Art. 30 skeleton", async () => {
+    // A hard DELETE here broke the integrity-hash chain once already (CRIT-7).
+    // The statement must be an UPDATE, and must not clear the hash columns.
+    await cleanupOldTestData();
+    const pii = statements().find((s) => s.includes("pii_retention_purge"))!;
+    expect(pii).toContain("UPDATE transactions");
+    expect(pii).not.toContain("DELETE FROM transactions");
+    expect(pii).not.toContain("integrity_hash =");
+    expect(pii).not.toContain("previous_hash =");
+    expect(pii).not.toContain("created_at =");
+  });
+});

--- a/apps/api/src/lib/data-retention.ts
+++ b/apps/api/src/lib/data-retention.ts
@@ -16,6 +16,32 @@ const BATCH_DELAY_MS = 100;
 export const TRANSACTION_RETENTION_DAYS = 1095; // 3 years
 
 /**
+ * Retention window for the PII COLUMNS of transactions whose capability is
+ * flagged `processes_personal_data`. Shorter than the compliance window above,
+ * and deliberately so.
+ *
+ * The two are not in conflict because the sweep redacts rather than deletes:
+ * the Art. 30 record-of-processing skeleton (status, capability slug,
+ * jurisdiction, transparency_marker, timestamps, price, latency, and the
+ * integrity-hash chain) survives for the full 1095 days, while the personal
+ * data itself — input, output, error, audit_trail, provenance,
+ * idempotency_key — is zeroed at 90. You keep the proof that processing
+ * happened without keeping the data it happened to, which is what Art. 5(1)(e)
+ * storage limitation actually asks for.
+ *
+ * On the dispute endpoint (`/v1/transactions/{id}/dispute`): after this window
+ * a dispute can still establish THAT a screening ran, when, and against which
+ * capability, but not re-derive its inputs. That is the correct trade. Holding
+ * identifiable personal data for three years *in case* someone might dispute
+ * it is precisely the retention that storage limitation forbids — the dispute
+ * right does not create a lawful basis for indefinite storage.
+ *
+ * 90 days gives roughly three times the one-month response window Art. 12(3)
+ * allows a controller, so a dispute raised in good time is fully evaluable.
+ */
+export const PII_RETENTION_DAYS = 90;
+
+/**
  * Retention policies aligned with regulatory requirements:
  * - Compliance data (transactions, quality): 3 years (Colorado AI Act SB 24-205)
  * - Operational data (test results, events): 90-180 days
@@ -147,10 +173,70 @@ async function purgeHealthMonitorEvents(cutoff: Date): Promise<number> {
 // sqs_daily_snapshot table is dropped in PR2.
 
 /**
+ * Redact the PII columns of transactions belonging to capabilities flagged
+ * `processes_personal_data`, on the shorter PII_RETENTION_DAYS window.
+ *
+ * Identical redaction to purgeTransactions — same columns zeroed, same chain-
+ * preserving semantics, same legal_hold exemption, same already-redacted skip
+ * so re-running is a true no-op. The only difference is WHICH rows it selects
+ * and HOW OLD they must be.
+ *
+ * DEC-20260504-B (Bulk-Operation Deploy Protocol): introducing this window is
+ * a workload-resumption event, not a routine deploy. Audited before merge on
+ * 2026-08-12: 57,345 rows / ~4.6 MB of PII columns would be redacted on the
+ * first run, against 803,489 total transactions with 0 on legal hold. Strategy
+ * chosen: SELF-THROTTLE — the LIMIT/BATCH_SIZE loop with BATCH_DELAY_MS below
+ * bounds each tick to 1000 rows, so the backlog drains over ~58 batches
+ * (~12s) rather than in one statement. No pre-drain script is needed at this
+ * volume, and the cap holds regardless of how large the backlog later grows.
+ *
+ * KNOWN GAP: solution executions have `capability_id IS NULL` (they carry
+ * `solution_slug` instead), so this join cannot see them — 310 such rows are
+ * currently older than the window. A solution that composes a PII capability
+ * therefore keeps its payload for the full 1095 days. Closing that needs a
+ * solution→capability mapping; tracked separately rather than guessed at here,
+ * because over-matching would redact non-PII solution data early.
+ */
+async function purgePiiTransactions(cutoff: Date): Promise<number> {
+  const db = getDb();
+  let redacted = 0;
+  while (true) {
+    const result = await db.execute(sql`
+      UPDATE transactions
+      SET
+        input = '{}'::jsonb,
+        output = NULL,
+        error = NULL,
+        audit_trail = NULL,
+        provenance = NULL,
+        idempotency_key = NULL,
+        deleted_at = NOW(),
+        redacted_at = NOW(),
+        deletion_reason = 'pii_retention_purge'
+      WHERE id IN (
+        SELECT t.id FROM transactions t
+        JOIN capabilities c ON c.id = t.capability_id
+        WHERE c.processes_personal_data = true
+          AND t.created_at < ${cutoff.toISOString()}::timestamptz
+          AND t.legal_hold = false
+          AND t.deleted_at IS NULL
+        LIMIT ${BATCH_SIZE}
+      )
+    `);
+    const count = (result as any).rowCount ?? 0;
+    redacted += count;
+    if (count < BATCH_SIZE) break;
+    await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
+  }
+  return redacted;
+}
+
+/**
  * Run data retention cleanup. Safe to call multiple times — idempotent.
  *
  * Retention windows:
  * - transactions: 3 years (Colorado AI Act compliance)
+ * - transactions with processes_personal_data: PII columns at 90 days
  * - transaction_quality: 3 years (paired with transactions)
  * - test_results: 90 days (operational)
  * - health_monitor_events: 180 days (operational)
@@ -178,6 +264,14 @@ export async function cleanupOldTestData(): Promise<void> {
   // working; the field is renamed to transactions_redacted in the log
   // payload to reflect actual semantics.
   const txRedacted = await purgeTransactions(threeYearsAgo);
+
+  // PII columns go earlier than the compliance skeleton — see
+  // PII_RETENTION_DAYS. Runs after the 3-year sweep so a row old enough for
+  // both is already redacted and skipped here rather than written twice.
+  const piiCutoff = new Date(now);
+  piiCutoff.setDate(piiCutoff.getDate() - PII_RETENTION_DAYS);
+  const piiRedacted = await purgePiiTransactions(piiCutoff);
+
   const eventsDeleted = await purgeHealthMonitorEvents(oneEightyDaysAgo);
 
   log.info(
@@ -186,6 +280,7 @@ export async function cleanupOldTestData(): Promise<void> {
       test_results_deleted: testResultsDeleted,
       transaction_quality_deleted: txQualityDeleted,
       transactions_redacted: txRedacted,
+      pii_transactions_redacted: piiRedacted,
       health_monitor_events_deleted: eventsDeleted,
     },
     "retention-cleanup-done",

--- a/apps/api/src/lib/platform-facts.test.ts
+++ b/apps/api/src/lib/platform-facts.test.ts
@@ -8,7 +8,7 @@ import {
   getActiveVendorNames,
   getStaleVendorNames,
 } from "./platform-facts.js";
-import { TRANSACTION_RETENTION_DAYS } from "./data-retention.js";
+import { TRANSACTION_RETENTION_DAYS, PII_RETENTION_DAYS } from "./data-retention.js";
 
 describe("platform-facts STATIC_FACTS", () => {
   it("retention_days_default mirrors TRANSACTION_RETENTION_DAYS", () => {
@@ -16,6 +16,19 @@ describe("platform-facts STATIC_FACTS", () => {
     // will display a number that doesn't match what the retention sweep
     // actually does. The cert audit found this at exactly 36x off.
     expect(STATIC_FACTS.retention_days_default).toBe(TRANSACTION_RETENTION_DAYS);
+  });
+
+  it("pii_retention_days mirrors PII_RETENTION_DAYS", () => {
+    // Guards the public claim: if the sweep window moves, the number we
+    // publish to data subjects has to move with it.
+    expect(STATIC_FACTS.pii_retention_days).toBe(PII_RETENTION_DAYS);
+  });
+
+  it("PII columns are dropped no later than the compliance skeleton", () => {
+    // A PII window longer than the compliance window would mean the personal
+    // data outlived the record it belongs to — nonsensical, and the sweep
+    // would never reach it.
+    expect(PII_RETENTION_DAYS).toBeLessThanOrEqual(TRANSACTION_RETENTION_DAYS);
   });
 
   it("retention_days_max_configurable is at least retention_days_default", () => {

--- a/apps/api/src/lib/platform-facts.ts
+++ b/apps/api/src/lib/platform-facts.ts
@@ -34,7 +34,7 @@
 
 import { sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
-import { TRANSACTION_RETENTION_DAYS } from "./data-retention.js";
+import { TRANSACTION_RETENTION_DAYS, PII_RETENTION_DAYS } from "./data-retention.js";
 import { getStraleJurisdiction, getProcessingLocation } from "./processing-location.js";
 
 // ─── Static facts (compile-time constants) ──────────────────────────────────
@@ -73,6 +73,21 @@ export const STATIC_FACTS = {
    * data-retention.ts; the platform-facts test asserts they're equal.
    */
   retention_days_default: TRANSACTION_RETENTION_DAYS,
+
+  /**
+   * How long the PERSONAL-DATA columns of a transaction are kept, in days,
+   * for capabilities flagged `processes_personal_data`.
+   *
+   * Published separately because `retention_days_default` alone would
+   * overstate what we hold: the Art. 30 record-of-processing skeleton lives
+   * for the full 1095 days, but input/output/error/audit_trail/provenance are
+   * zeroed at 90. Claiming only the 1095 figure would tell a data subject we
+   * keep their data three times longer than we do.
+   *
+   * Must match `PII_RETENTION_DAYS` in data-retention.ts; the platform-facts
+   * test asserts they're equal.
+   */
+  pii_retention_days: PII_RETENTION_DAYS,
 
   /**
    * Maximum the retention period can be configured to under enterprise


### PR DESCRIPTION
## Summary

Transactions kept `input`, `output`, `error`, `audit_trail`, `provenance` and `idempotency_key` for the full **three-year** compliance window — including for the **107 capabilities** flagged `processes_personal_data`. That is three years of person-level data held on a storage-limitation basis that does not support it.

This adds a second, shorter window for the PII columns only.

## The two windows don't conflict

Because the sweep **redacts rather than deletes**, the Art. 30 record-of-processing skeleton — status, capability slug, jurisdiction, `transparency_marker`, timestamps, price, latency, and the integrity-hash chain — still lives the full 1095 days. Only the personal data goes early.

You keep the proof that processing happened without keeping the data it happened to.

## On the dispute endpoint

After 90 days a dispute via `/v1/transactions/{id}/dispute` can still establish **that** a screening ran, when, and against which capability — but not re-derive its inputs.

That's the correct trade, not a regrettable one. Holding identifiable data for three years *in case* someone might dispute it is precisely the retention Art. 5(1)(e) forbids; the dispute right doesn't create a lawful basis for indefinite storage. 90 days is roughly **3× the one-month response window** Art. 12(3) allows a controller.

## DEC-20260504-B — accumulated-workload audit

Introducing a window is a workload-resumption event, not a routine deploy. Audited against **production** before merge:

```
803,489 transactions total · 1 previously redacted · 0 on legal hold
oldest row 2026-02-25 — the 1095-day sweep has never meaningfully fired
```

| Window | Rows on first run | PII bytes |
|---|---|---|
| 30d | 196,151 | 12.8 MB |
| **90d** | **57,345** | **4.6 MB** ← chosen |
| 180d | 0 | 0 |

**Deploy strategy: SELF-THROTTLE**, not pre-drain. The existing `LIMIT`/`BATCH_SIZE` loop with `BATCH_DELAY_MS` already bounds each pass to 1000 rows, so the 57k backlog drains over ~58 batches rather than one statement — and that bound holds however large a future backlog grows.

Redaction is an in-place `UPDATE`, so there's no volume-reclamation step and nothing resembling the 2026-05-04 crash, which came from bulk `DELETE` on accumulated rows.

## The public claim had to move too

`GET /v1/platform/facts` published only `retention_days_default: 1095`. Left alone, that would tell a data subject we keep their personal data **three times longer than we actually do**.

Now also publishes `pii_retention_days`, with a test asserting it tracks the constant — matching the existing guard on `retention_days_default`.

## Tests (DEC-20260504-A)

11 new tests. The bind-parameter assertion was **verified to discriminate**: a `Date` passed straight into a `sql` template is detected, an ISO string is not. That's the PR-43 failure mode, which shipped in this very file's cert-audit batch and silently 500'd for four days.

Worth flagging: the first version of that test **passed vacuously**. My mock mis-classified Drizzle's chunks — `StringChunk` holds literal SQL while bind params arrive as raw primitives, and I had it backwards, so the loop inspected an empty list. It now asserts a non-empty parameter list so it cannot silently inspect nothing again.

Other tests cover: PII window strictly shorter than the compliance window; `legal_hold` never touched; already-redacted rows skipped (re-run is a true no-op); `LIMIT` present; the two sweeps distinguishable via `deletion_reason`; every PII column zeroed rather than just `input`; and `UPDATE` not `DELETE`, with the hash columns and `created_at` untouched — the CRIT-7 chain-breakage regression.

| Gate | Result |
|---|---|
| `tsc --noEmit` | pass |
| `data-retention.test.ts` | 11/11 (new) |
| `platform-facts.test.ts` | 17/17 |
| `check-no-bare-catch` (F-0-009) | pass |
| `check-platform-facts-drift` | clean, both repos |

## Known gap — documented, not guessed

Solution executions have `capability_id IS NULL` (they carry `solution_slug`), so the join cannot see them. **310 such rows are already older than the window.** A solution composing a PII capability therefore keeps its payload for the full 1095 days.

Closing that needs a solution→capability mapping. Over-matching would redact non-PII solution data early, so it's filed rather than approximated here.

## Test plan

1. Merge and deploy; confirm `GET /v1/platform/facts` reports `pii_retention_days: 90` alongside `retention_days_default: 1095`.
2. After the next weekly sweep, check the `retention-cleanup-done` log line for a non-zero `pii_transactions_redacted` (expect ~57k on the first run, drained in ~58 batches).
3. Verify a redacted PII row keeps its skeleton: `SELECT status, capability_id, integrity_hash, created_at, input, output FROM transactions WHERE deletion_reason = 'pii_retention_purge' LIMIT 1` — hash and timestamps intact, `input = '{}'`, `output` NULL.
4. Confirm `legal_hold = true` rows are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
