### PR TITLE
feat(readiness): P3 — quality floor + transaction-failure taxonomy (autonomy ladder L1+L2)

### DIFF
--- a/apps/api/scripts/lib/internal-accounts.ts
+++ b/apps/api/scripts/lib/internal-accounts.ts
@@ -1,21 +1,6 @@
 /**
- * Canonical internal-account exclusion list for analytics and sweep tooling.
- *
- * Any transaction attributed to these emails is Strale's own traffic (founder,
- * test accounts, system) and must be excluded from real-traffic metrics —
- * completion rates, demand analysis, revenue. The quarantine floor
- * (DEC-20260812-A) reads completion rates, so pollution here directly changes
- * catalog decisions.
- *
- * NOTE: since-last-ext.ts, today-overview.ts and window-*.ts still carry
- * hand-copied versions of this list (pre-dating this module). Migrating them
- * is filed under the P2 right-sizing pass — update THIS file first, and sweep
- * the copies until then.
+ * Re-export shim: the canonical internal-account exclusion list lives in
+ * src/lib/internal-accounts.ts (runtime consumers — quality floor — need it,
+ * and scripts can import src but not vice versa). Update THAT file.
  */
-export const EXCLUDED_EMAILS = [
-  "petter@strale.io",
-  "test@strale.io",
-  "test2@strale.io",
-  "system@strale.internal",
-  "test@example.com",
-];
+export { EXCLUDED_INTERNAL_EMAILS, EXCLUDED_INTERNAL_EMAILS as EXCLUDED_EMAILS } from "../../src/lib/internal-accounts.js";

--- a/apps/api/src/capabilities/lib/web-provider.ts
+++ b/apps/api/src/capabilities/lib/web-provider.ts
@@ -253,11 +253,17 @@ export async function fetchPage(
           }
         }
         // HTTP response received but not usable HTML — fall through to Browserless
-      } else if (plainResp.status >= 400 && plainResp.status < 500) {
-        // 4xx errors (404, 403, etc.) are permanent — don't retry via Browserless.
-        // Prefix with "URL returned HTTP" so the catch block below recognizes it as fatal.
+      } else if ([404, 410, 401, 407].includes(plainResp.status)) {
+        // Genuinely permanent 4xx: missing (404/410) or auth-gated (401/407) —
+        // don't waste a 30s+ Browserless render. Prefix with "URL returned
+        // HTTP" so the catch block below recognizes it as fatal.
         throw new Error(`URL returned HTTP ${plainResp.status}. ${humanizeBrowserlessStatus(plainResp.status, targetUrl)}`);
       }
+      // Other 4xx (400/403/429) are routinely BOT-GATING, not permanent:
+      // EUR-Lex serves HTTP 400 to datacenter IPs and a 202-empty challenge
+      // to residential ones (observed live, Railway US East vs Sweden,
+      // 2026-08-12) — a rendered browser still succeeds. Fall through to
+      // Jina/Browserless like 5xx.
       // 5xx errors: fall through to Browserless (server might render differently)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -134,6 +134,13 @@ async function main() {
   const { startInvariantChecker } = await import("./jobs/invariant-checker.js");
   startInvariantChecker();
 
+  // DEC-20260812-A quality floor (Readiness P3): daily tick quarantining
+  // capabilities below the real-traffic completion floor. Self-throttled to
+  // 3 quarantines/run; deactivation is proposal-only. 15-min startup delay;
+  // advisory lock 20260812 dedups across instances.
+  const { startQualityFloor } = await import("./jobs/quality-floor.js");
+  startQualityFloor();
+
   const { startActivationDrip } = await import("./jobs/activation-drip.js");
   startActivationDrip();
 

--- a/apps/api/src/jobs/quality-floor.ts
+++ b/apps/api/src/jobs/quality-floor.ts
@@ -1,0 +1,167 @@
+/**
+ * Quality-floor job — applies the DEC-20260812-A floor on a daily tick
+ * (Readiness P3). Thin DB glue around the pure core in lib/quality-floor.ts.
+ *
+ * Per tick:
+ *   1. Aggregate 30d external traffic per active capability (internal
+ *      accounts excluded — same canonical list the analytics use).
+ *   2. Classify every failure (lib/transaction-failure-taxonomy.ts); failures the
+ *      caller caused don't count against the capability.
+ *   3. evaluateFloor() → at most maxQuarantinesPerRun quarantines/tick
+ *      (DEC-20260504-B self-throttle).
+ *   4. Apply: visible=false, x402_enabled=false (the danish-company-data
+ *      precedent — explicit-slug /v1/do stays reachable and unbilled on
+ *      failure). Every action and every proposal lands in
+ *      health_monitor_events (event_type 'quality_floor') for the doctor
+ *      report; nothing is silent.
+ *
+ * Deactivation is NEVER applied here — proposals only (escalation contract).
+ * Promotion/recovery is doctor-driven in v1 (see lib/quality-floor.ts header).
+ */
+import postgres from "postgres";
+import { getDb } from "../db/index.js";
+import { capabilities, healthMonitorEvents } from "../db/schema.js";
+import { eq } from "drizzle-orm";
+import { classifyTransactionFailure, CALLER_ATTRIBUTABLE } from "../lib/transaction-failure-taxonomy.js";
+import { evaluateFloor, DEFAULT_FLOOR_CONFIG, type FloorStats } from "../lib/quality-floor.js";
+import { EXCLUDED_INTERNAL_EMAILS } from "../lib/internal-accounts.js";
+import { logError, logWarn } from "../lib/log.js";
+
+const STARTUP_DELAY_MS = 15 * 60 * 1000; // let boot rush + first traffic settle
+const INTERVAL_MS = 24 * 60 * 60 * 1000;
+const ADVISORY_LOCK_ID = 20260812; // cross-instance dedup
+
+export async function runQualityFloorOnce(): Promise<{
+  outcome: string;
+  quarantined?: string[];
+  proposals?: string[];
+}> {
+  const connStr = process.env.DATABASE_URL;
+  if (!connStr) return { outcome: "skipped-no-db" };
+  const sql = postgres(connStr, { max: 1, idle_timeout: 30 });
+
+  try {
+    const [{ acquired }] = await sql<{ acquired: boolean }[]>`
+      SELECT pg_try_advisory_lock(${ADVISORY_LOCK_ID}) AS acquired`;
+    if (!acquired) return { outcome: "skipped-lock-busy" };
+
+    try {
+      // Per-capability 30d external rows. Failures carry their error text so
+      // the classifier can rule caller-attributable ones out of the
+      // denominator in JS (the taxonomy is deliberately not SQL).
+      const rows = await sql<{
+        slug: string;
+        lifecycle_state: string;
+        visible: boolean;
+        x402_enabled: boolean;
+        status: string;
+        error: string | null;
+        price_cents: number;
+        recent: boolean;
+        n: number;
+      }[]>`
+        SELECT c.slug, c.lifecycle_state, c.visible, c.x402_enabled,
+               t.status, t.error, COALESCE(t.price_cents, 0) AS price_cents,
+               (t.created_at > NOW() - INTERVAL '7 days') AS recent,
+               COUNT(*)::int AS n
+        FROM capabilities c
+        JOIN transactions t ON t.capability_id = c.id
+        WHERE c.is_active = true
+          AND t.created_at > NOW() - INTERVAL '30 days'
+          AND t.status IN ('completed', 'failed')
+          AND (t.user_id IS NULL OR t.user_id NOT IN (
+            SELECT id FROM users WHERE email = ANY(${EXCLUDED_INTERNAL_EMAILS})
+          ))
+        GROUP BY c.slug, c.lifecycle_state, c.visible, c.x402_enabled,
+                 t.status, t.error, t.price_cents, recent`;
+
+      const bySlug = new Map<string, FloorStats>();
+      for (const r of rows) {
+        let s = bySlug.get(r.slug);
+        if (!s) {
+          s = {
+            slug: r.slug,
+            lifecycleState: r.lifecycle_state,
+            visible: r.visible,
+            x402Enabled: r.x402_enabled,
+            eligibleCalls: 0,
+            completedCalls: 0,
+            revenueCents: 0,
+            recentEligibleCalls: 0,
+            recentCompletedCalls: 0,
+          };
+          bySlug.set(r.slug, s);
+        }
+        if (r.status === "completed") {
+          s.eligibleCalls += r.n;
+          s.completedCalls += r.n;
+          s.revenueCents += r.price_cents * r.n;
+          if (r.recent) {
+            s.recentEligibleCalls += r.n;
+            s.recentCompletedCalls += r.n;
+          }
+        } else if (!CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(r.error))) {
+          s.eligibleCalls += r.n;
+          if (r.recent) s.recentEligibleCalls += r.n;
+        }
+      }
+
+      const decisions = evaluateFloor([...bySlug.values()], DEFAULT_FLOOR_CONFIG);
+      const quarantined: string[] = [];
+      const proposals: string[] = [];
+      const db = getDb();
+
+      for (const d of decisions) {
+        if (d.action === "quarantine") {
+          await db
+            .update(capabilities)
+            .set({ visible: false, x402Enabled: false })
+            .where(eq(capabilities.slug, d.slug));
+          quarantined.push(d.slug);
+        }
+        if (d.deactivateProposal) proposals.push(d.slug);
+        await db.insert(healthMonitorEvents).values({
+          eventType: "quality_floor",
+          capabilitySlug: d.slug,
+          tier: 1,
+          actionTaken: d.action === "quarantine" ? "quarantined" : "flagged_only",
+          details: {
+            completion: Number(d.completion.toFixed(4)),
+            eligible_calls_30d: d.eligibleCalls,
+            deactivate_proposal: d.deactivateProposal,
+            requires_human: d.requiresHuman,
+            reason: d.reason,
+            dec: "DEC-20260812-A",
+          },
+        });
+      }
+
+      logWarn("quality-floor-tick", "floor evaluation complete", {
+        evaluated: bySlug.size,
+        decisions: decisions.length,
+        quarantined,
+        proposals,
+      });
+      return { outcome: "ok", quarantined, proposals };
+    } finally {
+      await sql`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`.catch((err) => logError("quality-floor-unlock-failed", err));
+    }
+  } catch (err) {
+    logError("quality-floor-failed", err);
+    return { outcome: "error" };
+  } finally {
+    await sql.end({ timeout: 5 }).catch((err) => logError("quality-floor-sql-end-failed", err));
+  }
+}
+
+export function startQualityFloor(): void {
+  setTimeout(() => {
+    void runQualityFloorOnce();
+    setInterval(() => void runQualityFloorOnce(), INTERVAL_MS);
+  }, STARTUP_DELAY_MS);
+  logWarn("quality-floor-scheduled", "daily quality-floor tick scheduled", {
+    startup_delay_ms: STARTUP_DELAY_MS,
+    interval_ms: INTERVAL_MS,
+    config: DEFAULT_FLOOR_CONFIG,
+  });
+}

--- a/apps/api/src/jobs/quality-floor.ts
+++ b/apps/api/src/jobs/quality-floor.ts
@@ -2,21 +2,34 @@
  * Quality-floor job — applies the DEC-20260812-A floor on a daily tick
  * (Readiness P3). Thin DB glue around the pure core in lib/quality-floor.ts.
  *
+ * ENFORCEMENT GATE (review H-4): dry-run by default. Until the env var
+ * QUALITY_FLOOR_ENFORCE=true is set (a human decision, made after reviewing
+ * dry-run events), NO catalog flags are written — every would-be action is
+ * recorded to health_monitor_events as 'dry_run_would_quarantine'. This is
+ * the kill switch and the brake: an autonomous, non-self-reversing,
+ * public-surface write path does not get to start enforcing on its first
+ * boot.
+ *
  * Per tick:
- *   1. Aggregate 30d external traffic per active capability (internal
- *      accounts excluded — same canonical list the analytics use).
- *   2. Classify every failure (lib/transaction-failure-taxonomy.ts); failures the
- *      caller caused don't count against the capability.
- *   3. evaluateFloor() → at most maxQuarantinesPerRun quarantines/tick
- *      (DEC-20260504-B self-throttle).
- *   4. Apply: visible=false, x402_enabled=false (the danish-company-data
- *      precedent — explicit-slug /v1/do stays reachable and unbilled on
- *      failure). Every action and every proposal lands in
- *      health_monitor_events (event_type 'quality_floor') for the doctor
- *      report; nothing is silent.
+ *   1. Aggregate 30d external PAID traffic per active/degraded capability
+ *      (internal accounts excluded by the canonical suffix rule; free-tier
+ *      rows excluded — anonymous €0 traffic is the cheapest failure-
+ *      fabrication vector, review H-1; soft-deleted rows excluded, M-8).
+ *   2. Classify failures (lib/transaction-failure-taxonomy.ts); caller-
+ *      attributable ones don't count. Distinct failure days feed the pure
+ *      core's burst guard.
+ *   3. evaluateFloor() → at most maxQuarantinesPerRun quarantines/tick.
+ *   4. Apply (enforce mode only): visible=false + x402_enabled=false inside
+ *      a transaction WITH its audit event (M-2) — a delisting without its
+ *      evidence must be impossible. updated_at bumped.
+ *   5. Always: per-decision events + a tick_complete heartbeat event, so
+ *      "SELECT max(created_at) FROM health_monitor_events WHERE
+ *      event_type='quality_floor'" is a real DEC-20260504-C proof query
+ *      even on a zero-decision tick (M-3).
  *
  * Deactivation is NEVER applied here — proposals only (escalation contract).
- * Promotion/recovery is doctor-driven in v1 (see lib/quality-floor.ts header).
+ * Promotion/recovery is doctor-driven in v1. Solution-step traffic is out of
+ * scope (M-6; see lib/quality-floor.ts header).
  */
 import postgres from "postgres";
 import { getDb } from "../db/index.js";
@@ -24,44 +37,99 @@ import { capabilities, healthMonitorEvents } from "../db/schema.js";
 import { eq } from "drizzle-orm";
 import { classifyTransactionFailure, CALLER_ATTRIBUTABLE } from "../lib/transaction-failure-taxonomy.js";
 import { evaluateFloor, DEFAULT_FLOOR_CONFIG, type FloorStats } from "../lib/quality-floor.js";
-import { EXCLUDED_INTERNAL_EMAILS } from "../lib/internal-accounts.js";
+import { INTERNAL_EMAIL_LIKE_PATTERNS, EXTRA_EXCLUDED_EMAILS } from "../lib/internal-accounts.js";
 import { logError, logWarn } from "../lib/log.js";
 
 const STARTUP_DELAY_MS = 15 * 60 * 1000; // let boot rush + first traffic settle
 const INTERVAL_MS = 24 * 60 * 60 * 1000;
 const ADVISORY_LOCK_ID = 20260812; // cross-instance dedup
 
+export interface FloorTrafficRow {
+  slug: string;
+  lifecycle_state: string;
+  visible: boolean;
+  x402_enabled: boolean;
+  status: string;
+  error: string | null;
+  price_cents: number;
+  day: string;
+  recent: boolean;
+  n: number;
+}
+
+/**
+ * Pure fold: SQL rows → per-capability FloorStats. Exported for unit tests —
+ * this is where eligibility, caller-attribution and the burst-guard inputs
+ * are actually computed (review test-gap #1).
+ */
+export function foldTrafficRows(rows: FloorTrafficRow[]): FloorStats[] {
+  const bySlug = new Map<string, FloorStats & { failureDays: Set<string> }>();
+  for (const r of rows) {
+    let s = bySlug.get(r.slug);
+    if (!s) {
+      s = {
+        slug: r.slug,
+        lifecycleState: r.lifecycle_state,
+        visible: r.visible,
+        x402Enabled: r.x402_enabled,
+        eligibleCalls: 0,
+        completedCalls: 0,
+        revenueCents: 0,
+        distinctFailureDays: 0,
+        recentEligibleCalls: 0,
+        recentCompletedCalls: 0,
+        failureDays: new Set<string>(),
+      };
+      bySlug.set(r.slug, s);
+    }
+    if (r.status === "completed") {
+      s.eligibleCalls += r.n;
+      s.completedCalls += r.n;
+      s.revenueCents += r.price_cents * r.n;
+      if (r.recent) {
+        s.recentEligibleCalls += r.n;
+        s.recentCompletedCalls += r.n;
+      }
+    } else if (!CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(r.error))) {
+      s.eligibleCalls += r.n;
+      s.failureDays.add(r.day);
+      if (r.recent) s.recentEligibleCalls += r.n;
+    }
+  }
+  return [...bySlug.values()].map((s) => {
+    const { failureDays, ...stats } = s;
+    return { ...stats, distinctFailureDays: failureDays.size };
+  });
+}
+
+export function isEnforceMode(): boolean {
+  return process.env.QUALITY_FLOOR_ENFORCE === "true";
+}
+
 export async function runQualityFloorOnce(): Promise<{
   outcome: string;
+  mode?: "enforce" | "dry_run";
   quarantined?: string[];
   proposals?: string[];
 }> {
   const connStr = process.env.DATABASE_URL;
   if (!connStr) return { outcome: "skipped-no-db" };
-  const sql = postgres(connStr, { max: 1, idle_timeout: 30 });
+  // No idle_timeout: the advisory lock lives on this session, and the apply
+  // loop runs elsewhere — an idle-closed connection would drop the lock
+  // mid-run (review M-1; matches test-scheduler / reindex-transactions).
+  const sql = postgres(connStr, { max: 1 });
 
   try {
     const [{ acquired }] = await sql<{ acquired: boolean }[]>`
       SELECT pg_try_advisory_lock(${ADVISORY_LOCK_ID}) AS acquired`;
     if (!acquired) return { outcome: "skipped-lock-busy" };
 
+    const mode = isEnforceMode() ? "enforce" : "dry_run";
     try {
-      // Per-capability 30d external rows. Failures carry their error text so
-      // the classifier can rule caller-attributable ones out of the
-      // denominator in JS (the taxonomy is deliberately not SQL).
-      const rows = await sql<{
-        slug: string;
-        lifecycle_state: string;
-        visible: boolean;
-        x402_enabled: boolean;
-        status: string;
-        error: string | null;
-        price_cents: number;
-        recent: boolean;
-        n: number;
-      }[]>`
+      const rows = await sql<FloorTrafficRow[]>`
         SELECT c.slug, c.lifecycle_state, c.visible, c.x402_enabled,
-               t.status, t.error, COALESCE(t.price_cents, 0) AS price_cents,
+               t.status, t.error, t.price_cents,
+               date_trunc('day', t.created_at)::date::text AS day,
                (t.created_at > NOW() - INTERVAL '7 days') AS recent,
                COUNT(*)::int AS n
         FROM capabilities c
@@ -69,80 +137,80 @@ export async function runQualityFloorOnce(): Promise<{
         WHERE c.is_active = true
           AND t.created_at > NOW() - INTERVAL '30 days'
           AND t.status IN ('completed', 'failed')
+          AND t.deleted_at IS NULL
+          AND COALESCE(t.is_free_tier, false) = false
           AND (t.user_id IS NULL OR t.user_id NOT IN (
-            SELECT id FROM users WHERE email = ANY(${EXCLUDED_INTERNAL_EMAILS})
+            SELECT id FROM users
+            WHERE email LIKE ANY(${INTERNAL_EMAIL_LIKE_PATTERNS})
+               OR email = ANY(${EXTRA_EXCLUDED_EMAILS})
           ))
         GROUP BY c.slug, c.lifecycle_state, c.visible, c.x402_enabled,
-                 t.status, t.error, t.price_cents, recent`;
+                 t.status, t.error, t.price_cents, day, recent`;
 
-      const bySlug = new Map<string, FloorStats>();
-      for (const r of rows) {
-        let s = bySlug.get(r.slug);
-        if (!s) {
-          s = {
-            slug: r.slug,
-            lifecycleState: r.lifecycle_state,
-            visible: r.visible,
-            x402Enabled: r.x402_enabled,
-            eligibleCalls: 0,
-            completedCalls: 0,
-            revenueCents: 0,
-            recentEligibleCalls: 0,
-            recentCompletedCalls: 0,
-          };
-          bySlug.set(r.slug, s);
-        }
-        if (r.status === "completed") {
-          s.eligibleCalls += r.n;
-          s.completedCalls += r.n;
-          s.revenueCents += r.price_cents * r.n;
-          if (r.recent) {
-            s.recentEligibleCalls += r.n;
-            s.recentCompletedCalls += r.n;
-          }
-        } else if (!CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(r.error))) {
-          s.eligibleCalls += r.n;
-          if (r.recent) s.recentEligibleCalls += r.n;
-        }
-      }
-
-      const decisions = evaluateFloor([...bySlug.values()], DEFAULT_FLOOR_CONFIG);
+      const stats = foldTrafficRows(rows);
+      const decisions = evaluateFloor(stats, DEFAULT_FLOOR_CONFIG);
       const quarantined: string[] = [];
       const proposals: string[] = [];
       const db = getDb();
 
       for (const d of decisions) {
-        if (d.action === "quarantine") {
-          await db
-            .update(capabilities)
-            .set({ visible: false, x402Enabled: false })
-            .where(eq(capabilities.slug, d.slug));
+        const willQuarantine = d.action === "quarantine" && mode === "enforce";
+        const details = {
+          mode,
+          completion: Number(d.completion.toFixed(4)),
+          eligible_calls_30d: d.eligibleCalls,
+          deactivate_proposal: d.deactivateProposal,
+          requires_human: d.requiresHuman,
+          reason: d.reason,
+          dec: "DEC-20260812-A",
+        };
+        if (willQuarantine) {
+          // Event and flag flip commit together (M-2): a delisting without
+          // its evidence must be impossible.
+          await db.transaction(async (tx) => {
+            await tx.insert(healthMonitorEvents).values({
+              eventType: "quality_floor",
+              capabilitySlug: d.slug,
+              tier: 2,
+              actionTaken: "quarantined",
+              details,
+            });
+            await tx
+              .update(capabilities)
+              .set({ visible: false, x402Enabled: false, updatedAt: new Date() })
+              .where(eq(capabilities.slug, d.slug));
+          });
           quarantined.push(d.slug);
+        } else {
+          await db.insert(healthMonitorEvents).values({
+            eventType: "quality_floor",
+            capabilitySlug: d.slug,
+            tier: d.action === "quarantine" ? 2 : 1,
+            actionTaken: d.action === "quarantine" ? "dry_run_would_quarantine" : "flagged_only",
+            details,
+          });
         }
         if (d.deactivateProposal) proposals.push(d.slug);
-        await db.insert(healthMonitorEvents).values({
-          eventType: "quality_floor",
-          capabilitySlug: d.slug,
-          tier: 1,
-          actionTaken: d.action === "quarantine" ? "quarantined" : "flagged_only",
-          details: {
-            completion: Number(d.completion.toFixed(4)),
-            eligible_calls_30d: d.eligibleCalls,
-            deactivate_proposal: d.deactivateProposal,
-            requires_human: d.requiresHuman,
-            reason: d.reason,
-            dec: "DEC-20260812-A",
-          },
-        });
       }
 
+      // Heartbeat: proves the tick ran even with zero decisions (M-3 /
+      // DEC-20260504-C — a log line is not verification).
+      await db.insert(healthMonitorEvents).values({
+        eventType: "quality_floor",
+        capabilitySlug: null,
+        tier: 1,
+        actionTaken: "tick_complete",
+        details: { mode, evaluated: stats.length, decisions: decisions.length, quarantined, proposals },
+      });
+
       logWarn("quality-floor-tick", "floor evaluation complete", {
-        evaluated: bySlug.size,
+        mode,
+        evaluated: stats.length,
         decisions: decisions.length,
         quarantined,
         proposals,
       });
-      return { outcome: "ok", quarantined, proposals };
+      return { outcome: "ok", mode, quarantined, proposals };
     } finally {
       await sql`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`.catch((err) => logError("quality-floor-unlock-failed", err));
     }
@@ -160,6 +228,7 @@ export function startQualityFloor(): void {
     setInterval(() => void runQualityFloorOnce(), INTERVAL_MS);
   }, STARTUP_DELAY_MS);
   logWarn("quality-floor-scheduled", "daily quality-floor tick scheduled", {
+    mode: isEnforceMode() ? "enforce" : "dry_run",
     startup_delay_ms: STARTUP_DELAY_MS,
     interval_ms: INTERVAL_MS,
     config: DEFAULT_FLOOR_CONFIG,

--- a/apps/api/src/lib/internal-accounts.ts
+++ b/apps/api/src/lib/internal-accounts.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonical internal-account exclusion list.
+ *
+ * Any transaction attributed to these emails is Strale's own traffic
+ * (founder, test accounts, system) and must be excluded from real-traffic
+ * metrics — completion rates, demand analysis, revenue. The quality floor
+ * (DEC-20260812-A) reads completion rates, so pollution here directly
+ * changes catalog decisions.
+ *
+ * Runtime consumers import from here; scripts/lib/internal-accounts.ts
+ * re-exports for operator tooling. The hand-copied lists still in
+ * since-last-ext.ts / today-overview.ts / window-*.ts are a P2 cleanup item.
+ */
+export const EXCLUDED_INTERNAL_EMAILS = [
+  "petter@strale.io",
+  "test@strale.io",
+  "test2@strale.io",
+  "system@strale.internal",
+  "test@example.com",
+];

--- a/apps/api/src/lib/internal-accounts.ts
+++ b/apps/api/src/lib/internal-accounts.ts
@@ -1,15 +1,51 @@
 /**
- * Canonical internal-account exclusion list.
+ * Canonical internal-account rule.
  *
- * Any transaction attributed to these emails is Strale's own traffic
- * (founder, test accounts, system) and must be excluded from real-traffic
- * metrics — completion rates, demand analysis, revenue. The quality floor
+ * Any traffic attributable to these accounts is Strale's own (founder, test
+ * accounts, system) and must be excluded from real-traffic metrics —
+ * completion rates, demand analysis, revenue. The quality floor
  * (DEC-20260812-A) reads completion rates, so pollution here directly
  * changes catalog decisions.
  *
+ * Review H-3 (2026-08-12): this is a SUFFIX rule plus extras — matching
+ * lib/daily-digest/fetch-platform.ts, which had the platform's real rule all
+ * along — not a literal address list. A literal list silently counted
+ * founder debugging accounts (which concentrate on broken capabilities) as
+ * customers.
+ *
  * Runtime consumers import from here; scripts/lib/internal-accounts.ts
- * re-exports for operator tooling. The hand-copied lists still in
- * since-last-ext.ts / today-overview.ts / window-*.ts are a P2 cleanup item.
+ * re-exports for operator tooling. fetch-platform.ts's local copy is a P2
+ * dedup item.
+ */
+
+export const INTERNAL_EMAIL_SUFFIXES = [
+  "@strale.io",
+  "@strale.dev",
+  "@strale.internal",
+  "@example.com",
+];
+
+export const EXTRA_EXCLUDED_EMAILS = [
+  // Founder personal account (Railway CLI, ad-hoc testing).
+  "petterlindstrom@hotmail.com",
+];
+
+/** SQL LIKE patterns for the suffix rule (postgres `LIKE ANY(...)`). */
+export const INTERNAL_EMAIL_LIKE_PATTERNS = INTERNAL_EMAIL_SUFFIXES.map((s) => `%${s}`);
+
+export function isInternalAccountEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  const e = email.toLowerCase();
+  return (
+    INTERNAL_EMAIL_SUFFIXES.some((s) => e.endsWith(s)) ||
+    EXTRA_EXCLUDED_EMAILS.includes(e)
+  );
+}
+
+/**
+ * Back-compat literal list for tools that filter by exact address. Prefer
+ * isInternalAccountEmail / the SQL patterns — this cannot express the suffix
+ * rule and exists only for the operator scripts' equality filters.
  */
 export const EXCLUDED_INTERNAL_EMAILS = [
   "petter@strale.io",
@@ -17,8 +53,5 @@ export const EXCLUDED_INTERNAL_EMAILS = [
   "test2@strale.io",
   "system@strale.internal",
   "test@example.com",
-  // Petter's personal account — was excluded only by the daily digest's
-  // separate EXTRA_EXCLUDED_EMAILS list (scripts survey found the divergence,
-  // 2026-08-12); the floor must not count founder test calls as customers.
-  "petterlindstrom@hotmail.com",
+  ...EXTRA_EXCLUDED_EMAILS,
 ];

--- a/apps/api/src/lib/internal-accounts.ts
+++ b/apps/api/src/lib/internal-accounts.ts
@@ -17,4 +17,8 @@ export const EXCLUDED_INTERNAL_EMAILS = [
   "test2@strale.io",
   "system@strale.internal",
   "test@example.com",
+  // Petter's personal account — was excluded only by the daily digest's
+  // separate EXTRA_EXCLUDED_EMAILS list (scripts survey found the divergence,
+  // 2026-08-12); the floor must not count founder test calls as customers.
+  "petterlindstrom@hotmail.com",
 ];

--- a/apps/api/src/lib/quality-floor.test.ts
+++ b/apps/api/src/lib/quality-floor.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import { evaluateFloor, DEFAULT_FLOOR_CONFIG, type FloorStats } from "./quality-floor.js";
 import { classifyTransactionFailure, CALLER_ATTRIBUTABLE } from "./transaction-failure-taxonomy.js";
 import { TOS_REFUSAL_MARKER } from "./tos-blocklist.js";
+import { foldTrafficRows, type FloorTrafficRow } from "../jobs/quality-floor.js";
+import { isInternalAccountEmail } from "./internal-accounts.js";
 
 // DEC-20260812-A floor semantics pinned both directions (DEC-20260504-A):
-// these encode the confirmed defaults — quarantine <70%, deactivate-proposal
-// <30%, ≥10 eligible calls/30d, max 3 quarantines/run, deactivation never
-// automatic, revenue earners' deactivation Petter-only.
+// quarantine <70%, deactivate-proposal <30%, ≥10 eligible calls/30d, max 3
+// quarantines/run, burst guard (≥2 distinct failure days), deactivation
+// never automatic, revenue-earner deactivation Petter-only.
 
 function cap(partial: Partial<FloorStats>): FloorStats {
   return {
@@ -17,6 +19,7 @@ function cap(partial: Partial<FloorStats>): FloorStats {
     eligibleCalls: 100,
     completedCalls: 100,
     revenueCents: 0,
+    distinctFailureDays: 5,
     recentEligibleCalls: 0,
     recentCompletedCalls: 0,
     ...partial,
@@ -32,22 +35,26 @@ describe("evaluateFloor", () => {
     const [d] = evaluateFloor([cap({ slug: "bad", completedCalls: 12 })]);
     expect(d.action).toBe("quarantine");
     expect(d.deactivateProposal).toBe(true);
-    // There is deliberately NO "deactivate" action in the type — the
-    // strongest automatic action is quarantine.
+    // There is deliberately NO "deactivate" action in the type.
   });
 
-  it("65% is quarantined without a deactivation proposal", () => {
+  it("65% is quarantined without a deactivation proposal; 70% exactly is not below floor", () => {
     const [d] = evaluateFloor([cap({ slug: "meh", completedCalls: 65 })]);
     expect(d.action).toBe("quarantine");
     expect(d.deactivateProposal).toBe(false);
-  });
-
-  it("70% exactly is NOT below the floor", () => {
     expect(evaluateFloor([cap({ completedCalls: 70 })])).toEqual([]);
   });
 
   it("under 10 eligible calls produces no verdict — noise, not signal", () => {
     expect(evaluateFloor([cap({ eligibleCalls: 9, completedCalls: 0 })])).toEqual([]);
+  });
+
+  it("single-day failure bursts NEVER quarantine on their own (H-1 burst guard)", () => {
+    const [d] = evaluateFloor([cap({ slug: "burst", completedCalls: 5, distinctFailureDays: 1 })]);
+    expect(d.action).toBe("none");
+    expect(d.reason).toMatch(/burst, not a trend/);
+    // The deactivation proposal still surfaces from the 30d figure.
+    expect(d.deactivateProposal).toBe(true);
   });
 
   it("revenue-earning deactivation candidates are marked Petter-only", () => {
@@ -57,39 +64,40 @@ describe("evaluateFloor", () => {
     expect(d2.requiresHuman).toBe(false);
   });
 
-  it("self-throttles: max 3 quarantines per run, worst-first, rest deferred loudly", () => {
+  it("self-throttles: max quarantines per run, worst-first, rest deferred loudly", () => {
     const rows = [10, 20, 30, 40, 50].map((pct, i) =>
       cap({ slug: `c${i}`, completedCalls: pct }),
     );
-    const decisions = evaluateFloor(rows);
+    // Explicit config so the parameter is exercised, not defaulted (review gap #3).
+    const decisions = evaluateFloor(rows, { ...DEFAULT_FLOOR_CONFIG, maxQuarantinesPerRun: 2 });
     const quarantined = decisions.filter((d) => d.action === "quarantine");
     const deferred = decisions.filter((d) => d.action === "none");
-    expect(quarantined.map((d) => d.slug)).toEqual(["c0", "c1", "c2"]);
-    expect(deferred).toHaveLength(2);
+    expect(quarantined.map((d) => d.slug)).toEqual(["c0", "c1"]);
+    expect(deferred).toHaveLength(3);
     expect(deferred[0].reason).toMatch(/budget exhausted/);
   });
 
-  it("defers when the trailing 7 days show recovery (the just-fixed-capability case)", () => {
-    // us-company-data on the day this shipped: 50%/30d dragging pre-fix
-    // failures, but healthy after the same-day PR #171 fix.
-    const [d] = evaluateFloor([
-      cap({ slug: "fixed", completedCalls: 50, recentEligibleCalls: 6, recentCompletedCalls: 6 }),
-    ]);
+  it("recovery override defers with proportional recent volume and STILL emits the proposal (M-5)", () => {
+    // 100 eligible calls → required recent ≥ max(3, ceil(0.25×100×7/30)) = 6.
+    const recovered = cap({ slug: "fixed", completedCalls: 25, recentEligibleCalls: 6, recentCompletedCalls: 6 });
+    const [d] = evaluateFloor([recovered]);
     expect(d.action).toBe("none");
     expect(d.reason).toMatch(/shows recovery/);
-    // Two healthy recent calls are NOT enough evidence to defer.
-    const [d2] = evaluateFloor([
-      cap({ slug: "thin", completedCalls: 50, recentEligibleCalls: 2, recentCompletedCalls: 2 }),
-    ]);
-    expect(d2.action).toBe("quarantine");
+    expect(d.deactivateProposal).toBe(true); // 25% < 30% — proposal survives deferral
+    // Three lucky calls on a high-volume disaster do NOT defer.
+    const lucky = cap({ slug: "lucky", completedCalls: 25, recentEligibleCalls: 3, recentCompletedCalls: 3 });
+    expect(evaluateFloor([lucky])[0].action).toBe("quarantine");
   });
 
-  it("non-active lifecycle and already-delisted capabilities are out of scope", () => {
+  it("degraded lifecycle is in scope (publicly listed → floor-eligible, M-7); probation is not", () => {
+    const [d] = evaluateFloor([cap({ slug: "deg", lifecycleState: "degraded", completedCalls: 10 })]);
+    expect(d.action).toBe("quarantine");
+    expect(evaluateFloor([cap({ lifecycleState: "probation", completedCalls: 0 })])).toEqual([]);
+  });
+
+  it("already-delisted capabilities are out of scope", () => {
     expect(
-      evaluateFloor([
-        cap({ lifecycleState: "probation", completedCalls: 0 }),
-        cap({ slug: "gone", visible: false, x402Enabled: false, completedCalls: 0 }),
-      ]),
+      evaluateFloor([cap({ slug: "gone", visible: false, x402Enabled: false, completedCalls: 0 })]),
     ).toEqual([]);
   });
 });
@@ -98,25 +106,78 @@ describe("classifyTransactionFailure", () => {
   it("caller-attributable classes never count against completion", () => {
     expect(CALLER_ATTRIBUTABLE.has(classifyTransactionFailure("Missing required input fields: url"))).toBe(true);
     expect(CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(`Trustpilot is not a supported source: its ${TOS_REFUSAL_MARKER}.`))).toBe(true);
+    expect(CALLER_ATTRIBUTABLE.has(classifyTransactionFailure("URL returned HTTP 404. This page does not exist."))).toBe(true);
   });
 
-  it("platform-side failures DO count", () => {
+  it("target-site and upstream 5xx COUNT against the capability (review H-2 — the outage-blindness class)", () => {
     for (const msg of [
-      "OPENREGISTER_API_KEY is required. Register at https://openregister.de/keys",
-      "The operation was aborted due to timeout",
-      "OpenRegister upstream error (HTTP 503). Retry advised.",
-      "TypeError: Cannot read properties of undefined",
+      "The Danish business registry (cvrapi.dk) returned a server error (HTTP 503). This is usually transient.",
+      "Companies House API returned a server error (HTTP 503)",
+      "The web page could not be loaded (HTTP 502).",
+      "URL returned HTTP 503. The target site returned a server error.",
+      "Zefix API error: HTTP 503",
     ]) {
-      expect(CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(msg)), msg).toBe(false);
+      const cls = classifyTransactionFailure(msg);
+      expect(cls, msg).toBe("upstream");
+      expect(CALLER_ATTRIBUTABLE.has(cls), msg).toBe(false);
     }
   });
 
-  it("classifies the taxonomy dimensions distinctly", () => {
-    expect(classifyTransactionFailure("COURTLISTENER rejected the token (HTTP 403). Verify COURTLISTENER_API_TOKEN.")).toBe("config");
+  it("platform config failures count and classify as config", () => {
+    expect(classifyTransactionFailure("OPENREGISTER_API_KEY is required. Register at https://openregister.de/keys")).toBe("config");
+    expect(classifyTransactionFailure("CourtListener rejected the token (HTTP 403). Verify COURTLISTENER_API_TOKEN.")).toBe("config");
+  });
+
+  it("classifies the remaining dimensions distinctly", () => {
     expect(classifyTransactionFailure("Request timed out after 35000ms")).toBe("timeout");
-    expect(classifyTransactionFailure("Zefix API error: HTTP 503")).toBe("upstream");
     expect(classifyTransactionFailure("eur-lex.europa.eu served an anti-bot challenge to the rendered browser as well.")).toBe("upstream");
+    expect(classifyTransactionFailure("TypeError: Cannot read properties of undefined")).toBe("internal");
     expect(classifyTransactionFailure("")).toBe("internal");
     expect(classifyTransactionFailure(null)).toBe("internal");
+  });
+});
+
+describe("foldTrafficRows (the SQL→stats fold — review test-gap #1)", () => {
+  function row(partial: Partial<FloorTrafficRow>): FloorTrafficRow {
+    return {
+      slug: "s",
+      lifecycle_state: "active",
+      visible: true,
+      x402_enabled: true,
+      status: "completed",
+      error: null,
+      price_cents: 5,
+      day: "2026-08-01",
+      recent: false,
+      n: 1,
+      ...partial,
+    };
+  }
+
+  it("excludes caller-attributable failures from the denominator, counts the rest, tracks failure days", () => {
+    const stats = foldTrafficRows([
+      row({ status: "completed", n: 4, recent: true }),
+      row({ status: "failed", error: "Missing required input fields: iban", n: 10, day: "2026-08-02" }),
+      row({ status: "failed", error: "Zefix API error: HTTP 503", n: 2, day: "2026-08-02" }),
+      row({ status: "failed", error: "upstream unavailable", n: 1, day: "2026-08-03", recent: true }),
+    ]);
+    expect(stats).toHaveLength(1);
+    const s = stats[0];
+    expect(s.eligibleCalls).toBe(7);        // 4 completed + 3 counted failures (10 caller-input excluded)
+    expect(s.completedCalls).toBe(4);
+    expect(s.distinctFailureDays).toBe(2);  // 08-02 and 08-03
+    expect(s.recentEligibleCalls).toBe(5);  // 4 completed + 1 counted failure
+    expect(s.recentCompletedCalls).toBe(4);
+    expect(s.revenueCents).toBe(20);
+  });
+});
+
+describe("isInternalAccountEmail (H-3 suffix rule)", () => {
+  it("matches by suffix and extras, not just literals", () => {
+    for (const e of ["anything@strale.io", "new-test@strale.dev", "x@example.com", "petterlindstrom@hotmail.com"]) {
+      expect(isInternalAccountEmail(e), e).toBe(true);
+    }
+    expect(isInternalAccountEmail("customer@gmail.com")).toBe(false);
+    expect(isInternalAccountEmail(null)).toBe(false);
   });
 });

--- a/apps/api/src/lib/quality-floor.test.ts
+++ b/apps/api/src/lib/quality-floor.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { evaluateFloor, DEFAULT_FLOOR_CONFIG, type FloorStats } from "./quality-floor.js";
+import { classifyTransactionFailure, CALLER_ATTRIBUTABLE } from "./transaction-failure-taxonomy.js";
+import { TOS_REFUSAL_MARKER } from "./tos-blocklist.js";
+
+// DEC-20260812-A floor semantics pinned both directions (DEC-20260504-A):
+// these encode the confirmed defaults — quarantine <70%, deactivate-proposal
+// <30%, ≥10 eligible calls/30d, max 3 quarantines/run, deactivation never
+// automatic, revenue earners' deactivation Petter-only.
+
+function cap(partial: Partial<FloorStats>): FloorStats {
+  return {
+    slug: "x",
+    lifecycleState: "active",
+    visible: true,
+    x402Enabled: true,
+    eligibleCalls: 100,
+    completedCalls: 100,
+    revenueCents: 0,
+    recentEligibleCalls: 0,
+    recentCompletedCalls: 0,
+    ...partial,
+  };
+}
+
+describe("evaluateFloor", () => {
+  it("healthy capabilities produce no decisions", () => {
+    expect(evaluateFloor([cap({ completedCalls: 95 })])).toEqual([]);
+  });
+
+  it("quarantines below 70% and proposes (never applies) deactivation below 30%", () => {
+    const [d] = evaluateFloor([cap({ slug: "bad", completedCalls: 12 })]);
+    expect(d.action).toBe("quarantine");
+    expect(d.deactivateProposal).toBe(true);
+    // There is deliberately NO "deactivate" action in the type — the
+    // strongest automatic action is quarantine.
+  });
+
+  it("65% is quarantined without a deactivation proposal", () => {
+    const [d] = evaluateFloor([cap({ slug: "meh", completedCalls: 65 })]);
+    expect(d.action).toBe("quarantine");
+    expect(d.deactivateProposal).toBe(false);
+  });
+
+  it("70% exactly is NOT below the floor", () => {
+    expect(evaluateFloor([cap({ completedCalls: 70 })])).toEqual([]);
+  });
+
+  it("under 10 eligible calls produces no verdict — noise, not signal", () => {
+    expect(evaluateFloor([cap({ eligibleCalls: 9, completedCalls: 0 })])).toEqual([]);
+  });
+
+  it("revenue-earning deactivation candidates are marked Petter-only", () => {
+    const [d] = evaluateFloor([cap({ completedCalls: 10, revenueCents: 225 })]);
+    expect(d.requiresHuman).toBe(true);
+    const [d2] = evaluateFloor([cap({ completedCalls: 10, revenueCents: 0 })]);
+    expect(d2.requiresHuman).toBe(false);
+  });
+
+  it("self-throttles: max 3 quarantines per run, worst-first, rest deferred loudly", () => {
+    const rows = [10, 20, 30, 40, 50].map((pct, i) =>
+      cap({ slug: `c${i}`, completedCalls: pct }),
+    );
+    const decisions = evaluateFloor(rows);
+    const quarantined = decisions.filter((d) => d.action === "quarantine");
+    const deferred = decisions.filter((d) => d.action === "none");
+    expect(quarantined.map((d) => d.slug)).toEqual(["c0", "c1", "c2"]);
+    expect(deferred).toHaveLength(2);
+    expect(deferred[0].reason).toMatch(/budget exhausted/);
+  });
+
+  it("defers when the trailing 7 days show recovery (the just-fixed-capability case)", () => {
+    // us-company-data on the day this shipped: 50%/30d dragging pre-fix
+    // failures, but healthy after the same-day PR #171 fix.
+    const [d] = evaluateFloor([
+      cap({ slug: "fixed", completedCalls: 50, recentEligibleCalls: 6, recentCompletedCalls: 6 }),
+    ]);
+    expect(d.action).toBe("none");
+    expect(d.reason).toMatch(/shows recovery/);
+    // Two healthy recent calls are NOT enough evidence to defer.
+    const [d2] = evaluateFloor([
+      cap({ slug: "thin", completedCalls: 50, recentEligibleCalls: 2, recentCompletedCalls: 2 }),
+    ]);
+    expect(d2.action).toBe("quarantine");
+  });
+
+  it("non-active lifecycle and already-delisted capabilities are out of scope", () => {
+    expect(
+      evaluateFloor([
+        cap({ lifecycleState: "probation", completedCalls: 0 }),
+        cap({ slug: "gone", visible: false, x402Enabled: false, completedCalls: 0 }),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("classifyTransactionFailure", () => {
+  it("caller-attributable classes never count against completion", () => {
+    expect(CALLER_ATTRIBUTABLE.has(classifyTransactionFailure("Missing required input fields: url"))).toBe(true);
+    expect(CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(`Trustpilot is not a supported source: its ${TOS_REFUSAL_MARKER}.`))).toBe(true);
+  });
+
+  it("platform-side failures DO count", () => {
+    for (const msg of [
+      "OPENREGISTER_API_KEY is required. Register at https://openregister.de/keys",
+      "The operation was aborted due to timeout",
+      "OpenRegister upstream error (HTTP 503). Retry advised.",
+      "TypeError: Cannot read properties of undefined",
+    ]) {
+      expect(CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(msg)), msg).toBe(false);
+    }
+  });
+
+  it("classifies the taxonomy dimensions distinctly", () => {
+    expect(classifyTransactionFailure("COURTLISTENER rejected the token (HTTP 403). Verify COURTLISTENER_API_TOKEN.")).toBe("config");
+    expect(classifyTransactionFailure("Request timed out after 35000ms")).toBe("timeout");
+    expect(classifyTransactionFailure("Zefix API error: HTTP 503")).toBe("upstream");
+    expect(classifyTransactionFailure("eur-lex.europa.eu served an anti-bot challenge to the rendered browser as well.")).toBe("upstream");
+    expect(classifyTransactionFailure("")).toBe("internal");
+    expect(classifyTransactionFailure(null)).toBe("internal");
+  });
+});

--- a/apps/api/src/lib/quality-floor.ts
+++ b/apps/api/src/lib/quality-floor.ts
@@ -13,18 +13,31 @@
  *     Petter-only decision under the escalation contract.
  *
  * "Eligible" excludes failures the caller caused (caller_input, tos_policy —
- * see transaction-failure-taxonomy.ts): a capability spammed with garbage input or
- * blocklisted URLs is not thereby broken.
+ * see transaction-failure-taxonomy.ts) and free-tier traffic (anonymous,
+ * €0-cost — the cheapest way to fabricate failures; review H-1).
+ *
+ * Abuse resistance (review H-1): counted failures must span at least
+ * `minDistinctFailureDays` calendar days — a single burst, whoever sent it,
+ * never quarantines by itself. Paired with the job's enforcement gate
+ * (dry-run by default until a human flips QUALITY_FLOOR_ENFORCE), this keeps
+ * v1 honest about its Sybil exposure instead of pretending thresholds fix it.
  *
  * Self-throttle (DEC-20260504-B): at most `maxQuarantinesPerRun` per tick.
- * The first run after a long-broken period is a workload-resumption event —
- * a bounded trickle beats a mass delisting nobody reviewed.
+ *
+ * Scope: lifecycle 'active' AND 'degraded' — both are publicly listed
+ * (routes/capabilities.ts lists both), so both must be floor-eligible
+ * (review M-7). Probation/validating/deactivated are out of scope.
  *
  * Recovery: quarantined capabilities receive no catalog traffic, so their
- * completion rate cannot self-heal. Promotion is therefore NOT automatic in
- * v1 — the platform-doctor flow re-verifies via the prod sweep and restores
- * the flags with the fix that made it pass. This is a deliberate gap,
- * documented, not an oversight.
+ * completion rate cannot self-heal. Promotion is NOT automatic in v1 — the
+ * platform-doctor flow re-verifies via the prod sweep and restores the flags
+ * with the fix that made it pass. Deliberate, documented gap.
+ *
+ * Known scope boundary (review M-6): solution-step executions do not write
+ * per-capability transaction rows, so bundle traffic is invisible here, and
+ * quarantine does not block the solution executor's in-process dispatch.
+ * The floor governs the direct-call surface only; solutions integrity is a
+ * separate P3.5 item.
  */
 
 export interface FloorStats {
@@ -32,12 +45,13 @@ export interface FloorStats {
   lifecycleState: string;
   visible: boolean;
   x402Enabled: boolean;
-  /** External calls in the window whose failure class is not caller-attributable. */
+  /** External, non-free-tier calls whose failure class is not caller-attributable. */
   eligibleCalls: number;
-  /** Completed calls in the window. */
   completedCalls: number;
   /** Revenue in the window (completed price_cents sum). */
   revenueCents: number;
+  /** Distinct calendar days on which counted (non-caller) failures occurred. */
+  distinctFailureDays: number;
   /** Same counters over the trailing 7 days — the recovery override. */
   recentEligibleCalls: number;
   recentCompletedCalls: number;
@@ -48,6 +62,8 @@ export interface FloorConfig {
   deactivateBelow: number;   // 0.30
   minCalls: number;          // 10
   maxQuarantinesPerRun: number;
+  /** Counted failures must span at least this many calendar days. */
+  minDistinctFailureDays: number;
 }
 
 export const DEFAULT_FLOOR_CONFIG: FloorConfig = {
@@ -55,12 +71,13 @@ export const DEFAULT_FLOOR_CONFIG: FloorConfig = {
   deactivateBelow: 0.3,
   minCalls: 10,
   maxQuarantinesPerRun: 3,
+  minDistinctFailureDays: 2,
 };
 
 export interface FloorDecision {
   slug: string;
   action: "quarantine" | "none";
-  /** Set when completion < deactivateBelow — surfaced to the doctor report; never auto-applied. */
+  /** Set when 30d completion < deactivateBelow — surfaced to the doctor report; never auto-applied. */
   deactivateProposal: boolean;
   /** Deactivation of a revenue earner is a Petter-only decision (escalation contract). */
   requiresHuman: boolean;
@@ -68,6 +85,8 @@ export interface FloorDecision {
   eligibleCalls: number;
   reason: string;
 }
+
+const FLOOR_LIFECYCLES = new Set(["active", "degraded"]);
 
 export function evaluateFloor(
   rows: FloorStats[],
@@ -79,9 +98,8 @@ export function evaluateFloor(
   // Deterministic order: worst completion first, so the throttle spends its
   // budget on the most broken capabilities.
   const candidates = rows
-    .filter((r) => r.lifecycleState === "active")
-    // Already delisted → nothing further to do automatically (recovery is
-    // doctor-driven, see header).
+    .filter((r) => FLOOR_LIFECYCLES.has(r.lifecycleState))
+    // Already delisted → nothing further to do automatically.
     .filter((r) => r.visible || r.x402Enabled)
     .filter((r) => r.eligibleCalls >= config.minCalls)
     .map((r) => ({ ...r, completion: r.completedCalls / r.eligibleCalls }))
@@ -90,34 +108,52 @@ export function evaluateFloor(
   for (const r of candidates) {
     if (r.completion >= config.quarantineBelow) continue;
 
-    // Recovery override: a capability fixed DURING the window still drags its
-    // pre-fix failures for 30 days. If the trailing 7 days show it healthy
-    // (≥3 eligible calls at/above the floor), defer — quarantining a
-    // just-repaired capability punishes the fix. (Observed the day this
-    // shipped: us-company-data at 50%/30d, fixed in PR #171 the same day.)
+    const belowDeactivate = r.completion < config.deactivateBelow;
+    const requiresHuman = belowDeactivate && r.revenueCents > 0;
+
+    // Burst guard (H-1): failures concentrated in fewer calendar days than
+    // the minimum never quarantine on their own — could be one incident or
+    // one adversary. Deferred loudly; the doctor sees the flag either way.
+    if (r.distinctFailureDays < config.minDistinctFailureDays) {
+      decisions.push({
+        slug: r.slug,
+        action: "none",
+        deactivateProposal: belowDeactivate,
+        requiresHuman,
+        completion: r.completion,
+        eligibleCalls: r.eligibleCalls,
+        reason: `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d, but counted failures span only ${r.distinctFailureDays} day(s) (< ${config.minDistinctFailureDays}) — burst, not a trend; deferred`,
+      });
+      continue;
+    }
+
+    // Recovery override (M-5 hardened): the trailing week must carry real
+    // volume relative to the window — flat "3 lucky calls" cannot defer a
+    // high-volume disaster. The deactivation PROPOSAL is still emitted from
+    // the 30d figure; only the quarantine action defers.
+    const recentRequired = Math.max(3, Math.ceil(0.25 * r.eligibleCalls * (7 / 30)));
     if (
-      r.recentEligibleCalls >= 3 &&
+      r.recentEligibleCalls >= recentRequired &&
       r.recentCompletedCalls / r.recentEligibleCalls >= config.quarantineBelow
     ) {
       decisions.push({
         slug: r.slug,
         action: "none",
-        deactivateProposal: false,
-        requiresHuman: false,
+        deactivateProposal: belowDeactivate,
+        requiresHuman,
         completion: r.completion,
         eligibleCalls: r.eligibleCalls,
-        reason: `30d completion ${(r.completion * 100).toFixed(0)}% is below floor, but the trailing 7d (${r.recentCompletedCalls}/${r.recentEligibleCalls}) shows recovery — deferring`,
+        reason: `30d completion ${(r.completion * 100).toFixed(0)}% is below floor, but the trailing 7d (${r.recentCompletedCalls}/${r.recentEligibleCalls}, required ≥${recentRequired}) shows recovery — deferring`,
       });
       continue;
     }
 
-    const belowDeactivate = r.completion < config.deactivateBelow;
     if (quarantinesLeft <= 0) {
       decisions.push({
         slug: r.slug,
         action: "none",
         deactivateProposal: belowDeactivate,
-        requiresHuman: belowDeactivate && r.revenueCents > 0,
+        requiresHuman,
         completion: r.completion,
         eligibleCalls: r.eligibleCalls,
         reason: `below floor (${(r.completion * 100).toFixed(0)}% of ${r.eligibleCalls}) but per-run quarantine budget exhausted — next tick`,
@@ -130,7 +166,7 @@ export function evaluateFloor(
       slug: r.slug,
       action: "quarantine",
       deactivateProposal: belowDeactivate,
-      requiresHuman: belowDeactivate && r.revenueCents > 0,
+      requiresHuman,
       completion: r.completion,
       eligibleCalls: r.eligibleCalls,
       reason: belowDeactivate

--- a/apps/api/src/lib/quality-floor.ts
+++ b/apps/api/src/lib/quality-floor.ts
@@ -1,0 +1,143 @@
+/**
+ * Quality floor — autonomy ladder L2 (Readiness P3, DEC-20260812-A).
+ *
+ * Pure decision core: given per-capability real-traffic stats over the floor
+ * window, decide who gets quarantined (delisted from catalog + x402, still
+ * reachable by explicit slug) and who becomes a deactivation PROPOSAL.
+ *
+ * The DEC's confirmed thresholds, verbatim:
+ *   - window: 30 days, minimum 10 eligible external calls
+ *   - completion < 70%  → quarantine
+ *   - completion < 30%  → deactivate — but deactivation is NEVER automatic:
+ *     it is always a proposal, and for revenue-earning capabilities it is a
+ *     Petter-only decision under the escalation contract.
+ *
+ * "Eligible" excludes failures the caller caused (caller_input, tos_policy —
+ * see transaction-failure-taxonomy.ts): a capability spammed with garbage input or
+ * blocklisted URLs is not thereby broken.
+ *
+ * Self-throttle (DEC-20260504-B): at most `maxQuarantinesPerRun` per tick.
+ * The first run after a long-broken period is a workload-resumption event —
+ * a bounded trickle beats a mass delisting nobody reviewed.
+ *
+ * Recovery: quarantined capabilities receive no catalog traffic, so their
+ * completion rate cannot self-heal. Promotion is therefore NOT automatic in
+ * v1 — the platform-doctor flow re-verifies via the prod sweep and restores
+ * the flags with the fix that made it pass. This is a deliberate gap,
+ * documented, not an oversight.
+ */
+
+export interface FloorStats {
+  slug: string;
+  lifecycleState: string;
+  visible: boolean;
+  x402Enabled: boolean;
+  /** External calls in the window whose failure class is not caller-attributable. */
+  eligibleCalls: number;
+  /** Completed calls in the window. */
+  completedCalls: number;
+  /** Revenue in the window (completed price_cents sum). */
+  revenueCents: number;
+  /** Same counters over the trailing 7 days — the recovery override. */
+  recentEligibleCalls: number;
+  recentCompletedCalls: number;
+}
+
+export interface FloorConfig {
+  quarantineBelow: number;   // 0.70
+  deactivateBelow: number;   // 0.30
+  minCalls: number;          // 10
+  maxQuarantinesPerRun: number;
+}
+
+export const DEFAULT_FLOOR_CONFIG: FloorConfig = {
+  quarantineBelow: 0.7,
+  deactivateBelow: 0.3,
+  minCalls: 10,
+  maxQuarantinesPerRun: 3,
+};
+
+export interface FloorDecision {
+  slug: string;
+  action: "quarantine" | "none";
+  /** Set when completion < deactivateBelow — surfaced to the doctor report; never auto-applied. */
+  deactivateProposal: boolean;
+  /** Deactivation of a revenue earner is a Petter-only decision (escalation contract). */
+  requiresHuman: boolean;
+  completion: number;
+  eligibleCalls: number;
+  reason: string;
+}
+
+export function evaluateFloor(
+  rows: FloorStats[],
+  config: FloorConfig = DEFAULT_FLOOR_CONFIG,
+): FloorDecision[] {
+  const decisions: FloorDecision[] = [];
+  let quarantinesLeft = config.maxQuarantinesPerRun;
+
+  // Deterministic order: worst completion first, so the throttle spends its
+  // budget on the most broken capabilities.
+  const candidates = rows
+    .filter((r) => r.lifecycleState === "active")
+    // Already delisted → nothing further to do automatically (recovery is
+    // doctor-driven, see header).
+    .filter((r) => r.visible || r.x402Enabled)
+    .filter((r) => r.eligibleCalls >= config.minCalls)
+    .map((r) => ({ ...r, completion: r.completedCalls / r.eligibleCalls }))
+    .sort((a, b) => a.completion - b.completion);
+
+  for (const r of candidates) {
+    if (r.completion >= config.quarantineBelow) continue;
+
+    // Recovery override: a capability fixed DURING the window still drags its
+    // pre-fix failures for 30 days. If the trailing 7 days show it healthy
+    // (≥3 eligible calls at/above the floor), defer — quarantining a
+    // just-repaired capability punishes the fix. (Observed the day this
+    // shipped: us-company-data at 50%/30d, fixed in PR #171 the same day.)
+    if (
+      r.recentEligibleCalls >= 3 &&
+      r.recentCompletedCalls / r.recentEligibleCalls >= config.quarantineBelow
+    ) {
+      decisions.push({
+        slug: r.slug,
+        action: "none",
+        deactivateProposal: false,
+        requiresHuman: false,
+        completion: r.completion,
+        eligibleCalls: r.eligibleCalls,
+        reason: `30d completion ${(r.completion * 100).toFixed(0)}% is below floor, but the trailing 7d (${r.recentCompletedCalls}/${r.recentEligibleCalls}) shows recovery — deferring`,
+      });
+      continue;
+    }
+
+    const belowDeactivate = r.completion < config.deactivateBelow;
+    if (quarantinesLeft <= 0) {
+      decisions.push({
+        slug: r.slug,
+        action: "none",
+        deactivateProposal: belowDeactivate,
+        requiresHuman: belowDeactivate && r.revenueCents > 0,
+        completion: r.completion,
+        eligibleCalls: r.eligibleCalls,
+        reason: `below floor (${(r.completion * 100).toFixed(0)}% of ${r.eligibleCalls}) but per-run quarantine budget exhausted — next tick`,
+      });
+      continue;
+    }
+
+    quarantinesLeft--;
+    decisions.push({
+      slug: r.slug,
+      action: "quarantine",
+      deactivateProposal: belowDeactivate,
+      requiresHuman: belowDeactivate && r.revenueCents > 0,
+      completion: r.completion,
+      eligibleCalls: r.eligibleCalls,
+      reason: belowDeactivate
+        ? `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d — below the 30% deactivation floor; quarantined now, deactivation is a ${r.revenueCents > 0 ? "Petter-only (revenue-earning)" : "human"} decision`
+        : `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d — below the 70% quarantine floor`,
+    });
+  }
+
+  return decisions;
+}

--- a/apps/api/src/lib/transaction-failure-taxonomy.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.ts
@@ -1,0 +1,56 @@
+/**
+ * Transaction-failure taxonomy — autonomy ladder L1 (Readiness P3,
+ * DEC-20260812-A).
+ *
+ * Classifies a failed CUSTOMER TRANSACTION's error text so the quality floor
+ * (and the platform-doctor report) can decompose failure rates into named
+ * causes — and, critically, so failures CAUSED BY THE CALLER never count
+ * against a capability's completion rate.
+ *
+ * Distinct from lib/failure-classifier.ts, which classifies TEST-RESULT
+ * failures for the test-intelligence system (7 verdicts, test-suite inputs).
+ * This module is for production transactions: different inputs, different
+ * consumers, deliberately separate.
+ *
+ * Pure string classification. Ordering matters: earlier, more specific
+ * classes win. Patterns lean on the platform's own stable error phrasings —
+ * when one changes, its test here fails loudly.
+ */
+import { isUserInputError } from "./circuit-breaker.js";
+import { TOS_REFUSAL_MARKER } from "./tos-blocklist.js";
+
+export type TransactionFailureClass =
+  | "caller_input"   // bad/missing input, wrong identifier, unresolvable name
+  | "tos_policy"     // per-source ToS refusal — a policy answer, not a defect
+  | "config"         // missing key/credential/env on our side
+  | "timeout"        // execution or upstream deadline exceeded
+  | "upstream"       // vendor/upstream failure: 5xx, quota, unavailability
+  | "internal";      // everything else — OUR bug until proven otherwise
+
+/** Classes that must NOT count against a capability's completion rate. */
+export const CALLER_ATTRIBUTABLE: ReadonlySet<TransactionFailureClass> = new Set([
+  "caller_input",
+  "tos_policy",
+]);
+
+// ENV-var-shaped names (OPENREGISTER_API_KEY, COURTLISTENER_API_TOKEN,
+// BROWSERLESS_URL…) — tight on purpose: env-key errors also contain the
+// generic "is required" that the caller-input pattern list matches, so
+// config MUST be checked first with a shape only our env errors have.
+const CONFIG_RE = /\b[A-Z][A-Z0-9]+(?:_[A-Z0-9]+)*_(?:KEY|TOKEN|SECRET|GUID|URL|PASSWORD)\b|not configured|rejected the (?:api )?key|missing credential/;
+// Route-level validation phrasings that the circuit-breaker's pattern list
+// (built for executor-thrown errors) does not carry.
+const ROUTE_INPUT_RE = /missing required (?:input )?fields?|provide one of:|looks like you (?:passed|placed)/i;
+const TIMEOUT_RE = /timed? ?out|timeout|deadline|aborted due to timeout|operation was aborted/i;
+const UPSTREAM_RE = /HTTP 5\d\d|upstream|unavailable|rate.?limit|too many requests|429|quota|service.*(?:down|error)|ECONNRESET|ECONNREFUSED|ENOTFOUND|socket hang up|anti-bot challenge/i;
+
+export function classifyTransactionFailure(error: string | null | undefined): TransactionFailureClass {
+  const msg = (error ?? "").trim();
+  if (!msg) return "internal";
+  if (msg.includes(TOS_REFUSAL_MARKER)) return "tos_policy";
+  if (CONFIG_RE.test(msg)) return "config";
+  if (ROUTE_INPUT_RE.test(msg) || isUserInputError(msg)) return "caller_input";
+  if (TIMEOUT_RE.test(msg)) return "timeout";
+  if (UPSTREAM_RE.test(msg)) return "upstream";
+  return "internal";
+}

--- a/apps/api/src/lib/transaction-failure-taxonomy.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.ts
@@ -7,16 +7,20 @@
  * causes — and, critically, so failures CAUSED BY THE CALLER never count
  * against a capability's completion rate.
  *
- * Distinct from lib/failure-classifier.ts, which classifies TEST-RESULT
- * failures for the test-intelligence system (7 verdicts, test-suite inputs).
- * This module is for production transactions: different inputs, different
- * consumers, deliberately separate.
+ * Distinct from lib/failure-classifier.ts (TEST-result verdicts) AND from
+ * circuit-breaker.ts's user-input list. Review H-2 (2026-08-12) proved the
+ * breaker list cannot be reused wholesale here: it answers "should this trip
+ * the breaker?" and deliberately includes target-site 5xx ("URL returned
+ * HTTP 5", "returned a server error") — correct for breakers (the TARGET
+ * site's outage isn't the capability's fault either), but fatal for the
+ * floor: counting a month-long upstream outage as caller fault would report
+ * 100% completion while every customer call fails. This module carries its
+ * own curated caller-attributable list; upstream/timeout checks run BEFORE
+ * the generic caller patterns.
  *
- * Pure string classification. Ordering matters: earlier, more specific
- * classes win. Patterns lean on the platform's own stable error phrasings —
- * when one changes, its test here fails loudly.
+ * Pure string classification, no imports beyond the ToS marker constant.
+ * Ordering matters and is pinned by tests both directions.
  */
-import { isUserInputError } from "./circuit-breaker.js";
 import { TOS_REFUSAL_MARKER } from "./tos-blocklist.js";
 
 export type TransactionFailureClass =
@@ -35,22 +39,54 @@ export const CALLER_ATTRIBUTABLE: ReadonlySet<TransactionFailureClass> = new Set
 
 // ENV-var-shaped names (OPENREGISTER_API_KEY, COURTLISTENER_API_TOKEN,
 // BROWSERLESS_URL…) — tight on purpose: env-key errors also contain the
-// generic "is required" that the caller-input pattern list matches, so
-// config MUST be checked first with a shape only our env errors have.
-const CONFIG_RE = /\b[A-Z][A-Z0-9]+(?:_[A-Z0-9]+)*_(?:KEY|TOKEN|SECRET|GUID|URL|PASSWORD)\b|not configured|rejected the (?:api )?key|missing credential/;
-// Route-level validation phrasings that the circuit-breaker's pattern list
-// (built for executor-thrown errors) does not carry.
-const ROUTE_INPUT_RE = /missing required (?:input )?fields?|provide one of:|looks like you (?:passed|placed)/i;
+// generic "is required", so config MUST be checked before caller patterns
+// with a shape only our env errors have. Case-sensitive env-var shape,
+// case-insensitive phrasings.
+const CONFIG_ENV_RE = /\b[A-Z][A-Z0-9]+(?:_[A-Z0-9]+)*_(?:KEY|TOKEN|SECRET|GUID|URL|PASSWORD)\b/;
+const CONFIG_PHRASE_RE = /not configured|rejected the (?:api )?(?:key|token)|missing credential/i;
+
 const TIMEOUT_RE = /timed? ?out|timeout|deadline|aborted due to timeout|operation was aborted/i;
-const UPSTREAM_RE = /HTTP 5\d\d|upstream|unavailable|rate.?limit|too many requests|429|quota|service.*(?:down|error)|ECONNRESET|ECONNREFUSED|ENOTFOUND|socket hang up|anti-bot challenge/i;
+
+// Upstream/vendor failure. Checked BEFORE the caller-input patterns so
+// target-site 5xx phrasings ("URL returned HTTP 503", "registry returned a
+// server error (HTTP 503)") land here, not in caller_input (review H-2).
+const UPSTREAM_RE = /HTTP 5\d\d|upstream|unavailable|rate.?limit(?:ed)?|too many requests|\b429\b|quota|service.*(?:down|error)|returned a server error|ECONNRESET|ECONNREFUSED|ENOTFOUND|socket hang up|anti-bot challenge/i;
+
+// Curated caller-attributable patterns. Route-level validation phrasings plus
+// the subset of the circuit-breaker's user-input list that is genuinely the
+// caller's doing. Deliberately ABSENT (they classify upstream above):
+// "URL returned HTTP 5", "returned a server error", "could not be loaded".
+const CALLER_INPUT_RE = new RegExp(
+  [
+    "missing required (?:input )?fields?",
+    "provide one of:",
+    "looks like you (?:passed|placed)",
+    "is required",
+    "invalid input",
+    "must provide",
+    "no dns records found",
+    "domain may not exist",
+    "url returned http 4",           // 4xx from the caller's own target URL
+    "this site exists but blocks",
+    "blocks automated access",
+    "not found",
+    "this url returns json",
+    "this url points to a pdf",
+    "this url points to an image",
+    "could not repair json",
+    "no confident .* match",         // scored name resolution refusals
+    "distinct .* entities match",    // tie refusals
+  ].join("|"),
+  "i",
+);
 
 export function classifyTransactionFailure(error: string | null | undefined): TransactionFailureClass {
   const msg = (error ?? "").trim();
   if (!msg) return "internal";
   if (msg.includes(TOS_REFUSAL_MARKER)) return "tos_policy";
-  if (CONFIG_RE.test(msg)) return "config";
-  if (ROUTE_INPUT_RE.test(msg) || isUserInputError(msg)) return "caller_input";
+  if (CONFIG_ENV_RE.test(msg) || CONFIG_PHRASE_RE.test(msg)) return "config";
   if (TIMEOUT_RE.test(msg)) return "timeout";
   if (UPSTREAM_RE.test(msg)) return "upstream";
+  if (CALLER_INPUT_RE.test(msg)) return "caller_input";
   return "internal";
 }


### PR DESCRIPTION
## Summary
- **The DEC-20260812-A quality floor, as code**: a daily tick that evaluates every active/degraded capability's 30-day real-traffic completion (internal accounts excluded by the canonical suffix rule, free-tier and soft-deleted rows excluded, caller-caused failures excluded via a new transaction-failure taxonomy) and quarantines below-floor capabilities — **dry-run by default**: no catalog flag is written until you set `QUALITY_FLOOR_ENFORCE=true` on Railway, after reviewing the recorded would-quarantine events.
- Confirmed defaults verbatim: quarantine <70%, deactivate-proposal <30% (never auto-applied; revenue earners Petter-only), ≥10 eligible calls/30d, max 3 quarantines/tick. Plus review-driven hardening: burst guard (failures must span ≥2 days), volume-proportional 7-day recovery override, transactional audit events, per-tick heartbeat.
- Riders: web-provider 4xx escalation fix (EUR-Lex serves HTTP 400 to datacenter IPs — verified failing in prod, now escalates to the browser tier; 404/410/401/407 stay fast-fail) and the internal-accounts suffix rule (the daily digest and the floor previously excluded different account sets).

## Adversarial review (pre-PR): 4 HIGHs found, all fixed
The reviewer's verdict on the first commit was "do not merge as-is" — it was right: the floor was blind to upstream outages (taxonomy reuse bug), gameable by anonymous traffic, fed by a polluted exclusion list, and had no brake. All four fixed in the hardening commit (see its body); the escalation-contract compliance section was verified clean by construction (no representable deactivate action, no lifecycle/is_active writes).
Caveats disclosed: cross-provider independent review not executable from this harness; unit tests capture decision shape rather than route/DB integration per the documented test-harness exemption; the escalation-contract guarantee rests on the type system + review, not a dedicated test. Known scope boundary (M-6, documented in-module): solution-step traffic is invisible to the floor and quarantine does not gate the in-process solution executor — P3.5 work.

## Verification
- 1095 tests pass (16 floor/taxonomy tests pin every rule both directions incl. the five real-world 5xx phrasings, burst guard, throttle at non-default config, fold logic, suffix rule)
- tsc, F-0-009, manifest guards clean
- Read-only prod preview of the decision path: 122 capabilities evaluated → 3 quarantine candidates + 1 throttled (matches the disposition's floor list)
- **Post-deploy proof (DEC-20260504-C)**: ~15 min after deploy, `SELECT * FROM health_monitor_events WHERE event_type='quality_floor' ORDER BY created_at DESC` must show a `tick_complete` heartbeat (+ dry-run decision events). I will run it.

## For Petter
The floor starts in **dry-run**. After a few days of reviewing its `dry_run_would_quarantine` events (they'll appear in the daily digest counts), set `QUALITY_FLOOR_ENFORCE=true` on Railway to arm it. Until then it observes and records only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)