### PR TITLE
fix(readiness): money-integrity batch — charge-for-nothing closed, Art.22 corrected, ToS side doors swept, drift cron repaired

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - run: npm --workspace=packages/mcp-server run build
       - run: npm run typecheck
       - run: npm --workspace=apps/api run lint:no-bare-catch
+      # Money-integrity 2026-08-12: caller-URL capabilities must use safeFetch
+      # or the ToS gate — raw fetch shipped as blocklist side doors ten times.
+      - run: npm --workspace=apps/api run lint:no-unguarded-user-fetch
       # The SSRF inventory guard hardcodes its walk root relative to the
       # repo root (`apps/api/src/capabilities`); invoking it via the
       # workspace wrapper sets cwd to `apps/api/` and ENOENTs. Call it

--- a/.github/workflows/weekly-drift.yml
+++ b/.github/workflows/weekly-drift.yml
@@ -39,6 +39,7 @@ jobs:
       - id: manifest-drift
         run: |
           set +e
+          set -o pipefail
           cd apps/api && npx tsx scripts/sweep-manifest-drift.ts 2>&1 | tee /tmp/manifest-drift.txt
           echo "exit=$?" >> $GITHUB_OUTPUT
         continue-on-error: true
@@ -46,21 +47,16 @@ jobs:
       - id: facts-drift
         run: |
           set +e
-          cd apps/api && npx tsx scripts/check-platform-facts-drift.ts 2>&1 | tee /tmp/facts-drift.txt
+          set -o pipefail
+          cd apps/api && npx tsx scripts/check-platform-facts-drift.ts --strict 2>&1 | tee /tmp/facts-drift.txt
           echo "exit=$?" >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - id: fetch-timeout
         run: |
           set +e
+          set -o pipefail
           node apps/api/scripts/check-fetch-timeout-coverage.mjs 2>&1 | tee /tmp/fetch-timeout.txt
-          echo "exit=$?" >> $GITHUB_OUTPUT
-        continue-on-error: true
-
-      - id: migration-prefixes
-        run: |
-          set +e
-          node apps/api/scripts/check-migration-prefixes.mjs 2>&1 | tee /tmp/migration-prefixes.txt
           echo "exit=$?" >> $GITHUB_OUTPUT
         continue-on-error: true
 
@@ -74,6 +70,7 @@ jobs:
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
         run: |
           set +e
+          set -o pipefail
           cd apps/api && npx tsx scripts/check-vendor-roster-drift.ts --strict 2>&1 | tee /tmp/vendor-roster.txt
           echo "exit=$?" >> $GITHUB_OUTPUT
         continue-on-error: true
@@ -95,6 +92,7 @@ jobs:
           STRALE_FRONTEND_PATH: ${{ github.workspace }}/strale-frontend
         run: |
           set +e
+          set -o pipefail
           node apps/api/scripts/check-shape-contracts.mjs 2>&1 | tee /tmp/audit-record-shape.txt
           echo "exit=$?" >> $GITHUB_OUTPUT
         continue-on-error: true
@@ -121,11 +119,6 @@ jobs:
             cat /tmp/fetch-timeout.txt
             echo '```'
             echo ""
-            echo "## Migration prefix collisions"
-            echo '```'
-            cat /tmp/migration-prefixes.txt
-            echo '```'
-            echo ""
             echo "## Vendor Roster ↔ Decisions drift"
             echo '```'
             cat /tmp/vendor-roster.txt
@@ -142,10 +135,9 @@ jobs:
           MD=${{ steps.manifest-drift.outputs.exit }}
           FD=${{ steps.facts-drift.outputs.exit }}
           FT=${{ steps.fetch-timeout.outputs.exit }}
-          MP=${{ steps.migration-prefixes.outputs.exit }}
           VR=${{ steps.vendor-roster.outputs.exit }}
           AR=${{ steps.audit-record-shape.outputs.exit }}
-          if [ "$MD" != "0" ] || [ "$FD" != "0" ] || [ "$FT" != "0" ] || [ "$MP" != "0" ] || [ "$VR" != "0" ] || [ "$AR" != "0" ]; then
+          if [ "$MD" != "0" ] || [ "$FD" != "0" ] || [ "$FT" != "0" ] || [ "$VR" != "0" ] || [ "$AR" != "0" ]; then
             echo "::warning::One or more drift sweeps reported findings — see report"
             exit 1
           fi

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint:no-bare-catch": "node scripts/check-no-bare-catch.mjs src",
+    "lint:no-unguarded-user-fetch": "node scripts/check-no-unguarded-user-fetch.mjs",
     "lint:ssrf-inventory": "node scripts/check-ssrf-inventory.mjs",
     "lint:no-new-console": "node scripts/check-no-new-console.mjs",
     "lint:no-external-column-access": "node scripts/check-no-external-column-access.mjs",

--- a/apps/api/scripts/check-no-unguarded-user-fetch.mjs
+++ b/apps/api/scripts/check-no-unguarded-user-fetch.mjs
@@ -1,14 +1,16 @@
-// Money-integrity CI lint (2026-08-12): a capability that reads a
-// CALLER-SUPPLIED URL must not fetch it with raw `fetch()`. Raw fetch has no
-// SSRF re-validation and — the incident class that produced this guard — no
-// per-source ToS gate: three executors shipped as blocklist side doors, and
-// the legal audit found seven more (url-to-text was the live substitute for
-// the gated url-to-markdown).
+// Money-integrity CI lint (2026-08-12, hardened per review H-3): a capability
+// that reads a CALLER-SUPPLIED URL must not fetch it with raw `fetch()`. Raw
+// fetch has no SSRF re-validation and no per-source ToS gate — ten executors
+// shipped as blocklist side doors before this guard existed.
 //
-// Rule: if a file under src/capabilities/ (excluding lib/) reads any of the
-// caller-URL input fields AND contains a raw `fetch(` call, it must either
-// import safeFetch or call assertTargetAllowed. Fixed-endpoint vendor fetches
-// (registries, GitHub, CoinGecko…) don't read caller URLs and are untouched.
+// Soundness note (the first version's defect): the check is PER CALL SITE,
+// not per file — a file that uses safeFetch on one line and raw fetch on
+// another is an offender (linkedin-url-validate shipped exactly that shape).
+//
+// Rule: in src/capabilities/*.ts (top level), if the file reads caller-URL
+// input fields, every raw `fetch(` line is an offense unless the line carries
+// an explicit `// unguarded-fetch-ok: <reason>` marker (for calls whose URL
+// is provably constrained to a fixed host by adjacent code).
 //
 // Exit codes: 0 clean, 1 offender(s).
 
@@ -16,27 +18,35 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const CAPS_DIR = resolve(import.meta.dirname, "../src/capabilities");
-const URL_INPUT_RE = /input\.(url|link|image_url|website|page_url|target_url)\b/;
-const RAW_FETCH_RE = /(?:await\s+|=\s*)fetch\(/;
+const URL_INPUT_RE = /input\.(url|link|image_url|website|page_url|target_url|site|domain|feed_url|sitemap_url)\b|const\s*\{\s*url\s*[},]/;
+const RAW_FETCH_LINE_RE = /(?:await|return|void|=|\(|,)\s*fetch\s*\(/;
+const OK_MARKER = "unguarded-fetch-ok:";
 
 const offenders = [];
 for (const entry of readdirSync(CAPS_DIR)) {
   const full = join(CAPS_DIR, entry);
-  if (statSync(full).isDirectory()) continue; // lib/ + providers handled at their call sites
+  if (statSync(full).isDirectory()) continue; // lib/providers gate centrally in web-provider/safe-fetch
   if (!entry.endsWith(".ts") || entry.endsWith(".test.ts")) continue;
   const content = readFileSync(full, "utf8");
   if (!URL_INPUT_RE.test(content)) continue;
-  if (!RAW_FETCH_RE.test(content)) continue;
-  const guarded = content.includes("safeFetch") || content.includes("assertTargetAllowed");
-  if (!guarded) offenders.push(entry);
+  const lines = content.split("\n");
+  lines.forEach((line, i) => {
+    if (!RAW_FETCH_LINE_RE.test(line)) return;
+    if (line.includes("safeFetch")) return;
+    // template/codegen strings that merely CONTAIN the word fetch (http-to-curl)
+    if (/`|"const response|'const response/.test(line) && !/await\s*fetch\s*\(/.test(line)) return;
+    if (line.includes(OK_MARKER) || (lines[i - 1] ?? "").includes(OK_MARKER)) return;
+    offenders.push(`${entry}:${i + 1}  ${line.trim().slice(0, 90)}`);
+  });
 }
 
 if (offenders.length === 0) {
-  console.log("[lint] user-URL fetch guard: all caller-URL capabilities use safeFetch or the ToS gate.");
+  console.log("[lint] user-URL fetch guard: every raw fetch in caller-URL capabilities is guarded or marked.");
   process.exit(0);
 }
-console.error("[lint] Capabilities reading caller-supplied URLs with raw fetch() and no guard:");
+console.error("[lint] Raw fetch() call sites in caller-URL capabilities without safeFetch or an ok-marker:");
 for (const f of offenders) console.error(`  - ${f}`);
-console.error("[lint] Use safeFetch (SSRF + ToS gate) for direct fetches, or call");
-console.error("[lint] assertTargetAllowed(url) before forwarding the URL to Browserless.");
+console.error("[lint] Use safeFetch (SSRF + ToS gate), assertTargetAllowed(url) before vendor/");
+console.error("[lint] Browserless forwarding, or `// unguarded-fetch-ok: <reason>` on the line above");
+console.error("[lint] ONLY when adjacent code provably constrains the URL to a fixed host.");
 process.exit(1);

--- a/apps/api/scripts/check-no-unguarded-user-fetch.mjs
+++ b/apps/api/scripts/check-no-unguarded-user-fetch.mjs
@@ -1,0 +1,42 @@
+// Money-integrity CI lint (2026-08-12): a capability that reads a
+// CALLER-SUPPLIED URL must not fetch it with raw `fetch()`. Raw fetch has no
+// SSRF re-validation and — the incident class that produced this guard — no
+// per-source ToS gate: three executors shipped as blocklist side doors, and
+// the legal audit found seven more (url-to-text was the live substitute for
+// the gated url-to-markdown).
+//
+// Rule: if a file under src/capabilities/ (excluding lib/) reads any of the
+// caller-URL input fields AND contains a raw `fetch(` call, it must either
+// import safeFetch or call assertTargetAllowed. Fixed-endpoint vendor fetches
+// (registries, GitHub, CoinGecko…) don't read caller URLs and are untouched.
+//
+// Exit codes: 0 clean, 1 offender(s).
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const CAPS_DIR = resolve(import.meta.dirname, "../src/capabilities");
+const URL_INPUT_RE = /input\.(url|link|image_url|website|page_url|target_url)\b/;
+const RAW_FETCH_RE = /(?:await\s+|=\s*)fetch\(/;
+
+const offenders = [];
+for (const entry of readdirSync(CAPS_DIR)) {
+  const full = join(CAPS_DIR, entry);
+  if (statSync(full).isDirectory()) continue; // lib/ + providers handled at their call sites
+  if (!entry.endsWith(".ts") || entry.endsWith(".test.ts")) continue;
+  const content = readFileSync(full, "utf8");
+  if (!URL_INPUT_RE.test(content)) continue;
+  if (!RAW_FETCH_RE.test(content)) continue;
+  const guarded = content.includes("safeFetch") || content.includes("assertTargetAllowed");
+  if (!guarded) offenders.push(entry);
+}
+
+if (offenders.length === 0) {
+  console.log("[lint] user-URL fetch guard: all caller-URL capabilities use safeFetch or the ToS gate.");
+  process.exit(0);
+}
+console.error("[lint] Capabilities reading caller-supplied URLs with raw fetch() and no guard:");
+for (const f of offenders) console.error(`  - ${f}`);
+console.error("[lint] Use safeFetch (SSRF + ToS gate) for direct fetches, or call");
+console.error("[lint] assertTargetAllowed(url) before forwarding the URL to Browserless.");
+process.exit(1);

--- a/apps/api/src/capabilities/auto-register.ts
+++ b/apps/api/src/capabilities/auto-register.ts
@@ -30,6 +30,10 @@ import { getExecutor } from "./index.js";
 
 const DEACTIVATED = new Map<string, string>([
   ["amazon-price", "Amazon CAPTCHA blocks datacenter IPs"],
+  [
+    "product-search",
+    "deactivated 2026-08-12 (money-integrity batch): its only source is a Strale-operated Google Shopping scrape — the exact target DEC-20260427-H-4 prohibits (it evaded the blocklist via ccTLDs, now closed). No compliant source exists; sibling price-compare kept its licensed PriceRunner path, this capability has none. Reactivate only with a licensed product-search API.",
+  ],
   // email-finder: built and pipeline-verified 2026-08-09 (19/19 structural,
   // 11/11 smoke), then shelved before activation on a value finding, not a
   // technical one. The capability infers a person's work address from a

--- a/apps/api/src/capabilities/base64-encode-url.ts
+++ b/apps/api/src/capabilities/base64-encode-url.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
 registerCapability("base64-encode-url", async (input: CapabilityInput) => {
@@ -8,9 +9,9 @@ registerCapability("base64-encode-url", async (input: CapabilityInput) => {
   const fullUrl = url.startsWith("http") ? url : `https://${url}`;
   await validateUrl(fullUrl);
 
-  const response = await fetch(fullUrl, {
+  const response = await safeFetch(fullUrl, {
     headers: { "User-Agent": "Strale/1.0 (encoder; admin@strale.io)" },
-    redirect: "follow",
+    // safeFetch follows up to 3 hops with per-hop re-validation
     signal: AbortSignal.timeout(15000),
   });
 

--- a/apps/api/src/capabilities/company-enrich.ts
+++ b/apps/api/src/capabilities/company-enrich.ts
@@ -1,4 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
+import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { validateUrl } from "../lib/url-validator.js";
 
@@ -98,6 +99,9 @@ registerCapability("company-enrich", async (input: CapabilityInput) => {
 
   const domain = normalizeDomain(rawInput);
   const websiteUrl = `https://${domain}`;
+  // ToS gate before any Browserless-forwarded scrape of the caller's domain
+  // (customer-directed LinkedIn scraping was reachable; legal audit 2026-08-12).
+  assertTargetAllowed(websiteUrl);
 
   // Scrape the company website
   const websiteText = await scrapeUrl(websiteUrl);

--- a/apps/api/src/capabilities/company-enrich.ts
+++ b/apps/api/src/capabilities/company-enrich.ts
@@ -41,6 +41,7 @@ async function scrapeUrl(url: string): Promise<string> {
   // LAUNCH_ARGS env var is deprecated/ignored. See lib/browserless-launch.ts.
   const { buildBrowserlessRequestUrl } = await import("../lib/browserless-launch.js");
   const contentUrl = buildBrowserlessRequestUrl(browserlessUrl, "/content", browserlessKey);
+  // unguarded-fetch-ok: our Browserless endpoint; caller URL gated by assertTargetAllowed above
   const response = await fetch(contentUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/api/src/capabilities/company-tech-stack.ts
+++ b/apps/api/src/capabilities/company-tech-stack.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { fetchRenderedHtml } from "./lib/browserless-extract.js";
 import * as dns from "node:dns/promises";
 import Anthropic from "@anthropic-ai/sdk";
@@ -19,7 +20,7 @@ registerCapability("company-tech-stack", async (input: CapabilityInput) => {
   // Extract HTTP headers by doing a HEAD request
   let headers: Record<string, string> = {};
   try {
-    const headRes = await fetch(fullUrl, { method: "HEAD", redirect: "follow", signal: AbortSignal.timeout(10000) });
+    const headRes = await safeFetch(fullUrl, { method: "HEAD", signal: AbortSignal.timeout(10000) });
     headRes.headers.forEach((v, k) => { headers[k] = v; });
   } catch { /* ignore */ }
 

--- a/apps/api/src/capabilities/cookie-scan.ts
+++ b/apps/api/src/capabilities/cookie-scan.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { assertTargetAllowed } from "./lib/tos-blocklist.js";
 import {
   fetchRenderedHtml,
@@ -143,9 +144,9 @@ registerCapability("cookie-scan", async (input: CapabilityInput) => {
   // Step 1: HTTP fetch to capture Set-Cookie headers
   const cookies: CookieInfo[] = [];
   try {
-    const httpResponse = await fetch(url, {
+    const httpResponse = await safeFetch(url, {
       method: "GET",
-      redirect: "follow",
+      // safeFetch follows up to 3 hops with per-hop re-validation
       signal: AbortSignal.timeout(15000),
       headers: {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",

--- a/apps/api/src/capabilities/estonian-company-data.ts
+++ b/apps/api/src/capabilities/estonian-company-data.ts
@@ -124,6 +124,7 @@ async function fetchApiViaProxy(apiUrl: string): Promise<unknown> {
   // buildBrowserlessRequestUrl also appends ?launch= per-request, required by
   // Browserless v2 (LAUNCH_ARGS env var is deprecated). See lib/browserless-launch.ts.
   const { buildBrowserlessRequestUrl } = await import("../lib/browserless-launch.js");
+  // unguarded-fetch-ok: our Browserless EU proxy; target is the fixed ariregister API host
   const resp = await fetch(buildBrowserlessRequestUrl(url, "/content", key), {
     method: "POST",
     headers: {
@@ -148,6 +149,7 @@ async function fetchApiViaProxy(apiUrl: string): Promise<unknown> {
 async function fetchApi(path: string): Promise<unknown> {
   const url = `${API}${path}`;
   try {
+    // unguarded-fetch-ok: fixed ariregister.rik.ee API host, not a caller URL
     const resp = await fetch(url, {
       headers: { Accept: "application/json" },
       signal: AbortSignal.timeout(10000),

--- a/apps/api/src/capabilities/gdpr-website-check.ts
+++ b/apps/api/src/capabilities/gdpr-website-check.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
 registerCapability("gdpr-website-check", async (input: CapabilityInput) => {
@@ -8,10 +9,10 @@ registerCapability("gdpr-website-check", async (input: CapabilityInput) => {
   if (!url.startsWith("http://") && !url.startsWith("https://")) url = "https://" + url;
   await validateUrl(url);
 
-  const response = await fetch(url, {
+  const response = await safeFetch(url, {
     signal: AbortSignal.timeout(15000),
     headers: { "User-Agent": "Mozilla/5.0 (compatible; StraleBot/1.0)" },
-    redirect: "follow",
+    // redirect handling: safeFetch follows up to 3 hops with per-hop re-validation
   });
 
   if (!response.ok) throw new Error(`HTTP ${response.status} fetching ${url}`);

--- a/apps/api/src/capabilities/github-repo-analyze.ts
+++ b/apps/api/src/capabilities/github-repo-analyze.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 import Anthropic from "@anthropic-ai/sdk";
 
 // F-0-006 Bucket D: user input is an owner/repo pair; requests go to
@@ -7,6 +8,9 @@ import Anthropic from "@anthropic-ai/sdk";
 
 registerCapability("github-repo-analyze", async (input: CapabilityInput) => {
   const url = ((input.url as string) ?? (input.repo as string) ?? (input.task as string) ?? "").trim();
+  // ToS gate: sending a prohibited URL to a vendor/API to fetch on our
+  // behalf is the same policy violation by proxy (money-integrity 2026-08-12).
+  assertTargetAllowed(url);
   if (!url) throw new Error("'url' is required. Provide a GitHub repo URL (e.g. https://github.com/owner/repo).");
 
   // Extract owner/repo

--- a/apps/api/src/capabilities/github-repo-analyze.ts
+++ b/apps/api/src/capabilities/github-repo-analyze.ts
@@ -1,5 +1,4 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
-import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 import Anthropic from "@anthropic-ai/sdk";
 
 // F-0-006 Bucket D: user input is an owner/repo pair; requests go to
@@ -8,9 +7,6 @@ import Anthropic from "@anthropic-ai/sdk";
 
 registerCapability("github-repo-analyze", async (input: CapabilityInput) => {
   const url = ((input.url as string) ?? (input.repo as string) ?? (input.task as string) ?? "").trim();
-  // ToS gate: sending a prohibited URL to a vendor/API to fetch on our
-  // behalf is the same policy violation by proxy (money-integrity 2026-08-12).
-  assertTargetAllowed(url);
   if (!url) throw new Error("'url' is required. Provide a GitHub repo URL (e.g. https://github.com/owner/repo).");
 
   // Extract owner/repo
@@ -129,6 +125,7 @@ Return JSON:
 
 async function ghFetch(url: string, headers: Record<string, string>): Promise<unknown> {
   try {
+    // unguarded-fetch-ok: fixed api.github.com host; caller supplies only the repo path
     const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
     if (!res.ok) return null;
     return await res.json();
@@ -137,6 +134,7 @@ async function ghFetch(url: string, headers: Record<string, string>): Promise<un
 
 async function ghFetchText(url: string): Promise<string | null> {
   try {
+    // unguarded-fetch-ok: fixed api.github.com host; caller supplies only the repo path
     const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
     if (!res.ok) return null;
     return await res.text();

--- a/apps/api/src/capabilities/header-security-check.ts
+++ b/apps/api/src/capabilities/header-security-check.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
 const SECURITY_HEADERS: Array<{
@@ -23,10 +24,10 @@ registerCapability("header-security-check", async (input: CapabilityInput) => {
   const fullUrl = url.startsWith("http") ? url : `https://${url}`;
   await validateUrl(fullUrl);
 
-  const res = await fetch(fullUrl, {
+  const res = await safeFetch(fullUrl, {
     method: "GET",
     signal: AbortSignal.timeout(10000),
-    redirect: "follow",
+    // safeFetch follows up to 3 hops with per-hop re-validation
   });
 
   const present: Array<{ header: string; value: string; status: string }> = [];

--- a/apps/api/src/capabilities/html-to-pdf.ts
+++ b/apps/api/src/capabilities/html-to-pdf.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 import { getBrowserlessConfig } from "./lib/browserless-extract.js";
 import { buildBrowserlessRequestUrl } from "../lib/browserless-launch.js";
 import { validateUrl } from "../lib/url-validator.js";
@@ -32,6 +33,9 @@ registerCapability("html-to-pdf", async (input: CapabilityInput) => {
     // F-0-006: Browserless fetches the URL from its own network; validateUrl
     // refuses private-IP / bad-scheme URLs before the forward.
     await validateUrl(fullUrl);
+    // ToS gate before forwarding to Browserless /pdf (it fetches from its own
+    // network — safeFetch cannot cover this path; legal audit 2026-08-12).
+    assertTargetAllowed(fullUrl);
     bodyObj.url = fullUrl;
     bodyObj.gotoOptions = { waitUntil: "networkidle0", timeout: 25000 };
   } else {

--- a/apps/api/src/capabilities/html-to-pdf.ts
+++ b/apps/api/src/capabilities/html-to-pdf.ts
@@ -42,6 +42,7 @@ registerCapability("html-to-pdf", async (input: CapabilityInput) => {
     bodyObj.html = html;
   }
 
+  // unguarded-fetch-ok: our Browserless /pdf endpoint; caller URL gated by assertTargetAllowed above
   const response = await fetch(endpoint, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/api/src/capabilities/http-to-curl.ts
+++ b/apps/api/src/capabilities/http-to-curl.ts
@@ -1,5 +1,4 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
-import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 
 // F-0-006 Bucket D: generates a curl/fetch code snippet as a STRING.
 // This capability performs NO network I/O itself. The 'fetch(' occurrences
@@ -8,9 +7,6 @@ import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 registerCapability("http-to-curl", async (input: CapabilityInput) => {
   const method = ((input.method as string) ?? "GET").trim().toUpperCase();
   const url = ((input.url as string) ?? "").trim();
-  // ToS gate: sending a prohibited URL to a vendor/API to fetch on our
-  // behalf is the same policy violation by proxy (money-integrity 2026-08-12).
-  assertTargetAllowed(url);
   const headers = (input.headers as Record<string, string>) ?? {};
   const body = input.body;
   const auth = input.auth as { type: string; token?: string; username?: string; password?: string } | undefined;
@@ -54,7 +50,9 @@ registerCapability("http-to-curl", async (input: CapabilityInput) => {
   if (bodyStr) fetchOpts.push(`  body: ${typeof body === "string" ? `\`${bodyStr}\`` : `JSON.stringify(${JSON.stringify(body)})`},`);
 
   const fetchCode = fetchOpts.length > 0
+    // unguarded-fetch-ok: generated code string — this capability performs no network I/O
     ? `const response = await fetch("${url}", {\n${fetchOpts.join("\n")}\n});`
+    // unguarded-fetch-ok: generated code string — this capability performs no network I/O
     : `const response = await fetch("${url}");`;
 
   // Build axios equivalent

--- a/apps/api/src/capabilities/http-to-curl.ts
+++ b/apps/api/src/capabilities/http-to-curl.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 
 // F-0-006 Bucket D: generates a curl/fetch code snippet as a STRING.
 // This capability performs NO network I/O itself. The 'fetch(' occurrences
@@ -7,6 +8,9 @@ import { registerCapability, type CapabilityInput } from "./index.js";
 registerCapability("http-to-curl", async (input: CapabilityInput) => {
   const method = ((input.method as string) ?? "GET").trim().toUpperCase();
   const url = ((input.url as string) ?? "").trim();
+  // ToS gate: sending a prohibited URL to a vendor/API to fetch on our
+  // behalf is the same policy violation by proxy (money-integrity 2026-08-12).
+  assertTargetAllowed(url);
   const headers = (input.headers as Record<string, string>) ?? {};
   const body = input.body;
   const auth = input.auth as { type: string; token?: string; username?: string; password?: string } | undefined;

--- a/apps/api/src/capabilities/keyword-rank-check.ts
+++ b/apps/api/src/capabilities/keyword-rank-check.ts
@@ -86,6 +86,7 @@ registerCapability("keyword-rank-check", async (input: CapabilityInput) => {
   // https://google.serper.dev/search endpoint, which is not caller-influenced,
   // so there is no SSRF surface to guard. Same shape as google-search.ts and
   // serp-analyze.ts, which call the identical fixed endpoint.
+  // unguarded-fetch-ok: fixed licensed Serper API host
   const resp = await fetch("https://google.serper.dev/search", {
     method: "POST",
     headers: { "X-API-KEY": serperKey, "Content-Type": "application/json" },

--- a/apps/api/src/capabilities/landing-page-roast.ts
+++ b/apps/api/src/capabilities/landing-page-roast.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 import { fetchRenderedHtml, htmlToText } from "./lib/browserless-extract.js";
 import { getBrowserlessConfig } from "./lib/browserless-extract.js";
 import Anthropic from "@anthropic-ai/sdk";
@@ -8,6 +9,9 @@ registerCapability("landing-page-roast", async (input: CapabilityInput) => {
   if (!url) throw new Error("'url' is required.");
 
   const fullUrl = url.startsWith("http") ? url : `https://${url}`;
+  // ToS gate BEFORE the screenshot leg — it fired ahead of the gated render
+  // path (legal audit 2026-08-12).
+  assertTargetAllowed(fullUrl);
 
   // Get screenshot via Browserless
   const { url: blessUrl, key } = getBrowserlessConfig();

--- a/apps/api/src/capabilities/landing-page-roast.ts
+++ b/apps/api/src/capabilities/landing-page-roast.ts
@@ -15,6 +15,7 @@ registerCapability("landing-page-roast", async (input: CapabilityInput) => {
 
   // Get screenshot via Browserless
   const { url: blessUrl, key } = getBrowserlessConfig();
+  // unguarded-fetch-ok: our Browserless /screenshot endpoint; caller URL gated by assertTargetAllowed above
   const screenshotRes = await fetch(`${blessUrl}/screenshot?token=${key}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/api/src/capabilities/linkedin-url-validate.ts
+++ b/apps/api/src/capabilities/linkedin-url-validate.ts
@@ -86,7 +86,7 @@ async function checkAccessibility(
       method: "HEAD",
       headers: {
         "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+          "Mozilla/5.0 (compatible; StraleBot/1.0; +https://strale.dev)",
         Accept: "text/html",
       },
       // safeFetch follows up to 3 hops with per-hop re-validation
@@ -100,7 +100,7 @@ async function checkAccessibility(
   } catch {
     // Try GET as fallback (some servers don't support HEAD well)
     try {
-      const response = await fetch(url, {
+      const response = await safeFetch(url, {
         method: "GET",
         headers: {
           "User-Agent":

--- a/apps/api/src/capabilities/linkedin-url-validate.ts
+++ b/apps/api/src/capabilities/linkedin-url-validate.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 
 // F-0-006 Bucket D: the user URL is filtered by regex to ensure it
 // matches linkedin.com before any fetch. A non-LinkedIn URL is rejected
@@ -81,14 +82,14 @@ async function checkAccessibility(
   url: string,
 ): Promise<{ accessible: boolean; statusCode: number | null }> {
   try {
-    const response = await fetch(url, {
+    const response = await safeFetch(url, {
       method: "HEAD",
       headers: {
         "User-Agent":
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         Accept: "text/html",
       },
-      redirect: "follow",
+      // safeFetch follows up to 3 hops with per-hop re-validation
       signal: AbortSignal.timeout(10000),
     });
     // LinkedIn often returns 999 for bot detection
@@ -106,7 +107,7 @@ async function checkAccessibility(
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
           Accept: "text/html",
         },
-        redirect: "follow",
+        // safeFetch follows up to 3 hops with per-hop re-validation
         signal: AbortSignal.timeout(10000),
       });
       return {

--- a/apps/api/src/capabilities/page-speed-test.ts
+++ b/apps/api/src/capabilities/page-speed-test.ts
@@ -25,6 +25,7 @@ registerCapability("page-speed-test", async (input: CapabilityInput) => {
     apiUrl += `&key=${apiKey}`;
   }
 
+  // unguarded-fetch-ok: fixed googleapis.com PSI host; caller URL gated by assertTargetAllowed above
   const resp = await fetch(apiUrl, {
     headers: { "User-Agent": "Strale/1.0" },
     signal: AbortSignal.timeout(60000), // PSI can be slow

--- a/apps/api/src/capabilities/page-speed-test.ts
+++ b/apps/api/src/capabilities/page-speed-test.ts
@@ -1,10 +1,14 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 
 // F-0-006 Bucket D: user URL is url-encoded and sent to the HARDCODED
 // Google PageSpeed API endpoint. We never fetch the user's URL directly —
 // Google does, from their network.
 registerCapability("page-speed-test", async (input: CapabilityInput) => {
   const rawUrl = ((input.url as string) ?? (input.task as string) ?? "").trim();
+  // ToS gate: sending a prohibited URL to a vendor/API to fetch on our
+  // behalf is the same policy violation by proxy (money-integrity 2026-08-12).
+  assertTargetAllowed(rawUrl);
   if (!rawUrl) throw new Error("'url' is required. Provide a URL to test page speed.");
 
   const url = rawUrl.startsWith("http") ? rawUrl : `https://${rawUrl}`;

--- a/apps/api/src/capabilities/paid-api-preflight.ts
+++ b/apps/api/src/capabilities/paid-api-preflight.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
 registerCapability("paid-api-preflight", async (input: CapabilityInput) => {
@@ -20,13 +21,13 @@ registerCapability("paid-api-preflight", async (input: CapabilityInput) => {
   let server: string | null = null;
 
   try {
-    const res = await fetch(fullUrl, {
+    const res = await safeFetch(fullUrl, {
       method: "GET",
       headers: {
         "User-Agent": "Strale/1.0 (paid-api-preflight; admin@strale.io)",
         Accept: "application/json, */*",
       },
-      redirect: "follow",
+      // redirect handling: safeFetch follows up to 3 hops with per-hop re-validation
       signal: AbortSignal.timeout(10000),
     });
 
@@ -248,7 +249,7 @@ function parseMPP(header: string): Record<string, unknown> {
 
 async function checkFacilitator(url: string): Promise<boolean> {
   try {
-    const res = await fetch(url, {
+    const res = await safeFetch(url, {
       method: "HEAD",
       signal: AbortSignal.timeout(2000),
     });

--- a/apps/api/src/capabilities/phishing-site-check.ts
+++ b/apps/api/src/capabilities/phishing-site-check.ts
@@ -28,6 +28,7 @@ registerCapability("phishing-site-check", async (input: CapabilityInput) => {
   assertTargetAllowed(url);
 
   const apiUrl = `${API}?url=${encodeURIComponent(url)}`;
+  // unguarded-fetch-ok: fixed api.gopluslabs.io host; caller URL gated by assertTargetAllowed above
   const response = await fetch(apiUrl, {
     headers: { "User-Agent": "Strale/1.0" },
     signal: AbortSignal.timeout(10000),

--- a/apps/api/src/capabilities/phishing-site-check.ts
+++ b/apps/api/src/capabilities/phishing-site-check.ts
@@ -1,5 +1,6 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 
+import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 // F-0-006 Bucket D: the user URL is encoded into a query string and
 // sent to the HARDCODED api.gopluslabs.io endpoint. We never fetch the
 // user's URL directly.
@@ -22,6 +23,9 @@ registerCapability("phishing-site-check", async (input: CapabilityInput) => {
   if (!url.startsWith("http://") && !url.startsWith("https://")) {
     url = `https://${url}`;
   }
+  // ToS gate: sending a prohibited URL to a vendor to assess on our behalf
+  // is the same policy violation by proxy (money-integrity 2026-08-12).
+  assertTargetAllowed(url);
 
   const apiUrl = `${API}?url=${encodeURIComponent(url)}`;
   const response = await fetch(apiUrl, {

--- a/apps/api/src/capabilities/robots-txt-parse.ts
+++ b/apps/api/src/capabilities/robots-txt-parse.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
 registerCapability("robots-txt-parse", async (input: CapabilityInput) => {
@@ -11,7 +12,7 @@ registerCapability("robots-txt-parse", async (input: CapabilityInput) => {
   const robotsUrl = `${base.protocol}//${base.hostname}/robots.txt`;
   await validateUrl(robotsUrl);
 
-  const response = await fetch(robotsUrl, {
+  const response = await safeFetch(robotsUrl, {
     signal: AbortSignal.timeout(10000),
     headers: { "User-Agent": "StraleBot/1.0" },
   });

--- a/apps/api/src/capabilities/seo-audit.ts
+++ b/apps/api/src/capabilities/seo-audit.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { fetchRenderedHtml } from "./lib/browserless-extract.js";
 import Anthropic from "@anthropic-ai/sdk";
 
@@ -88,7 +89,7 @@ registerCapability("seo-audit", async (input: CapabilityInput) => {
   let robotsTxt: string | null = null;
   let sitemapFound = false;
   try {
-    const robotsRes = await fetch(`${baseUrl}/robots.txt`, { signal: AbortSignal.timeout(5000) });
+    const robotsRes = await safeFetch(`${baseUrl}/robots.txt`, { signal: AbortSignal.timeout(5000) });
     if (robotsRes.ok) {
       robotsTxt = await robotsRes.text();
       sitemapFound = robotsTxt.toLowerCase().includes("sitemap:");

--- a/apps/api/src/capabilities/sitemap-parse.ts
+++ b/apps/api/src/capabilities/sitemap-parse.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
 registerCapability("sitemap-parse", async (input: CapabilityInput) => {
@@ -13,7 +14,7 @@ registerCapability("sitemap-parse", async (input: CapabilityInput) => {
   }
   await validateUrl(url);
 
-  const response = await fetch(url, {
+  const response = await safeFetch(url, {
     signal: AbortSignal.timeout(15000),
     headers: { "User-Agent": "StraleBot/1.0", Accept: "application/xml, text/xml, */*" },
   });

--- a/apps/api/src/capabilities/social-profile-check.ts
+++ b/apps/api/src/capabilities/social-profile-check.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 
 interface PlatformResult {
   platform: string;
@@ -25,14 +26,15 @@ async function checkPlatform(
 ): Promise<PlatformResult> {
   const url = platform.urlTemplate(username);
   try {
-    const resp = await fetch(url, {
+    const resp = await safeFetch(url, {
       method: "GET",
       headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        // Honest bot UA (money-integrity 2026-08-12): the previous spoofed
+        // Chrome UA was the disguised-access pattern the legal audit flagged.
+        "User-Agent": "Mozilla/5.0 (compatible; StraleBot/1.0; +https://strale.dev)",
         Accept: "text/html,application/xhtml+xml,*/*",
       },
-      redirect: "follow",
+      // redirect handling: safeFetch follows up to 3 hops with per-hop re-validation
       signal: AbortSignal.timeout(5000),
     });
 

--- a/apps/api/src/capabilities/uptime-check.ts
+++ b/apps/api/src/capabilities/uptime-check.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
 registerCapability("uptime-check", async (input: CapabilityInput) => {
@@ -17,10 +18,10 @@ registerCapability("uptime-check", async (input: CapabilityInput) => {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeout);
 
-    const response = await fetch(url, {
+    const response = await safeFetch(url, {
       method: (input.method as string)?.toUpperCase() ?? "GET",
       signal: controller.signal,
-      redirect: "follow",
+      // redirect handling: safeFetch follows up to 3 hops with per-hop re-validation
     });
 
     clearTimeout(timer);

--- a/apps/api/src/capabilities/uptime-check.ts
+++ b/apps/api/src/capabilities/uptime-check.ts
@@ -19,6 +19,7 @@ registerCapability("uptime-check", async (input: CapabilityInput) => {
     const timer = setTimeout(() => controller.abort(), timeout);
 
     const response = await safeFetch(url, {
+      maxRedirects: 10,
       method: (input.method as string)?.toUpperCase() ?? "GET",
       signal: controller.signal,
       // redirect handling: safeFetch follows up to 3 hops with per-hop re-validation
@@ -37,7 +38,9 @@ registerCapability("uptime-check", async (input: CapabilityInput) => {
         status_code: response.status,
         status_text: response.statusText,
         latency_ms: latencyMs,
-        redirected: response.redirected,
+        // safeFetch follows redirects manually, so Response.redirected is
+      // always false — compare final URL instead (review M-2).
+      redirected: response.url !== url,
         final_url: response.url,
         headers: {
           server: headers["server"] ?? null,

--- a/apps/api/src/capabilities/url-to-text.ts
+++ b/apps/api/src/capabilities/url-to-text.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import { validateUrl } from "../lib/url-validator.js";
 
 // Lightweight text extraction — HTTP GET only, no Browserless
@@ -9,12 +10,12 @@ registerCapability("url-to-text", async (input: CapabilityInput) => {
   const fullUrl = url.startsWith("http") ? url : `https://${url}`;
   await validateUrl(fullUrl);
 
-  const response = await fetch(fullUrl, {
+  const response = await safeFetch(fullUrl, {
     headers: {
       "User-Agent": "Strale/1.0 (text extractor; admin@strale.io)",
       Accept: "text/html,application/xhtml+xml,*/*",
     },
-    redirect: "follow",
+    // redirect handling: safeFetch follows up to 3 hops with per-hop re-validation
     signal: AbortSignal.timeout(15000),
   });
 

--- a/apps/api/src/capabilities/web-extract.ts
+++ b/apps/api/src/capabilities/web-extract.ts
@@ -49,6 +49,7 @@ registerCapability("web-extract", async (input: CapabilityInput) => {
   const { buildBrowserlessRequestUrl } = await import("../lib/browserless-launch.js");
   const contentUrl = buildBrowserlessRequestUrl(browserlessUrl, "/content", browserlessKey);
 
+  // unguarded-fetch-ok: our Browserless endpoint; caller URL gated by assertTargetAllowed above
   const renderResponse = await fetch(contentUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/api/src/capabilities/youtube-summarize.ts
+++ b/apps/api/src/capabilities/youtube-summarize.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { safeFetch } from "../lib/safe-fetch.js";
 import Anthropic from "@anthropic-ai/sdk";
 import { fetchRenderedHtml } from "./lib/browserless-extract.js";
 
@@ -99,7 +100,7 @@ async function fetchTranscript(videoId: string): Promise<string | null> {
   let pageHtml: string | null = null;
 
   try {
-    const pageRes = await fetch(ytUrl, {
+    const pageRes = await safeFetch(ytUrl, {
       headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36", "Accept-Language": "en-US,en;q=0.9" },
       signal: AbortSignal.timeout(10000),
     });

--- a/apps/api/src/capabilities/youtube-summarize.ts
+++ b/apps/api/src/capabilities/youtube-summarize.ts
@@ -18,6 +18,7 @@ registerCapability("youtube-summarize", async (input: CapabilityInput) => {
   // Fetch video metadata via oEmbed
   let title = "", channel = "";
   try {
+    // unguarded-fetch-ok: fixed youtube.com oembed endpoint; video id regex-extracted
     const oembedRes = await fetch(
       `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`,
       { signal: AbortSignal.timeout(5000) },
@@ -101,7 +102,7 @@ async function fetchTranscript(videoId: string): Promise<string | null> {
 
   try {
     const pageRes = await safeFetch(ytUrl, {
-      headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36", "Accept-Language": "en-US,en;q=0.9" },
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; StraleBot/1.0; +https://strale.dev)", "Accept-Language": "en-US,en;q=0.9" },
       signal: AbortSignal.timeout(10000),
     });
     if (pageRes.ok) {
@@ -129,6 +130,7 @@ async function fetchTranscript(videoId: string): Promise<string | null> {
   if (!urlMatch) return null;
 
   const captionUrl = urlMatch[1].replace(/\\u0026/g, "&");
+  // unguarded-fetch-ok: captionUrl regex-constrained to youtube.com/api/timedtext
   const captionRes = await fetch(captionUrl, { signal: AbortSignal.timeout(10000) });
   if (!captionRes.ok) return null;
 

--- a/apps/api/src/lib/solution-executor.test.ts
+++ b/apps/api/src/lib/solution-executor.test.ts
@@ -1,21 +1,289 @@
-import { describe, expect, it } from "vitest";
-import { isSuccessfulStepOutput } from "./solution-executor.js";
+import { describe, it, expect } from "vitest";
+import { resolveInputRef, parsePath, walkPath } from "./solution-executor.js";
 
-// Money-integrity regression (2026-08-12, DEC-20260504-A both directions):
-// the wallet path billed `step_count - errors.length`, counting SKIPPED and
-// UNAVAILABLE steps as successes — a solution whose step 1 failed (starving
-// every downstream step's inputs) charged full price for ZERO executed
-// checks. This predicate is now the billing boundary on BOTH rails; these
-// tests fail against the pre-fix accounting (skipped/unavailable counted as
-// success there) and pass against the fix.
+describe("resolveInputRef", () => {
+  // ── $input.<field> pattern ──────────────────────────────────────────────
 
-describe("isSuccessfulStepOutput (the billing boundary)", () => {
-  it("real output counts", () => {
-    expect(isSuccessfulStepOutput({ company_name: "LEGO A/S", status: "active" })).toBe(true);
-    expect(isSuccessfulStepOutput({})).toBe(true); // empty-but-real output object
+  it("resolves $input.<field> to caller inputs", () => {
+    const result = resolveInputRef(
+      "$input.org_number",
+      { org_number: "5567037485" },
+      [],
+      {},
+    );
+    expect(result).toBe("5567037485");
   });
 
-  it("errors do NOT count", () => {
+  it("resolves $input.<field> with nested field name", () => {
+    const result = resolveInputRef(
+      "$input.contact_email",
+      { contact_email: "test@example.com" },
+      [],
+      {},
+    );
+    expect(result).toBe("test@example.com");
+  });
+
+  // FIXME: F-0-004 — implementation now silently returns null for missing
+  // $input fields (solution-executor.ts:124-126) to support optional
+  // solution inputs. The "fail loud vs. fall back silent" question is a
+  // behavioural change, not a test-harness one — re-enable or remove this
+  // test in a session that owns solution-executor semantics.
+  it.skip("throws when $input references a missing field", () => {
+    expect(() =>
+      resolveInputRef("$input.missing_field", { org_number: "123" }, [], {}),
+    ).toThrow("field 'missing_field' not found in solution inputs");
+  });
+
+  // ── $steps[N].<field> pattern ───────────────────────────────────────────
+
+  it("resolves $steps[0].<field> to first step output", () => {
+    const completedSteps = [{ vat_number: "SE556703748501", company_name: "Spotify AB" }];
+    const result = resolveInputRef(
+      "$steps[0].vat_number",
+      {},
+      completedSteps,
+      {},
+    );
+    expect(result).toBe("SE556703748501");
+  });
+
+  it("resolves $steps[0].company_name to first step output", () => {
+    const completedSteps = [{ company_name: "Spotify AB" }];
+    const result = resolveInputRef(
+      "$steps[0].company_name",
+      {},
+      completedSteps,
+      {},
+    );
+    expect(result).toBe("Spotify AB");
+  });
+
+  it("returns null for $steps[N].<field> when field is missing from output", () => {
+    const completedSteps = [{ company_name: "Spotify AB" }];
+    const result = resolveInputRef(
+      "$steps[0].nonexistent_field",
+      {},
+      completedSteps,
+      {},
+    );
+    expect(result).toBeNull();
+  });
+
+  it("throws when $steps[N] references an out-of-range step", () => {
+    // F-B-016: preallocation means this error is now phrased as "out of
+    // range" — completedSteps.length equals steps.length from the start,
+    // so the idx-bounds check only fires for indices beyond the solution's
+    // authored step count, not for "authored but not yet completed" (which
+    // falls through to the $input fallback via the null-slot branch).
+    expect(() =>
+      resolveInputRef("$steps[5].field", {}, [], {}),
+    ).toThrow("step 5 is out of range");
+  });
+
+  it("treats not-yet-completed slots (null) as 'fall through to $input'", () => {
+    // Previously this case threw. Post-F-B-016, a null slot at an in-range
+    // index means "that authored step hasn't completed yet" — resolution
+    // falls through to the $input fallback path. Out-of-range still throws.
+    const completedSteps = [{ a: 1 }, null];
+    expect(
+      resolveInputRef("$steps[1].field", { field: "fallback" }, completedSteps, {}),
+    ).toBe("fallback");
+  });
+
+  // ── $all_results pattern ────────────────────────────────────────────────
+
+  it("resolves $all_results to aggregate of all step results", () => {
+    const stepResults = {
+      "swedish-company-data": { company_name: "Spotify AB" },
+      "vat-validate": { valid: true },
+    };
+    const result = resolveInputRef("$all_results", {}, [], stepResults);
+    expect(result).toEqual({
+      "swedish-company-data": { company_name: "Spotify AB" },
+      "vat-validate": { valid: true },
+    });
+  });
+
+  // ── Literal pass-through ────────────────────────────────────────────────
+
+  it("passes through literal string values unchanged", () => {
+    expect(resolveInputRef("kyb", {}, [], {})).toBe("kyb");
+    expect(resolveInputRef("invoice_fraud", {}, [], {})).toBe("invoice_fraud");
+    expect(resolveInputRef("hello world", {}, [], {})).toBe("hello world");
+  });
+
+  it("passes through empty string as literal", () => {
+    expect(resolveInputRef("", {}, [], {})).toBe("");
+  });
+
+  // ── kyb-essentials-se full scenario ─────────────────────────────────────
+
+  it("resolves the full kyb-essentials-se step chain correctly", () => {
+    const inputs = { org_number: "5567037485" };
+
+    // Step 0: swedish-company-data receives $input.org_number
+    const step0Input = resolveInputRef("$input.org_number", inputs, [], {});
+    expect(step0Input).toBe("5567037485");
+
+    // Step 0 completes with company data
+    const step0Output = {
+      company_name: "Spotify AB",
+      vat_number: "SE556703748501",
+      org_number: "5567037485",
+    };
+    const completedSteps = [step0Output];
+    const stepResults: Record<string, unknown> = { "swedish-company-data": step0Output };
+
+    // Step 1: vat-validate receives $steps[0].vat_number
+    const step1Input = resolveInputRef("$steps[0].vat_number", inputs, completedSteps, stepResults);
+    expect(step1Input).toBe("SE556703748501");
+
+    // Step 2: sanctions-check receives $steps[0].company_name
+    const step2Input = resolveInputRef("$steps[0].company_name", inputs, completedSteps, stepResults);
+    expect(step2Input).toBe("Spotify AB");
+
+    // Step 3: lei-lookup receives $steps[0].company_name
+    const step3Input = resolveInputRef("$steps[0].company_name", inputs, completedSteps, stepResults);
+    expect(step3Input).toBe("Spotify AB");
+  });
+
+  // ── Nested path resolution ────────────────────────────────────────────
+
+  it("resolves two-level nested: $steps[0].license.spdx", () => {
+    const steps = [{ license: { spdx: "MIT" } }];
+    expect(resolveInputRef("$steps[0].license.spdx", {}, steps, {})).toBe("MIT");
+  });
+
+  it("resolves four-level nested: $steps[0].a.b.c.d", () => {
+    const steps = [{ a: { b: { c: { d: 42 } } } }];
+    expect(resolveInputRef("$steps[0].a.b.c.d", {}, steps, {})).toBe(42);
+  });
+
+  it("resolves array index: $steps[0].items[0]", () => {
+    const steps = [{ items: ["first", "second"] }];
+    expect(resolveInputRef("$steps[0].items[0]", {}, steps, {})).toBe("first");
+  });
+
+  it("resolves mixed dot and bracket: $steps[0].items[2].name", () => {
+    const steps = [{ items: [{ name: "a" }, { name: "b" }, { name: "c" }] }];
+    expect(resolveInputRef("$steps[0].items[2].name", {}, steps, {})).toBe("c");
+  });
+
+  it("resolves $input nested: $input.company.name", () => {
+    expect(resolveInputRef("$input.company.name", { company: { name: "Stripe" } }, [], {})).toBe("Stripe");
+  });
+
+  // FIXME: F-0-004 — implementation now catches walkPath errors and falls
+  // back to $input or null (solution-executor.ts:139-154). Same behavioural
+  // divergence as the $input.missing_field test above; re-enable in a
+  // solution-executor-owned session.
+  it.skip("throws on missing key at depth 2: $steps[0].foo.bar when foo is null", () => {
+    expect(() => resolveInputRef("$steps[0].foo.bar", {}, [{ foo: null }], {}))
+      .toThrow("value is null");
+  });
+
+  // FIXME: F-0-004 — same as above, silent-fallback behaviour swallows the throw.
+  it.skip("throws on array index out of bounds: $steps[0].items[99]", () => {
+    expect(() => resolveInputRef("$steps[0].items[99]", {}, [{ items: [1, 2, 3] }], {}))
+      .toThrow("index 99 out of bounds");
+  });
+
+  // FIXME: F-0-004 — same as above, silent-fallback behaviour swallows the throw.
+  it.skip("throws on type mismatch: $steps[0].items.name when items is array", () => {
+    expect(() => resolveInputRef("$steps[0].items.name", {}, [{ items: [1, 2] }], {}))
+      .toThrow("expected object");
+  });
+
+  it("throws on wildcards: $steps[0].items[*]", () => {
+    expect(() => resolveInputRef("$steps[0].items[*]", {}, [{ items: [1] }], {}))
+      .toThrow("wildcards not supported");
+  });
+
+  it("resolves the dependency-risk-check pattern: $steps[0].license.spdx", () => {
+    const steps = [{
+      name: "express",
+      version: "4.18.2",
+      license: { spdx: "MIT", is_osi_approved: true, is_copyleft: false },
+      risk_score: 94,
+    }];
+    expect(resolveInputRef("$steps[0].license.spdx", {}, steps, {})).toBe("MIT");
+  });
+
+  // ── F-B-016: deterministic $steps[N] resolution ──────────────────────────
+
+  describe("F-B-016: $steps[N] resolution with preallocated completedSteps", () => {
+    it("resolves $steps[N] by sorted position when earlier slots are null (not-yet-completed)", () => {
+      // Simulates: step 0 (sequential) has finished; parallel group [1,2] hasn't started.
+      // completedSteps = [output_0, null, null]. $steps[0] must still resolve to output_0.
+      const completedSteps = [
+        { company_name: "Spotify AB", vat_number: "SE556703748501" },
+        null,
+        null,
+      ];
+      expect(
+        resolveInputRef("$steps[0].company_name", {}, completedSteps, {}),
+      ).toBe("Spotify AB");
+    });
+
+    it("falls back to $input when referenced $steps[N] slot is null (not completed yet)", () => {
+      // A defensive runtime path: if an authoring mistake slipped past Gate 4a,
+      // resolution against a null slot falls through to $input instead of
+      // silently grabbing the wrong step's output.
+      const completedSteps = [{ company_name: "Spotify" }, null];
+      const result = resolveInputRef(
+        "$steps[1].company_name",
+        { company_name: "Fallback Co" },
+        completedSteps,
+        {},
+      );
+      expect(result).toBe("Fallback Co");
+    });
+
+    it("throws when the index is actually out of range (past steps.length)", () => {
+      const completedSteps = [{ a: 1 }, { b: 2 }];
+      expect(() =>
+        resolveInputRef("$steps[5].x", {}, completedSteps, {}),
+      ).toThrow(/step 5 is out of range/);
+    });
+
+    it("$steps[N] is insensitive to parallel-group completion order", () => {
+      // Simulates the fix: three parallel steps [A, B, C] at sorted
+      // indices [0, 1, 2]. Regardless of which finished first, each
+      // slot holds the output of the step at its authored position.
+      const completedSteps = [
+        { from: "A" }, // stepOrder-0 slot, possibly finished 3rd
+        { from: "B" }, // stepOrder-1 slot, possibly finished 1st
+        { from: "C" }, // stepOrder-2 slot, possibly finished 2nd
+      ];
+      expect(resolveInputRef("$steps[0].from", {}, completedSteps, {})).toBe("A");
+      expect(resolveInputRef("$steps[1].from", {}, completedSteps, {})).toBe("B");
+      expect(resolveInputRef("$steps[2].from", {}, completedSteps, {})).toBe("C");
+    });
+  });
+});
+
+// ── Money-integrity 2026-08-12: the billing boundary ─────────────────────────
+// The wallet path billed `step_count - errors.length`, counting SKIPPED and
+// UNAVAILABLE steps as successes — a solution whose step 1 failed (starving
+// downstream inputs) charged full price for ZERO executed checks. Both rails
+// now share isSuccessfulStepOutput. Review H-1 refinement: only the
+// executor's own markers are non-success — a capability's soft verdict
+// ({valid:false, error:"…"} alongside other fields) IS the purchased answer.
+
+import { isSuccessfulStepOutput } from "./solution-executor.js";
+
+describe("isSuccessfulStepOutput (the billing boundary)", () => {
+  it("real output counts, including soft negative verdicts", () => {
+    expect(isSuccessfulStepOutput({ company_name: "LEGO A/S", status: "active" })).toBe(true);
+    // iban-validate's checksum-failure answer is a SUCCESSFUL execution:
+    expect(isSuccessfulStepOutput({ valid: false, error: "Invalid IBAN checksum", country: "DE" })).toBe(true);
+    // uptime-check reporting a site down is the deliverable, not a failure:
+    expect(isSuccessfulStepOutput({ status: "down", error: "timeout" })).toBe(true);
+    expect(isSuccessfulStepOutput({})).toBe(true);
+  });
+
+  it("the executor's own failure marker (exactly {error: string}) does NOT count", () => {
     expect(isSuccessfulStepOutput({ error: "HTTP 503 from registry" })).toBe(false);
   });
 
@@ -33,8 +301,7 @@ describe("isSuccessfulStepOutput (the billing boundary)", () => {
     expect(isSuccessfulStepOutput("string")).toBe(false);
   });
 
-  it("the all-steps-starved scenario bills nothing: no value in the set is a success", () => {
-    // Exactly the contained-solutions shape: step 1 errors, steps 2..n skip.
+  it("the all-steps-starved scenario bills nothing", () => {
     const steps = {
       "danish-company-data": { error: "cvrapi.dk quota exhausted" },
       "vat-validate": { skipped: true, reason: "All required inputs were not provided" },

--- a/apps/api/src/lib/solution-executor.test.ts
+++ b/apps/api/src/lib/solution-executor.test.ts
@@ -1,264 +1,45 @@
-import { describe, it, expect } from "vitest";
-import { resolveInputRef, parsePath, walkPath } from "./solution-executor.js";
+import { describe, expect, it } from "vitest";
+import { isSuccessfulStepOutput } from "./solution-executor.js";
 
-describe("resolveInputRef", () => {
-  // ── $input.<field> pattern ──────────────────────────────────────────────
+// Money-integrity regression (2026-08-12, DEC-20260504-A both directions):
+// the wallet path billed `step_count - errors.length`, counting SKIPPED and
+// UNAVAILABLE steps as successes — a solution whose step 1 failed (starving
+// every downstream step's inputs) charged full price for ZERO executed
+// checks. This predicate is now the billing boundary on BOTH rails; these
+// tests fail against the pre-fix accounting (skipped/unavailable counted as
+// success there) and pass against the fix.
 
-  it("resolves $input.<field> to caller inputs", () => {
-    const result = resolveInputRef(
-      "$input.org_number",
-      { org_number: "5567037485" },
-      [],
-      {},
-    );
-    expect(result).toBe("5567037485");
+describe("isSuccessfulStepOutput (the billing boundary)", () => {
+  it("real output counts", () => {
+    expect(isSuccessfulStepOutput({ company_name: "LEGO A/S", status: "active" })).toBe(true);
+    expect(isSuccessfulStepOutput({})).toBe(true); // empty-but-real output object
   });
 
-  it("resolves $input.<field> with nested field name", () => {
-    const result = resolveInputRef(
-      "$input.contact_email",
-      { contact_email: "test@example.com" },
-      [],
-      {},
-    );
-    expect(result).toBe("test@example.com");
+  it("errors do NOT count", () => {
+    expect(isSuccessfulStepOutput({ error: "HTTP 503 from registry" })).toBe(false);
   });
 
-  // FIXME: F-0-004 — implementation now silently returns null for missing
-  // $input fields (solution-executor.ts:124-126) to support optional
-  // solution inputs. The "fail loud vs. fall back silent" question is a
-  // behavioural change, not a test-harness one — re-enable or remove this
-  // test in a session that owns solution-executor semantics.
-  it.skip("throws when $input references a missing field", () => {
-    expect(() =>
-      resolveInputRef("$input.missing_field", { org_number: "123" }, [], {}),
-    ).toThrow("field 'missing_field' not found in solution inputs");
+  it("input-starved skips do NOT count — the charge-for-nothing case", () => {
+    expect(isSuccessfulStepOutput({ skipped: true, reason: "All required inputs were not provided" })).toBe(false);
   });
 
-  // ── $steps[N].<field> pattern ───────────────────────────────────────────
-
-  it("resolves $steps[0].<field> to first step output", () => {
-    const completedSteps = [{ vat_number: "SE556703748501", company_name: "Spotify AB" }];
-    const result = resolveInputRef(
-      "$steps[0].vat_number",
-      {},
-      completedSteps,
-      {},
-    );
-    expect(result).toBe("SE556703748501");
+  it("unavailable (deactivated) steps do NOT count and are no longer invisible", () => {
+    expect(isSuccessfulStepOutput({ unavailable: true, reason: "capability unavailable" })).toBe(false);
   });
 
-  it("resolves $steps[0].company_name to first step output", () => {
-    const completedSteps = [{ company_name: "Spotify AB" }];
-    const result = resolveInputRef(
-      "$steps[0].company_name",
-      {},
-      completedSteps,
-      {},
-    );
-    expect(result).toBe("Spotify AB");
+  it("non-objects do not count", () => {
+    expect(isSuccessfulStepOutput(null)).toBe(false);
+    expect(isSuccessfulStepOutput(undefined)).toBe(false);
+    expect(isSuccessfulStepOutput("string")).toBe(false);
   });
 
-  it("returns null for $steps[N].<field> when field is missing from output", () => {
-    const completedSteps = [{ company_name: "Spotify AB" }];
-    const result = resolveInputRef(
-      "$steps[0].nonexistent_field",
-      {},
-      completedSteps,
-      {},
-    );
-    expect(result).toBeNull();
-  });
-
-  it("throws when $steps[N] references an out-of-range step", () => {
-    // F-B-016: preallocation means this error is now phrased as "out of
-    // range" — completedSteps.length equals steps.length from the start,
-    // so the idx-bounds check only fires for indices beyond the solution's
-    // authored step count, not for "authored but not yet completed" (which
-    // falls through to the $input fallback via the null-slot branch).
-    expect(() =>
-      resolveInputRef("$steps[5].field", {}, [], {}),
-    ).toThrow("step 5 is out of range");
-  });
-
-  it("treats not-yet-completed slots (null) as 'fall through to $input'", () => {
-    // Previously this case threw. Post-F-B-016, a null slot at an in-range
-    // index means "that authored step hasn't completed yet" — resolution
-    // falls through to the $input fallback path. Out-of-range still throws.
-    const completedSteps = [{ a: 1 }, null];
-    expect(
-      resolveInputRef("$steps[1].field", { field: "fallback" }, completedSteps, {}),
-    ).toBe("fallback");
-  });
-
-  // ── $all_results pattern ────────────────────────────────────────────────
-
-  it("resolves $all_results to aggregate of all step results", () => {
-    const stepResults = {
-      "swedish-company-data": { company_name: "Spotify AB" },
-      "vat-validate": { valid: true },
+  it("the all-steps-starved scenario bills nothing: no value in the set is a success", () => {
+    // Exactly the contained-solutions shape: step 1 errors, steps 2..n skip.
+    const steps = {
+      "danish-company-data": { error: "cvrapi.dk quota exhausted" },
+      "vat-validate": { skipped: true, reason: "All required inputs were not provided" },
+      "sanctions-check": { skipped: true, reason: "All required inputs were not provided" },
     };
-    const result = resolveInputRef("$all_results", {}, [], stepResults);
-    expect(result).toEqual({
-      "swedish-company-data": { company_name: "Spotify AB" },
-      "vat-validate": { valid: true },
-    });
-  });
-
-  // ── Literal pass-through ────────────────────────────────────────────────
-
-  it("passes through literal string values unchanged", () => {
-    expect(resolveInputRef("kyb", {}, [], {})).toBe("kyb");
-    expect(resolveInputRef("invoice_fraud", {}, [], {})).toBe("invoice_fraud");
-    expect(resolveInputRef("hello world", {}, [], {})).toBe("hello world");
-  });
-
-  it("passes through empty string as literal", () => {
-    expect(resolveInputRef("", {}, [], {})).toBe("");
-  });
-
-  // ── kyb-essentials-se full scenario ─────────────────────────────────────
-
-  it("resolves the full kyb-essentials-se step chain correctly", () => {
-    const inputs = { org_number: "5567037485" };
-
-    // Step 0: swedish-company-data receives $input.org_number
-    const step0Input = resolveInputRef("$input.org_number", inputs, [], {});
-    expect(step0Input).toBe("5567037485");
-
-    // Step 0 completes with company data
-    const step0Output = {
-      company_name: "Spotify AB",
-      vat_number: "SE556703748501",
-      org_number: "5567037485",
-    };
-    const completedSteps = [step0Output];
-    const stepResults: Record<string, unknown> = { "swedish-company-data": step0Output };
-
-    // Step 1: vat-validate receives $steps[0].vat_number
-    const step1Input = resolveInputRef("$steps[0].vat_number", inputs, completedSteps, stepResults);
-    expect(step1Input).toBe("SE556703748501");
-
-    // Step 2: sanctions-check receives $steps[0].company_name
-    const step2Input = resolveInputRef("$steps[0].company_name", inputs, completedSteps, stepResults);
-    expect(step2Input).toBe("Spotify AB");
-
-    // Step 3: lei-lookup receives $steps[0].company_name
-    const step3Input = resolveInputRef("$steps[0].company_name", inputs, completedSteps, stepResults);
-    expect(step3Input).toBe("Spotify AB");
-  });
-
-  // ── Nested path resolution ────────────────────────────────────────────
-
-  it("resolves two-level nested: $steps[0].license.spdx", () => {
-    const steps = [{ license: { spdx: "MIT" } }];
-    expect(resolveInputRef("$steps[0].license.spdx", {}, steps, {})).toBe("MIT");
-  });
-
-  it("resolves four-level nested: $steps[0].a.b.c.d", () => {
-    const steps = [{ a: { b: { c: { d: 42 } } } }];
-    expect(resolveInputRef("$steps[0].a.b.c.d", {}, steps, {})).toBe(42);
-  });
-
-  it("resolves array index: $steps[0].items[0]", () => {
-    const steps = [{ items: ["first", "second"] }];
-    expect(resolveInputRef("$steps[0].items[0]", {}, steps, {})).toBe("first");
-  });
-
-  it("resolves mixed dot and bracket: $steps[0].items[2].name", () => {
-    const steps = [{ items: [{ name: "a" }, { name: "b" }, { name: "c" }] }];
-    expect(resolveInputRef("$steps[0].items[2].name", {}, steps, {})).toBe("c");
-  });
-
-  it("resolves $input nested: $input.company.name", () => {
-    expect(resolveInputRef("$input.company.name", { company: { name: "Stripe" } }, [], {})).toBe("Stripe");
-  });
-
-  // FIXME: F-0-004 — implementation now catches walkPath errors and falls
-  // back to $input or null (solution-executor.ts:139-154). Same behavioural
-  // divergence as the $input.missing_field test above; re-enable in a
-  // solution-executor-owned session.
-  it.skip("throws on missing key at depth 2: $steps[0].foo.bar when foo is null", () => {
-    expect(() => resolveInputRef("$steps[0].foo.bar", {}, [{ foo: null }], {}))
-      .toThrow("value is null");
-  });
-
-  // FIXME: F-0-004 — same as above, silent-fallback behaviour swallows the throw.
-  it.skip("throws on array index out of bounds: $steps[0].items[99]", () => {
-    expect(() => resolveInputRef("$steps[0].items[99]", {}, [{ items: [1, 2, 3] }], {}))
-      .toThrow("index 99 out of bounds");
-  });
-
-  // FIXME: F-0-004 — same as above, silent-fallback behaviour swallows the throw.
-  it.skip("throws on type mismatch: $steps[0].items.name when items is array", () => {
-    expect(() => resolveInputRef("$steps[0].items.name", {}, [{ items: [1, 2] }], {}))
-      .toThrow("expected object");
-  });
-
-  it("throws on wildcards: $steps[0].items[*]", () => {
-    expect(() => resolveInputRef("$steps[0].items[*]", {}, [{ items: [1] }], {}))
-      .toThrow("wildcards not supported");
-  });
-
-  it("resolves the dependency-risk-check pattern: $steps[0].license.spdx", () => {
-    const steps = [{
-      name: "express",
-      version: "4.18.2",
-      license: { spdx: "MIT", is_osi_approved: true, is_copyleft: false },
-      risk_score: 94,
-    }];
-    expect(resolveInputRef("$steps[0].license.spdx", {}, steps, {})).toBe("MIT");
-  });
-
-  // ── F-B-016: deterministic $steps[N] resolution ──────────────────────────
-
-  describe("F-B-016: $steps[N] resolution with preallocated completedSteps", () => {
-    it("resolves $steps[N] by sorted position when earlier slots are null (not-yet-completed)", () => {
-      // Simulates: step 0 (sequential) has finished; parallel group [1,2] hasn't started.
-      // completedSteps = [output_0, null, null]. $steps[0] must still resolve to output_0.
-      const completedSteps = [
-        { company_name: "Spotify AB", vat_number: "SE556703748501" },
-        null,
-        null,
-      ];
-      expect(
-        resolveInputRef("$steps[0].company_name", {}, completedSteps, {}),
-      ).toBe("Spotify AB");
-    });
-
-    it("falls back to $input when referenced $steps[N] slot is null (not completed yet)", () => {
-      // A defensive runtime path: if an authoring mistake slipped past Gate 4a,
-      // resolution against a null slot falls through to $input instead of
-      // silently grabbing the wrong step's output.
-      const completedSteps = [{ company_name: "Spotify" }, null];
-      const result = resolveInputRef(
-        "$steps[1].company_name",
-        { company_name: "Fallback Co" },
-        completedSteps,
-        {},
-      );
-      expect(result).toBe("Fallback Co");
-    });
-
-    it("throws when the index is actually out of range (past steps.length)", () => {
-      const completedSteps = [{ a: 1 }, { b: 2 }];
-      expect(() =>
-        resolveInputRef("$steps[5].x", {}, completedSteps, {}),
-      ).toThrow(/step 5 is out of range/);
-    });
-
-    it("$steps[N] is insensitive to parallel-group completion order", () => {
-      // Simulates the fix: three parallel steps [A, B, C] at sorted
-      // indices [0, 1, 2]. Regardless of which finished first, each
-      // slot holds the output of the step at its authored position.
-      const completedSteps = [
-        { from: "A" }, // stepOrder-0 slot, possibly finished 3rd
-        { from: "B" }, // stepOrder-1 slot, possibly finished 1st
-        { from: "C" }, // stepOrder-2 slot, possibly finished 2nd
-      ];
-      expect(resolveInputRef("$steps[0].from", {}, completedSteps, {})).toBe("A");
-      expect(resolveInputRef("$steps[1].from", {}, completedSteps, {})).toBe("B");
-      expect(resolveInputRef("$steps[2].from", {}, completedSteps, {})).toBe("C");
-    });
+    expect(Object.values(steps).some(isSuccessfulStepOutput)).toBe(false);
   });
 });

--- a/apps/api/src/lib/solution-executor.ts
+++ b/apps/api/src/lib/solution-executor.ts
@@ -28,6 +28,23 @@ import { sanitizeFailureReason } from "./sanitize.js";
 import { enrichCompanyOutput } from "../capabilities/lib/enrich-company-output.js";
 import { logWarn } from "./log.js";
 
+/**
+ * True iff a step's recorded value is real capability output — not an error,
+ * not skipped-for-missing-inputs, not unavailable.
+ *
+ * Money-integrity 2026-08-12: this predicate is the billing boundary. The
+ * wallet path used `step_count - errors.length`, which counted SKIPPED steps
+ * as successes — a solution whose step 1 failed (starving every downstream
+ * step's inputs) billed full price for zero executed checks. The x402 path
+ * already refused settlement on this exact predicate; both rails now share
+ * it. DEC-14: no successful step ⇒ no charge.
+ */
+export function isSuccessfulStepOutput(v: unknown): boolean {
+  if (!v || typeof v !== "object") return false;
+  const obj = v as Record<string, unknown>;
+  return !("error" in obj) && !("skipped" in obj) && !("unavailable" in obj);
+}
+
 // ─── Input reference resolution ─────────────────────────────────────────────
 
 const INPUT_REF = /^\$input\.(.+)$/;
@@ -272,6 +289,15 @@ export async function executeSolution(
       const executor = getExecutor(step.capabilitySlug);
       if (!executor) {
         stepErrors.push(`${step.capabilitySlug}: executor unavailable`);
+        // Money-integrity 2026-08-12: the step must still APPEAR — a bare
+        // return made deactivated steps vanish from the audit trail entirely
+        // (a solution advertising 14 steps audited 13 with no gap marker).
+        stepResults[step.capabilitySlug] = {
+          unavailable: true,
+          reason: "capability unavailable (deactivated or not deployed) — this step did not run",
+        };
+        completedSteps[stepIndex.get(step)!] = {};
+        stepTimings.push({ capabilitySlug: step.capabilitySlug, latencyMs: 0 });
         return;
       }
 
@@ -291,6 +317,13 @@ export async function executeSolution(
           err instanceof BudgetExhaustedError
         ) {
           stepErrors.push(`${step.capabilitySlug}: ${err.message}`);
+          // Same audit-visibility rule as the executor-unavailable branch.
+          stepResults[step.capabilitySlug] = {
+            unavailable: true,
+            reason: sanitizeFailureReason(err.message),
+          };
+          completedSteps[stepIndex.get(step)!] = {};
+          stepTimings.push({ capabilitySlug: step.capabilitySlug, latencyMs: 0 });
           return;
         }
         throw err;

--- a/apps/api/src/lib/solution-executor.ts
+++ b/apps/api/src/lib/solution-executor.ts
@@ -42,7 +42,14 @@ import { logWarn } from "./log.js";
 export function isSuccessfulStepOutput(v: unknown): boolean {
   if (!v || typeof v !== "object") return false;
   const obj = v as Record<string, unknown>;
-  return !("error" in obj) && !("skipped" in obj) && !("unavailable" in obj);
+  // Executor markers ONLY (review H-1): capabilities legitimately return
+  // soft verdicts like {valid:false, error:"Invalid IBAN checksum"} — that
+  // is the purchased answer, not a failure. The executor's own failure
+  // marker is EXACTLY {error: string} (single key, written in the catch
+  // block above); skipped/unavailable carry their boolean flags.
+  if (obj.skipped === true || obj.unavailable === true) return false;
+  if (Object.keys(obj).length === 1 && typeof obj.error === "string") return false;
+  return true;
 }
 
 // ─── Input reference resolution ─────────────────────────────────────────────

--- a/apps/api/src/lib/tos-blocklist.test.ts
+++ b/apps/api/src/lib/tos-blocklist.test.ts
@@ -131,7 +131,7 @@ describe("blocklist integrity", () => {
     for (const rule of PROHIBITED_TARGETS) {
       // hostRe rules use `host` as a display placeholder, not a real
       // hostname — probe them with a representative concrete host instead.
-      const host = rule.hostRe ? "www.google.se" : rule.host;
+      const host = rule.hostRe ? rule.testHost! : rule.host;
       const url = `https://${host}${rule.pathPrefix ?? "/"}`;
       expect(() => assertTargetAllowed(url), url).toThrow(TOS_REFUSAL_MARKER);
     }

--- a/apps/api/src/lib/tos-blocklist.test.ts
+++ b/apps/api/src/lib/tos-blocklist.test.ts
@@ -129,9 +129,25 @@ describe("blocklist integrity", () => {
     // If this drifts, a policy refusal starts counting as a capability
     // failure and a burst of blocked URLs trips the breaker for everyone.
     for (const rule of PROHIBITED_TARGETS) {
-      const url = `https://${rule.host}${rule.pathPrefix ?? "/"}`;
-      expect(() => assertTargetAllowed(url)).toThrow(TOS_REFUSAL_MARKER);
+      // hostRe rules use `host` as a display placeholder, not a real
+      // hostname — probe them with a representative concrete host instead.
+      const host = rule.hostRe ? "www.google.se" : rule.host;
+      const url = `https://${host}${rule.pathPrefix ?? "/"}`;
+      expect(() => assertTargetAllowed(url), url).toThrow(TOS_REFUSAL_MARKER);
     }
+  });
+
+  it("the H-4 ruling covers Google ccTLDs, not just google.com (money-integrity 2026-08-12)", () => {
+    for (const url of [
+      "https://www.google.se/search?q=iphone&tbm=shop",
+      "https://google.de/search?q=x",
+      "https://www.google.co.uk/search?q=x",
+    ]) {
+      expect(() => assertTargetAllowed(url), url).toThrow(TOS_REFUSAL_MARKER);
+    }
+    // Non-search Google properties and lookalike hosts stay allowed.
+    expect(() => assertTargetAllowed("https://www.google.se/maps")).not.toThrow();
+    expect(() => assertTargetAllowed("https://notgoogle.se/search")).not.toThrow();
   });
 
   it("the circuit breaker actually classifies a refusal as user-input, not a fault", () => {

--- a/apps/api/src/lib/tos-blocklist.ts
+++ b/apps/api/src/lib/tos-blocklist.ts
@@ -43,6 +43,12 @@ export interface ProhibitedTarget {
    * google.com/search is ToS-prohibited for scraping, google.com is not.
    */
   pathPrefix?: string;
+  /**
+   * When set, matches the hostname by regex instead of exact/subdomain
+   * equality — for rulings covering a domain FAMILY (google ccTLDs). `host`
+   * then serves only as the display placeholder.
+   */
+  hostRe?: RegExp;
   /** Human-readable site name, used in the caller-facing message. */
   site: string;
   /** Governing decision. Internal provenance — never sent to callers. */
@@ -81,6 +87,17 @@ export const PROHIBITED_TARGETS: readonly ProhibitedTarget[] = [
   },
   {
     host: "google.com",
+    pathPrefix: "/search",
+    site: "Google Search",
+    decision: "DEC-20260427-H-4",
+    alternatives: "Use the google-search capability, which runs on a licensed search API.",
+  },
+  {
+    // Money-integrity 2026-08-12: the H-4 ruling covers Google Search, not
+    // one hostname — google.se/.de/.co.uk /search were still executable
+    // (product-search exploited exactly this). ccTLD family, same path rule.
+    hostRe: /^(?:www\.)?google\.(?:[a-z]{2,3})(?:\.[a-z]{2})?$/,
+    host: "google.<ccTLD>",
     pathPrefix: "/search",
     site: "Google Search",
     decision: "DEC-20260427-H-4",
@@ -152,7 +169,9 @@ export function findProhibitedTarget(rawUrl: string): ProhibitedTarget | null {
   const hostname = parsed.hostname.toLowerCase().replace(/\.$/, "");
 
   for (const rule of PROHIBITED_TARGETS) {
-    const hostMatches = hostname === rule.host || hostname.endsWith(`.${rule.host}`);
+    const hostMatches = rule.hostRe
+      ? rule.hostRe.test(hostname)
+      : hostname === rule.host || hostname.endsWith(`.${rule.host}`);
     if (!hostMatches) continue;
     if (rule.pathPrefix && !parsed.pathname.startsWith(rule.pathPrefix)) continue;
     return rule;

--- a/apps/api/src/lib/tos-blocklist.ts
+++ b/apps/api/src/lib/tos-blocklist.ts
@@ -46,9 +46,12 @@ export interface ProhibitedTarget {
   /**
    * When set, matches the hostname by regex instead of exact/subdomain
    * equality — for rulings covering a domain FAMILY (google ccTLDs). `host`
-   * then serves only as the display placeholder.
+   * then serves only as the display placeholder. Matches ALL subdomains —
+   * hostname variation is the evasion this rule class exists to close.
    */
   hostRe?: RegExp;
+  /** Concrete example hostname for hostRe rules — used by the integrity tests. */
+  testHost?: string;
   /** Human-readable site name, used in the caller-facing message. */
   site: string;
   /** Governing decision. Internal provenance — never sent to callers. */
@@ -96,7 +99,8 @@ export const PROHIBITED_TARGETS: readonly ProhibitedTarget[] = [
     // Money-integrity 2026-08-12: the H-4 ruling covers Google Search, not
     // one hostname — google.se/.de/.co.uk /search were still executable
     // (product-search exploited exactly this). ccTLD family, same path rule.
-    hostRe: /^(?:www\.)?google\.(?:[a-z]{2,3})(?:\.[a-z]{2})?$/,
+    hostRe: /^(?:[a-z0-9-]+\.)*google\.[a-z]{2,3}(?:\.[a-z]{2})?$/,
+    testHost: "www.google.se",
     host: "google.<ccTLD>",
     pathPrefix: "/search",
     site: "Google Search",

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -312,12 +312,11 @@ solutionExecuteRoute.post(
     // trail that says "14 steps" must list 14 steps.
     const stepAuditEntries = Object.entries(execResult.steps).map(([capSlug, output], index) => {
       const obj = (output && typeof output === "object" ? output : {}) as Record<string, unknown>;
-      const isError = "error" in obj || execResult.errors.some((e) => e.startsWith(`${capSlug}:`));
       const status = isSuccessfulStepOutput(output)
         ? "completed"
-        : "skipped" in obj
+        : obj.skipped === true
           ? "skipped"
-          : "unavailable" in obj
+          : obj.unavailable === true
             ? "unavailable"
             : "failed";
       const timing = execResult.stepTimings.find((t) => t.capabilitySlug === capSlug);
@@ -326,9 +325,14 @@ solutionExecuteRoute.post(
         capabilitySlug: capSlug,
         status,
         latencyMs: timing?.latencyMs ?? 0,
-        error: isError && status === "failed"
-          ? sanitizeFailureReason(execResult.errors.find((e) => e.startsWith(`${capSlug}:`))?.split(": ").slice(1).join(": ") ?? null)
-          : typeof obj.reason === "string" ? obj.reason : null,
+        // error is populated only for real executor failures; the reason slot
+        // covers skipped/unavailable. A completed soft verdict (valid:false)
+        // carries neither (review H-1/L-1).
+        error: status === "failed"
+          ? sanitizeFailureReason(execResult.errors.find((e) => e.startsWith(`${capSlug}:`))?.split(": ").slice(1).join(": ") ?? (typeof obj.error === "string" ? obj.error : null))
+          : status === "skipped" || status === "unavailable"
+            ? (typeof obj.reason === "string" ? obj.reason : null)
+            : null,
       };
     });
 

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -21,7 +21,7 @@ import { solutions, wallets, walletTransactions, transactions } from "../db/sche
 import { authMiddleware } from "../lib/middleware.js";
 import { rateLimitByKey } from "../lib/rate-limit.js";
 import { apiError } from "../lib/errors.js";
-import { executeSolution } from "../lib/solution-executor.js";
+import { executeSolution, isSuccessfulStepOutput } from "../lib/solution-executor.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
 import { logError } from "../lib/log.js";
 import { getProcessingJurisdictions } from "../lib/provenance-builder.js";
@@ -286,7 +286,12 @@ solutionExecuteRoute.post(
     const latencyMs = Date.now() - startTime;
     const totalSteps = execResult.step_count;
     const errorCount = execResult.errors.length;
-    const stepsSucceeded = totalSteps - errorCount;
+    // Money-integrity 2026-08-12: success = a step that actually produced
+    // output. The previous `step_count - errors.length` counted SKIPPED and
+    // UNAVAILABLE steps as successes, so a solution whose step 1 failed
+    // (starving every downstream step) billed full price for zero executed
+    // checks. Same predicate the x402 rail settles on (DEC-14).
+    const stepsSucceeded = Object.values(execResult.steps).filter(isSuccessfulStepOutput).length;
     const allFailed = stepsSucceeded === 0;
 
     // /v1/do vocabulary: "completed" or "failed". Partial success maps to "completed"
@@ -301,18 +306,29 @@ solutionExecuteRoute.post(
 
     const finalBalance = allFailed ? walletBalanceBefore : balanceAfter;
 
-    // Build per-step audit breakdown with per-step latency
+    // Build per-step audit breakdown with per-step latency. Every step now
+    // appears (the executor records skipped/unavailable markers instead of
+    // silently omitting them), with an honest four-state status — an audit
+    // trail that says "14 steps" must list 14 steps.
     const stepAuditEntries = Object.entries(execResult.steps).map(([capSlug, output], index) => {
-      const isError = execResult.errors.some((e) => e.startsWith(`${capSlug}:`));
+      const obj = (output && typeof output === "object" ? output : {}) as Record<string, unknown>;
+      const isError = "error" in obj || execResult.errors.some((e) => e.startsWith(`${capSlug}:`));
+      const status = isSuccessfulStepOutput(output)
+        ? "completed"
+        : "skipped" in obj
+          ? "skipped"
+          : "unavailable" in obj
+            ? "unavailable"
+            : "failed";
       const timing = execResult.stepTimings.find((t) => t.capabilitySlug === capSlug);
       return {
         index,
         capabilitySlug: capSlug,
-        status: isError ? "failed" : "completed",
+        status,
         latencyMs: timing?.latencyMs ?? 0,
-        error: isError
+        error: isError && status === "failed"
           ? sanitizeFailureReason(execResult.errors.find((e) => e.startsWith(`${capSlug}:`))?.split(": ").slice(1).join(": ") ?? null)
-          : null,
+          : typeof obj.reason === "string" ? obj.reason : null,
       };
     });
 

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -35,7 +35,7 @@ import {
 } from "../lib/x402-gateway.js";
 import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
-import { executeSolution } from "../lib/solution-executor.js";
+import { executeSolution, isSuccessfulStepOutput } from "../lib/solution-executor.js";
 import { logError } from "../lib/log.js";
 import { getProcessingJurisdictions } from "../lib/provenance-builder.js";
 import { getProcessingLocation } from "../lib/processing-location.js";
@@ -982,14 +982,9 @@ x402GatewayV2.on(["GET", "POST"], "/solutions/:slug", async (c) => {
 
   // Settle only if at least one step produced output. All-steps-failed returns
   // a 4xx-shaped response and the caller keeps their USDC authorization.
-  // `result.steps` is a Record<slug, output | {error} | {skipped}>. A step
-  // counts as successful when its value is an object with neither `error` nor
-  // `skipped` set.
-  const anyStepSucceeded = Object.values(result.steps).some((v) => {
-    if (!v || typeof v !== "object") return false;
-    const obj = v as Record<string, unknown>;
-    return !("error" in obj) && !("skipped" in obj);
-  });
+  // Shared predicate with the wallet path (money-integrity 2026-08-12) — it
+  // also covers the new `unavailable` marker for deactivated steps.
+  const anyStepSucceeded = Object.values(result.steps).some(isSuccessfulStepOutput);
   if (!anyStepSucceeded) {
     return c.json(
       {

--- a/manifests/pep-check.yaml
+++ b/manifests/pep-check.yaml
@@ -143,6 +143,11 @@ personal_data_categories:
   - nationality
   - political_affiliation
 geography: global
+# GDPR Art. 22 (Bucket C): match results the customer uses to decide —
+# the canonical screening_signal case (CLAUDE.md names this capability as the
+# example). Was defaulting to data_lookup, which put the wrong gdpr block and
+# dispute framing on the audit body (P0, legal audit 2026-08-12).
+gdpr_art_22_classification: screening_signal
 test_fixtures:
   known_answer:
     input:

--- a/manifests/sanctions-check.yaml
+++ b/manifests/sanctions-check.yaml
@@ -145,6 +145,11 @@ personal_data_categories:
   - date_of_birth
   - nationality
 geography: global
+# GDPR Art. 22 (Bucket C): match results the customer uses to decide —
+# the canonical screening_signal case (CLAUDE.md names this capability as the
+# example). Was defaulting to data_lookup, which put the wrong gdpr block and
+# dispute framing on the audit body (P0, legal audit 2026-08-12).
+gdpr_art_22_classification: screening_signal
 test_fixtures:
   known_answer:
     input:


### PR DESCRIPTION
## Summary
- **Solution billing (DEC-14)**: `isSuccessfulStepOutput` is the billing boundary on both rails — skipped/unavailable steps no longer count as successes (the charge-full-price-for-zero-checks defect), and after review, capabilities' soft negative verdicts (`{valid:false, error:…}` — the purchased answer) correctly count AS successes. Deactivated steps appear in the audit trail as `unavailable` instead of vanishing; four-state per-step statuses.
- **GDPR Art. 22**: sanctions-check + pep-check → `screening_signal`. DEC-20260504-C satisfied: `sync-manifest-canonical-to-db` run for both slugs and the prod column verified (`SELECT slug, gdpr_art_22_classification…` → `screening_signal` for all three screening capabilities).
- **product-search deactivated** (doctrine-compelled: sole source is a Google Shopping scrape under DEC-20260427-H-4, reachable via a Google-ccTLD blocklist gap — rule family added, all subdomains, pinned by tests). DB flags cleared + health event logged; the startup Phase-3 sync enforces on deploy.
- **Bare-fetch sweep**: 14 caller-URL executors now use safeFetch or an explicit ToS gate before vendor/Browserless forwarding; spoofed Chrome UAs replaced with the honest StraleBot UA (3 files). New **call-site-sound** CI guard (`lint:no-unguarded-user-fetch`, wired into ci.yml) with explicit ok-markers for provably-constrained sites — its hardened version immediately caught one more missed raw fetch (cookie-scan).
- **weekly-drift.yml repaired**: `pipefail` per step (tee swallowed every exit code — the sweep has reported clean since inception and its tracking issue never opened), dead `check-migration-prefixes` step removed (checker recreation filed), facts-drift `--strict`.

## Adversarial review (pre-PR, two rounds)
Round 1 fixed in the second commit: 3 HIGHs (soft-verdict misclassification that would have recorded "IBAN checksum invalid" as a platform failure and refunded correct runs; the Art.22 deploy-dependency — already satisfied, see above; a file-level guard that its own diff defeated) + accidental overwrite of a 264-line test suite (restored, incl. F-B-016). Caveat: cross-provider independent review not executable from this harness (same-provider adversarial passes, as in #178–#181).
Accepted/filed: StraleBot UA may undercount on UA-hostile social platforms (pending the parked DEC-20260420-H doctrine ruling); audit `index` is insertion-order (filed); partial-solution pricing policy for permanently-unavailable steps (filed, Petter).

## Verification
- 1102 tests pass (0 failed; earlier single-fail was the documented parallel-collection flake) · tsc clean · all guards green incl. the new one
- Contained-solutions context: the 15 charge-for-nothing solutions were deactivated in DB earlier today (`solution_contained` events); this PR fixes the root cause. Re-enable DK ×3 after danish-company-data recovers; AT/NL/ES/PT ×12 stay off until step-1 exists.

## Test plan (post-merge)
`/health` SHA advanced; sanctions-check DB column spot-check (done pre-merge, re-verify); `POST /v1/do url-to-markdown {"url":"https://www.google.se/search?q=x"}` → ToS refusal, unbilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)