### PR TITLE
feat(kyb): open name paths on five registry capabilities; fix finnish resolver

### DIFF
--- a/apps/api/scripts/check-identity-fixture-shape.mjs
+++ b/apps/api/scripts/check-identity-fixture-shape.mjs
@@ -120,9 +120,13 @@ const NAME_FIELDS = new Set([
 // own canonical formats.
 const INPUT_REGEX_BY_SLUG = {
   "swedish-company-data":    { fields: ["org_number"],      regex: /^\d{6}-\d{4}$/ },
-  "norwegian-company-data":  { fields: ["org_number"],      regex: /^\d{9}$/ },
+  // NO + FI known_answer fixtures deliberately exercise the NAME path since
+  // PR #184 (Gate 5 SECONDARY coverage — the path that actually broke in
+  // prod); the ID path is exercised by schema_check/dependency_health via
+  // health_check_input. Same free-text treatment as german-company-data.
+  "norwegian-company-data":  { fields: ["company_name", "org_number"], regex: null },
   "danish-company-data":     { fields: ["cvr_number"],      regex: /^\d{8}$/ },
-  "finnish-company-data":    { fields: ["business_id"],     regex: /^\d{7}-\d$/ },
+  "finnish-company-data":    { fields: ["company_name", "business_id"], regex: null },
   "uk-company-data":         { fields: ["company_number"],  regex: /^[A-Z0-9]{8}$/ },
   "irish-company-data":      { fields: ["cro_number"],      regex: /^\d{4,7}$/ },
   "french-company-data":     { fields: ["siren"],           regex: /^\d{9}(\d{5})?$/ },

--- a/apps/api/src/capabilities/belgian-company-data.ts
+++ b/apps/api/src/capabilities/belgian-company-data.ts
@@ -1,5 +1,6 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { deriveVatBE } from "../lib/vat-derivation.js";
+import { firstString } from "./lib/input-aliases.js";
 
 /**
  * Belgian company data via the CBEAPI.be vendor wrapper of KBO/BCE
@@ -135,14 +136,17 @@ async function lookupViaCbeApi(
 }
 
 registerCapability("belgian-company-data", async (input: CapabilityInput) => {
-  const raw =
-    (input.enterprise_number as string) ??
-    (input.company_name as string) ??
-    (input.task as string) ??
-    "";
-  if (typeof raw !== "string" || !raw.trim()) {
+  // firstString skips blank strings, so {"enterprise_number": "", "company_name": "X"}
+  // resolves via the name instead of dying on the empty field the route's anyOf
+  // already accepted. Alias surface matches the danish/finnish/norwegian siblings.
+  const raw = firstString(
+    input,
+    "enterprise_number", "company_name", "name", "query", "task",
+  );
+  if (!raw) {
     throw new Error(
-      "'enterprise_number' or 'company_name' is required. Provide a KBO/BCE number (e.g. 0404.616.494) or company name.",
+      "'enterprise_number' or 'company_name' is required. Provide a KBO/BCE number (e.g. 0404.616.494) " +
+        "or company name. Aliases accepted: name, query, task.",
     );
   }
 

--- a/apps/api/src/capabilities/estonian-company-data.ts
+++ b/apps/api/src/capabilities/estonian-company-data.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { and, eq, isNull } from "drizzle-orm";
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { firstString } from "./lib/input-aliases.js";
 import { getBrowserlessConfig, htmlToText } from "./lib/browserless-extract.js";
 import { getDb } from "../db/index.js";
 import { eeDirectors, eeDirectorsSync } from "../db/schema.js";
@@ -251,9 +252,18 @@ async function searchCompany(query: string, isRegCode: boolean): Promise<Record<
 }
 
 registerCapability("estonian-company-data", async (input: CapabilityInput) => {
-  const raw = (input.registry_code as string) ?? (input.company_name as string) ?? (input.task as string) ?? "";
-  if (typeof raw !== "string" || !raw.trim()) {
-    throw new Error("'registry_code' or 'company_name' is required. Provide an Estonian registry code (8 digits) or company name.");
+  // firstString skips blank strings, so an empty identifier field alongside a
+  // real company_name resolves via the name instead of erroring on input the
+  // route's anyOf already accepted. Alias surface matches the Nordic siblings.
+  const raw = firstString(
+    input,
+    "registry_code", "company_name", "name", "query", "task",
+  );
+  if (!raw) {
+    throw new Error(
+      "'registry_code' or 'company_name' is required. Provide an Estonian registry code (8 digits) " +
+        "or company name. Aliases accepted: name, query, task.",
+    );
   }
 
   const trimmed = raw.trim();

--- a/apps/api/src/capabilities/finnish-company-data.test.ts
+++ b/apps/api/src/capabilities/finnish-company-data.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { pickUnambiguous, scorePool } from "./finnish-company-data.js";
+
+// Synthetic PRH company records — shape mirrors the v3 API's `companies[]`
+// entries as consumed by scorePool (businessId keys the pool; names carry
+// optional endDate).
+function company(names: Array<{ name: string; endDate?: string | null }>) {
+  return { names };
+}
+
+describe("finnish scorePool", () => {
+  it("ignores ended names — a defunct alias must not resolve (Rovio regression)", () => {
+    // "Rovio" used to return Combiholding Oy via "E E Rovio Oy" (ended 2020).
+    const pool = new Map<string, any>([
+      ["2674369-7", company([
+        { name: "E E Rovio Oy", endDate: "2020-08-26" },
+        { name: "Combiholding Oy" },
+      ])],
+    ]);
+    const { exact, high } = scorePool("Rovio", pool);
+    expect(exact.size).toBe(0);
+    expect(high.size).toBe(0);
+  });
+
+  it("matches current names after legal-form suffix stripping", () => {
+    const pool = new Map<string, any>([
+      ["0112038-9", company([
+        { name: "Oy Nokia Ab", endDate: "1997-01-01" },
+        { name: "Nokia Oyj" },
+      ])],
+    ]);
+    const { exact } = scorePool("Nokia", pool);
+    expect([...exact.keys()]).toEqual(["0112038-9"]);
+    expect(exact.get("0112038-9")).toBe("Nokia Oyj");
+  });
+
+  it("promotes an id from high to exact when a later current name scores exact", () => {
+    const pool = new Map<string, any>([
+      ["111-1", company([
+        { name: "Acme Consulting Oy" }, // high vs "Acme Consulting Group"? keep simple:
+        { name: "Acme Group Oy" },
+      ])],
+    ]);
+    // "Acme Group" scores high on "Acme Consulting Oy"? Not necessarily — use
+    // a direct exact on the second name to assert the high-map cleanup.
+    const { exact, high } = scorePool("Acme Group", pool);
+    expect(exact.has("111-1")).toBe(true);
+    expect(high.has("111-1")).toBe(false);
+  });
+});
+
+describe("finnish pickUnambiguous", () => {
+  it("returns the single candidate with its match metadata", () => {
+    const r = pickUnambiguous("Nokia", new Map([["0112038-9", "Nokia Oyj"]]), "exact");
+    expect(r).toEqual({
+      businessId: "0112038-9",
+      matchedName: "Nokia Oyj",
+      matchConfidence: "exact",
+    });
+  });
+
+  it("refuses ties, listing the candidates", () => {
+    const bucket = new Map([
+      ["111-1", "Nokia Oy"],
+      ["222-2", "Nokia Oyj"],
+    ]);
+    expect(() => pickUnambiguous("Nokia", bucket, "exact")).toThrow(/Ambiguous.*2 distinct.*Nokia Oy \(111-1\).*Nokia Oyj \(222-2\)/s);
+  });
+});

--- a/apps/api/src/capabilities/finnish-company-data.ts
+++ b/apps/api/src/capabilities/finnish-company-data.ts
@@ -47,45 +47,100 @@ async function extractCompanyName(naturalLanguage: string): Promise<string> {
   return name;
 }
 
-async function searchPrh(name: string): Promise<string> {
-  // PRH's `name=` parameter is a FUZZY search across every historical name a
-  // company has ever held, and results come back ordered by business ID, not
-  // by relevance. Taking companies[0] blindly returns an unrelated legal
-  // entity: searching "Nokia" yields Fysios Mehiläinen Oy, Tikkurila Oyj and
-  // Nokian Vuokrakodit — Nokia Oyj (0112038-9) is not among them at all.
-  //
-  // Returning a confidently-wrong company from a KYB lookup is worse than
-  // returning nothing: the caller has no way to detect it. So we pull a page
-  // of candidates and only accept one whose name actually matches, reusing the
-  // same classifier us-company-data uses to refuse weak SEC EDGAR matches.
-  const url = `${PRH_API}?name=${encodeURIComponent(name)}&totalResults=false&maxResults=20`;
+async function prhNameQuery(name: string): Promise<any[]> {
+  // PRH v3 ignores maxResults — a broad query returns a full page (~60
+  // records, 200+KB). The generous timeout is deliberate: this exact call
+  // timed out twice from Railway US East at 10s (once cut mid-body as
+  // "Unterminated string in JSON"), which is what broke the name path in
+  // production on 2026-08-12.
+  const url = `${PRH_API}?name=${encodeURIComponent(name)}&totalResults=false`;
   const response = await fetch(url, {
     headers: { Accept: "application/json" },
-    signal: AbortSignal.timeout(10000),
+    signal: AbortSignal.timeout(20000),
   });
   if (!response.ok) throw new Error(`PRH API search returned HTTP ${response.status}`);
   const data = (await response.json()) as any;
-  const companies = data?.companies;
-  if (!companies || companies.length === 0) {
+  return (data?.companies ?? []) as any[];
+}
+
+export interface PrhNameResolution {
+  businessId: string;
+  matchedName: string;
+  matchConfidence: "exact" | "high";
+}
+
+export function scorePool(
+  searched: string,
+  pool: Map<string, any>,
+): { exact: Map<string, string>; high: Map<string, string> } {
+  // Each company carries every name it has ever held. Names with an endDate
+  // are dead — matching on them resolves defunct entities: "Rovio" used to
+  // return Combiholding Oy via "E E Rovio Oy" (ended 2020) and "Nordea"
+  // returned a branch deregistered in 2018. Only current names identify a
+  // company; a query that matches nothing current is refused, not guessed.
+  const exact = new Map<string, string>();
+  const high = new Map<string, string>();
+  for (const [id, c] of pool) {
+    for (const n of (c.names ?? []) as Array<{ name?: string; endDate?: string | null }>) {
+      if (!n?.name || n.endDate) continue;
+      const { match_confidence } = classifyNameMatch(searched, n.name);
+      if (match_confidence === "exact") {
+        exact.set(id, n.name);
+        high.delete(id);
+      } else if (match_confidence === "high" && !exact.has(id)) {
+        high.set(id, n.name);
+      }
+    }
+  }
+  return { exact, high };
+}
+
+export function pickUnambiguous(
+  searched: string,
+  bucket: Map<string, string>,
+  label: "exact" | "high",
+): PrhNameResolution {
+  if (bucket.size === 1) {
+    const [businessId, matchedName] = bucket.entries().next().value!;
+    return { businessId, matchedName, matchConfidence: label };
+  }
+  const listing = [...bucket.entries()]
+    .slice(0, 5)
+    .map(([id, n]) => `${n} (${id})`)
+    .join("; ");
+  throw new Error(
+    `Ambiguous Finnish company name "${searched}": ${bucket.size} distinct registered ` +
+      `entities are ${label === "exact" ? "exact" : "close"} matches — ${listing}. ` +
+      `Provide the Business ID directly (e.g. 0112038-9) to disambiguate.`,
+  );
+}
+
+async function searchPrh(name: string): Promise<PrhNameResolution> {
+  // PRH's `name=` parameter is a FUZZY substring search across every name a
+  // company has ever held, ordered by business ID and paginated at ~60
+  // records. Page one is stable and does contain the major brands ("Nokia" →
+  // Nokia Oyj at index ~36 of 63), so a single scored pass over it resolves
+  // well-known names — but result order carries no relevance signal, and a
+  // company outside page one is simply not found (refused with guidance).
+  //
+  // Returning a confidently-wrong company from a KYB lookup is worse than
+  // returning nothing (the caller cannot detect it), so acceptance is
+  // scored — exact wins, unique high is the floor, ties are refused — using
+  // the same classifier us-company-data uses for SEC EDGAR.
+  const pool = new Map<string, any>();
+  for (const c of await prhNameQuery(name)) {
+    const id = c.businessId?.value ?? c.businessId;
+    if (id && !pool.has(id)) pool.set(id, c);
+  }
+  if (pool.size === 0) {
     throw new Error(`No Finnish company found matching "${name}".`);
   }
 
-  // Each company carries every name it has held; score against all of them and
-  // keep the best. `exact` wins outright; otherwise `high` is the floor.
-  let best: { id: string; name: string; confidence: string } | null = null;
-  for (const c of companies) {
-    const id = c.businessId?.value ?? c.businessId;
-    if (!id) continue;
-    for (const n of (c.names ?? []) as Array<{ name?: string }>) {
-      if (!n?.name) continue;
-      const { match_confidence } = classifyNameMatch(name, n.name);
-      if (match_confidence === "exact") return id;
-      if (match_confidence === "high" && !best) best = { id, name: n.name, confidence: match_confidence };
-    }
-  }
-  if (best) return best.id;
+  const { exact, high } = scorePool(name, pool);
+  if (exact.size > 0) return pickUnambiguous(name, exact, "exact");
+  if (high.size > 0) return pickUnambiguous(name, high, "high");
 
-  const sample = companies
+  const sample = [...pool.values()]
     .slice(0, 3)
     .map((c: any) => (c.names ?? [])[0]?.name)
     .filter(Boolean)
@@ -188,13 +243,26 @@ registerCapability("finnish-company-data", async (input: CapabilityInput) => {
 
   const trimmed = rawInput.trim();
   let businessId = isBusinessId(trimmed) ?? findBusinessId(trimmed);
+  let nameResolution: PrhNameResolution | null = null;
 
   if (!businessId) {
-    const companyName = await extractCompanyName(trimmed);
-    businessId = await searchPrh(companyName);
+    // company_name/name are DECLARED to be the company name — search them
+    // literally. The LLM extraction step is only for free-text query/task
+    // inputs ("look up Nokia in Finland"), which keeps the declared-name path
+    // deterministic and free of per-call Anthropic cost.
+    const declaredName = firstString(input, "company_name", "name").trim();
+    const companyName = declaredName || (await extractCompanyName(trimmed));
+    nameResolution = await searchPrh(companyName);
+    businessId = nameResolution.businessId;
   }
 
   const output = await fetchCompany(businessId);
+  if (nameResolution) {
+    // Surface how the name resolved so callers can gate on fuzzy resolution
+    // (same pattern as us-company-data's match_confidence).
+    output.match_confidence = nameResolution.matchConfidence;
+    output.matched_registry_name = nameResolution.matchedName;
+  }
 
   // Evidence Tier framework labels + Tier 1 canonical aliases (DEC-20260518-A).
   // Resolves alias keys at runtime; only sets a canonical if not already present.

--- a/apps/api/src/lib/brreg-fetch.ts
+++ b/apps/api/src/lib/brreg-fetch.ts
@@ -75,14 +75,28 @@ export async function searchBrregByName(name: string): Promise<string> {
     throw new Error(`No Norwegian company found matching "${name}".`);
   }
 
-  let best: string | null = null;
+  // Ties are refused, not first-hit-resolved: two distinct entities scoring
+  // equally means the bare name cannot identify one legal entity, and the
+  // manifest promises "an ambiguous name is refused rather than resolved to
+  // the wrong legal entity". Same doctrine as finnish-company-data.
+  const exact = new Map<string, string>();
+  const high = new Map<string, string>();
   for (const e of entities) {
     if (!e.organisasjonsnummer || !e.navn) continue;
     const { match_confidence } = classifyNameMatch(name, e.navn);
-    if (match_confidence === "exact") return String(e.organisasjonsnummer);
-    if (match_confidence === "high" && best === null) best = String(e.organisasjonsnummer);
+    if (match_confidence === "exact") exact.set(String(e.organisasjonsnummer), e.navn);
+    else if (match_confidence === "high") high.set(String(e.organisasjonsnummer), e.navn);
   }
-  if (best !== null) return best;
+  const refuseTie = (bucket: Map<string, string>, label: string): string => {
+    if (bucket.size === 1) return bucket.keys().next().value!;
+    const listing = [...bucket.entries()].slice(0, 5).map(([id, n]) => `${n} (${id})`).join("; ");
+    throw new Error(
+      `Ambiguous Norwegian company name "${name}": ${bucket.size} distinct registered ` +
+        `entities are ${label} matches — ${listing}. Provide the org number (9 digits) to disambiguate.`,
+    );
+  };
+  if (exact.size > 0) return refuseTie(exact, "exact");
+  if (high.size > 0) return refuseTie(high, "close");
 
   const closest = entities.slice(0, 3).map((e) => e.navn).filter(Boolean).join(", ");
   throw new Error(

--- a/apps/api/src/lib/gate5-path-coverage.test.ts
+++ b/apps/api/src/lib/gate5-path-coverage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { enumerateEntryPoints } from "./gate5-path-coverage.js";
+
+// Regression coverage for the alias refinement (KYB build-out 2026-08-12):
+// alias fields funnel into the same firstString dispatch chain as their
+// canonical field, so they must not be counted as separate entry points —
+// otherwise every schema unblock (adding org_number/name/query/task aliases)
+// demands N duplicate fixtures of the same two code paths.
+describe("gate5 enumerateEntryPoints alias handling", () => {
+  const danishStyleSchema = {
+    type: "object",
+    required: [],
+    properties: {
+      cvr_number: { type: "string", description: "Danish CVR number (8 digits)" },
+      org_number: { type: "string", description: "Alias for cvr_number" },
+      company_number: { type: "string", description: "Alias for cvr_number" },
+      company_name: { type: "string", description: "Danish company name (resolved via scored registry search)" },
+      name: { type: "string", description: "Alias for company_name" },
+      query: { type: "string", description: "Free-text alias — CVR number or company name" },
+      task: { type: "string", description: "Free-text alias — CVR number or company name" },
+    },
+  };
+
+  it("keeps canonical ID and name fields as the only entry points", () => {
+    const eps = enumerateEntryPoints("danish-company-data", danishStyleSchema);
+    const fields = eps.map((e) => `${e.field}:${e.pathType}`).sort();
+    expect(fields).toEqual(["company_name:SECONDARY", "cvr_number:PRIMARY"]);
+  });
+
+  it("skips 'Free-text input' style descriptions (belgian task field)", () => {
+    const eps = enumerateEntryPoints("belgian-company-data", {
+      properties: {
+        enterprise_number: { type: "string", description: "KBO/BCE enterprise number (e.g. 0404.616.494)" },
+        company_name: { type: "string", description: "Belgian company name (fuzzy match)" },
+        task: { type: "string", description: "Free-text input — first matching enterprise number or name is used" },
+      },
+    });
+    expect(eps.map((e) => e.field).sort()).toEqual(["company_name", "enterprise_number"]);
+  });
+
+  it("still counts real name fields without alias descriptions", () => {
+    const eps = enumerateEntryPoints("x", {
+      properties: {
+        company_name: { type: "string", description: "Company name" },
+      },
+    });
+    expect(eps).toHaveLength(1);
+    expect(eps[0].pathType).toBe("SECONDARY");
+  });
+
+  it("does NOT declassify an alias whose target field is missing from the schema", () => {
+    // Prose alone must not remove an entry point: "Alias for X" with no X in
+    // properties falls through to normal classification.
+    const eps = enumerateEntryPoints("x", {
+      properties: {
+        cvr_number: { type: "string", description: "Danish CVR number (8 digits)" },
+        name: { type: "string", description: "Alias for company_name" },
+      },
+    });
+    const fields = eps.map((e) => `${e.field}:${e.pathType}`).sort();
+    expect(fields).toEqual(["cvr_number:PRIMARY", "name:SECONDARY"]);
+  });
+});

--- a/apps/api/src/lib/gate5-path-coverage.ts
+++ b/apps/api/src/lib/gate5-path-coverage.ts
@@ -90,6 +90,7 @@ function classifyField(fieldName: string, fieldDescription?: string): PathType |
     return null;
   }
 
+
   // Check field name against ID patterns first
   if (ID_FIELD_PATTERNS.some((p) => p.test(fieldName))) {
     return "PRIMARY";
@@ -146,8 +147,18 @@ export function enumerateEntryPoints(
   const fieldNames = Object.keys(properties);
 
   for (const fieldName of fieldNames) {
-    const prop = properties[fieldName];
-    const desc = prop?.description ?? "";
+    const prop: { type?: string; description?: string } | undefined = properties[fieldName];
+    const desc: string = prop?.description ?? "";
+
+    // Alias fields funnel into the same firstString dispatch chain as their
+    // canonical field — not separate handler paths, so requiring a fixture
+    // per alias would demand N duplicate fixtures of the same code path.
+    // "Alias for X" only declassifies when X actually exists in this schema:
+    // prose alone cannot remove the last entry point of a path. "Free-text"
+    // catch-alls (task/query) are declared funnels to the canonical dispatch.
+    const aliasTarget = /^alias for ([a-z0-9_]+)/i.exec(desc.trim())?.[1];
+    if (aliasTarget && properties[aliasTarget]) continue;
+    if (/^free-text/i.test(desc.trim())) continue;
 
     if (isDualPurposeField(fieldName, desc)) {
       entryPoints.push({

--- a/audit-output/parallel-audits-2026-08-12/austria-firmenbuch-integration-spec.md
+++ b/audit-output/parallel-audits-2026-08-12/austria-firmenbuch-integration-spec.md
@@ -1,0 +1,107 @@
+# Austria Firmenbuch HVD — integration spec (build-ready, blocked on API key)
+
+**Status 2026-08-12:** everything verifiable without a key is verified; the build is
+parked because the API key requires a JustizOnline registration — a Petter action.
+Once `FIRMENBUCH_API_KEY` is in `.env` + Railway, the executor build + onboarding is
+a ~1–2 hour session with live verification.
+
+## Why this matters
+
+Free, official, real-time, CC BY 4.0 (Austria's IWG explicitly extends reuse to
+commercial purposes), and it carries the **officer/managing-director leg** that the
+Openapi WW-Top vendor route cannot supply. It flips AT from "deactivated pending
+aggregator" to "direct API" — the same class as brreg.no/PRH. Source research:
+`kyb-coverage-research.md` §2.1 (this directory).
+
+## Petter action (the blocker)
+
+Register for an API key: <https://justizonline.gv.at/jop/web/iwg/register>
+("Antrag auf Informationsweiterverwendung" tile). The research notes production
+keys and rate limits may involve contact with the BMJ integration team; rate
+limits are NOT published. Once received, set `FIRMENBUCH_API_KEY` locally and on
+Railway.
+
+## Verified facts (2026-08-12)
+
+- Endpoint: `POST https://justizonline.gv.at/jop/api/at.gv.justiz.fbw/ws`
+- Auth: `X-Api-Key: <key>` header. Without it every path (incl. the WSDL at
+  `/jop/api/at.gv.justiz.fbw/ws/fbw.wsdl`) returns `401 {"message":"Unauthorized"}`
+  — confirmed by direct probe.
+- Protocol: SOAP 1.2 (`Content-Type: application/soap+xml;charset=UTF-8`, empty
+  `SOAPAction`).
+- Request shapes confirmed via the community Postman collection
+  (github.com/Lukhers-dev/firmenbuch-HVD — the project behind openfirmenbuch.at):
+
+### Name search
+
+```xml
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+               xmlns:suc="ns://firmenbuch.justiz.gv.at/Abfrage/SucheFirmaRequest">
+  <soap:Header/>
+  <soap:Body>
+    <suc:SUCHEFIRMAREQUEST>
+      <suc:FIRMENWORTLAUT>Datenkraftwerk GmbH</suc:FIRMENWORTLAUT>
+      <suc:EXAKTESUCHE>true</suc:EXAKTESUCHE>
+      <suc:SUCHBEREICH>1</suc:SUCHBEREICH>
+      <suc:GERICHT></suc:GERICHT>
+      <suc:RECHTSFORM></suc:RECHTSFORM>
+      <suc:RECHTSEIGENSCHAFT></suc:RECHTSEIGENSCHAFT>
+      <suc:ORTNR></suc:ORTNR>
+    </suc:SUCHEFIRMAREQUEST>
+  </soap:Body>
+</soap:Envelope>
+```
+
+### Company extract (Auszug) by FN number
+
+```xml
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+               xmlns:aus="ns://firmenbuch.justiz.gv.at/Abfrage/v2/AuszugRequest">
+  <soap:Header/>
+  <soap:Body>
+    <aus:AUSZUG_V2_REQUEST>
+      <aus:FNR>5h</aus:FNR>
+      <aus:STICHTAG>2015-12-22</aus:STICHTAG>
+      <aus:UMFANG>Kurzinformation</aus:UMFANG>
+    </aus:AUSZUG_V2_REQUEST>
+  </soap:Body>
+</soap:Envelope>
+```
+
+Other operations available (same endpoint): `SUCHEURKUNDEREQUEST` (documents by
+FNR), `VERAENDERUNGENFIRMAREQUEST` / `VERAENDERUNGENURKUNDEREQUEST` (change feeds,
+date-ranged, optionally filtered by GERICHT/RECHTSFORM).
+
+## Unknown until the key exists
+
+- **Response XML schema** — the WSDL is behind the 401. Do NOT write the response
+  parser speculatively; fetch the WSDL first, then parse.
+- `UMFANG` values beyond `Kurzinformation` (a fuller extract level presumably
+  carries the officer list — verify which level includes "involved persons").
+- Rate limits (unpublished — ask when requesting the production key).
+
+## Build plan for the unblock session
+
+1. Fetch the WSDL with the key; read `AUSZUG_V2` response schema.
+2. Executor `apps/api/src/capabilities/austrian-company-data.ts`:
+   - Input: `fn_number` | `company_name` (+ `name`/`query`/`task` aliases),
+     `required: []` + anyOf branches, same pattern as norwegian.
+   - Name path: `SUCHEFIRMAREQUEST` with `EXAKTESUCHE=true` first; on miss retry
+     `EXAKTESUCHE=false` and score candidates with `classifyNameMatch`
+     (exact wins / unique high / refuse ties) — same doctrine as FI/NO/DE/US.
+   - Extract path: `AUSZUG_V2_REQUEST` at the UMFANG level that includes officers.
+   - `AbortSignal.timeout` on all calls; XML parsing via the same lib other
+     SOAP-consuming code uses (check `swift-message-parse` neighbours; if none,
+     `fast-xml-parser` is already in the dependency tree — verify before adding).
+   - Provenance: `acquisition_method: "direct_api"`, license CC BY 4.0, attribution
+     "Quelle: Bundesministerium für Justiz / Firmenbuch" (CC BY requires it).
+   - Evidence-Tier canonical aliases + `ubo_availability: "restricted"` (WiEReG is
+     legally gated — see kyb-coverage-research.md; never claim UBO here).
+3. Manifest with `gdpr_art_22_classification: data_lookup`, officers ⇒
+   `processes_personal_data: true`, `personal_data_categories: [name, professional]`
+   (the PII enum has no "officers" value — FI/NO/EE use name + professional for
+   the same data; gate at onboarding-gates.ts rejects unknown categories).
+4. Full pipeline: `onboard.ts --discover --strict`, validate-capability,
+   smoke-test, readiness. Health-check input: a stable large company FN.
+5. Re-enable AT solutions (kyb-essentials-at etc.) ONLY after step-1 verified —
+   they are currently contained (2026-08-12) because step-1 always threw.

--- a/manifests/belgian-company-data.yaml
+++ b/manifests/belgian-company-data.yaml
@@ -20,9 +20,23 @@ input_schema:
     company_name:
       type: string
       description: Belgian company name (fuzzy match)
+    name:
+      type: string
+      description: Alias for company_name
+    query:
+      type: string
+      description: Free-text alias — enterprise number or company name
     task:
       type: string
       description: Free-text input — first matching enterprise number or name is used
+  # anyOf makes "at least one identifying field" visible to callers and lets
+  # the route reject {} before billing, instead of billing-then-erroring.
+  anyOf:
+    - required: [enterprise_number]
+    - required: [company_name]
+    - required: [name]
+    - required: [query]
+    - required: [task]
 output_schema:
   type: object
   example:

--- a/manifests/danish-company-data.yaml
+++ b/manifests/danish-company-data.yaml
@@ -24,12 +24,42 @@ quota_window: daily
 quota_cap: 50
 input_schema:
   type: object
-  required:
-    - cvr_number
+  # No field is individually required: a CVR number OR a company name is
+  # enough, and the executor enforces that itself (firstString alias chain).
+  # Listing cvr_number as `required` made the ROUTE reject
+  # {"company_name": "Novo Nordisk"} before the executor's name path
+  # (fixed 2026-08-09) could ever run. Same defect class as PR #168 (norwegian).
+  required: []
   properties:
     cvr_number:
       type: string
-      description: Danish CVR number (8 digits) or company name
+      description: Danish CVR number (8 digits)
+    org_number:
+      type: string
+      description: Alias for cvr_number
+    company_number:
+      type: string
+      description: Alias for cvr_number
+    company_name:
+      type: string
+      description: Danish company name (resolved via scored registry search)
+    name:
+      type: string
+      description: Alias for company_name
+    query:
+      type: string
+      description: Free-text alias — CVR number or company name
+    task:
+      type: string
+      description: Free-text alias — CVR number or company name
+  anyOf:
+    - required: [cvr_number]
+    - required: [org_number]
+    - required: [company_number]
+    - required: [company_name]
+    - required: [name]
+    - required: [query]
+    - required: [task]
 output_schema:
   type: object
   example:

--- a/manifests/estonian-company-data.yaml
+++ b/manifests/estonian-company-data.yaml
@@ -28,6 +28,23 @@ input_schema:
         Company name. Resolved against the Business Register and accepted only on a
         confident name match — an ambiguous name is refused rather than resolved to
         the wrong legal entity.
+    name:
+      type: string
+      description: Alias for company_name
+    query:
+      type: string
+      description: Free-text alias — registry code or company name
+    task:
+      type: string
+      description: Free-text alias — registry code or company name
+  # anyOf makes "at least one identifying field" visible to callers and lets
+  # the route reject {} before billing, instead of billing-then-erroring.
+  anyOf:
+    - required: [registry_code]
+    - required: [company_name]
+    - required: [name]
+    - required: [query]
+    - required: [task]
 output_schema:
   type: object
   example:

--- a/manifests/finnish-company-data.yaml
+++ b/manifests/finnish-company-data.yaml
@@ -13,12 +13,38 @@ price_cents: 5
 is_free_tier: false
 input_schema:
   type: object
-  required:
-    - business_id
+  # No field is individually required: a business ID OR a company name is
+  # enough, and the executor enforces that itself (firstString alias chain).
+  # Listing business_id as `required` made the ROUTE reject
+  # {"company_name": "Nokia"} before the executor's name path (fixed
+  # 2026-08-09) could ever run. Same defect class as PR #168 (norwegian).
+  required: []
   properties:
     business_id:
       type: string
-      description: Finnish Business ID (e.g. 0112038-9) or company name
+      description: Finnish Business ID (e.g. 0112038-9)
+    org_number:
+      type: string
+      description: Alias for business_id
+    company_name:
+      type: string
+      description: Finnish company name (resolved via scored PRH search)
+    name:
+      type: string
+      description: Alias for company_name
+    query:
+      type: string
+      description: Free-text alias — business ID or company name
+    task:
+      type: string
+      description: Free-text alias — business ID or company name
+  anyOf:
+    - required: [business_id]
+    - required: [org_number]
+    - required: [company_name]
+    - required: [name]
+    - required: [query]
+    - required: [task]
 output_schema:
   type: object
   example:
@@ -71,13 +97,20 @@ personal_data_categories:
   - professional
 geography: nordic
 test_fixtures:
+  # known_answer exercises the NAME path (Gate 5 SECONDARY); schema_check runs
+  # on health_check_input below and keeps the ID path covered.
   known_answer:
     input:
-      business_id: 0112038-9
+      company_name: Nokia Oyj
     expected_fields:
       - field: company_name
-        operator: not_null
+        operator: contains
         reliability: guaranteed
+        value: Nokia
+      - field: business_id
+        operator: equals
+        reliability: guaranteed
+        value: 0112038-9
   health_check_input:
     business_id: 0112038-9
 output_field_reliability:
@@ -91,6 +124,9 @@ output_field_reliability:
   registration_date: guaranteed
   vat_number: guaranteed
   website: rare
+  # Present only when the lookup resolved via the name path (not on ID lookups).
+  match_confidence: rare
+  matched_registry_name: rare
 limitations:
   - title: Does not cover sole traders without a separate business ID — about 10%
     text: Does not cover sole traders (toiminimi) without separate business ID
@@ -102,3 +138,13 @@ limitations:
     category: freshness
     severity: info
     workaround: Check the report_date field and query PRH's financial statement database for the most recent filing
+  - title: Name search requires native Finnish spelling (diacritics are significant)
+    text: PRH's name search does not fold diacritics — "Mehilainen" finds nothing while "Mehiläinen" matches. ASCII-typed names for companies with ä/ö/å in their registered name will be refused rather than resolved.
+    category: coverage
+    severity: info
+    workaround: Type the company name with its native spelling, or provide the Business ID directly (e.g. 0112038-9)
+  - title: Bare brand names only resolve when they equal the registered name minus its legal form
+    text: Name matching is deliberately conservative — a single-word query only resolves when the registered name normalizes to exactly that word ("Nokia" → Nokia Oyj works; "Nordea" is refused because the registered name is "Nordea Bank Abp"). Companies whose legal name carries descriptive words beyond the brand are refused from a bare brand query rather than guessed.
+    category: coverage
+    severity: info
+    workaround: Provide more of the legal name ("Nordea Bank") or the Business ID directly

--- a/manifests/norwegian-company-data.yaml
+++ b/manifests/norwegian-company-data.yaml
@@ -34,6 +34,24 @@ input_schema:
     company_number:
       type: string
       description: Alias for org_number
+    name:
+      type: string
+      description: Alias for company_name
+    query:
+      type: string
+      description: Free-text alias — org number or company name
+    task:
+      type: string
+      description: Free-text alias — org number or company name
+  # anyOf makes "at least one identifying field" visible to callers and lets
+  # the route reject {} before billing, instead of billing-then-erroring.
+  anyOf:
+    - required: [org_number]
+    - required: [company_number]
+    - required: [company_name]
+    - required: [name]
+    - required: [query]
+    - required: [task]
 output_schema:
   type: object
   example:
@@ -105,13 +123,20 @@ personal_data_categories:
   - professional
 geography: nordic
 test_fixtures:
+  # known_answer exercises the NAME path (Gate 5 SECONDARY); schema_check runs
+  # on health_check_input below and keeps the ID path covered.
   known_answer:
     input:
-      org_number: "984851006"
+      company_name: Equinor
     expected_fields:
       - field: company_name
-        operator: not_null
+        operator: contains
         reliability: guaranteed
+        value: EQUINOR
+      - field: org_number
+        operator: equals
+        reliability: guaranteed
+        value: "923609016"
   health_check_input:
     org_number: "923609016"
 output_field_reliability:


### PR DESCRIPTION
## Summary
- Opens the company-name input path on danish/finnish (was 400-blocked at the route — the #168/#173 defect class) and aligns/tightens norwegian/belgian/estonian: `required: []` + `anyOf`, alias surface matching each executor's `firstString` chain. `{}` now gets a clean 400 listing accepted fields instead of billing-then-erroring.
- Rewrites the finnish name resolver: single scored pass over PRH's search page with a 20s timeout (the 10s timeout truncating PRH's 200KB pages is what broke prod), an `endDate` filter so defunct historical names never resolve, tie refusal, and `match_confidence`/`matched_registry_name` on the output. Declared `company_name` no longer routes through the Haiku extraction step (deterministic, no per-call LLM cost); the LLM is reserved for free-text `query`/`task`.
- brreg-fetch (norwegian): tie refusal added — the manifest promised "ambiguous names are refused" but the code was first-hit-wins.
- belgian/estonian executors: `firstString` so `{"enterprise_number": "", "company_name": "X"}` resolves via the name instead of dying on input the route just accepted.
- Gate 5: alias fields are no longer separate entry points; "Alias for X" only declassifies when X exists in the same schema (prose alone cannot remove a path's last entry point). Unit-tested.
- Austria Firmenbuch HVD: build-ready integration spec (`audit-output/parallel-audits-2026-08-12/austria-firmenbuch-integration-spec.md`). **Blocked on a JustizOnline API-key registration — Petter action** (https://justizonline.gv.at/jop/web/iwg/register). Endpoint/auth/request shapes verified; response schema is behind the key wall, so no speculative executor was written.

## DEC-20260504-C evidence (deploy-mechanism verification)
The route reads `capabilities.input_schema` from the DB, not the YAML — a manifest-only PR changes nothing in production. All five slugs were synced via `sync-manifest-canonical-to-db.ts` and verified:
- Row query: `has_anyof=true` for all five (danish 7 branches, finnish 6, norwegian 6, belgian 5, estonian 5).
- Live prod `/v1/do`: finnish `{}` → 400 naming the six accepted fields (unbilled); norwegian `{"company_name":"Equinor"}` → EQUINOR ASA, billed €0.05; finnish `{"company_name":"Nokia"}` reached the executor (schema unblock confirmed) and exposed the PRH timeout this PR's executor fix addresses — **the finnish executor fix needs this deploy**, post-merge verification planned: prod call must return Nokia Oyj 0112038-9.

## Verification
- `tsc --noEmit` clean; full vitest suite green on re-run (single flake in first run, known collection-starvation class).
- New tests: finnish scorePool/pickUnambiguous (endDate/Rovio regression, tie refusal), gate5 alias handling (4 cases).
- Live resolver checks: Nokia→0112038-9 exact, Kesko→0109862-8 exact, Nokia Oyj→exact, **Rovio→refused** (was Combiholding Oy via a name ended 2020), **Nordea→refused** (was a branch deregistered 2018), ID path 173ms. Norwegian Equinor→923609016 after tie-refusal change.
- validate-capability + smoke-test green for all five slugs (gate 5 noted below).

## Reviewer findings (two adversarial passes, both applied or dispositioned)
Same-provider review disclosure: both passes ran on Claude Opus (cross-provider review unavailable in-harness).

**Fixed in this PR:** defunct-name resolution (technical H — Rovio/Nordea, verified refusing); variant-probe phase removed entirely (its justifying premise — "Nokia Oyj absent from page one" — was empirically false; reviewer replayed the API and found it at index 36, and the phase bypassed the ambiguity guarantee); belgian/estonian `??`-chain contradiction (product M); brreg first-hit-wins vs manifest promise (both reviews); LLM in known_answer path (both reviews); gate5 prose-only declassification (technical M); Austria spec PII enum (`officers` → `name, professional`); PRH diacritic + single-token-brand limitations documented in the manifest.

**Accepted, not fixed here:**
- Gate 5 SECONDARY stays uncovered for danish (quarantined upstream), belgian, estonian — the pipeline supports one known_answer fixture per capability, so a multi-path cap can only fixture-cover one path (german has the inverse gap on main). Finnish+norwegian known_answer flipped to the name path (the failure-prone one); ID paths still exercised by dependency_health. Follow-up queued: dual-fixture support in onboard + gate5.
- Name path runs sync at ~2-4s p50, worst ~30s (20s search + 10s fetch); `avg_latency_ms` reflects the dominant ID path. If p95 becomes a problem, the async threshold handles it via a latency bump.
- "Nordea"-class bare-brand queries refuse rather than resolve (registered name "Nordea Bank Abp" is multi-word) — deliberate doctrine (refuse > wrong entity), now documented as a manifest limitation.
- `Neste`/`Posti` now refuse where main returned a (defunct) entity — behavior change is doctrinally correct per reviewer verification.
- Danish schema advertises a name path while the capability is quarantined (`visible: false`, off x402) — reachable only by explicit slug; recovery session re-verifies.

## Test plan
- Post-deploy: `POST /v1/do {"capability_slug":"finnish-company-data","max_price_cents":50,"inputs":{"company_name":"Nokia"}}` → Nokia Oyj, 0112038-9, `match_confidence: "exact"`.
- `inputs: {}` on any of the five → 400 listing accepted fields, no charge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)