### PR TITLE
fix(honesty): hs-code-lookup relabel + DK email draft + CA/JP official-API evidence

### DIFF
--- a/audit-output/parallel-audits-2026-08-12/ca-jp-tos-verification.md
+++ b/audit-output/parallel-audits-2026-08-12/ca-jp-tos-verification.md
@@ -1,0 +1,83 @@
+# CA/JP registry access verification — evidence for the doctrine ruling (2026-08-12)
+
+Requested context: DEC-20260428-A (Tier 1 no-scraping) vs DEC-20260518-F
+(per-call parsing of statutorily-public registries under four constraints)
+decides whether canadian/japanese-company-data can stay live. This pass
+verified what those capabilities actually hit and what compliant
+alternatives exist.
+
+## Headline: both countries have OFFICIAL free APIs — the scrapes can retire
+
+The doctrine ruling no longer needs to carry CA or JP. Both should migrate to
+official endpoints, which is cleaner than any per-call-parsing justification.
+GR/MT/HU remain the genuinely sharp DEC-20260518-F cases.
+
+## Canada — Corporations Canada official JSON API (endpoint probed 2026-08-12)
+
+- Current executor: Browserless-renders the legacy UI + LLM extraction —
+  `fdrlCrpDtls.html?corpId=` for numeric IDs, `fdrlCrpSrch.html` for names.
+- **Official API**: `GET https://ised-isde.canada.ca/cc/lgcy/api/corporations/{corp_id}.json?lang=eng`
+  — probe evidence is NEGATIVE-path only: an unknown ID returns clean JSON
+  (`["could not find corporation …"]`, HTTP 200), proving the endpoint exists
+  and speaks JSON, not the success-path shape. The claim that it carries
+  **status, registered office address, directors** comes from the Open
+  Government Portal docs ("Federal Corporations — API Documentation", dataset
+  `0032ce54-c5dd-4b66-99a0-320a7b5e99f2`), not from the probe. No key
+  required on the probe.
+- **Bulk**: "Federal Corporations" JSON datasets (split into four files as of
+  April 2026) under the **Open Government Licence – Canada** (re-use,
+  redistribution, intermixing permitted).
+- robots.txt: no Disallow on `/cc/lgcy/*` (checked 2026-08-12) — the current
+  scrape isn't robots-prohibited, but that's moot given the API.
+- **Name search**: the per-ID endpoint is confirmed; the API doc resource
+  needs a read during migration for the name-search endpoint shape (a naive
+  guess 302'd). Fallback: bulk dataset as the name index + per-ID API live.
+- **Migration**: swap fetchRenderedHtml+LLM for the JSON API. No credential,
+  no Petter action — but gated on one positive probe against a real
+  corporation number (first step of the migration session), and on
+  confirming the live API endpoint itself carries the Open Government
+  Licence (evidenced here only for the bulk datasets) before the licence is
+  asserted in per-response provenance.
+
+## Japan — NTA Corporate Number Web-API Ver.4 (official, free, CC BY 4.0)
+
+- Current executor: Browserless-renders `houjin-bangou.nta.go.jp` search pages.
+- **Official Web-API**: free, XML/JSON, returns corporate number, name,
+  address, entity type, status. NTA publishes the underlying data under
+  **CC BY 4.0** (open-data declaration) — commercial use with attribution.
+- **Requires an application ID** ("利用届出" usage notification form):
+  https://www.houjin-bangou.nta.go.jp/webapi/riyo-todokede/ — **Petter
+  action, ~5 minutes, a form not an account**. ID arrives by email.
+- robots.txt: none (404/error page) — current scrape not robots-prohibited;
+  moot after migration.
+- **Migration**: once `HOUJIN_BANGOU_APP_ID` exists, swap the scrape for the
+  Web-API. Note the NTA data covers identity (no officers) — same coverage as
+  today's scrape, so no capability surface change.
+
+## Doctrine ruling — what remains for Petter
+
+With CA/JP exiting the contested set via official APIs, DEC-20260518-F's
+per-call-parsing question decides only: **GR** (free by statute, HTML only —
+the sharpest case), **MT/HU/LU** (paid/closed anyway), and the general
+posture for future registries. Recommendation unchanged: affirm F as the
+operative interpretation of A, with a per-registry ToS check recorded in each
+capability's manifest before relying on it.
+
+## Interim status (until migrations land) — recommendation, not a ruling
+
+Whether the current Browserless-rendered fetches may keep running until the
+migrations land is exactly the DEC-20260428-A-vs-DEC-20260518-F question
+that is still **pending Petter's ruling** (CLAUDE.md's active text calls
+Tier 1 absolute; F is not yet in CLAUDE.md's Active Decisions, and sibling
+audit docs apply the absolutist reading). This doc's recommendation: keep
+them live during the short migration window — the data is statutorily
+public, access is per-call, robots.txt does not prohibit the paths, and
+attribution is preserved — but that is a recommendation for the ruling to
+confirm, not a status this doc can grant itself. If Petter rules
+absolutist, deactivate both until the API migrations land.
+
+Sources: [Federal Corporations dataset](https://open.canada.ca/data/en/dataset/0032ce54-c5dd-4b66-99a0-320a7b5e99f2),
+[API doc resource](https://open.canada.ca/data/en/dataset/0032ce54-c5dd-4b66-99a0-320a7b5e99f2/resource/582644d6-e3a2-4fc6-a647-a07d81cc8104),
+[Corporations Canada data services](https://ised-isde.canada.ca/site/corporations-canada/en/data-services),
+[NTA Web-API notification form](https://www.houjin-bangou.nta.go.jp/webapi/riyo-todokede/),
+[Corporate Number (Wikipedia)](https://en.wikipedia.org/wiki/Corporate_Number).

--- a/handoff/_general/from-code/2026-08-12-dk-cvr-s2s-email-draft.md
+++ b/handoff/_general/from-code/2026-08-12-dk-cvr-s2s-email-draft.md
@@ -1,0 +1,50 @@
+# DK CVR system-to-system access — email draft (Petter: review, fill placeholders, send)
+
+**To:** cvrselvbetjening@erst.dk
+**From:** petter@strale.io
+**Subject:** Application for system-to-system access to CVR data (distribution.virk.dk)
+
+---
+
+Dear CVR team at Erhvervsstyrelsen,
+
+I would like to apply for system-to-system access to CVR data via
+distribution.virk.dk, per the process described at
+https://datacvr.virk.dk/artikel/system-til-system-adgang-til-cvr-data.
+
+**About us:**
+- Company: Strale [LEGAL ENTITY NAME], Sweden
+- Registration number: [SWEDISH ORG NUMBER]
+- Website: https://strale.dev
+- Contact: Petter Lindström, petter@strale.io
+
+**Intended use:**
+Strale operates a data platform that provides company-verification lookups
+(KYB — know your business) to software customers. We need programmatic access
+to CVR master data (company name, status, address, legal form, registration
+date) and, where publicly available, information on management/officers and
+beneficial owners (reelle ejere), to answer individual per-company lookup
+requests initiated by our customers.
+
+**Access pattern:**
+- Individual per-entity queries only (no bulk replication of the register)
+- Expected volume: low — under 1,000 queries per month initially
+- Data is retrieved on demand and attributed to CVR/Erhvervsstyrelsen as the
+  source in every response we deliver
+
+We are happy to provide any further information you need, and to comply with
+any terms of use attached to the access.
+
+Thank you, and best regards,
+
+Petter Lindström
+Founder, Strale
+petter@strale.io · https://strale.dev
+
+---
+
+**Before sending, fill in:** legal entity name + Swedish org number.
+**After the credential arrives:** danish-company-data migrates from cvrapi.dk
+(quota-broken) to distribution.virk.dk, then un-quarantine + re-enable the
+3 DK solutions. Same credential unlocks DK officers AND the public beneficial-
+owner register — the only free UBO source outside the UK.

--- a/manifests/hs-code-lookup.yaml
+++ b/manifests/hs-code-lookup.yaml
@@ -4,8 +4,8 @@
 slug: hs-code-lookup
 name: HS Code Lookup
 description: >-
-  Classify a product into Harmonized System (HS) commodity codes. Returns primary HS code, chapter, section, and
-  alternative classifications with confidence levels.
+  AI-suggested HS commodity codes for a product description, with alternatives and confidence.
+  Not an official customs classification.
 category: trade
 cost_class: paid_prepaid
 quota_window: none
@@ -23,17 +23,19 @@ output_schema:
   type: object
   example:
     notes: >-
-      The query 'test_value' is a placeholder or test string and does not describe an actual product or commodity. A
-      valid product description is required for HS classification. Please provide a specific product name or detailed
-      description (e.g., 'cotton t-shirt', 'aluminum wire', 'frozen chicken breast', etc.).
-    query: test_value
-    chapter: N/A
-    section: N/A
-    confidence: N/A
-    primary_hs_code: Unable to classify
-    alternative_codes: []
-    chapter_description: N/A
-    primary_description: Not a valid product description
+      Knitted cotton T-shirts classify under 6109.10. Blended-fabric shirts may fall under 6109.90
+      depending on fibre composition. Verify with binding tariff information for customs filings.
+    query: cotton t-shirt
+    chapter: "61"
+    section: Section XI — Textiles and textile articles
+    confidence: high
+    primary_hs_code: "6109.10"
+    alternative_codes:
+      - hs_code: "6109.90"
+        description: T-shirts of other textile materials (if not pure cotton)
+        confidence: medium
+    chapter_description: Articles of apparel and clothing accessories, knitted or crocheted
+    primary_description: T-shirts, singlets and other vests, knitted or crocheted, of cotton
   properties:
     chapter:
       type: string
@@ -45,18 +47,31 @@ output_schema:
       type: array
     primary_description:
       type: string
-data_source: Harmonized System nomenclature database (WCO)
-data_source_type: api
+# Honest sourcing (2026-08-12, Petter-approved relabel): there is no WCO
+# database behind this capability — the classification is LLM recall of HS
+# nomenclature. Claiming "WCO database" was a machine-surface lie.
+# data_source_type ai_assisted (NOT computed): computed maps to
+# capability_type=deterministic, which disables retry, makes the failure
+# classifier rewrite Anthropic outages as capability bugs (poisoning the
+# quality floor), and drops the cap out of the Anthropic upstream-health
+# gate. Review-caught before it could land.
+data_source: Claude Haiku (Anthropic API) — LLM classification, no WCO database
+data_source_type: ai_assisted
 transparency_tag: ai_generated
-freshness_category: live-fetch
+# reference-data, not computed: HS nomenclature IS a data dependency with a
+# real staleness axis (~5-year revision cycle; model recall pinned to its
+# training cutoff). "Computed (no data dependency)" would be a new lie.
+freshness_category: reference-data
 maintenance_class: requires-domain-expertise
 # SA.2b: per-capability PII classification (F-A-003, F-A-009)
 processes_personal_data: false
 geography: global
 test_fixtures:
   known_answer:
+    # A real product, not a placeholder: with 'test_value' the model refused
+    # and the test only proved four strings were non-null on garbage input.
     input:
-      product: test_value
+      product: cotton t-shirt
     expected_fields:
       - field: chapter
         operator: not_null
@@ -104,3 +119,11 @@ limitations:
     category: accuracy
     severity: warning
     workaround: Use the suggested HS code as a starting point and verify with your customs broker or national tariff database
+  - title: HS edition tracking is not guaranteed — nomenclature revises on a ~5-year cycle
+    text: >-
+      Classifications come from the model's knowledge of HS nomenclature, which is pinned to its training
+      cutoff. Codes changed in the most recent HS revision (HS2022 → HS2028 cycle) may be suggested in
+      their older form.
+    category: freshness
+    severity: info
+    workaround: Cross-check the suggested code against your national tariff database's current edition


### PR DESCRIPTION
## Summary
- hs-code-lookup honesty relabel (Petter-approved): the "WCO database" data_source was a lie — it's a pure Claude Haiku call. Relabeled with `ai_assisted` type, `reference-data` freshness, an HS-edition limitation, a real fixture input, and a realistic output example.
- DK CVR S2S email draft for Petter (fill legal-entity placeholders, send to cvrselvbetjening@erst.dk — 3-week clock).
- CA/JP doctrine evidence: both countries have official free APIs (Corporations Canada JSON endpoint probed live; NTA Web-API Ver.4, CC BY 4.0 with a 5-minute form for the app ID). Migrations retire both scrapes; the DEC-20260428-A/518-F ruling then only carries GR/MT/HU + general posture.

## DB state (already applied, verified)
- `data_source`, `description`, `freshness_category` synced to prod; `capability_type` confirmed still `ai_assisted` in prod (the hybrid-authority field was never touched — verified by row query after the review flagged the risk).
- Fixture resynced (8 checks, baseline cleared); fixture input verified live via /v1/do (€0.03, completed).

## Reviewer findings (one combined adversarial pass, opus — same-provider, disclosed)
HIGH (fixed): `data_source_type: computed` would have flipped `capability_type` to `deterministic` on a future re-create — disabling retry, rewriting Anthropic outages as capability bugs (poisoning the newly-armed quality floor), and dropping the cap from the upstream-health gate. Changed to `ai_assisted`; prod DB confirmed unaffected.
MEDIUM (fixed): freshness "computed" would have claimed "no data dependency" (HS revises ~5-yearly) → `reference-data` + limitation; JP form URL typo; CA "verified live" over-claim reworded (negative-path probe only, migration gated on one positive probe + licence check on the API endpoint itself); interim-status section reframed as recommendation pending Petter's ruling rather than self-granted status.
Noted for a future sweep: ~7 other pure-Claude manifests use `data_source_type: api` — if `ai_assisted` is right here it's right there too.

## Verification
- validate-capability: 19 ✓ / 0 ✗. Smoke: green except the standard ALLOW_MATRIX paid-cap refusal on internal-test live execution (pre-existing cost protection, not a regression).
- Docs-only otherwise; no code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)