### PR TITLE
feat(kyb): officer extraction LV + richer SK/UK; canadian-company-data → official API

### DIFF
--- a/apps/api/scripts/tier-coverage-allowlist.txt
+++ b/apps/api/scripts/tier-coverage-allowlist.txt
@@ -22,3 +22,5 @@ norwegian-company-data
 polish-company-data
 swedish-company-data
 us-company-data
+# uk: tier fixture capture requires COMPANIES_HOUSE_API_KEY (prod-only); recapture in a keyed environment
+uk-company-data

--- a/apps/api/src/capabilities/canadian-company-data.test.ts
+++ b/apps/api/src/capabilities/canadian-company-data.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { findRegistryNumber } from "./canadian-company-data.js";
+
+// Registry-number detection for the Corporations Canada JSON API migration:
+// corp IDs are NOT fixed-width (corp 1007 is real), 9 digits = business
+// number, and short digit runs inside free text stay ambiguous.
+describe("canadian findRegistryNumber", () => {
+  it("accepts modern 7-digit corporation numbers", () => {
+    expect(findRegistryNumber("3000061")).toBe("3000061");
+  });
+
+  it("accepts legacy short corporation numbers", () => {
+    expect(findRegistryNumber("1007")).toBe("1007");
+  });
+
+  it("accepts 9-digit business numbers, with separators stripped", () => {
+    expect(findRegistryNumber("106 679 285")).toBe("106679285");
+  });
+
+  it("extracts a 7-9 digit number embedded in free text", () => {
+    expect(findRegistryNumber("look up corp 3000061 for me")).toBe("3000061");
+  });
+
+  it("does NOT extract short digit runs from free text (too ambiguous)", () => {
+    expect(findRegistryNumber("founded in 2024 in Toronto")).toBeNull();
+  });
+
+  it("does not truncate longer digit runs into a wrong ID", () => {
+    // The old /\d{7}/ rule matched the first 7 digits of a 10-digit run and
+    // looked up an unrelated corporation.
+    expect(findRegistryNumber("id 1234567890")).toBeNull();
+  });
+
+  it("returns null for pure names", () => {
+    expect(findRegistryNumber("Abbotsford Chamber of Commerce")).toBeNull();
+  });
+});

--- a/apps/api/src/capabilities/canadian-company-data.ts
+++ b/apps/api/src/capabilities/canadian-company-data.ts
@@ -7,21 +7,140 @@ import {
 } from "./lib/browserless-extract.js";
 
 // Canada — Corporations Canada (ISED)
-// Corporation number: 7-digit federal number
-const CORP_NUM_RE = /^\d{7}$/;
+//
+// Numeric lookups use the OFFICIAL JSON API (no key, no rendering):
+//   GET https://ised-isde.canada.ca/cc/lgcy/api/corporations/{id}.json?lang=eng
+// It accepts a 7-digit corporation number OR a 9-digit business number and
+// returns [englishData, null] — or, for unknown IDs, a plain array of two
+// error STRINGS (not [data, null]), which is why the parser type-checks
+// element 0. Verified live 2026-08-12 (corp 1007, 3000061).
+//
+// Named directors are NOT in the API response — only directorLimits
+// (min/max). The web UI shows names, but scraping it is exactly the
+// DEC-20260428-A/DEC-20260518-F question pending Petter's ruling, so
+// tier_2_available stays false with an honest reason.
+//
+// The name-search path still Browserless-renders the site search (the API
+// has no name search — probed 2026-08-12, non-JSON 302). Same page as
+// before this migration; it is the remaining doctrine-gated surface here.
+const CORP_API = "https://ised-isde.canada.ca/cc/lgcy/api/corporations";
 
-function findCorpNum(input: string): string | null {
+// Corporation IDs are NOT fixed-width: modern CBCA corps have 7 digits but
+// older federal corps have shorter IDs (corp 1007 = Abbotsford Chamber of
+// Commerce, verified live). 9 digits = business number. Any all-digit input
+// up to 9 digits goes to the API; embedded numbers only count at 7-9 digits
+// (shorter embedded digit runs inside free text are too ambiguous).
+const REGISTRY_NUM_RE = /^\d{1,9}$/;
+
+export function findRegistryNumber(input: string): string | null {
   const cleaned = input.replace(/[\s.-]/g, "");
-  if (CORP_NUM_RE.test(cleaned)) return cleaned;
-  const match = input.match(/\d{7}/);
-  return match && CORP_NUM_RE.test(match[0]) ? match[0] : null;
+  if (REGISTRY_NUM_RE.test(cleaned)) return cleaned;
+  const match = input.match(/\b\d{7,9}\b/);
+  return match ? match[0] : null;
 }
 
-async function lookupCompany(query: string, isNumber: boolean): Promise<Record<string, unknown>> {
-  const searchUrl = isNumber
-    ? `https://ised-isde.canada.ca/cc/lgcy/fdrlCrpDtls.html?corpId=${query}`
-    : `https://ised-isde.canada.ca/cc/lgcy/fdrlCrpSrch.html?V_SEARCH.command=search&V_SEARCH.docsStart=0&V_SEARCH.docsCount=10&V_SEARCH.srchNm=${encodeURIComponent(query)}`;
+interface CorpApiRecord {
+  corporationId?: string;
+  act?: string;
+  status?: string;
+  corporationNames?: Array<{
+    CorporationName?: { name?: string; nameType?: string; current?: boolean; effectiveDate?: string };
+  }>;
+  // The API really does spell it "adresses" (verified live) — accept both.
+  adresses?: Array<{ address?: ApiAddress }>;
+  addresses?: Array<{ address?: ApiAddress }>;
+  directorLimits?: { minimum?: number; maximum?: number };
+  businessNumbers?: { businessNumber?: string };
+  annualReturns?: Array<{ annualReturn?: { yearOfFiling?: string } }>;
+  activities?: Array<{ activity?: { activity?: string; date?: string } }>;
+}
 
+interface ApiAddress {
+  addressLine?: string[];
+  city?: string;
+  postalCode?: string;
+  provinceCode?: string;
+  countryCode?: string;
+  current?: boolean;
+}
+
+async function fetchCorporationJson(registryNumber: string): Promise<Record<string, unknown>> {
+  const url = `${CORP_API}/${encodeURIComponent(registryNumber)}.json?lang=eng`;
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!response.ok) {
+    throw new Error(`Corporations Canada API returned HTTP ${response.status}`);
+  }
+  const data = (await response.json()) as unknown[];
+  const first = Array.isArray(data) ? data[0] : null;
+  if (typeof first === "string") {
+    // Not-found shape: ["could not find corporation …", "… est inconnu."]
+    throw new Error(
+      `No Canadian federal corporation found for "${registryNumber}". ` +
+        `Provide a federal corporation number (older corporations have fewer than 7 digits) ` +
+        `or a 9-digit business number; provincially registered businesses are not in this registry.`,
+    );
+  }
+  if (!first || typeof first !== "object") {
+    throw new Error("Corporations Canada API returned an unexpected response shape.");
+  }
+  const c = first as CorpApiRecord;
+
+  const currentName = (c.corporationNames ?? [])
+    .map((n) => n.CorporationName)
+    .find((n) => n?.current);
+  const nameHistory = (c.corporationNames ?? [])
+    .map((n) => n.CorporationName)
+    .filter((n): n is NonNullable<typeof n> => Boolean(n?.name) && !n?.current)
+    .map((n) => n.name);
+
+  // ?.length fallthrough (not ??): an empty "adresses" array must not shadow
+  // a populated "addresses" if upstream ever fixes their key spelling.
+  const addrArray = (c.adresses?.length ? c.adresses : c.addresses) ?? [];
+  const addrEntry = addrArray.map((a) => a.address).find((a) => a?.current) ?? addrArray[0]?.address;
+  const address = addrEntry
+    ? [
+        ...(addrEntry.addressLine ?? []),
+        [addrEntry.city, addrEntry.provinceCode].filter(Boolean).join(" "),
+        addrEntry.postalCode,
+        addrEntry.countryCode,
+      ]
+        .filter(Boolean)
+        .join(", ") || null
+    : null;
+
+  const incorporation = (c.activities ?? [])
+    .map((a) => a.activity)
+    .find((a) => a?.activity === "Incorporation");
+
+  return {
+    company_name: currentName?.name ?? null,
+    // corporation_number kept alongside registration_number: it was the
+    // pre-migration output contract's guaranteed field.
+    corporation_number: c.corporationId ?? registryNumber,
+    registration_number: c.corporationId ?? registryNumber,
+    business_number: c.businessNumbers?.businessNumber ?? null,
+    status: c.status ?? null,
+    business_type: c.act ?? null,
+    address,
+    registration_date: incorporation?.date ?? currentName?.effectiveDate ?? null,
+    name_history: nameHistory,
+    director_limits: c.directorLimits ?? null,
+    latest_annual_return_year:
+      (c.annualReturns ?? [])
+        .map((r) => r.annualReturn?.yearOfFiling)
+        .filter(Boolean)
+        .sort()
+        .at(-1) ?? null,
+    industry: null,
+    jurisdiction: "CA",
+  };
+}
+
+async function lookupByName(query: string): Promise<Record<string, unknown>> {
+  const searchUrl = `https://ised-isde.canada.ca/cc/lgcy/fdrlCrpSrch.html?V_SEARCH.command=search&V_SEARCH.docsStart=0&V_SEARCH.docsCount=10&V_SEARCH.srchNm=${encodeURIComponent(query)}`;
   const html = await fetchRenderedHtml(searchUrl);
   const text = htmlToText(html);
 
@@ -39,21 +158,53 @@ registerCapability("canadian-company-data", async (input: CapabilityInput) => {
   }
 
   const trimmed = raw.trim();
-  const corpNum = findCorpNum(trimmed);
+  if (trimmed.length < 2) {
+    // Principle B: never reach the paid LLM/Browserless path on junk input.
+    throw new Error("Input must be at least 2 characters.");
+  }
+  const registryNumber = findRegistryNumber(trimmed);
 
   let output: Record<string, unknown>;
-  if (corpNum) {
-    output = await lookupCompany(corpNum, true);
+  let viaApi = false;
+  if (registryNumber) {
+    output = await fetchCorporationJson(registryNumber);
+    viaApi = true;
   } else {
     const name = await extractCompanyName(trimmed, "Canadian");
-    output = await lookupCompany(name, false);
+    output = await lookupByName(name);
+  }
+
+  // Evidence Tier canonical aliases + honest Tier-2/UBO posture.
+  {
+    const o = output;
+    if (o.legal_name === undefined) o.legal_name = o.company_name;
+    if (o.primary_registration_id === undefined) o.primary_registration_id = o.registration_number;
+    if (o.legal_form === undefined) o.legal_form = o.business_type;
+    if (o.registered_address === undefined) o.registered_address = o.address;
+    if (o.date_incorporated === undefined) o.date_incorporated = o.registration_date;
+    o.tier_2_available = false;
+    o.tier_2_available_reason =
+      "Corporations Canada's JSON API exposes director count limits but not named directors; " +
+      "the web UI shows names but automated extraction from it is pending a sourcing-doctrine ruling";
+    o.ubo_availability = "restricted";
+    o.ubo_availability_reason =
+      "CBCA individuals-with-significant-control information is filed with Corporations Canada but " +
+      "not exposed via the public JSON API";
   }
 
   return {
     output,
-    provenance: {
-      source: "ised-isde.canada.ca",
-      fetched_at: new Date().toISOString(),
-    },
+    provenance: viaApi
+      ? {
+          source: "ised-isde.canada.ca (Corporations Canada JSON API)",
+          source_url: `${CORP_API}/${encodeURIComponent(registryNumber!)}.json?lang=eng`,
+          fetched_at: new Date().toISOString(),
+          acquisition_method: "direct_api" as const,
+          primary_source_reference: `${CORP_API}/${encodeURIComponent(registryNumber!)}.json?lang=eng`,
+        }
+      : {
+          source: "ised-isde.canada.ca",
+          fetched_at: new Date().toISOString(),
+        },
   };
 });

--- a/apps/api/src/capabilities/latvian-company-data.ts
+++ b/apps/api/src/capabilities/latvian-company-data.ts
@@ -1,5 +1,6 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { deriveVatLV } from "../lib/vat-derivation.js";
+import { logWarn } from "../lib/log.js";
 
 /**
  * Latvian company data via the data.gov.lv CKAN datastore API.
@@ -17,6 +18,12 @@ import { deriveVatLV } from "../lib/vat-derivation.js";
 const LV_DATASTORE_API = "https://data.gov.lv/dati/api/3/action/datastore_search";
 // Resource ID for "Uzņēmumu reģistra atvērtie dati" on data.gov.lv.
 const LV_RESOURCE_ID = "25e80bf3-f107-4ab4-89ef-251b5b9374e9";
+// Resource ID for the officers dataset ("Tiesību subjekta valdes locekļu,
+// pārstāvēttiesīgo biedru vai citu pārstāvēttiesīgo personu saraksts") —
+// package `officers`, publisher LR Uzņēmumu reģistrs, CC0 1.0, datastore-
+// queryable. Lists CURRENT representation-entitled persons only (no history).
+// Verified live 2026-08-12: airBaltic (40003245752) → 2 board members.
+const LV_OFFICERS_RESOURCE_ID = "e665114a-73c2-4375-9470-55874b4cfa6b";
 
 // Latvian unified registration number: 11 digits.
 const REG_RE = /^\d{11}$/;
@@ -71,6 +78,116 @@ async function callDatastore(qs: URLSearchParams): Promise<LvRecord[]> {
     throw new Error("Latvian Open Data Portal returned success=false");
   }
   return data.result.records ?? [];
+}
+
+interface LvOfficerRecord {
+  name?: string | null;
+  position?: string | null;
+  governing_body?: string | null;
+  entity_type?: string | null;
+  rights_of_representation_type?: string | null;
+  representation_with_at_least?: string | number | null;
+  registered_on?: string | null;
+  // latvian_identity_number_masked exists upstream but is deliberately never
+  // read: even masked national IDs are data minimization we don't need.
+}
+
+interface LegalRepresentative {
+  // Canonical cross-country shape (NO/CZ/EE/CY parity): type discriminator +
+  // date_of_birth always present. DOB is deliberately null here — see the
+  // manifest limitation (a Strale data-minimization choice, not an upstream
+  // absence: the dataset publishes birth_date and masked personal codes,
+  // which this handler never reads).
+  type: "person" | "organisation";
+  name: string;
+  role: string;
+  role_code: string | null;
+  role_group: string;
+  rights_of_representation: string | null;
+  representation_with_at_least: number | null;
+  start_date: string | null;
+  date_of_birth: null;
+}
+
+// Maps (not object literals) to avoid prototype-key collisions on
+// upstream-controlled strings ("constructor" would resolve on an object).
+const LV_POSITION_LABELS = new Map<string, string>([
+  ["BOARD_MEMBER", "Board member"],
+  ["CHAIR_OF_BOARD", "Chair of the board"],
+  ["DEPUTY_CHAIR_OF_BOARD", "Deputy chair of the board"],
+]);
+
+// role_group tokens follow the EE vocabulary (management_board /
+// supervisory_council) so cross-country grouping works; a shared enum for
+// all six countries is queued follow-up work.
+const LV_BODY_GROUPS = new Map<string, string>([
+  ["EXECUTIVE_BOARD", "management_board"],
+  ["SUPERVISORY_BOARD", "supervisory_council"],
+]);
+
+interface LvOfficersResult {
+  representatives: LegalRepresentative[];
+  total: number;
+}
+
+/**
+ * Fetch current representation-entitled persons (board members etc.) for an
+ * entity from the UR officers dataset. Best-effort: a failure here degrades
+ * tier_2_available and yields NULL fields (never a fake empty list — "0
+ * officers" and "lookup failed" are materially different KYB answers), and
+ * the swallow is logged so it is visible in prod (DEC-20260504-A).
+ */
+async function fetchLegalRepresentatives(regcode: string): Promise<LvOfficersResult | null> {
+  try {
+    const filters = JSON.stringify({ at_legal_entity_registration_number: Number(regcode) });
+    const qs = new URLSearchParams({
+      resource_id: LV_OFFICERS_RESOURCE_ID,
+      filters,
+      limit: "50",
+    });
+    const res = await fetch(`${LV_DATASTORE_API}?${qs.toString()}`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!res.ok) {
+      logWarn("lv-officers-fetch", `officers datastore returned HTTP ${res.status}`, { regcode });
+      return null;
+    }
+    const data = (await res.json()) as {
+      success: boolean;
+      result?: { records?: LvOfficerRecord[]; total?: number };
+    };
+    if (!data.success) {
+      logWarn("lv-officers-fetch", "officers datastore returned success=false", { regcode });
+      return null;
+    }
+    const records = data.result?.records ?? [];
+    const representatives = records
+      .filter((r) => clean(r.name ?? null))
+      .map((r): LegalRepresentative => {
+        const position = clean(r.position ?? null);
+        const body = clean(r.governing_body ?? null);
+        const atLeast = r.representation_with_at_least;
+        return {
+          type: clean(r.entity_type ?? null) === "LEGAL_ENTITY" ? "organisation" : "person",
+          name: (r.name as string).trim(),
+          role: (position ? LV_POSITION_LABELS.get(position) : null) ?? position ?? body ?? "Representative",
+          role_code: position,
+          role_group: (body ? LV_BODY_GROUPS.get(body) : null) ?? "representation",
+          rights_of_representation: clean(r.rights_of_representation_type ?? null),
+          representation_with_at_least:
+            atLeast != null && atLeast !== "" && Number.isFinite(Number(atLeast)) ? Number(atLeast) : null,
+          start_date: r.registered_on ? String(r.registered_on).slice(0, 10) : null,
+          date_of_birth: null,
+        };
+      });
+    // CKAN reports the true total; if it exceeds our page the count field
+    // stays honest even though the array is truncated.
+    return { representatives, total: data.result?.total ?? representatives.length };
+  } catch (err) {
+    logWarn("lv-officers-fetch", `officers datastore query failed: ${(err as Error).message}`, { regcode });
+    return null;
+  }
 }
 
 async function lookupByRegcode(regcode: string): Promise<LvRecord> {
@@ -133,6 +250,7 @@ registerCapability("latvian-company-data", async (input: CapabilityInput) => {
   const record = reg ? await lookupByRegcode(reg) : await lookupByName(trimmed);
 
   const regNum = String(record.regcode);
+  const officersResult = await fetchLegalRepresentatives(regNum);
   const output = {
     company_name: clean(record.name),
     reg_number: regNum,
@@ -147,6 +265,10 @@ registerCapability("latvian-company-data", async (input: CapabilityInput) => {
     sepa_creditor_id: clean(record.sepa),
     atvk_code: record.atvk != null ? String(record.atvk) : null,
     vat_number: deriveVatLV(regNum),
+    // null (not []) when the officers query failed: "no officers" is an
+    // affirmative claim this response cannot make in that case.
+    legal_representatives: officersResult?.representatives ?? null,
+    total_legal_representatives: officersResult?.total ?? null,
     jurisdiction: "LV",
   };
 
@@ -167,8 +289,19 @@ registerCapability("latvian-company-data", async (input: CapabilityInput) => {
     if (o.legal_form === undefined) o.legal_form = (o.business_type ?? o.company_type ?? o.entity_type ?? o.legal_form_code ?? o.legal_form_id);
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
-    o.tier_2_available = false;
-    o.tier_2_available_reason = "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked";
+    if (officersResult === null) {
+      o.tier_2_available = false;
+      o.tier_2_available_reason =
+        "officers dataset query failed on this call — representation data temporarily unavailable, retry later";
+    } else if (officersResult.representatives.length === 0) {
+      o.tier_2_available = false;
+      o.tier_2_available_reason =
+        "no current representation-entitled persons listed for this entity in the UR officers dataset";
+    } else {
+      o.tier_2_available = true;
+      o.tier_2_available_reason =
+        "current board members / representation-entitled persons from the UR officers dataset (data.gov.lv, CC0 1.0)";
+    }
     o.ubo_availability = "unavailable_no_registry";
     o.ubo_availability_reason = "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation";
   }

--- a/apps/api/src/capabilities/slovak-company-data.ts
+++ b/apps/api/src/capabilities/slovak-company-data.ts
@@ -38,6 +38,16 @@ interface RpoLegalForm extends ValidityWindow {
 
 interface RpoStatutoryBody extends ValidityWindow {
   personName?: { formatedName?: string };
+  // Verified live 2026-08-12 (ico 36674141): RPO also returns the role
+  // ("Konateľ" + code) and the membership start date per statutory-body
+  // member — previously collapsed away into a name-only string.
+  stakeholderType?: { value?: string; code?: string };
+  // Corporate statutory bodies: the exact shape is UNVERIFIED live (the
+  // probed entity had a natural-person konateľ only). RPO's entity root uses
+  // windowed fullNames[] arrays, so both a scalar and the windowed-array
+  // shape are accepted defensively.
+  fullName?: string;
+  fullNames?: Array<ValidityWindow & { value?: string }>;
 }
 
 interface RpoSearchResultEntry {
@@ -167,9 +177,32 @@ registerCapability("slovak-company-data", async (input: CapabilityInput) => {
   const currentIdentifier = pickCurrent(entity.identifiers);
   const currentRegOffice = pickCurrent(entity.sourceRegister?.registrationOffices);
   const currentRegNumber = pickCurrent(entity.sourceRegister?.registrationNumbers);
-  const directors = (entity.statutoryBodies ?? []).flatMap((b) =>
-    !b.validTo && b.personName?.formatedName ? [b.personName.formatedName] : [],
-  );
+  // Structured representatives (NO/CZ/EE canonical shape with a type
+  // discriminator); `directors` stays as the legacy name-only array and
+  // keeps its ORIGINAL semantics — natural persons only — so consumers
+  // screening directors as individuals (PEP/adverse-media) never receive a
+  // company name in it.
+  const representatives = (entity.statutoryBodies ?? []).flatMap((b) => {
+    if (b.validTo) return [];
+    const personName = b.personName?.formatedName;
+    const corpName = personName
+      ? null
+      : b.fullName ?? pickCurrent(b.fullNames)?.value ?? null;
+    const name = personName ?? corpName;
+    if (!name) return [];
+    return [
+      {
+        type: personName ? ("person" as const) : ("organisation" as const),
+        name,
+        role: b.stakeholderType?.value ?? "Statutory body member",
+        role_code: b.stakeholderType?.code ?? null,
+        role_group: "statutory_body",
+        start_date: b.validFrom ?? null,
+        date_of_birth: null,
+      },
+    ];
+  });
+  const directors = representatives.filter((r) => r.type === "person").map((r) => r.name);
 
   return {
     output: {
@@ -193,10 +226,16 @@ registerCapability("slovak-company-data", async (input: CapabilityInput) => {
       primary_registration_id: currentRegNumber?.value ?? null,
       registered_address: formatAddress(currentAddress),
       date_incorporated: entity.establishment ?? null,
-      legal_representatives: directors,
-      // Evidence Tier framework labels (DEC-20260518-A)
-      tier_2_available: true,
-      tier_2_available_reason: "Legal representatives extracted from Slovak Register of Legal Persons (RPO).",
+      legal_representatives: representatives,
+      total_legal_representatives: representatives.length,
+      // Evidence Tier framework labels (DEC-20260518-A). Length-gated, not
+      // hardcoded true: an entity with zero current statutory-body members
+      // must not claim representative data is available.
+      tier_2_available: representatives.length > 0,
+      tier_2_available_reason:
+        representatives.length > 0
+          ? "Legal representatives (role, start date) extracted from the Slovak Register of Legal Persons (RPO)."
+          : "No current statutory-body members listed for this entity in RPO.",
       ubo_availability: "unavailable_no_registry",
       ubo_availability_reason: "RPVS (Register partnerov verejného sektora) not accessible for foreign users at v1; verification pending public-source confirmation",
     },

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -61,7 +61,16 @@ async function searchCompany(name: string): Promise<string> {
   return items[0].company_number;
 }
 
-async function fetchOfficers(companyNumber: string): Promise<Array<{ name: string; role: string; start_date: string | null }>> {
+interface UkOfficer {
+  type: "person" | "organisation";
+  name: string;
+  role: string;
+  role_code: string;
+  start_date: string | null;
+  date_of_birth: null;
+}
+
+async function fetchOfficers(companyNumber: string): Promise<UkOfficer[]> {
   const key = getApiKey();
   const url = `${API}/company/${companyNumber}/officers?items_per_page=100`;
   const response = await fetch(url, {
@@ -77,9 +86,18 @@ async function fetchOfficers(companyNumber: string): Promise<Array<{ name: strin
   return items
     .filter((o) => !o.resigned_on)
     .map((o) => ({
+      // Companies House marks corporate officers via the officer_role token
+      // (e.g. "corporate-director", "corporate-secretary").
+      type: String(o.officer_role ?? "").startsWith("corporate") ? "organisation" as const : "person" as const,
       name: o.name ?? "",
       role: o.officer_role ?? "",
+      role_code: o.officer_role ?? "",
       start_date: o.appointed_on ?? null,
+      // Companies House supplies partial DOB (year+month) for people; we
+      // deliberately emit null for canonical-shape parity with NO/CZ/EE and
+      // data minimization. The richer uk-companies-house-officers capability
+      // carries the partial DOB for callers who need it.
+      date_of_birth: null,
     }));
 }
 
@@ -170,8 +188,14 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
     if (o.registered_address === undefined) o.registered_address = (o.address ?? o.office_address);
     if (o.date_incorporated === undefined) o.date_incorporated = (o.incorporation_date ?? o.registered_date ?? o.registration_date ?? o.founded ?? o.uen_issue_date ?? o.registered_at);
     if (o.legal_representatives === undefined) o.legal_representatives = officers;
-    o.tier_2_available = true;
-    o.tier_2_available_reason = "Legal representatives extracted from UK Companies House Officers register.";
+    o.total_legal_representatives = officers.length;
+    // Length-gated (was hardcoded true): an entity with no active officers
+    // in the response must not claim representative data is available.
+    o.tier_2_available = officers.length > 0;
+    o.tier_2_available_reason =
+      officers.length > 0
+        ? "Legal representatives extracted from UK Companies House Officers register."
+        : "No active officers returned by Companies House for this company.";
     o.ubo_availability = "available";
     o.ubo_availability_reason = "Beneficial ownership data available via UK PSC register.";
   }

--- a/apps/api/tests/fixtures/tier-coverage/latvian-company-data.json
+++ b/apps/api/tests/fixtures/tier-coverage/latvian-company-data.json
@@ -12,5 +12,16 @@
   "sepa_creditor_id": "LV78ZZZ40003245752",
   "atvk_code": "807600",
   "vat_number": "LV40003245752",
-  "jurisdiction": "LV"
+  "legal_representatives": "[REDACTED]",
+  "total_legal_representatives": 2,
+  "jurisdiction": "LV",
+  "legal_name": "Air Baltic Corporation AS",
+  "primary_registration_id": "40003245752",
+  "legal_form": "Akciju sabiedrība",
+  "registered_address": "Mārupes nov., Mārupes pag., Lidosta \"Rīga\", Tehnikas iela 3",
+  "date_incorporated": "1995-02-08",
+  "tier_2_available": true,
+  "tier_2_available_reason": "current board members / representation-entitled persons from the UR officers dataset (data.gov.lv, CC0 1.0)",
+  "ubo_availability": "unavailable_no_registry",
+  "ubo_availability_reason": "Programmatic UBO access not yet operational at v1; verification pending public-source confirmation"
 }

--- a/apps/api/tests/fixtures/tier-coverage/slovak-company-data.json
+++ b/apps/api/tests/fixtures/tier-coverage/slovak-company-data.json
@@ -13,5 +13,15 @@
   "nace_description": "Nešpecializovaný veľkoobchod",
   "directors": "[REDACTED]",
   "last_updated": "2025-07-07",
-  "jurisdiction": "SK"
+  "jurisdiction": "SK",
+  "legal_name": "SEXES spol. s r. o.",
+  "primary_registration_id": "Sro/42251/B",
+  "registered_address": "Ružová dolina 14, 821 09 Bratislava - mestská časť Ružinov, Slovenská republika",
+  "date_incorporated": "2006-09-13",
+  "legal_representatives": "[REDACTED]",
+  "total_legal_representatives": 1,
+  "tier_2_available": true,
+  "tier_2_available_reason": "Legal representatives (role, start date) extracted from the Slovak Register of Legal Persons (RPO).",
+  "ubo_availability": "unavailable_no_registry",
+  "ubo_availability_reason": "RPVS (Register partnerov verejného sektora) not accessible for foreign users at v1; verification pending public-source confirmation"
 }

--- a/manifests/canadian-company-data.yaml
+++ b/manifests/canadian-company-data.yaml
@@ -11,28 +11,43 @@ price_cents: 80
 is_free_tier: false
 input_schema:
   type: object
-  required:
-    - corporation_number
+  # No field is individually required: a corporation/business number OR a
+  # company name is enough, and the executor enforces that itself. The old
+  # schema's required: [corporation_number] blocked the name path at the
+  # route — the #168/#173 defect class.
+  required: []
   properties:
     corporation_number:
       type: string
-      description: Canadian corporation number or company name
+      description: Federal corporation number (older corporations have fewer than 7 digits) or 9-digit business number
+    company_name:
+      type: string
+      description: Company name (resolved via the Corporations Canada site search)
+    task:
+      type: string
+      description: Free-text alias — corporation number or company name
+  anyOf:
+    - required: [corporation_number]
+    - required: [company_name]
+    - required: [task]
 output_schema:
   type: object
   example:
-    status: unknown
-    address: null
+    status: Active
+    address: 207 - 32900 SOUTH FRASER WAY, ABBOTSFORD BC, V2S 5A1, CA
+    company_name: Abbotsford Chamber of Commerce
+    business_type: Boards of Trade Act - Part II
+    corporation_number: "1007"
+    registration_number: "1007"
+    business_number: "106679285"
+    registration_date: "1947-01-10"
+    name_history: []
+    director_limits: { minimum: 3, maximum: 30 }
+    latest_annual_return_year: "2026"
     industry: null
-    directors: null
-    company_name: null
-    business_type: null
-    registration_date: null
-    registration_number: null
+    jurisdiction: CA
+    tier_2_available: false
   properties:
-    vat_number:
-      type:
-        - string
-        - "null"
     status:
       type: string
     company_name:
@@ -41,9 +56,28 @@ output_schema:
       type: string
     corporation_number:
       type: string
-data_source: Corporations Canada / Provincial registries
-data_source_type: scrape
-transparency_tag: ai_generated
+    registration_number:
+      type: string
+    business_number:
+      type:
+        - string
+        - "null"
+    name_history:
+      type: array
+    director_limits:
+      type:
+        - object
+        - "null"
+data_source: Corporations Canada (ISED) official JSON API — numeric lookups; site search for name lookups
+# api, not scrape: the numeric path (the dominant, health-checked path) is a
+# direct keyless government JSON API. The name-search path still renders the
+# site search — documented in the limitation below.
+data_source_type: api
+# mixed, not ai_generated: numeric lookups are a verbatim JSON mapping with
+# zero LLM involvement (algorithmic); name-path lookups use AI extraction
+# from rendered HTML. One scalar cannot be exact for both — mixed is the
+# honest label, with the split documented in limitations.
+transparency_tag: mixed
 freshness_category: live-fetch
 maintenance_class: scraping-stable-target
 # SA.2b: per-capability PII classification (F-A-003, F-A-009)
@@ -54,9 +88,14 @@ personal_data_categories:
   - professional
 geography: global
 test_fixtures:
+  # Fixture corp swapped 2026-08-12: 2408951 is not resolvable via the
+  # official JSON API (pre-migration scrape-era fixture). 1007 (Abbotsford
+  # Chamber of Commerce, Active since 1947) chosen over a numbered company:
+  # health checks re-fetch this record repeatedly and personal holding
+  # companies registered at private residences don't belong in fixtures.
   known_answer:
     input:
-      corporation_number: "2408951"
+      corporation_number: "1007"
     expected_fields:
       - field: status
         operator: not_null
@@ -66,15 +105,50 @@ test_fixtures:
         reliability: guaranteed
         value: string
   health_check_input:
-    corporation_number: "2408951"
+    corporation_number: "1007"
 output_field_reliability:
   status: guaranteed
   company_name: guaranteed
   business_type: guaranteed
   corporation_number: guaranteed
+  registration_number: guaranteed
+  business_number: common
+  address: common
+  registration_date: common
+  name_history: common
+  director_limits: common
+  latest_annual_return_year: common
+  industry: rare
+  tier_2_available: guaranteed
+  tier_2_available_reason: guaranteed
+  ubo_availability: guaranteed
+  ubo_availability_reason: guaranteed
 limitations:
   - title: Covers federally incorporated Canadian companies — provincially registered businesses may have limited data
     text: Covers federally incorporated companies — provincially registered businesses may have limited information
     category: coverage
     severity: info
     workaround: For provincial companies, supplement with the relevant provincial registry (e.g., Ontario ONBIS, BC Registry)
+  - title: Named directors are not exposed by the Corporations Canada JSON API
+    text: >-
+      The official JSON API returns director count limits (minimum/maximum) but not director names.
+      director_limits is a governance constraint from the articles, NOT a count of current directors.
+      Named-director extraction from the web UI is paused pending a sourcing-doctrine ruling.
+    category: coverage
+    severity: info
+    workaround: Order a corporate profile from Corporations Canada, or check the corporation's own filings
+  - title: Transparency differs by lookup path — numeric lookups are algorithmic, name lookups use AI extraction
+    text: >-
+      Corporation/business-number lookups read the official JSON API verbatim (no AI involved). Company-name
+      lookups render the Corporations Canada site search and extract results with an LLM, and may return
+      looser fields. The transparency_tag "mixed" reflects this split.
+    category: accuracy
+    severity: info
+    workaround: Provide the corporation number for a fully algorithmic answer
+  - title: name_history may be empty even when a name change is on record
+    text: >-
+      The JSON API's corporationNames array sometimes carries only the current name even when the
+      activities feed records a name-change event. An empty name_history is not proof no rename occurred.
+    category: coverage
+    severity: info
+    workaround: Check the corporation's activity history on Corporations Canada for name-change events

--- a/manifests/canadian-company-data.yaml
+++ b/manifests/canadian-company-data.yaml
@@ -48,6 +48,12 @@ output_schema:
     jurisdiction: CA
     tier_2_available: false
   properties:
+    tier_2_available_reason:
+      type: string
+    ubo_availability:
+      type: string
+    ubo_availability_reason:
+      type: string
     status:
       type: string
     company_name:

--- a/manifests/cz-company-data.yaml
+++ b/manifests/cz-company-data.yaml
@@ -24,6 +24,10 @@ input_schema:
 output_schema:
   type: object
   properties:
+    ubo_availability:
+      type: string
+    ubo_availability_reason:
+      type: string
     ico:
       type: string
     company_name:

--- a/manifests/cz-company-data.yaml
+++ b/manifests/cz-company-data.yaml
@@ -70,6 +70,7 @@ output_schema:
       type: boolean
     tier_2_available_reason:
       type: string
+geography: eu
 processes_personal_data: true
 personal_data_categories:
   - name
@@ -154,3 +155,5 @@ output_field_reliability:
   signing_authority: common
   tier_2_available: guaranteed
   tier_2_available_reason: guaranteed
+  ubo_availability: guaranteed
+  ubo_availability_reason: guaranteed

--- a/manifests/latvian-company-data.yaml
+++ b/manifests/latvian-company-data.yaml
@@ -69,6 +69,42 @@ output_schema:
       type: string
     jurisdiction:
       type: string
+    legal_representatives:
+      type:
+        - array
+        - "null"
+      description: Current board members / representation-entitled persons (UR officers dataset); null when the officers query failed
+    total_legal_representatives:
+      type:
+        - integer
+        - "null"
+      description: True total from the registry (may exceed the returned array's length of 50); null when the officers query failed
+    tier_2_available:
+      type: boolean
+    tier_2_available_reason:
+      type: string
+    legal_name:
+      type: string
+    primary_registration_id:
+      type:
+        - string
+        - "null"
+    registered_address:
+      type:
+        - string
+        - "null"
+    date_incorporated:
+      type:
+        - string
+        - "null"
+    ubo_availability:
+      type: string
+    ubo_availability_reason:
+      type: string
+    legal_form:
+      type:
+        - string
+        - "null"
 data_source: Latvian Open Data Portal (data.gov.lv) — Uzņēmumu reģistra atvērtie dati CKAN datastore_search API
 data_source_type: api
 transparency_tag: algorithmic
@@ -147,7 +183,30 @@ output_field_reliability:
   atvk_code: common
   vat_number: common
   jurisdiction: guaranteed
+  # Both null (not asserted) when the officers query fails — "0 officers"
+  # and "lookup failed" are different KYB answers.
+  legal_representatives: common
+  total_legal_representatives: common
+  tier_2_available: guaranteed
+  tier_2_available_reason: guaranteed
+  ubo_availability: guaranteed
+  ubo_availability_reason: guaranteed
+  # Evidence-Tier canonical aliases (always assigned by the alias block).
+  legal_name: guaranteed
+  primary_registration_id: guaranteed
+  legal_form: guaranteed
+  registered_address: guaranteed
+  date_incorporated: guaranteed
 limitations:
+  - title: Officer data lists current representation-entitled persons only — no historical officers, no birth data
+    text: >-
+      The UR officers dataset (data.gov.lv, CC0 1.0) lists persons currently entitled to represent the
+      entity (board members, chair). Resigned or historical officers are not included. The upstream dataset
+      publishes birth dates and masked personal codes, but Strale deliberately never reads them (data
+      minimization) — date_of_birth is always null by choice, not upstream absence.
+    category: coverage
+    severity: info
+    workaround: For historical officer data, order an extract from the Latvian Enterprise Register (info.ur.gov.lv)
   - title: Daily snapshot — sub-day filings may not be reflected immediately
     text: >-
       The Latvian Open Data Portal publishes a daily snapshot. Filings submitted today may not be reflected in the API

--- a/manifests/norwegian-company-data.yaml
+++ b/manifests/norwegian-company-data.yaml
@@ -65,6 +65,10 @@ output_schema:
     registration_date: "1995-03-12"
     industry_description: Utvinning av råolje
   properties:
+    ubo_availability:
+      type: string
+    ubo_availability_reason:
+      type: string
     status:
       type: string
     address:

--- a/manifests/norwegian-company-data.yaml
+++ b/manifests/norwegian-company-data.yaml
@@ -155,6 +155,8 @@ output_field_reliability:
   total_legal_representatives: guaranteed
   tier_2_available: guaranteed
   tier_2_available_reason: guaranteed
+  ubo_availability: guaranteed
+  ubo_availability_reason: guaranteed
 limitations:
   - title: Does not cover sole proprietorships — about 15% of Norwegian businesses
     text: Does not cover sole proprietorships (enkeltpersonforetak)

--- a/manifests/slovak-company-data.yaml
+++ b/manifests/slovak-company-data.yaml
@@ -30,6 +30,33 @@ input_schema:
 output_schema:
   type: object
   properties:
+    legal_representatives:
+      type: array
+      description: Current statutory-body members with type (person/organisation), role, role_code, start_date
+    total_legal_representatives:
+      type: integer
+    tier_2_available:
+      type: boolean
+    tier_2_available_reason:
+      type: string
+    legal_name:
+      type: string
+    primary_registration_id:
+      type:
+        - string
+        - "null"
+    registered_address:
+      type:
+        - string
+        - "null"
+    date_incorporated:
+      type:
+        - string
+        - "null"
+    ubo_availability:
+      type: string
+    ubo_availability_reason:
+      type: string
     ico:
       type: string
     company_name:
@@ -165,3 +192,14 @@ output_field_reliability:
   directors: common
   last_updated: common
   jurisdiction: guaranteed
+  legal_representatives: common
+  total_legal_representatives: guaranteed
+  tier_2_available: guaranteed
+  tier_2_available_reason: guaranteed
+  ubo_availability: guaranteed
+  ubo_availability_reason: guaranteed
+  # Evidence-Tier canonical aliases (always assigned in the output block).
+  legal_name: guaranteed
+  primary_registration_id: common
+  registered_address: guaranteed
+  date_incorporated: common

--- a/manifests/uk-company-data.yaml
+++ b/manifests/uk-company-data.yaml
@@ -34,6 +34,10 @@ output_schema:
     dissolution_date: null
     incorporation_date: "2017-06-30"
   properties:
+    ubo_availability:
+      type: string
+    ubo_availability_reason:
+      type: string
     status:
       type: string
     address:

--- a/manifests/uk-company-data.yaml
+++ b/manifests/uk-company-data.yaml
@@ -56,6 +56,15 @@ output_schema:
         type: string
     has_charges:
       type: boolean
+    legal_representatives:
+      type: array
+      description: Active officers with type (person/organisation), role, role_code, start_date; date_of_birth deliberately null (see uk-companies-house-officers for partial DOB)
+    total_legal_representatives:
+      type: integer
+    tier_2_available:
+      type: boolean
+    tier_2_available_reason:
+      type: string
 data_source: Companies House (UK Government)
 data_source_type: api
 transparency_tag: ai_generated
@@ -113,6 +122,11 @@ output_field_reliability:
   jurisdiction: guaranteed
   sic_codes: common
   has_charges: guaranteed
+  legal_representatives: common
+  tier_2_available: guaranteed
+  tier_2_available_reason: guaranteed
+  ubo_availability: guaranteed
+  ubo_availability_reason: guaranteed
 limitations:
   - title: Companies House API includes LLPs but sole traders and unregistered partnerships are not covered
     text: >-


### PR DESCRIPTION
## Summary
- **Latvia** gains board-member extraction from the official UR officers dataset (CC0 1.0, datastore-queryable — verified live: airBaltic → 2 board members with roles and representation rights). The mapper's discovery: NO/CZ/EE already extract officers, UK has it twice — Latvia was the one genuine gap.
- **Slovak** representatives enriched from name-only strings to the canonical structured shape (role "Konateľ", codes, start dates were being fetched and discarded); `directors` keeps natural-persons-only semantics.
- **UK** officers get type/role_code, a total count, and a length-gated `tier_2_available` (was hardcoded `true` — an active lie for officer-less entities; same fix on SK).
- **Canada** numeric lookups migrate from Browserless scraping to the official Corporations Canada JSON API (keyless, verified live incl. the `["could not find…"]` not-found shape and the upstream `"adresses"` key misspelling). Name search keeps the site render pending the doctrine ruling — the scraped surface shrinks, it doesn't grow.
- Cross-country consistency: LV/SK emit the canonical `type: person|organisation` discriminator + `date_of_birth` parity; LV uses the EE role_group vocabulary; NO/CZ manifest ubo-key drift closed; cz `geography` set.

## DB state (applied + verified out-of-band)
Canonical syncs (input/output schemas, transparency), fixture resyncs (CA fixture → corp 1007), backfills (reliability/limitations/PII) for canadian/latvian/slovak/uk/cz; tier fixtures recaptured for latvian/slovak; uk allowlisted for tier capture (needs the prod-only Companies House key) with a reason comment.

## Reviewer findings (two adversarial opus passes — same-provider, disclosed — all HIGHs fixed)
- **LV failure-vs-zero (both reviews, HIGH):** a failed officers query used to emit `legal_representatives: [], total: 0` — an affirmative "no officers" claim on an outage, invisible in prod. Now: NULL fields, logged warn, distinct reason strings, reliability downgraded to `common`.
- **CA manifest honesty (both reviews, HIGH):** `data_source_type: scrape` + `transparency_tag: ai_generated` contradicted the new direct-API path → `api` + `mixed` with a limitation documenting the per-path split. Also fixed: input schema blocked `company_name` at the route (the #168/#173 class — now anyOf), not-found message contradicted the accepted ID range, `adresses`-vs-`addresses` empty-array fallthrough, fixture swapped off a personal holding company registered at a private residence (→ corp 1007, an org address, Active since 1947).
- **SK corporate-officer semantics (technical M):** `directors` could have received company names after the enrichment — restored to natural persons only; corporate-body name shape handled defensively (scalar + windowed-array) since no corporate-konateľ entity could be live-probed.
- **LV extras:** truncation-honest total from CKAN, joint-signature threshold mapped, prototype-safe Maps, provenance/limitation reframed (DOB absence is a Strale minimization choice — the upstream dataset does publish birth data we deliberately never read).
- Accepted/queued: shared LegalRepresentative type + role_group enum across all six countries (LV/SK now follow EE vocabulary; NO/CZ still emit native tokens — pre-existing), coverage-matrix tier-2 counts (leg legend not locatable this session), SK role_code codelist qualifier, UK officer thinness beyond type/role_code (richer sibling capability exists).

## Verification
- tsc clean; new tests 11/11 (CA registry-number rules incl. the old truncate-to-wrong-corp bug, gate5); full suite green on re-run (single first-run failure = known collection-starvation flake).
- Live: CA corp 3000061 + 1007 + not-found; LV airBaltic (2 reps, canonical shape); SK ico 36674141 ("Konateľ", start date). UK needs the prod key — post-deploy check below.
- validate-capability: only the documented structural gate-5 one-fixture limit remains (same as #184's cohort).

## Test plan (post-deploy)
- `POST /v1/do uk-company-data {"company_number":"00445790"}` → `legal_representatives` with `type`/`role_code`, `total_legal_representatives`, length-gated tier_2.
- `POST /v1/do latvian-company-data {"reg_number":"40003245752"}` → 2 board members, `total_legal_representatives: 2`.
- `POST /v1/do canadian-company-data {"corporation_number":"1007"}` → Abbotsford Chamber of Commerce, Active, via direct API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)