### PR TITLE
feat(kyb): spanish-company-data reactivated on OpenMercantil (BORME-derived)

### DIFF
--- a/apps/api/src/capabilities/guarded-executor.test.ts
+++ b/apps/api/src/capabilities/guarded-executor.test.ts
@@ -378,3 +378,43 @@ describe("budget race", () => {
     expect(exhausted).toBe(40);
   });
 });
+
+// ─── Bind-parameter shape (DEC-20260504-A) ──────────────────────────────────
+//
+// Regression for the PR #43 bind-encoder bug class, re-surfaced 2026-08-12 by
+// the first free_quota smoke run: a Date instance inside db.execute(sql``)
+// queryChunks reaches the postgres-js encoder as a raw object and throws
+// "argument must be of type string ... Received an instance of Date".
+// windowStart must be bound as an ISO string. This test fails against the
+// un-applied fix (windowStart as Date) and passes with it.
+describe("budget-counter bind shapes (DEC-20260504-A)", () => {
+  // Scope note: this observes the binds of the INSERT ... ON CONFLICT path
+  // only — the threshold-alert UPDATEs run behind a fire-and-forget promise
+  // and don't fire at test_count=1, so their windowStart binds are protected
+  // by the parameter's string type, not by this assertion.
+  function containsDate(value: unknown, seen = new Set<unknown>()): boolean {
+    if (value instanceof Date) return true;
+    if (value === null || typeof value !== "object") return false;
+    if (seen.has(value)) return false;
+    seen.add(value);
+    // Object.values covers array elements too — no separate array branch.
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      if (containsDate(v, seen)) return true;
+    }
+    return false;
+  }
+
+  it("no Date instance reaches db.execute() on the free_quota budget path", async () => {
+    stubMeta({ slug: "x", cost_class: "free_quota", quota_window: "daily", quota_cap: 200 });
+    mockDbExecute.mockResolvedValueOnce([
+      { test_count: 1, budget_cap: 40, alert_30_fired_at: null, alert_50_fired_at: null, alert_80_fired_at: null, hard_stop_fired_at: null },
+    ]);
+    mockExecutor.mockResolvedValueOnce({ output: {}, provenance: { source: "x", fetched_at: "" } });
+    await guardedExecute("x", {}, internalCtx());
+    for (const call of mockDbExecute.mock.calls) {
+      for (const arg of call) {
+        expect(containsDate(arg)).toBe(false);
+      }
+    }
+  });
+});

--- a/apps/api/src/capabilities/guarded-executor.ts
+++ b/apps/api/src/capabilities/guarded-executor.ts
@@ -316,7 +316,12 @@ export async function assertBudgetAvailable(
     );
   }
   const budgetCap = computeBudgetCap(meta);
-  const windowStart = computeWindowStart(meta.quota_window, meta.quota_reset_dom);
+  // Bound as an ISO STRING, never a Date instance: a Date inside
+  // db.execute(sql``) queryChunks hits the postgres-js encoder as a raw
+  // object and throws 'argument must be of type string... Received an
+  // instance of Date' — the PR #43 bind-encoder bug class (DEC-20260504-A).
+  // Surfaced live 2026-08-12 by the first free_quota smoke run.
+  const windowStart = computeWindowStart(meta.quota_window, meta.quota_reset_dom).toISOString();
   const windowKind = meta.quota_window;
 
   const db = getDb();
@@ -371,7 +376,7 @@ async function maybeFireThresholdAlerts(
   slug: string,
   meta: CapabilityCostMeta,
   budgetCap: number,
-  windowStart: Date,
+  windowStart: string, // ISO string — see the bind-encoder note in assertBudgetAvailable
   windowKind: "daily" | "monthly",
 ): Promise<void> {
   const pct = row.test_count / budgetCap;

--- a/apps/api/src/capabilities/spanish-company-data.ts
+++ b/apps/api/src/capabilities/spanish-company-data.ts
@@ -1,79 +1,323 @@
-// Spain — Openapi.com ES-Advanced (Tier-3 vendor aggregator).
+// Spain — OpenMercantil.es (Tier-2 vendor aggregation of BORME).
 //
-// Phase 2b Openapi resolver replication. REPLACES the prior empresia.es +
-// infocif.es Browserless scraping path (Tier 1 violation per
-// DEC-20260427-I-4, deactivated 2026-04-29). Openapi is the licensed
-// multi-country aggregator path per DEC-20260507-C.
+// v3 (2026-08-12): REPLACES the Openapi ES-Advanced path, which had been
+// deactivated in prod (is_active=false, lifecycle degraded — the ES
+// solutions' step-1 threw on every call). OpenMercantil is a normalized
+// database accumulated from the official BORME gazette (Agencia Estatal
+// BOE): free tier 200 req/day without auth, officers ("cargos") included —
+// the leg Openapi ES-Advanced never carried.
 //
-// Identifier shape: Spanish CIF/NIF — letter + 7 digits + check character
-// (letter or digit), e.g. A28015865 for Telefónica. The capability also
-// accepts ES-prefix VAT (ESA28015865) and strips the prefix.
+// DEC-20260428-A Tier 2 compliance:
+//   - underlying data is statutorily public (BORME, Ley 37/2007 reuse)
+//   - vendor publishes machine-readable licence + attribution requirements
+//     in-band (_source_catalog on every response; verified live 2026-08-12)
+//   - provenance carries upstream_vendor + vendor_aggregation +
+//     primary_source_reference to the BORME
+//   - per-act registral references (S/H/I-A data) are preserved in events
 //
-// Field coverage (Matrix row 34867c87-082c-8178-8061-eda241b42b63):
-// Tier 1 6/7 (no legal_form via *-Advanced),
-// Tier 2 4/5 (no directors via *-Advanced — IT-only product line),
-// Tier 3 2/6 (NACE + last_filing_date; share_capital NOT returned by
-// ES-Advanced — Matrix's 3/6 claim with "share capital" is over-stated
-// by 1; only IT-Advanced has shareCapital).
-//
-// Direct Registradores / opendata.registradores.org integration queued
-// as v1.1 quality upgrade per DEC-20260507-C (separate workstream).
+// Known coverage honesty: BORME-derived coverage effectively starts 2009;
+// companies with no BORME activity since then (verified: Inditex/A15075062)
+// are ABSENT. Refuse, never guess — documented as a manifest limitation.
 
 import { registerCapability, type CapabilityInput } from "./index.js";
-import { executeOpenapiCapability } from "./lib/openapi-resolver.js";
+import { firstString } from "./lib/input-aliases.js";
+import { classifyNameMatch } from "../lib/company-name-match.js";
+import { logWarn } from "../lib/log.js";
+
+const OM_API = "https://openmercantil.es/api/v1";
 
 // CIF/NIF canonical: 1 letter + 7 digits + 1 check char (letter or digit).
 const ES_NIF_RE = /^[A-Z]\d{7}[A-Z0-9]$/;
 
+// Trailing Spanish legal forms, stripped LOCALLY before scoring so
+// "Banco Santander" matches "BANCO SANTANDER SA". Deliberately not added to
+// the shared CORP_SUFFIX_RE: bare "sl" as a global token would eat leading
+// words in real names ("SL Industries") — the same failure class that kept
+// "kg"/"ev" out of the shared regex.
+const ES_LEGAL_FORM_TAIL_RE =
+  /[,\s]+(s\.?\s?a\.?u?|s\.?\s?l\.?u?|s\.?\s?l\.?l|s\.?\s?coop(?:erativa)?|s\.?\s?com|a\.?\s?i\.?\s?e|s\.?\s?c\.?\s?p)\.?\s*$/i;
+
 function normaliseEsIdentifier(raw: string): string | null {
   const cleaned = raw.replace(/[\s.-]/g, "").toUpperCase();
-  // Strip ES-prefix VAT shape (ESA28015865 → A28015865)
   const stripped = cleaned.startsWith("ES") ? cleaned.slice(2) : cleaned;
   return ES_NIF_RE.test(stripped) ? stripped : null;
 }
 
-registerCapability("spanish-company-data", async (input: CapabilityInput) => {
-  const rawInput =
-    (input.vat_number as string) ??
-    (input.nif as string) ??
-    (input.cif as string) ??
-    (input.identifier as string) ??
-    "";
-  if (typeof rawInput !== "string" || !rawInput.trim()) {
+function stripEsLegalForm(name: string): string {
+  return name.replace(ES_LEGAL_FORM_TAIL_RE, "").trim();
+}
+
+// BORME cargo → canonical role_group (EE vocabulary; shared enum queued).
+function roleGroupFor(role: string): string {
+  const r = role.toLowerCase();
+  if (/liquidador/.test(r)) return "liquidation";
+  if (/apoderad/.test(r)) return "procuration";
+  if (/adm|consejer|president|vicepresident|secretari/.test(r)) return "management_board";
+  return "other";
+}
+
+// Corporate officers (auditor firms, corporate administrators) are companies.
+// Heuristic, with the documented false-positive tolerance of the cypriot
+// type-tag precedent; covers abbreviations AND spelled-out legal forms.
+function officerType(name: string): "person" | "organisation" {
+  const n = name.trim();
+  return ES_LEGAL_FORM_TAIL_RE.test(` ${n}`) ||
+    /\b(S\.?A\.?U?|S\.?L\.?U?|SLU|COOP|SOCIEDAD\s+(ANONIMA|LIMITADA|COOPERATIVA))\.?$/i.test(n)
+    ? "organisation"
+    : "person";
+}
+
+interface OmSearchItem {
+  slug?: string;
+  name?: string;
+  cif?: string;
+  province?: string;
+}
+
+interface OmCompanyResponse {
+  company?: {
+    slug?: string;
+    name?: string;
+    cif?: string;
+    company_type?: string;
+    status?: string;
+    address?: string;
+    date_creation?: string;
+    aliases?: string[];
+  };
+  kpis?: { acts_count?: number; first_seen?: string; last_seen?: string; province_count?: number };
+  top_provinces?: Array<{ province?: string; count?: number }>;
+  officers?: {
+    current?: Array<{ name?: string; role?: string; since?: string }>;
+  };
+  events?: Array<{
+    id?: string;
+    date?: string;
+    type?: string;
+    province?: string;
+    details?: string; // carries the per-act registral reference (Sección/Hoja/Inscripción)
+  }>;
+  _attributions?: Record<string, string>;
+}
+
+async function omFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${OM_API}${path}`, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(15000),
+  });
+  if (res.status === 429) {
     throw new Error(
-      "'vat_number' or 'nif' is required. Provide a Spanish CIF/NIF (letter + 7 digits + check character, e.g. A28015865). ES-prefix VAT format is also accepted (e.g. ESA28015865).",
+      "OpenMercantil free-tier daily quota (200 requests) exhausted — retry after the daily reset.",
     );
   }
-  const normalised = normaliseEsIdentifier(rawInput.trim());
-  if (!normalised) {
-    throw new Error(
-      `'${rawInput.trim()}' is not a valid Spanish CIF/NIF. Expected format: letter + 7 digits + check character (e.g. A28015865).`,
-    );
-  }
-  const __etResult = await executeOpenapiCapability(
-    {
-      countryCode: "ES",
-      identifierRegex: ES_NIF_RE,
-      openapiProduct: "es-advanced",
-      capabilitySlug: "spanish-company-data",
-    },
-    normalised,
+  if (!res.ok) throw new Error(`OpenMercantil API returned HTTP ${res.status}`);
+  return (await res.json()) as T;
+}
+
+async function omSearch(query: string): Promise<OmSearchItem[]> {
+  const data = await omFetch<{ count?: number; items?: OmSearchItem[] }>(
+    `/search?q=${encodeURIComponent(query)}`,
   );
+  return data.items ?? [];
+}
+
+async function resolveByNif(nif: string): Promise<string> {
+  const items = await omSearch(nif);
+  const hit = items.find((i) => (i.cif ?? "").toUpperCase() === nif);
+  if (!hit?.slug) {
+    if (items.length > 0) {
+      // The search matched records but none carries this CIF — a vendor
+      // data-shape case, not a coverage gap; don't blame the coverage window.
+      throw new Error(
+        `The BORME-derived register returned candidates for "${nif}" but none with that exact CIF. ` +
+          `Try the company name instead.`,
+      );
+    }
+    throw new Error(
+      `No Spanish company found for CIF/NIF ${nif} in the BORME-derived register. ` +
+        `Coverage starts with 2009 BORME activity — long-inactive registrations may be absent.`,
+    );
+  }
+  return hit.slug;
+}
+
+async function resolveByName(name: string): Promise<string> {
+  const items = (await omSearch(name)).filter((i) => i.slug && i.name);
+  if (items.length === 0) {
+    throw new Error(
+      `No Spanish company found matching "${name}". Provide the CIF/NIF ` +
+        `(e.g. A28015865) for an exact lookup.`,
+    );
+  }
+  // Score against the registered name with and without its trailing legal
+  // form; exact wins, unique high is the floor, ties are refused — a wrong
+  // company from a KYB lookup is worse than no answer.
+  const exact = new Map<string, string>();
+  const high = new Map<string, string>();
+  for (const it of items) {
+    const candidates = [it.name!, stripEsLegalForm(it.name!)];
+    let best: "exact" | "high" | null = null;
+    for (const c of candidates) {
+      const { match_confidence } = classifyNameMatch(name, c);
+      if (match_confidence === "exact") best = "exact";
+      else if (match_confidence === "high" && best !== "exact") best = "high";
+    }
+    if (best === "exact") {
+      exact.set(it.slug!, it.name!);
+      high.delete(it.slug!);
+    } else if (best === "high" && !exact.has(it.slug!)) {
+      high.set(it.slug!, it.name!);
+    }
+  }
+  const pick = (bucket: Map<string, string>, label: string): string => {
+    if (bucket.size === 1) return bucket.keys().next().value!;
+    const listing = [...bucket.entries()].slice(0, 5).map(([s, n]) => `${n} (${s})`).join("; ");
+    throw new Error(
+      `Ambiguous Spanish company name "${name}": ${bucket.size} distinct registered entities ` +
+        `are ${label} matches — ${listing}. Provide the CIF/NIF to disambiguate.`,
+    );
+  };
+  if (exact.size > 0) return pick(exact, "exact");
+  if (high.size > 0) return pick(high, "close");
+  const sample = items.slice(0, 3).map((i) => i.name).join(", ");
+  throw new Error(
+    `No confident Spanish registry match for "${name}" (closest: ${sample}). ` +
+      `Provide the CIF/NIF (e.g. A28015865) for an exact lookup.`,
+  );
+}
+
+registerCapability("spanish-company-data", async (input: CapabilityInput) => {
+  const rawInput = firstString(
+    input,
+    "nif", "cif", "vat_number", "identifier",
+    "company_name", "name", "query", "task",
+  );
+  if (!rawInput) {
+    throw new Error(
+      "A Spanish company identifier or name is required. Provide 'nif'/'cif' " +
+        "(letter + 7 digits + check char, e.g. A28015865; ES-prefixed VAT accepted) " +
+        "or 'company_name'. Aliases accepted: vat_number, identifier, name, query, task.",
+    );
+  }
+  const trimmed = rawInput.trim();
+  if (trimmed.length < 2) {
+    throw new Error("Input must be at least 2 characters.");
+  }
+
+  const nif = normaliseEsIdentifier(trimmed);
+  const slug = nif ? await resolveByNif(nif) : await resolveByName(trimmed);
+
+  const data = await omFetch<OmCompanyResponse>(`/company/${encodeURIComponent(slug)}`);
+  const c = data.company ?? {};
+  if (!c.name) {
+    throw new Error("OpenMercantil returned an unexpected company shape (no name).");
+  }
+
+  const officersRaw = data.officers?.current;
+  const representatives = Array.isArray(officersRaw)
+    ? officersRaw
+        .filter((o) => typeof o.name === "string" && o.name.trim())
+        .map((o) => ({
+          type: officerType(o.name!),
+          name: o.name!.trim(),
+          role: o.role ?? "Cargo",
+          role_code: null,
+          role_group: roleGroupFor(o.role ?? ""),
+          start_date: o.since ?? null,
+          date_of_birth: null,
+        }))
+    : null;
+  if (representatives === null) {
+    logWarn("es-officers", "OpenMercantil response carried no officers block", { slug });
+  }
+
+  const statusRaw = c.status ?? null;
+  // Normalized cross-country status enum (active/inactive/unknown) with the
+  // native Spanish value preserved in status_raw.
+  const status = statusRaw === "Activa"
+    ? "active"
+    : statusRaw && /extinguid|baja|disuelt|cerrad|liquidad/i.test(statusRaw)
+      ? "inactive"
+      : statusRaw
+        ? "unknown"
+        : null;
+  const output: Record<string, unknown> = {
+    company_name: c.name,
+    nif: c.cif ?? nif ?? null,
+    vat_number: c.cif ? `ES${c.cif}` : null,
+    company_type: c.company_type ?? null,
+    status,
+    status_raw: statusRaw,
+    address: c.address?.trim() ? c.address : null,
+    province: data.top_provinces?.[0]?.province ?? null,
+    registration_date: c.date_creation?.trim() ? c.date_creation : null,
+    first_borme_activity: data.kpis?.first_seen ?? null,
+    last_borme_activity: data.kpis?.last_seen ?? null,
+    borme_acts_count: data.kpis?.acts_count ?? null,
+    // null (not []) when the response carried no officers block: "no
+    // officers" is an affirmative claim this response cannot make then.
+    legal_representatives: representatives,
+    total_legal_representatives: representatives?.length ?? null,
+    // Per-fact primary-source provenance (DEC-20260428-A Tier 2): the most
+    // recent BORME acts with their registral references, so every officer or
+    // status fact can be traced to a specific gazette publication.
+    recent_borme_acts: (data.events ?? []).slice(0, 5).map((e) => ({
+      date: e.date ?? null,
+      type: e.type ?? null,
+      province: e.province ?? null,
+      registral_reference: e.details ?? null,
+    })),
+    jurisdiction: "ES",
+  };
+
+  // Evidence Tier canonical aliases + honest Tier-2/UBO posture.
+  output.legal_name = output.company_name;
+  output.primary_registration_id = output.nif;
+  output.legal_form = output.company_type;
+  output.registered_address = output.address;
+  // NEVER fall back to first_borme_activity here: that is the coverage-window
+  // floor (~2009), not an incorporation date — the fallback made Spain's
+  // oldest companies read as founded in 2009 (review-caught fabrication in a
+  // canonical cross-country field). Null when the register doesn't say.
+  output.date_incorporated = output.registration_date ?? null;
+  if (representatives === null) {
+    output.tier_2_available = false;
+    output.tier_2_available_reason =
+      "officers block missing from the vendor response on this call — representation data temporarily unavailable, retry later";
+  } else if (representatives.length === 0) {
+    output.tier_2_available = false;
+    output.tier_2_available_reason =
+      "no current officers (cargos) on record for this entity in the BORME-derived register";
+  } else {
+    output.tier_2_available = true;
+    output.tier_2_available_reason =
+      "current officers (cargos vigentes) from BORME appointment/cessation acts via OpenMercantil.es";
+  }
+  output.ubo_availability = "unavailable_no_registry";
+  output.ubo_availability_reason =
+    "Spain's RETIR/beneficial-ownership registry is not publicly accessible; BORME does not carry ownership";
+
+  // Prefer the vendor's in-band attribution requirement (it ships on every
+  // response); fall back to the verified 2026-08-12 wording so a vendor
+  // policy change surfaces here instead of silently drifting.
+  const inBandAttribution = Object.values(data._attributions ?? {}).filter(Boolean).join(" ");
+
   return {
-    ...__etResult,
-    output: {
-      ...__etResult.output,
-      // Evidence Tier 1 canonical aliases (DEC-20260518-A)
-      legal_name: (__etResult.output as Record<string, unknown>).company_name,
-      primary_registration_id: (__etResult.output as Record<string, unknown>).registration_number,
-      date_incorporated: (__etResult.output as Record<string, unknown>).registered_date,
-      // Evidence Tier framework labels (DEC-20260518-A)
-      tier_2_available: false,
-      tier_2_available_reason: "Openapi-served endpoint does not expose directors at current tier (universal caveat for WW-Top + *-Advanced products; IT-Full deferred to v1.1)",
-      ubo_availability: "restricted",
-      ubo_availability_reason: "RCTIR (Registro Central de Titularidades Reales) access restricted to AML-obliged entities",
+    output,
+    provenance: {
+      source: "openmercantil.es (BORME-derived)",
+      source_url: `https://openmercantil.es/empresa/${encodeURIComponent(slug)}`,
+      fetched_at: new Date().toISOString(),
+      acquisition_method: "vendor_aggregation" as const,
+      upstream_vendor: "OpenMercantil.es",
+      primary_source_reference: "https://www.boe.es/diario_borme/",
+      license: "CC BY 4.0 (OpenMercantil datasets); Condiciones BOE de reutilización, Ley 37/2007 (BORME)",
+      license_url: "https://www.boe.es/informacion/aviso_legal/index.php",
+      attribution: inBandAttribution
+        ? `Datos: OpenMercantil.es. ${inBandAttribution}`
+        : "Datos: OpenMercantil.es, derivado del BORME. Basado en datos de la Agencia Estatal Boletín Oficial del Estado.",
+      source_note:
+        "Normalized from official BORME gazette acts; per-act registral references carried in recent_borme_acts.",
     },
   };
 });
-
-export { ES_NIF_RE };

--- a/manifests/spanish-company-data.yaml
+++ b/manifests/spanish-company-data.yaml
@@ -1,126 +1,213 @@
 slug: spanish-company-data
 name: Spanish Company Data
 description: >-
-  Look up Spanish company data via Openapi.com ES-Advanced (Tier-3 vendor aggregator). Accepts Spanish CIF/NIF
-  (letter + 7 digits + check char). Returns name, registration number, status, registered address, registration
-  date, LEI, primary NACE code, last filing date (from balance-sheet data), and last-update timestamp. Directors
-  are not returned at the *-Advanced tier (Italian product line only).
+  Look up Spanish company data from the BORME-derived OpenMercantil register. Accepts CIF/NIF or company
+  name. Returns identity, status, legal form, current officers (cargos) with roles, and BORME activity
+  history for 2.8M+ Spanish companies.
 category: company-data
-cost_class: paid_per_call
-price_cents: 6
+# OpenMercantil free tier: 200 requests/day without auth. Each lookup costs
+# 2 upstream calls (search + company), so ~100 lookups/day headroom.
+cost_class: free_quota
+quota_window: daily
+# Authored in CAPABILITY-CALL units (review M-5): the vendor allows 200
+# requests/day and each lookup consumes 2 (search + company), so 100
+# lookups/day. computeBudgetCap takes 10% of this for internal tests —
+# 10 lookups = 20 vendor requests = 10% of the vendor quota, as intended.
+quota_cap: 100
+price_cents: 5
 is_free_tier: false
-avg_latency_ms: 2400
+avg_latency_ms: 900
 input_schema:
   type: object
-  required:
-    - vat_number
+  # No field is individually required: a CIF/NIF OR a company name is enough,
+  # and the executor enforces that itself (firstString alias chain).
+  required: []
   properties:
+    nif:
+      type: string
+      description: Spanish CIF/NIF (letter + 7 digits + check char, e.g. A28015865); ES-prefixed VAT accepted
+    cif:
+      type: string
+      description: Alias for nif
     vat_number:
       type: string
-      description: Spanish CIF/NIF (letter + 7 digits + check char, e.g. A28015865) or ES-prefix VAT (ESA28015865).
+      description: Alias for nif — ES-prefix VAT format accepted (ESA28015865)
+    identifier:
+      type: string
+      description: Alias for nif
+    company_name:
+      type: string
+      description: Spanish company name (scored match — ambiguous names are refused, never guessed)
+    name:
+      type: string
+      description: Alias for company_name
+    query:
+      type: string
+      description: Free-text alias — CIF/NIF or company name
+    task:
+      type: string
+      description: Free-text alias — CIF/NIF or company name
+  anyOf:
+    - required: [nif]
+    - required: [cif]
+    - required: [vat_number]
+    - required: [identifier]
+    - required: [company_name]
+    - required: [name]
+    - required: [query]
+    - required: [task]
 output_schema:
   type: object
   example:
-    company_name: Telefonica, SA
-    native_company_name: null
-    registration_number: A28015865
-    vat_number: ESA28015865
-    country_code: ES
-    legal_form: null
+    company_name: CONSTRUCCIONES AMENABAR SA
+    nif: A20072302
+    vat_number: ESA20072302
+    company_type: S.A.
     status: active
-    is_active: true
-    registered_date: "1924-04-19"
-    registered_address: "Calle Gran Via, 28 5 28, 28013, Madrid, ES"
-    lei_code: 549300EEJH4FEPDBBR25
-    nace_codes:
-      - code: "6190"
-        description: Other telecommunications activities
-    company_size: null
-    source_as_of: "2026-05-10T14:33:21.000Z"
-    last_filing_date: "2024-12-31"
+    status_raw: Activa
+    address: null
+    province: Gipuzkoa
+    registration_date: null
+    first_borme_activity: "2009-04-16"
+    last_borme_activity: "2026-01-15"
+    borme_acts_count: 79
+    total_legal_representatives: 22
+    tier_2_available: true
+    jurisdiction: ES
   properties:
     company_name: { type: string }
-    native_company_name: { type: ["string", "null"] }
-    registration_number: { type: string }
-    vat_number: { type: string }
-    country_code: { type: string }
+    nif:
+      type: ["string", "null"]
+      description: CIF; can be null on name-path lookups when the BORME record carries no published CIF
+    vat_number: { type: ["string", "null"] }
+    company_type: { type: ["string", "null"] }
+    status:
+      type: ["string", "null"]
+      enum: [active, inactive, unknown, null]
+    status_raw:
+      type: ["string", "null"]
+      description: Native Spanish register status (Activa, Extinguida, ...)
+    address: { type: ["string", "null"] }
+    province:
+      type: ["string", "null"]
+      description: Province with the most BORME filings for this company — an activity-location proxy, NOT the registered office
+    recent_borme_acts:
+      type: array
+      description: Most recent BORME acts with per-act registral references (Sección/Hoja/Inscripción) — the primary-source trace for officer and status facts
+    registration_date: { type: ["string", "null"] }
+    first_borme_activity: { type: ["string", "null"] }
+    last_borme_activity: { type: ["string", "null"] }
+    borme_acts_count: { type: ["integer", "null"] }
+    legal_representatives:
+      type: ["array", "null"]
+      description: >-
+        Current officers (cargos vigentes) with type (person/organisation), native Spanish role
+        (Apoderado, Adm. Unico, Consejero...), role_group (management_board/procuration/liquidation/other),
+        and start date. Null (not empty) when the officers block was unavailable on this call.
+    total_legal_representatives: { type: ["integer", "null"] }
+    tier_2_available: { type: boolean }
+    tier_2_available_reason: { type: string }
+    ubo_availability: { type: string }
+    ubo_availability_reason: { type: string }
+    legal_name: { type: string }
+    primary_registration_id: { type: ["string", "null"] }
     legal_form: { type: ["string", "null"] }
-    status: { type: string, enum: [active, inactive, unknown] }
-    is_active: { type: boolean }
-    registered_date: { type: ["string", "null"] }
     registered_address: { type: ["string", "null"] }
-    lei_code: { type: ["string", "null"] }
-    nace_codes: { type: array }
-    company_size: { type: ["string", "null"] }
-    source_as_of: { type: ["string", "null"] }
-    last_filing_date: { type: ["string", "null"] }
-data_source: Openapi.com ES-Advanced (Tier-3 vendor aggregator; Spanish company-data product line)
+    date_incorporated: { type: ["string", "null"] }
+    jurisdiction: { type: string }
+data_source: OpenMercantil.es — BORME-derived register (Agencia Estatal BOE primary source), Tier-2 vendor aggregation
 data_source_type: api
 transparency_tag: algorithmic
 freshness_category: live-fetch
-maintenance_class: commercial-stable-api
+maintenance_class: free-stable-api
 gdpr_art_22_classification: data_lookup
 processes_personal_data: true
 personal_data_categories:
   - name
-  - address
   - professional
 geography: eu
 test_fixtures:
   known_answer:
     input:
-      vat_number: A28015865
+      nif: A20072302
     expected_fields:
-      - { field: company_name, operator: not_null, reliability: guaranteed }
-      - { field: country_code, operator: equals, reliability: guaranteed, value: ES }
-      - { field: status, operator: equals, reliability: guaranteed, value: active }
-      - { field: is_active, operator: equals, reliability: guaranteed, value: true }
-      - { field: registered_address, operator: not_null, reliability: guaranteed }
-      - { field: registration_number, operator: not_null, reliability: guaranteed }
-      - { field: nace_codes, operator: not_null, reliability: guaranteed }
-      - { field: last_filing_date, operator: not_null, reliability: guaranteed }
+      - { field: company_name, operator: contains, reliability: guaranteed, value: AMENABAR }
+      - { field: nif, operator: equals, reliability: guaranteed, value: A20072302 }
+      - { field: status, operator: not_null, reliability: guaranteed }
+      - { field: jurisdiction, operator: equals, reliability: guaranteed, value: ES }
+      - { field: tier_2_available, operator: not_null, reliability: guaranteed }
   health_check_input:
-    vat_number: A28015865
+    nif: A20072302
 output_field_reliability:
   company_name: guaranteed
-  native_company_name: rare
-  registration_number: guaranteed
-  vat_number: guaranteed
-  country_code: guaranteed
-  legal_form: rare
+  # common, not guaranteed: name-path lookups can hit BORME records with no
+  # published CIF (nif/vat_number/primary_registration_id null then).
+  nif: common
+  vat_number: common
+  recent_borme_acts: common
+  company_type: common
   status: guaranteed
-  is_active: guaranteed
-  registered_date: guaranteed
-  registered_address: guaranteed
-  lei_code: common
-  nace_codes: guaranteed
-  company_size: rare
-  source_as_of: guaranteed
-  last_filing_date: guaranteed
+  status_raw: common
+  address: rare
+  province: common
+  registration_date: rare
+  first_borme_activity: common
+  last_borme_activity: common
+  borme_acts_count: common
+  # Null (not asserted) when the vendor response carried no officers block —
+  # "0 officers" and "block unavailable" are different KYB answers.
+  legal_representatives: common
+  total_legal_representatives: common
+  tier_2_available: guaranteed
+  tier_2_available_reason: guaranteed
+  ubo_availability: guaranteed
+  ubo_availability_reason: guaranteed
+  legal_name: guaranteed
+  primary_registration_id: common
+  legal_form: common
+  registered_address: rare
+  date_incorporated: common
+  jurisdiction: guaranteed
 limitations:
-  - title: Gated behind OPENAPI_ENABLED flag pending resale addendum countersignature
+  - title: Coverage starts with 2009 BORME activity — some listed parent entities are absent
     text: >-
-      Strale's resale of Openapi.com data requires the addendum issued via Openapi case 151296 (2026-05-08) to be
-      countersigned. Until then, OPENAPI_ENABLED stays false in production and this capability returns
-      capability-unavailable. price_cents flips from 6 to 5 (€0.061 → €0.05 net) when Moonlighter AB VAT confirms.
-    category: availability
+      The register is accumulated from BORME gazette acts from ~2009 onward. Companies with no BORME
+      activity in that window are absent — verified to include several IBEX-listed PARENT entities
+      (Telefónica SA, Banco Santander SA, Inditex SA) even though their operating subsidiaries
+      (Telefónica Móviles España, Santander Consumer Finance, ...) are covered. The 2.8M-company SME and
+      operating-company population — the usual KYB target — is the covered set. Absent companies are
+      refused, never guessed.
+    category: coverage
     severity: warning
-  - title: Legal form not returned at ES-Advanced tier
-    text: Openapi ES-Advanced does not return Spanish legal form (S.A., S.L., etc.).
-    category: coverage
-    severity: info
-  - title: Directors not available at ES-Advanced tier
+    workaround: For listed parents, use lei-lookup (GLEIF) or the CNMV's public issuer registry
+  - title: Not an official source — normalized by a third party from official BORME acts
     text: >-
-      Directors / officers / shareholders are NOT returned at ES-Advanced — the directors-gap closure is IT-only
-      via Openapi IT-Full. Direct Registradores / opendata.registradores.org integration queued as v1.1 quality
-      upgrade per DEC-20260507-C.
-    category: coverage
+      OpenMercantil self-describes as not an official source. Every fact derives from official BORME
+      gazette publications (per-act registral references are preserved), but the normalization layer is a
+      small third-party project — treat as Tier-2 vendor aggregation, not registry ground truth.
+    category: accuracy
     severity: info
-  - title: Share capital not returned at ES-Advanced tier
+    workaround: Confirm critical facts against the BORME act cited in the record or a Registro Mercantil extract
+  - title: Officer list reflects BORME appointment/cessation acts, not a maintained register snapshot
     text: >-
-      Despite the Matrix's "share capital via balanceSheets" claim, the ES-Advanced response contains employees /
-      netWorth / operatingRevenue / equity / totalAssets per year, but NOT a dedicated shareCapital field. Tier 3
-      coverage is 2/6 (NACE + last_filing_date), not 3/6. Matrix needs reconciliation; documented for chat to
-      address separately. Only IT-Advanced surfaces shareCapital.
-    category: coverage
+      Current officers are derived from appointment (Nombramientos), re-election and cessation acts. An
+      officer whose cessation was never published, or whose appointment predates coverage, may be listed
+      incorrectly. Dates of birth are never available (BORME does not publish them).
+    category: accuracy
     severity: info
+  - title: Single-operator vendor — no SLA, no contract, no indemnification
+    text: >-
+      OpenMercantil is a small single-operator project offering a free unauthenticated API. There is no
+      service agreement, uptime commitment, or indemnification. The underlying facts are statutory open
+      data (BORME, Ley 37/2007 reuse right), so the legal exposure is the normalization layer's
+      availability and accuracy, not the data's redistributability. Durability risk is accepted and
+      monitored; a registry-direct or paid-tier fallback is the upgrade path if the service degrades.
+    category: availability
+    severity: info
+  - title: Free-tier quota is 200 upstream requests/day (~100 lookups)
+    text: >-
+      The vendor's free tier allows 200 requests/day; each lookup consumes two (search + company fetch).
+      Quota exhaustion returns a clear retry-later error, never a partial answer.
+    category: throughput
+    severity: info
+    workaround: Vendor's Profesional tier (5,000/day, €57/mo) is the upgrade path if ES volume materializes


### PR DESCRIPTION
## Summary
- Reactivates spanish-company-data on OpenMercantil.es — a Tier-2 vendor aggregation of the official BORME gazette (free, 200 req/day, no auth). The old Openapi ES-Advanced path was gated on a never-countersigned resale addendum: the capability sat `is_active=false` and the three contained ES solutions' step-1 threw on every call. Officers (cargos) now included — the leg Openapi never carried.
- NIF + scored name paths (tie refusal, refuse-don't-guess); canonical officer shape with BORME-cargo role_group mapping; per-act registral references (`recent_borme_acts`) as the per-fact primary-source trace; in-band vendor attribution.
- Fixes the free_quota budget path for ALL free_quota capabilities: `windowStart` was bound as a `Date` instance into `db.execute(sql\`\`)` — the PR #43 bind-encoder class (DEC-20260504-A) — throwing on every internal-test-context execution. Surfaced by this capability's first smoke run; regression test added (walks all `db.execute` binds for `Date` shapes; fails against the un-applied fix).

## DEC-20260504-A compliance
The guarded-executor fix carries `guarded-executor.test.ts` › "budget-counter bind shapes": recursive Date-shape walk over every `db.execute()` argument on the free_quota budget path. Customer traffic was never affected (the budget check runs only for internal_test context).

## Coverage honesty (verified live)
Covered: the 2.8M SME/operating-company population — Construcciones Amenabar by NIF and name (22 officers), Telefónica Móviles, Santander Consumer Finance, Repsol Petróleo, Mercadona all present. Absent: IBEX listed PARENT entities (Telefónica SA, Banco Santander SA, Inditex SA — no BORME activity in the vendor's 2009+ window). Documented as a warning-severity limitation with the GLEIF workaround. Absent companies are refused, never guessed.

## Reviewer findings (one combined adversarial opus pass — same-provider, disclosed)
HIGH (fixed): `date_incorporated` fell back to `first_borme_activity` — the coverage-window floor — fabricating 2009 incorporation dates for Spain's oldest companies in a canonical cross-country field. Now null when the register doesn't say.
MEDIUM (all fixed): nif/primary_registration_id downgraded to `common` (name-path records may lack a CIF); `province` documented as an activity-location proxy, not the registered office; Tier-2 record completed (per-fact registral refs now in the response, in-band attribution read, single-operator durability limitation added); quota_cap re-authored in capability-call units (100) so the 10% internal-test budget means what it says — the review found german-company-data has the same 2:1 skew (follow-up queued).
LOW (fixed): status normalized to active/inactive/unknown enum with `status_raw` preserved; officerType covers spelled-out legal forms; distinct error when candidates exist but no CIF matches; provenance slug encoded; regression-test scope comment. Accepted: officerType surname false-positive class ("DE SA") per the documented cypriot precedent; 4th copy of the person/organisation heuristic — shared-helper cleanup queued with the LegalRepresentative type.

## DB state (applied + verified)
Canonical sync ×2, fixture resync (NIF A20072302), backfills, cost_class `free_quota`/`daily`/cap 100 seeded, reactivation flags set with a `capability_promoted` event (tier 2, reversal instructions in details). Validate: only the structural gate-5 one-fixture limit. Smoke: 11/11 after the bind fix.

## Test plan (post-deploy)
- `POST /v1/do {"capability_slug":"spanish-company-data","max_price_cents":50,"inputs":{"nif":"A20072302"}}` → Construcciones Amenabar, status active, 22 officers, 5 recent_borme_acts.
- `inputs: {"company_name":"Mercadona"}` → resolves (single exact match).
- Re-enable the 3 ES solutions after this verifies (separate ops action, reversal-logged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)