### PR TITLE
feat(x402): config-gated facilitator switch for CDP Bazaar indexing

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -53,6 +53,16 @@ async function main() {
     console.log("[startup] All provider env vars present.");
   }
 
+  // x402 facilitator selection — logged at boot so a flag flip is verifiable
+  // from the deploy log (DEC-20260504-C: confirm the deploy produced the
+  // expected effect, don't assume). The import also forces
+  // resolveFacilitatorSelection's fail-fast to run before traffic is served.
+  const { getFacilitatorSelection } = await import("./lib/x402-gateway.js");
+  const facilitatorSelection = getFacilitatorSelection();
+  console.log(
+    `[startup] x402 facilitator: ${facilitatorSelection.kind} (mode=${facilitatorSelection.mode}) ${facilitatorSelection.url}`,
+  );
+
   // Manifest hygiene: unauthenticated providers must either declare a pool of
   // fallback base URLs (so one throttled endpoint doesn't trip the probe) or
   // explicitly accept the risk. This enforces the lesson from the publicnode

--- a/apps/api/src/lib/x402-facilitator.test.ts
+++ b/apps/api/src/lib/x402-facilitator.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Facilitator selection matrix — the Bazaar facilitator switch.
+ *
+ * `resolveFacilitatorSelection` decides which facilitator processes verify and
+ * settle. That is a money-path decision, so every cell of the matrix is pinned
+ * here rather than left to be inferred from the implementation.
+ *
+ * Three properties matter most, and each has a dedicated test below:
+ *
+ *  1. **Deploying the switch moves no traffic.** The default mode ("auto")
+ *     reproduces the pre-switch rule exactly (mainnet + CDP keys → CDP, else
+ *     the HTTP facilitator). Shipping this change without setting
+ *     X402_FACILITATOR must be a no-op.
+ *  2. **Rollback does not require deleting credentials.**
+ *     X402_FACILITATOR=legacy pins the HTTP facilitator even when CDP keys are
+ *     present. Under the old implicit rule the only way back was to remove the
+ *     keys from Railway.
+ *  3. **A half-configured cutover fails loudly.** @coinbase/x402 happily builds
+ *     an unauthenticated config when keys are absent, which would 401 on every
+ *     paid call at settle time — after the capability has already run. Mode
+ *     "cdp" without both keys throws at resolve time instead.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import {
+  resolveFacilitatorSelection,
+  CDP_FACILITATOR_URL,
+  DEFAULT_LEGACY_FACILITATOR_URL,
+  type FacilitatorEnv,
+} from "./x402-gateway.js";
+
+const KEYS: FacilitatorEnv = {
+  CDP_API_KEY_ID: "test-key-id",
+  CDP_API_KEY_SECRET: "test-key-secret",
+};
+
+const MAINNET: FacilitatorEnv = { X402_NETWORK: "base" };
+const TESTNET: FacilitatorEnv = { X402_NETWORK: "base-sepolia" };
+
+describe("resolveFacilitatorSelection — mode 'auto' (default)", () => {
+  it("defaults to auto when X402_FACILITATOR is unset", () => {
+    expect(resolveFacilitatorSelection({}).mode).toBe("auto");
+  });
+
+  it("treats an empty / whitespace value as unset rather than erroring", () => {
+    expect(resolveFacilitatorSelection({ X402_FACILITATOR: "" }).mode).toBe("auto");
+    expect(resolveFacilitatorSelection({ X402_FACILITATOR: "   " }).mode).toBe("auto");
+  });
+
+  // The four cells below ARE the pre-switch rule. If any of them changes,
+  // deploying the switch with no env set would move production traffic.
+  it("mainnet + CDP keys → CDP", () => {
+    const s = resolveFacilitatorSelection({ ...MAINNET, ...KEYS });
+    expect(s.kind).toBe("cdp");
+    expect(s.url).toBe(CDP_FACILITATOR_URL);
+  });
+
+  it("mainnet without CDP keys → legacy", () => {
+    expect(resolveFacilitatorSelection(MAINNET).kind).toBe("legacy");
+  });
+
+  it("testnet with CDP keys → legacy (network gate preserved)", () => {
+    expect(resolveFacilitatorSelection({ ...TESTNET, ...KEYS }).kind).toBe("legacy");
+  });
+
+  it("testnet without CDP keys → legacy", () => {
+    expect(resolveFacilitatorSelection(TESTNET).kind).toBe("legacy");
+  });
+
+  it("defaults the network to base-sepolia, so a bare env is legacy", () => {
+    const s = resolveFacilitatorSelection(KEYS);
+    expect(s.kind).toBe("legacy");
+    expect(s.url).toBe(DEFAULT_LEGACY_FACILITATOR_URL);
+  });
+
+  it("recognises the CAIP-2 spelling of Base mainnet", () => {
+    const s = resolveFacilitatorSelection({ X402_NETWORK: "eip155:8453", ...KEYS });
+    expect(s.kind).toBe("cdp");
+  });
+});
+
+describe("resolveFacilitatorSelection — mode 'cdp' (rollout target)", () => {
+  it("selects CDP on mainnet", () => {
+    const s = resolveFacilitatorSelection({ X402_FACILITATOR: "cdp", ...MAINNET, ...KEYS });
+    expect(s.kind).toBe("cdp");
+    expect(s.url).toBe(CDP_FACILITATOR_URL);
+  });
+
+  it("selects CDP on testnet too, so the switch can be rehearsed before prod", () => {
+    const s = resolveFacilitatorSelection({ X402_FACILITATOR: "cdp", ...TESTNET, ...KEYS });
+    expect(s.kind).toBe("cdp");
+  });
+
+  it("never reports the legacy URL, even when X402_FACILITATOR_URL is set", () => {
+    // Regression guard for the surface bug this change also fixed: discovery
+    // documents must advertise the facilitator that actually settles, so the
+    // selection's URL has to come from the selection and not the env var.
+    const s = resolveFacilitatorSelection({
+      X402_FACILITATOR: "cdp",
+      X402_FACILITATOR_URL: "https://x402.org/facilitator",
+      ...MAINNET,
+      ...KEYS,
+    });
+    expect(s.url).toBe(CDP_FACILITATOR_URL);
+  });
+
+  it("throws when both CDP credentials are missing", () => {
+    expect(() => resolveFacilitatorSelection({ X402_FACILITATOR: "cdp", ...MAINNET })).toThrow(
+      /CDP_API_KEY_ID and CDP_API_KEY_SECRET/,
+    );
+  });
+
+  it("throws when only the key id is set", () => {
+    expect(() =>
+      resolveFacilitatorSelection({
+        X402_FACILITATOR: "cdp",
+        CDP_API_KEY_ID: "id-only",
+        ...MAINNET,
+      }),
+    ).toThrow(/CDP_API_KEY_ID and CDP_API_KEY_SECRET/);
+  });
+
+  it("throws when only the secret is set", () => {
+    expect(() =>
+      resolveFacilitatorSelection({
+        X402_FACILITATOR: "cdp",
+        CDP_API_KEY_SECRET: "secret-only",
+        ...MAINNET,
+      }),
+    ).toThrow(/CDP_API_KEY_ID and CDP_API_KEY_SECRET/);
+  });
+
+  it("treats whitespace-only credentials as missing", () => {
+    // Railway variables that were "cleared" by blanking the field arrive as
+    // empty or whitespace strings, not as undefined.
+    expect(() =>
+      resolveFacilitatorSelection({
+        X402_FACILITATOR: "cdp",
+        CDP_API_KEY_ID: "  ",
+        CDP_API_KEY_SECRET: "",
+        ...MAINNET,
+      }),
+    ).toThrow(/CDP_API_KEY_ID and CDP_API_KEY_SECRET/);
+  });
+});
+
+describe("resolveFacilitatorSelection — mode 'legacy' (rollback lever)", () => {
+  it("pins the legacy facilitator even on mainnet with CDP keys present", () => {
+    // The whole point of the lever: rolling back must not require deleting
+    // credentials from Railway.
+    const s = resolveFacilitatorSelection({ X402_FACILITATOR: "legacy", ...MAINNET, ...KEYS });
+    expect(s.kind).toBe("legacy");
+    expect(s.url).toBe(DEFAULT_LEGACY_FACILITATOR_URL);
+  });
+
+  it("honours a custom X402_FACILITATOR_URL", () => {
+    const s = resolveFacilitatorSelection({
+      X402_FACILITATOR: "legacy",
+      X402_FACILITATOR_URL: "https://facilitator.example.test",
+      ...MAINNET,
+      ...KEYS,
+    });
+    expect(s.url).toBe("https://facilitator.example.test");
+  });
+
+  it("falls back to the default URL when X402_FACILITATOR_URL is blank", () => {
+    const s = resolveFacilitatorSelection({
+      X402_FACILITATOR: "legacy",
+      X402_FACILITATOR_URL: "   ",
+    });
+    expect(s.url).toBe(DEFAULT_LEGACY_FACILITATOR_URL);
+  });
+});
+
+describe("resolveFacilitatorSelection — input handling", () => {
+  it("is case- and whitespace-insensitive", () => {
+    expect(resolveFacilitatorSelection({ X402_FACILITATOR: "  CDP  ", ...KEYS }).kind).toBe("cdp");
+    expect(resolveFacilitatorSelection({ X402_FACILITATOR: "Legacy" }).kind).toBe("legacy");
+  });
+
+  it("throws on an unknown mode rather than silently defaulting", () => {
+    // A typo'd value must not quietly resolve to auto — that would look like a
+    // successful cutover while settlement stayed on the old facilitator.
+    expect(() => resolveFacilitatorSelection({ X402_FACILITATOR: "coinbase" })).toThrow(
+      /must be one of auto \| cdp \| legacy/,
+    );
+  });
+
+  it("reports the configured mode back, so the boot log can state it", () => {
+    expect(resolveFacilitatorSelection({ X402_FACILITATOR: "legacy" }).mode).toBe("legacy");
+    expect(resolveFacilitatorSelection({ X402_FACILITATOR: "cdp", ...KEYS }).mode).toBe("cdp");
+  });
+});
+
+/**
+ * Discovery surfaces must advertise the facilitator that actually settles.
+ *
+ * `/x402/catalog` and `/.well-known/x402.json` both used to read
+ * `process.env.X402_FACILITATOR_URL ?? "https://x402.org/facilitator"`
+ * directly. Once mode=cdp is live that would publish x402.org while payments
+ * settled through CDP — a lie in the two documents every x402 scanner reads.
+ *
+ * No HTTP harness exists for x402-gateway-v2.ts, so this is a source-static
+ * check in the style of x402-gateway-v2.settlement-order.test.ts
+ * (DEC-20260504-A test-harness exemption).
+ */
+describe("x402 discovery surfaces", () => {
+  const __dirname_ = dirname(fileURLToPath(import.meta.url));
+  const GATEWAY_V2 = resolve(__dirname_, "../routes/x402-gateway-v2.ts");
+
+  it("do not hardcode a facilitator URL", () => {
+    const source = readFileSync(GATEWAY_V2, "utf-8");
+    const codeLines = source
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("//") && !line.trim().startsWith("*"));
+    expect(codeLines.join("\n")).not.toContain("X402_FACILITATOR_URL");
+  });
+
+  it("read the facilitator from the resolved selection", () => {
+    const source = readFileSync(GATEWAY_V2, "utf-8");
+    // Once in /x402/catalog, once in getX402Manifest (/.well-known/x402.json).
+    const uses = source.match(/facilitator:\s*getFacilitatorUrl\(\)/g) ?? [];
+    expect(uses.length).toBe(2);
+  });
+});

--- a/apps/api/src/lib/x402-gateway.ts
+++ b/apps/api/src/lib/x402-gateway.ts
@@ -26,7 +26,6 @@ const WALLET_ADDRESS = process.env.X402_WALLET_ADDRESS ?? "";
 // x402 v1 simple network names ("base", "base-sepolia") for compatibility
 // with the canonical x402-fetch client. See x402-gateway-v2.ts for rationale.
 const NETWORK = process.env.X402_NETWORK ?? "base-sepolia";
-const FACILITATOR_URL = process.env.X402_FACILITATOR_URL ?? "https://x402.org/facilitator";
 const EUR_USD_RATE = parseFloat(process.env.EUR_USD_RATE ?? "1.08");
 if (!Number.isFinite(EUR_USD_RATE) || EUR_USD_RATE <= 0) {
   // Fail fast at module load: a malformed env value ("1,085", "") would
@@ -59,27 +58,162 @@ export function isX402Configured(): boolean {
   return WALLET_ADDRESS.length > 0;
 }
 
+// ─── Facilitator selection ──────────────────────────────────────────────────
+//
+// Which facilitator processes verify/settle is a money-path decision, so it is
+// an explicit, reviewable config switch rather than an implicit consequence of
+// which credentials happen to be present.
+//
+// `X402_FACILITATOR` selects the mode:
+//
+//   auto    (default) — Base mainnet + CDP keys present → CDP; otherwise the
+//                       HTTP facilitator at X402_FACILITATOR_URL. This is the
+//                       historical behaviour, kept as the default so deploying
+//                       this change alone moves no traffic.
+//   cdp               — always Coinbase's CDP facilitator. Requires
+//                       CDP_API_KEY_ID + CDP_API_KEY_SECRET; refuses to start
+//                       without them (see below). This is the rollout target.
+//   legacy            — always the HTTP facilitator at X402_FACILITATOR_URL,
+//                       even when CDP keys are present. This is the rollback
+//                       lever: flipping back does not require deleting keys.
+//
+// Why the rollout matters (2026-08-12 distribution audit): the CDP Bazaar —
+// the discovery index behind Agentic.Market and several downstream
+// aggregators — catalogues a resource when *its own facilitator* processes a
+// PaymentPayload carrying the bazaar extension. Strale already emits a
+// complete `extensions.bazaar` block on every 402 (see buildBazaarDiscovery in
+// routes/x402-gateway-v2.ts), but it is emitted into a facilitator that does
+// not catalogue it. Routing settlement through CDP makes the whole paid
+// catalog self-index off organic traffic.
+//
+// This switch changes only WHICH facilitator is called. It does not touch the
+// verify → execute → settle ordering (DEC-14); both callers below are
+// unchanged, and x402-gateway-v2.settlement-order.test.ts still pins the
+// ordering at the route layer.
+
+/** Coinbase CDP facilitator base URL, from @coinbase/x402's createFacilitatorConfig. */
+export const CDP_FACILITATOR_URL = "https://api.cdp.coinbase.com/platform/v2/x402";
+
+/** Facilitator used when no X402_FACILITATOR_URL is configured. */
+export const DEFAULT_LEGACY_FACILITATOR_URL = "https://x402.org/facilitator";
+
+export type FacilitatorMode = "auto" | "cdp" | "legacy";
+
+export interface FacilitatorSelection {
+  /** The facilitator the payment path will actually call. */
+  kind: "cdp" | "legacy";
+  /** Its URL — also what discovery surfaces must advertise. */
+  url: string;
+  /** The configured mode that produced this selection. */
+  mode: FacilitatorMode;
+}
+
+/** Env slice the selection depends on. Passed explicitly so it is testable. */
+export interface FacilitatorEnv {
+  X402_FACILITATOR?: string;
+  X402_FACILITATOR_URL?: string;
+  X402_NETWORK?: string;
+  CDP_API_KEY_ID?: string;
+  CDP_API_KEY_SECRET?: string;
+}
+
+const FACILITATOR_MODES: readonly FacilitatorMode[] = ["auto", "cdp", "legacy"];
+
+function isMainnetNetwork(network: string): boolean {
+  return network === "base" || network === "eip155:8453";
+}
+
+/**
+ * Resolve which facilitator to use from environment configuration.
+ *
+ * Pure — no module state, no side effects — so the selection matrix can be
+ * unit-tested without touching process.env or constructing a client.
+ *
+ * @throws if X402_FACILITATOR is set to an unknown value, or is set to "cdp"
+ *   without both CDP credentials. Failing loudly is deliberate: @coinbase/x402
+ *   builds an unauthenticated config when keys are absent, so a silent fallback
+ *   would produce 401s from CDP on every paid call — or, worse, look like a
+ *   successful cutover while nothing indexes.
+ */
+export function resolveFacilitatorSelection(env: FacilitatorEnv): FacilitatorSelection {
+  const raw = (env.X402_FACILITATOR ?? "").trim().toLowerCase();
+  const mode = (raw === "" ? "auto" : raw) as FacilitatorMode;
+  if (!FACILITATOR_MODES.includes(mode)) {
+    throw new Error(
+      `X402_FACILITATOR must be one of ${FACILITATOR_MODES.join(" | ")}, got "${env.X402_FACILITATOR}"`,
+    );
+  }
+
+  const legacyUrl = env.X402_FACILITATOR_URL?.trim() || DEFAULT_LEGACY_FACILITATOR_URL;
+  const hasCdpKeys = Boolean(env.CDP_API_KEY_ID?.trim() && env.CDP_API_KEY_SECRET?.trim());
+
+  if (mode === "legacy") {
+    return { kind: "legacy", url: legacyUrl, mode };
+  }
+
+  if (mode === "cdp") {
+    if (!hasCdpKeys) {
+      throw new Error(
+        "X402_FACILITATOR=cdp requires both CDP_API_KEY_ID and CDP_API_KEY_SECRET. " +
+          "Set them, or use X402_FACILITATOR=legacy.",
+      );
+    }
+    // Deliberately not gated on mainnet: running mode=cdp against
+    // base-sepolia is the supported way to rehearse the switch before
+    // pointing production traffic at it.
+    return { kind: "cdp", url: CDP_FACILITATOR_URL, mode };
+  }
+
+  // auto — the pre-switch rule, preserved exactly.
+  const network = env.X402_NETWORK ?? "base-sepolia";
+  if (isMainnetNetwork(network) && hasCdpKeys) {
+    return { kind: "cdp", url: CDP_FACILITATOR_URL, mode };
+  }
+  return { kind: "legacy", url: legacyUrl, mode };
+}
+
+// Resolve once at module load so a misconfiguration surfaces at boot rather
+// than on the first paid call. Mirrors the EUR_USD_RATE fail-fast above: a
+// config error that only appears mid-payment is far more expensive than one
+// that stops the deploy.
+// Cast: ProcessEnv is an index-signature type, so TS's weak-type check rejects
+// it against FacilitatorEnv's all-optional shape. The value shapes match
+// (string | undefined), and every field is read defensively above.
+const FACILITATOR_SELECTION = resolveFacilitatorSelection(process.env as FacilitatorEnv);
+
+/** The facilitator selection this process is running with. */
+export function getFacilitatorSelection(): FacilitatorSelection {
+  return FACILITATOR_SELECTION;
+}
+
+/**
+ * The facilitator URL discovery surfaces must advertise.
+ *
+ * `/x402/catalog` and `/.well-known/x402.json` previously hardcoded
+ * X402_FACILITATOR_URL, which would have advertised x402.org while payments
+ * actually settled through CDP. Both now read this.
+ */
+export function getFacilitatorUrl(): string {
+  return FACILITATOR_SELECTION.url;
+}
+
 // ─── Facilitator client (lazy init) ─────────────────────────────────────────
 
-// Base mainnet requires Coinbase's CDP facilitator (JWT-auth, paid).
-// Base Sepolia (and other testnets) work with the free x402.org facilitator.
-// Selection is network-based: any "base" network with CDP keys → CDP; else → X402_FACILITATOR_URL.
 let _facilitator: HTTPFacilitatorClient | null = null;
 
 function getFacilitator(): HTTPFacilitatorClient {
   if (_facilitator) return _facilitator;
 
-  const cdpKeyId = process.env.CDP_API_KEY_ID;
-  const cdpKeySecret = process.env.CDP_API_KEY_SECRET;
-  const isMainnet = NETWORK === "base" || NETWORK === "eip155:8453";
-
-  if (isMainnet && cdpKeyId && cdpKeySecret) {
-    // Use CDP facilitator for Base mainnet
-    const config = createFacilitatorConfig(cdpKeyId, cdpKeySecret);
+  if (FACILITATOR_SELECTION.kind === "cdp") {
+    // createFacilitatorConfig supplies the CDP base URL plus a JWT
+    // createAuthHeaders hook; the keys are known present (validated above).
+    const config = createFacilitatorConfig(
+      process.env.CDP_API_KEY_ID,
+      process.env.CDP_API_KEY_SECRET,
+    );
     _facilitator = new HTTPFacilitatorClient(config);
   } else {
-    // Testnet or missing CDP keys → free x402.org facilitator
-    _facilitator = new HTTPFacilitatorClient({ url: FACILITATOR_URL });
+    _facilitator = new HTTPFacilitatorClient({ url: FACILITATOR_SELECTION.url });
   }
   return _facilitator;
 }

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -31,6 +31,7 @@ import {
   eurCentsToUsdcAtomic,
   eurCentsToUsdString,
   encodePaymentResponseHeader,
+  getFacilitatorUrl,
   type X402VerifiedPayment,
 } from "../lib/x402-gateway.js";
 import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
@@ -855,7 +856,9 @@ x402GatewayV2.get("/catalog", async (c) => {
   return c.json({
     x402: true,
     network: NETWORK,
-    facilitator: process.env.X402_FACILITATOR_URL ?? "https://x402.org/facilitator",
+    // Must reflect the facilitator payments actually settle through, not the
+    // legacy URL env var — see getFacilitatorUrl in lib/x402-gateway.ts.
+    facilitator: getFacilitatorUrl(),
     wallet: WALLET_ADDRESS || null,
     capabilities: caps,
     solutions: sols,
@@ -1370,7 +1373,8 @@ export async function getX402Manifest(): Promise<{
 
   return {
     x402: true,
-    facilitator: process.env.X402_FACILITATOR_URL ?? "https://x402.org/facilitator",
+    // Advertise the facilitator that actually processes verify/settle.
+    facilitator: getFacilitatorUrl(),
     network: NETWORK,
     wallet: WALLET_ADDRESS || null,
     endpoints,

--- a/docs/operations/x402-facilitator-switch.md
+++ b/docs/operations/x402-facilitator-switch.md
@@ -1,0 +1,120 @@
+# x402 facilitator switch — CDP rollout runbook
+
+**Status:** shipped behind a flag, not yet rolled out.
+**Money path.** Read this before flipping anything.
+
+## Why
+
+The CDP Bazaar is the x402 discovery index that Agentic.Market and several
+downstream aggregators read from. It catalogues a resource when **Coinbase's own
+facilitator** processes a `PaymentPayload` carrying the bazaar extension —
+cataloguing happens at settlement time, not at declaration time.
+
+Strale already emits a complete `extensions.bazaar` block on every 402
+(`buildBazaarDiscovery` in `apps/api/src/routes/x402-gateway-v2.ts`), including
+the v1 `outputSchema` descriptor shape and the v2 top-level `extensions`. That
+metadata is currently emitted into a facilitator that does not catalogue it, so
+none of the paid catalog is indexed. Routing settlement through CDP makes the
+whole paid catalog self-index off organic traffic — no per-endpoint submission.
+
+Source: `audit-output/parallel-audits-2026-08-12/distribution-playbook.md` §0 and §1.1.
+
+## What shipped
+
+`X402_FACILITATOR` selects the facilitator explicitly. Before this change,
+selection was an implicit consequence of credential presence: mainnet + CDP keys
+→ CDP, silently. That meant setting a credential moved the money path, and
+rolling back meant deleting the credential.
+
+| Mode | Behaviour |
+|---|---|
+| `auto` (default) | Base mainnet **and** CDP keys present → CDP; otherwise the HTTP facilitator at `X402_FACILITATOR_URL`. Identical to the pre-switch rule. |
+| `cdp` | Always Coinbase CDP. Requires both CDP keys; **refuses to boot** without them. The rollout target. |
+| `legacy` | Always the HTTP facilitator at `X402_FACILITATOR_URL`, even with CDP keys present. The rollback lever. |
+
+The default is `auto` rather than `legacy` so that deploying this change on its
+own moves no traffic under any existing Railway configuration. `legacy` is
+available as an explicit pin, which is what makes rollback a one-variable edit.
+
+Selection is resolved once at module load (`resolveFacilitatorSelection`), so a
+bad value or a half-configured `cdp` stops the deploy rather than surfacing
+mid-payment. The resolved selection is logged at boot:
+
+```
+[startup] x402 facilitator: cdp (mode=cdp) https://api.cdp.coinbase.com/platform/v2/x402
+```
+
+**Ordering is unchanged.** This switch decides *which* facilitator is called,
+never *when*. The verify → execute → settle order (DEC-14) is untouched, and
+`x402-gateway-v2.settlement-order.test.ts` still pins it.
+
+## Required config
+
+| Variable | Value | Notes |
+|---|---|---|
+| `X402_FACILITATOR` | `cdp` | Absent/`auto` keeps today's behaviour. |
+| `CDP_API_KEY_ID` | *(from CDP portal)* | Already read by the pre-existing auto path. |
+| `CDP_API_KEY_SECRET` | *(from CDP portal)* | Both required, or boot fails. |
+
+Obtain the pair from the Coinbase Developer Platform portal under the account
+that owns the receiving wallet. Both are secrets — set them in Railway
+variables, never in a committed file.
+
+## Rollout
+
+1. **Rehearse on testnet.** `X402_NETWORK=base-sepolia` + `X402_FACILITATOR=cdp`
+   in a non-production environment. Mode `cdp` is deliberately not gated on
+   mainnet so this rehearsal is possible. Confirm the boot log names CDP and
+   that a test call verifies and settles.
+2. **Flip on Railway.** Set `X402_FACILITATOR=cdp` (plus both CDP keys).
+   Redeploy. Confirm the boot log line names `cdp`.
+3. **Confirm the discovery surfaces agree.** Both now report the live
+   facilitator rather than a hardcoded URL:
+   ```
+   curl -s https://api.strale.io/x402/catalog        | jq .facilitator
+   curl -s https://api.strale.io/.well-known/x402.json | jq .facilitator
+   ```
+   Both must return the CDP URL. If either still returns `x402.org`, the
+   selection did not take effect — stop and investigate before sending traffic.
+4. **Run a real paid call on Base mainnet.** A cheap endpoint is enough
+   (`/x402/iban-validate`). Verify: the capability returns output, the
+   `X-Payment-Response` header carries a tx hash, the on-chain transfer landed,
+   and the amount matches the advertised `maxAmountRequired` exactly.
+5. **Verify Bazaar indexing.** Cataloguing happens on settlement, so it needs at
+   least one successful paid call through CDP first. Check the CDP discovery
+   API / Bazaar listing for `api.strale.io` resources. Expect propagation lag —
+   do not conclude failure from an immediate empty result. Downstream
+   (Agentic.Market, x402-list.com) cascades later still.
+6. **Watch for a green week.** Settlement success rate, orphan settlements
+   (`x402_orphan_settlements`), and `/v1/do` x402 error rates should be
+   unchanged from the legacy baseline.
+7. **Remove the legacy path after a green week.** Once CDP has run clean for
+   seven days: drop the `auto`/`legacy` branches, `X402_FACILITATOR_URL`, and
+   `DEFAULT_LEGACY_FACILITATOR_URL`, and make CDP unconditional. Not before —
+   the branch is the rollback.
+
+## Rollback
+
+Set `X402_FACILITATOR=legacy` and redeploy. Leave the CDP keys in place; the
+mode pin wins over credential presence. Confirm the boot log names `legacy`.
+
+## Known gaps
+
+- **Indexing is not verifiable from this repo.** Whether CDP actually catalogues
+  Strale's endpoints can only be confirmed by observing the Bazaar after a real
+  paid call. The facilitator *API* contract is verified (`@coinbase/x402@2.1.0`
+  is a repo dependency and `createFacilitatorConfig` is read directly); the
+  *indexing* behaviour is taken from Coinbase's seller docs via the distribution
+  audit and is unverified here.
+- **CDP drops v2 extensions on mainnet** (upstream issue referenced in
+  `buildBazaarDiscovery`). The v1 `outputSchema` descriptor shape is already
+  emitted as a hedge. If indexing does not appear after step 5, that hedge —
+  not the facilitator — is the first thing to examine.
+- **Optional Bazaar metadata not yet emitted.** The spec supports `serviceName`
+  (≤32 ASCII), up to 5 `tags`, and `iconUrl` on the resource object; Bazaar
+  search ranks partly on metadata completeness. Cheap follow-up, deliberately
+  out of scope here to keep the money-path diff reviewable.
+- **`platform-facts.ts` describes payments as "Coinbase x402 facilitator"**
+  (`payments_x402`). That string is accurate only once mode `cdp` is live. It is
+  a subprocessor-disclosure surface, so it was left untouched rather than
+  changed speculatively — update it as part of the flip.


### PR DESCRIPTION
## Summary
- Makes the x402 facilitator an explicit, reviewable config switch (`X402_FACILITATOR=auto|cdp|legacy`) instead of an implicit consequence of which credentials are present. **Deploying this alone moves no traffic**: `auto` (the default) reproduces the pre-existing selection rule cell-for-cell (pinned by tests).
- Fixes a latent discovery lie: `/x402/catalog` and `/.well-known/x402.json` hardcoded the legacy facilitator URL — once CDP settles payments they would have advertised x402.org while settling through Coinbase. Both now advertise the facilitator that actually processes verify/settle.
- Boot log line for the resolved selection (DEC-20260504-C: verify the flip from the deploy log, don't assume). `mode=cdp` fail-fasts at boot without both CDP keys — `@coinbase/x402` silently builds an *unauthenticated* config otherwise, which would 401 at settle time after the capability had already run.
- Runbook: `docs/operations/x402-facilitator-switch.md` (rehearse on base-sepolia → flip → curl both discovery surfaces → one real paid call → check Bazaar indexing → green week → remove legacy).

## Why
The CDP Bazaar catalogues a resource when its own facilitator settles a payment carrying the bazaar extension. Strale already emits the extension on every 402 — into a facilitator that doesn't catalogue it. This is the biggest single distribution lever from the audit; the traffic-generation review independently confirmed Strale absent from Onyx Bazaar (which auto-indexes from CDP).

## Petter actions to actually flip (nothing flips on merge)
1. Create CDP API keys in the Coinbase CDP portal; set `CDP_API_KEY_ID` + `CDP_API_KEY_SECRET` on Railway.
2. Set `X402_FACILITATOR=cdp`; confirm the boot log says `x402 facilitator: cdp`.
3. We verify: both discovery surfaces show the CDP URL, one real paid call on Base settles, Bazaar indexing appears (propagation lags).
Rollback: `X402_FACILITATOR=legacy`, redeploy — no key deletion needed.

## Verification
- 33 tests green (23 new selection-matrix + surface-guard cases; settlement-order suite untouched and passing — DEC-14 ordering not modified). tsc clean.
- New-behavior tests confirmed to FAIL against the un-applied change (author stashed the gateway edits and watched the discovery tests go red).
- Authored by a sandboxed agent in an isolated worktree; reviewed by the main session (same-provider disclosure applies).

## Known caveats (from the author, verified reasonable)
- The *indexing* claim rests on Coinbase's seller docs; only observable post-flip. If indexing doesn't appear, the first suspect is the documented CDP-drops-v2-extensions hedge in `buildBazaarDiscovery`, not the facilitator.
- `platform-facts.ts` already names the Coinbase facilitator — accurate only once `cdp` is live; update at flip time.
- Optional Bazaar ranking metadata (serviceName/tags/icon) deliberately left out of the money-path diff; cheap follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)