### PR TITLE
feat(ci): weekly TOAST-readability scan over compliance JSONB columns

### DIFF
--- a/.github/workflows/weekly-drift.yml
+++ b/.github/workflows/weekly-drift.yml
@@ -18,6 +18,11 @@ on:
 jobs:
   sweep:
     runs-on: ubuntu-latest
+    # Minimal token scope: the job now carries a prod DB credential, so the
+    # GITHUB_TOKEN is pinned to exactly what the issue-opening step needs.
+    permissions:
+      contents: read
+      issues: write
     env:
       AUDIT_HMAC_SECRET: ci-placeholder-secret-at-least-32-chars-long-0123456789
       FRONTEND_URL: https://strale.dev
@@ -97,6 +102,20 @@ jobs:
           echo "exit=$?" >> $GITHUB_OUTPUT
         continue-on-error: true
 
+      # TOAST-readability scan over compliance-critical JSONB columns.
+      # Added after the 2026-08-12 incident: a lost TOAST chunk in
+      # transactions.audit_trail sat undetected for four months. A weekly
+      # full-detoast pass bounds detection latency to days.
+      - id: toast-readability
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          set +e
+          set -o pipefail
+          node apps/api/scripts/check-audit-trail-readability.mjs 2>&1 | tee /tmp/toast-readability.txt
+          echo "exit=$?" >> $GITHUB_OUTPUT
+        continue-on-error: true
+
       # Aggregate report. Step fails (and triggers issue creation) if
       # ANY upstream sweep reported drift.
       - id: aggregate
@@ -128,6 +147,11 @@ jobs:
             echo '```'
             cat /tmp/audit-record-shape.txt
             echo '```'
+            echo ""
+            echo "## TOAST readability (audit/compliance JSONB columns)"
+            echo '```'
+            cat /tmp/toast-readability.txt
+            echo '```'
           } > /tmp/report.md
           cat /tmp/report.md
 
@@ -137,7 +161,8 @@ jobs:
           FT=${{ steps.fetch-timeout.outputs.exit }}
           VR=${{ steps.vendor-roster.outputs.exit }}
           AR=${{ steps.audit-record-shape.outputs.exit }}
-          if [ "$MD" != "0" ] || [ "$FD" != "0" ] || [ "$FT" != "0" ] || [ "$VR" != "0" ] || [ "$AR" != "0" ]; then
+          TR=${{ steps.toast-readability.outputs.exit }}
+          if [ "$MD" != "0" ] || [ "$FD" != "0" ] || [ "$FT" != "0" ] || [ "$VR" != "0" ] || [ "$AR" != "0" ] || [ "$TR" != "0" ]; then
             echo "::warning::One or more drift sweeps reported findings — see report"
             exit 1
           fi

--- a/apps/api/scripts/check-audit-trail-readability.mjs
+++ b/apps/api/scripts/check-audit-trail-readability.mjs
@@ -1,0 +1,121 @@
+// Weekly TOAST-readability scan over money/compliance-critical JSONB columns.
+//
+// Why this exists: on 2026-08-12 a TOAST corruption ("missing chunk number 0
+// for toast value 32384 in pg_toast_16411") was found in
+// transactions.audit_trail — one row from 2026-04-04, discovered only four
+// months later by an unrelated full-table scan. The row is documented with an
+// approved corruption marker (health_monitor_events event_type
+// 'audit_corruption_documented'). This scan makes any recurrence surface
+// within a week instead of months.
+//
+// Mechanism: length(col::text) forces a full detoast of every value; a lost
+// TOAST chunk raises a PostgresError with code XX000 ("missing chunk ...").
+//
+// OUTPUT SAFETY: this script's output is tee'd into a PUBLIC GitHub issue by
+// the weekly-drift workflow. postgres.js connection/auth error messages embed
+// the DB host:port and username — so err.message is only ever printed for
+// genuine corruption-class Postgres errors (whose messages name TOAST values,
+// not endpoints). Everything else is reported as a sanitized code.
+//
+// Exit codes:
+//   0 — every scanned column fully readable
+//   1 — at least one column raised a corruption-class error
+//   2 — could not scan (connection/auth/schema/config problem — NOT corruption)
+
+import postgres from "postgres";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error("check-audit-trail-readability: DATABASE_URL is not set");
+  process.exit(2);
+}
+
+// Curated list: the audit/compliance artifacts (transactions is the EU AI Act
+// record + hash chain) and the catalog surfaces machines read. Extend when a
+// new TOAST-able compliance column ships.
+const TARGETS = [
+  ["transactions", ["audit_trail", "input", "output", "provenance"]],
+  ["health_monitor_events", ["details"]],
+  ["capabilities", ["input_schema", "output_schema", "output_field_reliability", "onboarding_manifest"]],
+  ["test_suites", ["input", "validation_rules", "baseline_output"]],
+];
+
+// Corruption-class SQLSTATEs: internal_error (XX000, the "missing chunk"
+// class), data_corrupted (XX001), index_corrupted (XX002).
+const CORRUPTION_CODES = new Set(["XX000", "XX001", "XX002"]);
+
+const IDENT_RE = /^[a-z_]+$/;
+
+const sql = postgres(DATABASE_URL, {
+  max: 1,
+  idle_timeout: 5,
+  ssl: "require",
+  connect_timeout: 30,
+  // Bound every statement: a hung seq scan must not pin the xmin horizon
+  // (blocking autovacuum on transactions) beyond five minutes.
+  connection: { statement_timeout: "300s" },
+});
+
+let corruption = 0;
+let scanErrors = 0;
+for (const [table, columns] of TARGETS) {
+  // The identifiers are compile-time constants; this assertion keeps the
+  // sql.unsafe below safe against a future refactor wiring input into TARGETS.
+  if (!IDENT_RE.test(table) || columns.some((c) => !IDENT_RE.test(c))) {
+    console.error(`invalid identifier in TARGETS: ${table} / ${columns.join(",")}`);
+    process.exit(2);
+  }
+  // One query per TABLE (not per column): transactions is the largest,
+  // write-hottest table — one seq scan + detoast pass instead of four.
+  const sumExprs = columns.map((c) => `coalesce(sum(length("${c}"::text)), 0)::bigint AS "${c}"`).join(", ");
+  try {
+    const rows = await sql.unsafe(
+      `SELECT count(*)::bigint AS __rows, ${sumExprs} FROM "${table}"`,
+    );
+    const r = rows[0];
+    console.log(`ok      ${table} — ${r.__rows} rows; bytes: ${columns.map((c) => `${c}=${r[c]}`).join(" ")}`);
+  } catch (err) {
+    if (CORRUPTION_CODES.has(err?.code)) {
+      // Per-column retry so the report attributes the corruption precisely.
+      for (const column of columns) {
+        try {
+          await sql.unsafe(`SELECT coalesce(sum(length("${column}"::text)), 0) FROM "${table}"`);
+          console.log(`ok      ${table}.${column}`);
+        } catch (colErr) {
+          if (CORRUPTION_CODES.has(colErr?.code)) {
+            corruption++;
+            // Corruption-class messages name TOAST values, not endpoints —
+            // safe to print (and needed for the bisect).
+            console.error(`CORRUPT ${table}.${column} — [${colErr.code}] ${colErr.message}`);
+            console.error(
+              `        Bisect per created_at range probing length(${column}::text) — see the ` +
+                `2026-08-12 incident notes (handoff 2026-08-12-readiness-p2-p3-parallel-audits.md).`,
+            );
+          } else {
+            scanErrors++;
+            console.error(`SCAN-ERROR ${table}.${column} — [${colErr?.code ?? "no-code"}] (message withheld: may embed connection details)`);
+          }
+        }
+      }
+    } else {
+      // Connection/auth/schema/timeout — NOT corruption. Message withheld:
+      // postgres.js embeds host:port/username in these, and this output lands
+      // in a public issue.
+      scanErrors++;
+      console.error(`SCAN-ERROR ${table} — [${err?.code ?? "no-code"}] could not scan (message withheld: may embed connection details)`);
+    }
+  }
+}
+
+await sql.end();
+
+if (corruption > 0) {
+  console.error(`\ntoast-readability: ${corruption} column(s) UNREADABLE — storage corruption, investigate immediately`);
+  process.exit(1);
+}
+if (scanErrors > 0) {
+  console.error(`\ntoast-readability: could not complete the scan (${scanErrors} error(s)) — check DATABASE_URL/connectivity. NOT a corruption signal.`);
+  process.exit(2);
+}
+console.log("\ntoast-readability: all scanned columns fully readable");
+process.exit(0);


### PR DESCRIPTION
## Summary
- Weekly drift-cron step that full-detoasts 12 compliance-critical JSONB columns (transactions × 4, health_monitor_events, capabilities × 4, test_suites × 3) so a lost TOAST chunk surfaces within a week — the 2026-08-12 audit_trail corruption sat undetected for four months.

## Review findings (one adversarial opus pass — all fixed pre-PR)
- **HIGH: public-issue credential leak** — the workflow tees step output into a public GitHub issue, and postgres.js connection/auth errors embed the DB host:port and username. Fixed: only corruption-class SQLSTATEs (XX000/XX001/XX002) print the Postgres message (which names TOAST values, not endpoints); all other errors print a sanitized code with the message withheld. Verified with a live bad-URL run: `[ENOTFOUND] could not scan (message withheld…)`.
- **HIGH: false corruption alarms** — a network blip used to print "storage corruption, investigate immediately". Fixed: non-corruption errors exit 2 with "NOT a corruption signal"; only genuine corruption codes exit 1.
- MEDIUM: `ssl: "require"` (house convention, was missing); one query per table instead of per column (4 seq scans not 13 on the write-hottest table) with per-column retry on corruption for precise attribution; `statement_timeout: 300s` bounds the xmin-horizon pin.
- LOW: job-level `permissions: {contents: read, issues: write}` (the job now carries a DB credential); identifier regex assertion on the `sql.unsafe` constants.

## Ops note
`DATABASE_URL` repo secret created today (`gh secret set`, Actions-encrypted). Side effect worth knowing: the existing manifest-drift cron step also reads DATABASE_URL from env — it has silently lacked DB access in the cron until now, so next Monday's run may report real drift for the first time.

## Verification
- Clean prod run: 810k transactions / 12 columns / ~110MB detoasted, exit 0.
- Sanitized failure path verified live (bad URL → codes only, exit 2).
- Detection mechanism proven against the actual corruption earlier tonight: the identical query errored before the approved marker was written, passes after.
- Workflow YAML parses; step matches sibling pipefail/tee/exit-output pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)