### PR TITLE
chore(sdk): version bumps for attribution-header releases

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strale-mcp",
   "mcpName": "io.github.strale-io/strale",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "MCP server for Strale — pre-flight check any paid API before your agent pays, plus 250+ business data, compliance, and validation tools for Claude, Cursor, Windsurf, and any MCP client",
   "type": "module",
   "main": "./dist/server.js",

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -70,7 +70,7 @@ export interface StraleClientOptions {
 
 // Attribution client identifier — package name/version, sent as
 // X-Strale-Client on every API call this package makes.
-const STRALE_CLIENT_ID = "strale-mcp/0.2.4";
+const STRALE_CLIENT_ID = "strale-mcp/0.2.5";
 
 // ─── HTTP helpers ───────────────────────────────────────────────────────────
 

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "straleio"
-version = "0.1.3"
+version = "0.1.4"
 description = "Python SDK for the Strale API — let AI agents buy capabilities at runtime"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/sdk-python/straleio/__init__.py
+++ b/packages/sdk-python/straleio/__init__.py
@@ -58,4 +58,4 @@ __all__ = [
     "strale_web3_guard",
 ]
 
-__version__ = "0.1.1"
+__version__ = "0.1.4"

--- a/packages/sdk-python/straleio/client.py
+++ b/packages/sdk-python/straleio/client.py
@@ -62,7 +62,7 @@ class Strale:
             headers={
                 "Authorization": f"Bearer {self._api_key}",
                 # Channel attribution: identifies this SDK on the API side.
-                "X-Strale-Client": "straleio-python/0.1.3",
+                "X-Strale-Client": "straleio-python/0.1.4",
             },
         )
 

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "straleio",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript SDK for the Strale API — let AI agents buy capabilities at runtime",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -232,7 +232,7 @@ export class Strale {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
       // Channel attribution: identifies this SDK on the API side.
-      "X-Strale-Client": "straleio-js/0.1.2",
+      "X-Strale-Client": "straleio-js/0.1.3",
       ...extraHeaders,
     };
 


### PR DESCRIPTION
## Summary
- Bumps straleio-js 0.1.2→0.1.3, strale-mcp 0.2.4→0.2.5, straleio-python 0.1.3→0.1.4 and syncs the X-Strale-Client tokens to match.
- Why: the attribution headers merged in #194 reused already-published version numbers — the registries hold March/April artifacts *without* the header under those numbers, so a republish is rejected. New versions are required for the headers to ever reach users.
- Also fixes pre-existing drift: sdk-python `__version__` said 0.1.1 while pyproject said 0.1.3 — both now 0.1.4.

## Verification
- `npm run build` clean on sdk-typescript and mcp-server; `python -m build` produced straleio-0.1.4 sdist+wheel.
- Mechanical version/string bump — no logic changes (7 lines).

## Publish state
- PyPI straleio 0.1.4: publishing with the local token after merge.
- npm straleio 0.1.3 + strale-mcp 0.2.5: blocked — local npm token is expired (401 on `npm whoami`). Petter needs to `npm login` or issue a fresh granular token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)