### PR TITLE
docs(strategy): demand-mined build queue — three corrections to the 2026-08-12 ranking

### DIFF
--- a/docs/strategy/2026-08-demand-mined-build-queue.md
+++ b/docs/strategy/2026-08-demand-mined-build-queue.md
@@ -1,0 +1,289 @@
+# Demand-mined build queue — what production traffic actually asks for
+
+**Date:** 2026-08-13
+**Mode:** READ-ONLY analysis. Production DB queried via temporary scripts (deleted after use); SELECT only. Deliverables: this file + `manifests-drafts/`.
+**Window:** 30 days and 90 days to 2026-08-13, internal accounts excluded (`petter@`, `test@`, `test2@`, `system@strale.internal`, `test@example.com`), `status <> 'health_probe'`.
+**Extends:** `audit-output/parallel-audits-2026-08-12/catalog-buildout-strategy.md` (2026-08-12). That document's structural conclusions still hold; this one adds a day of fresh data, the first look at `discovery_hits`, and **three findings that change its ranking**. It does not restate its analysis.
+
+**Excluded from all "missing" lists** (shipped dark 2026-08-13, `is_active = true`, `x402_enabled = false`): `google-news-search`, `serp-related-questions`, `email-auth-check`. Also `page-exists` (dark 2026-08-12).
+
+---
+
+## 0. What changed since yesterday
+
+Three corrections to the 2026-08-12 ranking, each from evidence that document did not have:
+
+1. **Rank #9 `package-download-stats` should be demoted, not built.** The 94 calls of workaround traffic that justified it are Strale's own free-tier ops agent fetching Strale's own package pages. Not customer demand. (§3.1)
+2. **A new Rank-0 fix outranks the entire build list: the test scheduler is rate-limiting a revenue-earning capability.** `brazilian-company-data` took **3,592 internal test calls** in 90 days against a free upstream, exhausted its quota, and the paying customer's calls now fail with `ReceitaWS returned HTTP 429`. (§3.2)
+3. **The paying customer's geography is LatAm, not the EU.** 50 paid Google searches for Mexican freight-carrier contacts and a Brazil→email-verification pipeline. Strale has ~20 EU registries and no Mexican one. (§2.1)
+
+---
+
+## 1. Headline numbers (fresh)
+
+| Measure | 30 days | 90 days |
+|---|---|---|
+| External calls | 2,296 | 4,068 |
+| Failed | 244 (10.6%) | 512 (12.6%) |
+| External revenue | **€132.19** | **€253.40** |
+| x402 share | 97.5% | 98.7% |
+| Distinct paying wallets | 19 | 36 |
+| **Revenue destroyed by failures** (failed calls × list price) | **€21.74** | €45.36 |
+| Top wallet `0x9D3d9410…` | **€118.56 (89.7%)** | — |
+
+Monthly: Apr €47.84 · May €115.17 · Jun €107.57 · Jul €68.30 · **Aug (13d) €66.59**.
+
+Two things to read off this. First, **concentration got worse**, not better: 53% of 90-day revenue → 90% of 30-day revenue in one wallet, which ran 1,951 calls across 92 capabilities on 27 of the last 30 days. Second, **€21.74 of the €132.19 earned in 30 days was matched by €21.74 destroyed** — a 16.4% uplift available with no new source, no new licence, no new maintenance. The 2026-08-12 conclusion that fixes beat builds is not just still true; the ratio is now 1:1.
+
+`failed_requests` remains structurally unusable as a ranking input: **77 rows, all time**, and the x402 gateway still writes nothing to it (`failedRequests` inserts appear only at `apps/api/src/routes/do.ts:652, 880, 920, 968`; `x402-gateway-v2.ts` still returns bare 404s). 97.5% of revenue arrives on a rail that produces no miss signal. **Step 0 of the intake loop has not shipped.** Everything below is therefore mined from *purchase and failure* data — what people paid for and what broke — not from *miss* data.
+
+---
+
+## 2. The strongest signal: the buyer's geography is LatAm
+
+### 2.1 Mexico — 50 paid Google searches, zero capability
+
+The top wallet ran 50 `google-search` calls in 30 days (€5.00, 100% success) with a single, mechanical query template. Verbatim, consecutive:
+
+```
+"AUTEK TRADING" 墨西哥 phone contact
+"AUTO EXPRESS NOR Y CARIBE" 墨西哥 phone contact
+"AUTOFLETES CHIHUAHUA" 墨西哥 phone contact
+"AUTO FLETES OMEGA" 墨西哥 phone contact
+"AUTO LINEAS REGIO MONTANAS" 墨西哥 phone contact
+"AUTOTRANSPORTES PARADA HERMANOS" 墨西哥 phone contact
+"CIMA TERMINAL SA DE CV" 墨西哥 phone contact
+"COMERCIALIZADORA DE SUMINISTROS MOCAVA SA DE CV" 墨西哥 phone contact
+```
+
+This is a company-by-company sweep of Mexican freight carriers for business contact details, driven by a Chinese-language agent (`墨西哥` = "Mexico"). It is the clearest unmet need in the entire corpus, and it has three properties that make it unusually strong evidence:
+
+- **It is paid.** 50 calls at €0.10, not a probe, not a free-tier caller.
+- **It is a workaround.** The buyer is paying for unstructured Google HTML because no structured Mexican business-directory lookup exists. Every one of those 50 calls needed a downstream parse the buyer had to do themselves.
+- **It is repetitive and template-driven** — the signature of an automated pipeline, i.e. it will recur.
+
+Geographic tokens across all search-shaped inputs, 90 days: **Mexico 50 · UK 5 · US 3 · Brazil 3 · India 1**, rest untagged. The one country with double-digit geographic demand is the one country with no registry capability.
+
+### 2.2 Brazil — an earning pipeline the platform is breaking
+
+Capability adjacency (pairs called by the same payer inside 120s), 30 days:
+
+| Pair | n |
+|---|---|
+| `keyword-suggest` → `google-search` | 142 |
+| **`brazilian-company-data` → `email-validate`** | **77** |
+| `google-search` → `keyword-suggest` | 75 |
+| `keyword-suggest` → `serp-analyze` | 28 |
+| `barcode-lookup` → `google-search` | 20 |
+| `serp-analyze` → `backlink-check` | 18 |
+| `google-search` → `pricing-page-extract` | 12 |
+| `serp-analyze` → `price-compare` | 12 |
+
+The #2 pair is a **Brazilian company → contact-verification pipeline**, and it is the only registry capability in the adjacency table at all. `brazilian-company-data` is the only non-EU, non-UK registry earning external money (29 calls / 30d, €0.85) — and 12 of those 29 fail. See §3.2 for why.
+
+### 2.3 Startup-status research — served by a capability that shipped dark today
+
+Verbatim `google-search` / `brand-mention-search` queries, 90 days:
+
+```
+Qapital app 2026 shutting down OR layoffs OR "still active" news
+Neurable company 2026 news layoffs acquired shutdown
+DressX 2026 lawsuit OR layoffs OR "shut down" OR raises OR undress follow-up
+"TruPlay" raised OR raises OR funding OR investors million
+Synthesis school Chrisman Frank funding "led by" a16z OR seed OR Series
+Swsh joinswsh funding round raised Scooter Braun employees
+Upbound Group Brigit acquisition
+Southeast Asia M&A funding deals July 2026
+```
+
+~18 news/funding-intent queries: *is this startup still alive, did it raise, was it acquired.* `google-news-search` shipped dark this morning and serves this directly. **This is a merchandising task, not a build** — see §4.
+
+### 2.4 Agents arrive with names, not identifiers
+
+Across `*-company-data` capabilities, 90 days, by input shape:
+
+| Capability | name-shaped input | identifier input | failed / total |
+|---|---|---|---|
+| `uk-company-data` | **24** | 6 | 5 / 30 |
+| `us-company-data` | 5 | 21 | **17 / 26** |
+| `german-company-data` | **12** | 3 | 4 / 15 |
+| `french-company-data` | 5 | 5 | 5 / 10 |
+| `danish-company-data` | 4 | 7 | 11 / 11 |
+| `belgian-company-data` | 4 | 5 | 5 / 9 |
+| `finnish-company-data` | 2 | 7 | 7 / 9 |
+
+Representative failures, verbatim from `transactions.error`:
+
+```
+'cik' or 'company_name' is required. Provide a CIK number or US company name.          (×4)
+No confident SEC EDGAR match for "Apple". The closest filing belongs to a different
+  entity ("Apple Hospitality REIT, Inc…")                                              (×3)
+'company_number' or 'company_name' is required.                                        (×2)
+All data providers failed for finnish-company-data: prh-api: 'business_id' is required  (×2)
+```
+
+The `"Apple"` case is the shape of the whole problem: the agent has a **name**, the registry indexes **identifiers**, and the platform correctly refuses rather than returning the wrong company (per `feedback_registry_name_search_never_ranks.md`). Correct behaviour, unserved demand. Corroborated in `failed_requests` by slug guesses `company-lookup` (€0.50 bid), `contact-verify`, `lead-enrich`, `solutions/lead-enrich`, and `spanish-company-data`.
+
+---
+
+## 3. Three corrections to the 2026-08-12 ranking
+
+### 3.1 `package-download-stats` (was Rank #9) — demand evidence does not survive attribution
+
+The 2026-08-12 doc cited "a caller repeatedly fetched pepy.tech through `url-to-markdown` and 404'd (4×)". The full cluster is larger and its attribution is fatal:
+
+| Target host | calls | failed |
+|---|---|---|
+| `www.npmjs.com` | 26 | **26** |
+| `pypistats.org` | 24 | 0 |
+| `pypi.org` | 17 | 0 |
+| `pepy.tech` | 13 | 4 |
+| `npm-stat.com` | 7 | 0 |
+| `api.npmjs.org` | 6 | **6** |
+
+Every URL names a **Strale package**: `strale-mcp`, `straleio`, `langchain-strale`, `crewai-strale`, `strale-semantic-kernel`. The caller is `is_free_tier = true`, `user_id IS NULL`, wallet path, active 2026-05-17 → 2026-06-21 and **silent since**. This is Strale's own distribution-tracking ops agent, on the free tier, paying nothing. It is not a customer.
+
+**Verdict: not a BUILD on demand grounds.** It stays in the queue at the bottom (§5, #7) purely as a zero-maintenance dark-launch candidate that removes 32 guaranteed failures from a free-tier surface — with the honest note that its only known caller is us.
+
+### 3.2 NEW Rank 0 — the test scheduler is destroying paid calls
+
+`brazilian-company-data`, 90 days, by caller:
+
+| Caller | completed | failed |
+|---|---|---|
+| `system@strale.internal` (test scheduler) | 1,450 | **2,142** |
+| x402 paying customer | 19 | **12** |
+| test2@ | 1 | 0 |
+
+**3,592 internal calls against ReceitaWS** — a free, unauthenticated Brazilian upstream — running continuously since 2026-05-15. The paying customer's 12 failures are all `ReceitaWS returned HTTP 429`. We are rate-limiting ourselves out of our own revenue.
+
+This is not confined to Brazil. Internal test load, 30 days: **82,780 calls across 218 capabilities, 38,774 failed.** Worst internal:external ratios:
+
+| Capability | internal 30d | external 30d | ratio |
+|---|---|---|---|
+| `vat-validate` | 1,961 | **0** | ∞ |
+| `lei-lookup` | 1,998 | 3 | 666:1 |
+| `polish-company-data` | 1,299 (899 failed) | **0** | ∞ |
+| `ssl-check` | 1,288 | 9 | 143:1 |
+| `exchange-rate` | 1,024 | 9 | 114:1 |
+| `mx-lookup` | 506 | 2 | 253:1 |
+| `canadian-company-data` | 503 | **0** | ∞ |
+| `vasp-verify` | 504 | **0** | ∞ |
+
+`vat-validate` sends **1,961 requests per month to the European Commission's VIES service** for a capability with zero external calls. `lei-lookup` sends 1,998 to GLEIF. These are official public services with fair-use expectations, and this is a reputational exposure as much as a quality one.
+
+Two mechanisms are tangled here and both need separating before the DEC-20260812-A quality floor can be trusted:
+
+- **A large share of the 38,774 internal failures are negative tests firing correctly.** Literal fixture values leak into upstream error strings — `Unknown model 'test_value'` (×275) — and hundreds of rows are `'x' is required` by design. Raw completion rate cannot distinguish these from real breakage. This is the same classifier gap the 2026-08-12 doc named (§1.6); here is the magnitude.
+- **`polish-company-data` fails 899/1,299 with `Polish company name search is unavailable: the only compliant data path is the K…`** — the scheduler is repeatedly testing a path the capability structurally refuses to serve. That is a fixture defect burning 1,299 calls/month.
+
+**Recommended action (platform-autonomous under the DEC-20260812-A escalation contract):** exclude capabilities with an external-facing quota-limited upstream from hourly free-tier scheduling, or move them to fixture mode. The "free" in "hourly free-only scheduling" (DEC-20260503-B) currently means *€0 cost to us* — it does not account for *quota consumed at the upstream*. That is the bug. Test Infrastructure Cost Principle A covers billable calls; there is no principle covering rate-limited free calls, and this is the case for adding one.
+
+### 3.3 `discovery_hits` — the discovery surfaces are being catalogued, not shopped
+
+First look at the table (live since 2026-08-13 08:09 UTC; **224 rows over ~4.5 hours** — far too thin to conclude anything, reported for shape only).
+
+| Endpoint | hits | distinct IPs |
+|---|---|---|
+| `/mcp:initialize` | 128 | 29 |
+| `/.well-known/agent-card.json` | 64 | 9 |
+| `/.well-known/x402.json` | 27 | 15 |
+| `/llms.txt` | 6 | 5 |
+| `/x402/catalog` | 1 | 1 |
+
+Essentially all of it is **registry and directory crawlers**, self-identifying in the UA: `Szerverbank-Public-Agent-Observer/1.0` (51), `glimind-probe/0.1.0` (38), `aisec-registry-probe/0.4` (21), `mcpbeat/0.1` (16), `yellowmcp-health/1.0` (13), `smithery-probe/0` (8), `glama/1.0.0` (7), `x402-observatory/0.2` (6), `agent-tools.cloud/0.1` (6), `Waggle/1.0`, `MCPScoringEngine/1.0`, `mcpgrade/0.1`, `wmcp-grader/1.0`, `reliability-bureau-spike/0.1`, plus Googlebot.
+
+Conversion, joined on the documented key (`transactions.client_meta->>'ip_day_hash'` = `discovery_hits.ip_hash`, same day):
+
+| Endpoint | distinct IPs | matched calls |
+|---|---|---|
+| `/mcp:initialize` | 29 | **0** |
+| `/.well-known/x402.json` | 15 | 1 |
+| `/.well-known/agent-card.json` | 9 | **0** |
+| `/llms.txt` | 5 | **0** |
+| `/x402/catalog?src=verify-test` | 1 | 1 (our own verification) |
+
+**`src_tag` has exactly one value in the wild — `verify-test`, our own smoke check.** No tagged directory submission has ever been fetched. The channel-attribution instrument works; there is nothing tagged to attribute yet. That is a WS5/distribution finding, not a catalogue one: **tagging the directory submissions is a prerequisite for any claim that directory listings produce buyers.**
+
+Separately, `transactions.client_meta` is near-empty for the traffic that matters: 2,256 of 2,295 external calls in 30 days carry `src: (none), ua: (none)`. The x402 path does not appear to populate `client_meta`. Worth confirming before the attribution rollup is trusted.
+
+---
+
+## 4. Cheapest wins: merchandising, not building
+
+Three capabilities shipped dark and one shipped 5 days ago have **demand already on record** and zero calls. None needs engineering — they need to be made visible and x402-enabled after their first green week.
+
+| Capability | Status | Demand already recorded |
+|---|---|---|
+| `email-auth-check` | dark 08-13, `x402_enabled=false` | `failed_requests` 2026-08-13: task **`"check email auth"`** (no_match, €0.10 bid). Plus 2 paid `dns-lookup` calls with `record_type: TXT` on `_dmarc.*` domains — an agent hand-rolling DMARC lookups. One failed: `No DNS records found for "_dmarc.americanexpress.com"` |
+| `google-news-search` | dark 08-13, `x402_enabled=false` | The ~18 funding/shutdown queries in §2.3, currently paid for at €0.10 as raw `google-search` |
+| `serp-related-questions` | dark 08-13, `x402_enabled=false` | `keyword-suggest` 147 calls / 100% + `serp-analyze` 90 / 100% in 30d — the two cleanest SEO earners, and the `keyword-suggest → google-search` pair is the #1 adjacency at 142 |
+| `domain-contact-extract` | shipped 08-08, x402 **on**, **0 external calls** | 52 `google-search` calls with contact intent (§2.1). The buyer is paying for Google to find business contacts while a purpose-built capability sits unused and undiscovered |
+
+`domain-contact-extract` is the important one: it is live, x402-enabled, five days old, and the single largest customer is spending money on a worse workaround for the same job. That is a discovery failure, not a demand failure. The `related_capabilities` hint (2026-08-12 Rank 0.5) is the fix, and this is now a second concrete case for it.
+
+---
+
+## 5. The ranked build queue
+
+Rank 0 items are not builds but sit at the top of the same queue because their expected value dominates. Prices follow DEC-20260302-A (€0.02–€1.00).
+
+### Rank 0 — fixes, in expected-value order
+
+| # | Action | Evidence (30d unless noted) | Effort |
+|---|---|---|---|
+| **0.1** | **Stop the test scheduler consuming quota-limited free upstreams** — exclude or fixture-mode them | 82,780 internal calls; `vat-validate` 1,961:0 vs VIES; `brazilian-company-data` 3,592/90d → paying customer gets 429 | Medium |
+| **0.2** | **`product-reviews-extract`** — restrict declared inputs to lawful sources, refuse the rest fast | 37/42 fail; **€9.25 lost** — the single largest lost-revenue line. 30× HTTP 403, 6× "Trustpilot ToS prohibits" | Medium (listing-honesty call) |
+| **0.3** | **`screenshot-url`** — remove `waitForSelector` for the v1 prod endpoint | 21/47 fail, €1.05 lost, **20× the same v1/v2 error**. Unchanged since 2026-08-12; hits the top wallet | Small, prod-verify required |
+| **0.4** | **`tech-stack-detect`** — 403 handling + declare the input contract | 43/210 fail, €1.29 lost; 21× 403, **12× "Provide 'url' … or 'domain'"** | Small |
+| **0.5** | **`url-to-markdown`** — route `npmjs.com`/`api.npmjs.org` to `npm-package-info`; return JSON URLs as success | 16/51 fail; npmjs.com **26/26** and api.npmjs.org **6/6** across 90d | Small |
+| **0.6** | **`related_capabilities` hint in successful responses** | `domain-contact-extract` 0 calls vs 52 paid Google workarounds (§4) | Small |
+| **0.7** | **Ship the x402 miss log** (`x402-gateway-v2.ts` → `failedRequests`, `failure_type: 'x402_unknown_slug'`) | 97.5% of revenue produces no miss signal. Carried unmoved from 2026-08-12 §4 Step 0 | Small |
+
+### Rank 1–7 — builds
+
+Source rule: free/official, or a vendor already paid for and live in prod. Nothing here needs a new vendor relationship or a Browserless/LLM dependency.
+
+| # | Capability | Demand evidence | Source & feasibility | Effort | Maint. | Price | Revenue hypothesis |
+|---|---|---|---|---|---|---|---|
+| **1** | **`mexican-company-data`** | **50 paid `google-search` calls**, verbatim `"AUTOFLETES CHIHUAHUA" 墨西哥 phone contact` ×50 distinct carriers, 100% success, one wallet, 30d. Zero Mexican capability exists | **INEGI DENUE API** — official, free, token via registration. `Nombre` method searches by name/razón social; returns `Nombre`, `Razon_social`, `Clase_actividad`, `Telefono`, `Correo_e`, `Sitio_internet`, `Latitud/Longitud`. 6M+ establishments | **M** | low | €0.05 | Replaces a €0.10 unstructured search with a €0.05 structured lookup at higher value. 50 calls/30d ≈ €2.50/mo from **one known buyer**; the real prize is proving the LatAm leg exists |
+| **2** | **`company-name-resolve`** | 45+ name-shaped arrivals across 8 registries (§2.4); **17/26 `us-company-data` failures**; verbatim `No confident SEC EDGAR match for "Apple"`; slug guesses `company-lookup`, `contact-verify`, `lead-enrich` | Composes existing primitives: Serper (paid, live) + DNS verification + the registries we already run. Organisation-level only — **no personal data, no email inference** | **M** | near-zero | €0.05 | Converts refusals into calls across the whole registry shelf. ~45 refused calls/30d → even 50% conversion is €1.10/mo direct, but it unblocks the 20-registry catalogue that has earned €0 |
+| **3** | **`product-offers-lookup`** | The retail recipe is real and entirely broken: `barcode-lookup → google-search` 20 pairs, `serp-analyze → barcode-lookup` 13, `serp-analyze → price-compare` 12. `product-search` **0/5**, `price-compare` 4/8, `product-reviews-extract` 5/42 — **€10.60 lost/30d** to 403s and 429s | **Serper.dev `/shopping`** — same vendor as `google-search`, key live in prod. Licensed SERP, **no scraping** (replaces the Tier-1-problematic scrapers) | **S** | near-zero | €0.10 | Directly recovers demand currently converting at ~15%. Even half the €10.60/30d lost line is €5/mo, and it retires two delisting candidates |
+| **4** | **`domain-email-provider-detect`** | The email cluster is the volume leader: `email-validate` 422 calls/100%, `email-deliverability-check` 136/100%, `lead-email-verify` the #1 solution (57 calls, €11.40). Adjacency `keyword-suggest → email-validate` 13 | DNS MX only, via the existing `mx-lookup` primitive. **Zero external cost, zero vendor** | **S** | **zero** | €0.03 | Low ticket, high attach. Sells on the same call as `email-validate`; at 10% attach to 422 calls ≈ €1.25/mo, and it is genuinely zero-maintenance |
+| **5** | **`sec-edgar-name-search`** | `us-company-data` **17/26 failed**, `'cik' or 'company_name' is required` ×4, plus the "Apple" mis-resolution. US is the weakest identity leg | `efts.sec.gov/LATEST/search-index` — free, official, no auth, public domain, documented fair-access (declared UA, ≤10 req/s) | **S** | low | €0.05 | Fixes a 27%-completion capability rather than adding surface. Carried from 2026-08-12 #7 with stronger numbers |
+| **6** | **`wayback-snapshot-lookup`** | `pricing-page-extract` 16 calls, 14 ok, **€4.20** — best margin in competitive-intelligence; `google-search → pricing-page-extract` 12 pairs. "What did this page say last quarter" is the obvious extension | Internet Archive Availability + CDX API — free, no auth, documented | **S** | low | €0.05 | Inferential, not direct. Carried unchanged from 2026-08-12 #8 |
+| **7** | **`package-download-stats`** | ⚠️ **Attribution failed — see §3.1.** 94 workaround calls, but the caller is Strale's own free-tier ops agent, silent since 2026-06-21 | npm registry downloads API + pypistats.org — free, no auth. **npm rate limits are undocumented** (verification debt) | **S** | near-zero | €0.03 | **No revenue hypothesis.** Justified only as a zero-maintenance dark-launch that removes 32 guaranteed free-tier failures. Build it last or not at all |
+
+### Explicitly declined this round
+
+| Idea | Why |
+|---|---|
+| `spanish-company-data` | 1 `no_match` (€0.50 bid, 2026-08-12) from an internal-shaped curl caller. ES is deactivated pending an aggregator; n=1 does not reopen it |
+| Country registry #21+ (generic) | 12 company-data capabilities have earned **€0 in 90 days**. DEC-20260812-A / direction plan §4.5 already require a named buyer. Mexico (#1) is the exception *because* it has one |
+| Flight search · agentic commerce · `email-finder` · `keyword-metrics` · `us-trademark-search` · suggest-log noise (`oauth`, `wikipedia`, …) | Unchanged from 2026-08-12 §2 "Explicitly declined". No new evidence |
+| Free-text reasoning/writing tasks in `failed_requests` (Arbor, agentdex.dev, Hyperspell, `zzz-`/`totally-fake-`/`nonexistent-` negatives) | ~30 of 77 rows. Marketplace liveness probes and LLM prompts, never a capability gap |
+
+---
+
+## 6. Honest caveats
+
+1. **n = 1, and it got worse.** One wallet is 89.7% of 30-day revenue. Candidates #1, #3 and most of Rank 0 are bets on that single customer's pipeline. If it stops, revenue falls to roughly €14/month. The 2026-08-12 recommendation — *find out who `0x9D3d9410…` is* — is now the highest-value action available, and this analysis strengthens rather than weakens it: we now know they run a **LatAm B2B contact-and-verification pipeline** with a Chinese-language operator layer, which is a specific enough profile to go looking for.
+2. **`failed_requests` still cannot rank anything.** 77 rows all-time, ~30 of them bot noise, and the 97.5%-of-revenue rail writes nothing. Every "demand" claim here is inferred from purchases and failures, which shows what people *bought*, not what they *wanted and could not get*. Rank 0.7 remains the single highest-leverage instrumentation gap.
+3. **`discovery_hits` has 4.5 hours of data.** §3.3 is a shape observation, not a finding. Re-run after two weeks before drawing any conclusion about discovery-to-revenue conversion. The zero-conversion result is what you would expect from crawler traffic and proves nothing yet.
+4. **The internal-test finding (§3.2) is not fully diagnosed.** I have counts and error strings, not a read of the scheduler's tier assignment. The claim "hourly free-only scheduling ignores upstream quota" is inferred from `external_cost_cents = 0` selecting ReceitaWS/VIES/GLEIF; someone should confirm against `test-runner.ts` before acting. The *effect* — 2,142 failed internal Brazil calls and a 429'd paying customer — is directly observed and not in doubt.
+5. **Mexican business phone/email data touches personal data at the margin.** DENUE covers establishments including sole traders, where a business phone may also be a personal one. The draft manifest sets `processes_personal_data: true` and `gdpr_art_22_classification: data_lookup`, and the limitations say so. This needs a human read before launch, not an engineering decision.
+6. **DENUE rate limits and terms of use are unpublished.** The API docs state neither. Verification debt to close before build, same class as the Austrian Firmenbuch item (2026-08-12 §5 V1).
+7. **Nothing here measures cost.** Unchanged from 2026-08-12 §5.8. The €21.74/30d lost-revenue figure is a list-price ceiling, not margin; capabilities failing on 403 may be *cheaper* failed than served.
+8. **The 2026-08-12 TOAST corruption warning still stands.** All queries here ran with `max_parallel_workers_per_gather = 0` and none errored, which is consistent with that report and neither confirms nor clears it.
+
+---
+
+## 7. Recommendation
+
+Unchanged in direction from 2026-08-12, sharpened by the new evidence:
+
+1. **Fix Rank 0.1 first.** It is not a capability bug — it is the platform's own test infrastructure destroying paid calls and sending ~4,000 requests/month to VIES and GLEIF for capabilities nobody buys. It is the only item on this list with a compliance dimension.
+2. **Merchandise before building** (§4). Four capabilities with recorded demand and zero calls. `domain-contact-extract` losing to a Google workaround is the proof that discovery, not supply, is the binding constraint.
+3. **Then build #1–#4.** Mexico is the first capability in a year with a named, paying, repeat buyer identifiable *before* the build. That is the standard the intake loop was designed to enforce, and it is the reason to build it despite twelve dead country registries.
+
+Draft manifests for #1–#5 are in `manifests-drafts/`. They are **not** in `manifests/` and must not enter the onboarding pipeline until the executors exist and the verification debt in each `# DRAFT` header is closed.

--- a/manifests-drafts/README.md
+++ b/manifests-drafts/README.md
@@ -1,0 +1,39 @@
+# manifests-drafts/ — NOT the onboarding pipeline
+
+Draft capability manifests produced by the 2026-08-13 demand-mining analysis
+(`docs/strategy/2026-08-demand-mined-build-queue.md`).
+
+**These files are deliberately outside `manifests/`.** `apps/api/scripts/onboard.ts`
+takes an explicit `--manifest <path>`, so nothing here is picked up automatically —
+but do not point it at this directory either. A draft manifest is a **proposal**,
+not a capability:
+
+- No executor exists at `apps/api/src/capabilities/<slug>.ts` for any of these.
+- `expected_fields` and `output_field_reliability` are **hand-written guesses**, not
+  discovered from live output. The pipeline generates those with `--discover`; the
+  values here will be wrong in detail.
+- Each file opens with a `# DRAFT` header listing the **verification debt** that must
+  be closed before the capability is built — unpublished rate limits, unconfirmed
+  response fields, terms-of-use reads, and (for `mexican-company-data`) a personal-data
+  judgement that is a human call, not an engineering one.
+
+## Promotion path
+
+1. Close the verification debt in the header. If a source turns out not to support the
+   capability, delete the draft and record the decline in `docs/demand/intake-log.md`.
+2. Write the executor.
+3. Move the file to `manifests/`, strip the `# DRAFT` block.
+4. Run the real pipeline per CLAUDE.md — `onboard.ts --discover` regenerates
+   `expected_fields` and `output_field_reliability` from live output, overwriting the
+   guesses here.
+5. `validate-capability.ts`, `checkReadiness`, `smoke-test.ts` as normal.
+
+## Contents
+
+| Draft | Queue rank | Source | Verification debt |
+|---|---|---|---|
+| `mexican-company-data.yaml` | 1 | INEGI DENUE API (official, free, token) | Rate limits + ToS unpublished; personal-data call |
+| `company-name-resolve.yaml` | 2 | Composes Serper + DNS + existing registries | Per-registry match thresholds |
+| `product-offers-lookup.yaml` | 3 | Serper.dev `/shopping` (vendor already live) | Response shape not yet captured |
+| `domain-email-provider-detect.yaml` | 4 | DNS MX only (zero external cost) | Provider fingerprint list needs sourcing |
+| `sec-edgar-name-search.yaml` | 5 | SEC EDGAR full-text search (official, free) | Fair-access UA/rate compliance |

--- a/manifests-drafts/company-name-resolve.yaml
+++ b/manifests-drafts/company-name-resolve.yaml
@@ -1,0 +1,183 @@
+# DRAFT — NOT FOR THE ONBOARDING PIPELINE
+#
+# Queue rank 2. Demand: agents arrive holding a NAME, registries index IDENTIFIERS.
+# 45+ name-shaped arrivals across 8 *-company-data capabilities in 90d; us-company-data
+# 17/26 failed; verbatim errors `'cik' or 'company_name' is required` (x4) and
+# `No confident SEC EDGAR match for "Apple"` (x3). Slug guesses in failed_requests:
+# company-lookup (EUR0.50 bid), contact-verify, lead-enrich, solutions/lead-enrich.
+# See docs/strategy/2026-08-demand-mined-build-queue.md §2.4.
+#
+# VERIFICATION DEBT — close before building:
+#   1. Per-registry match thresholds are UNDEFINED. This capability exists precisely
+#      because taking result[0] is wrong — see feedback_registry_name_search_never_ranks.md
+#      (PRH orders by business ID, Brreg alphabetically, EDGAR searches filings not
+#      entities; result[0] returned Fysios for "Nokia"). Every backing registry needs its
+#      own scoring rule and its own refusal threshold before this ships. Do not build a
+#      generic "best match" — build a scorer that refuses.
+#   2. Decide the refusal contract: does an ambiguous result 200 with candidates and
+#      confidence: "ambiguous", or 4xx? Recommendation below is 200-with-candidates,
+#      because a 4xx here reproduces the failure this capability is meant to remove.
+#   3. Confirm which registries are in scope at launch. The draft assumes the ones with
+#      recorded name-shaped demand (UK, US, DE, FR, BE, FI, DK) plus domain resolution.
+#   4. ORGANISATION-LEVEL ONLY. This must never infer or return a person's email or
+#      direct phone. The standing email-finder refusal (auto-register DEACTIVATED map,
+#      CNIL/Kaspr EUR240k) applies. Officer/director names already published by a
+#      registry are a separate question and are OUT of scope for this draft.
+
+slug: company-name-resolve
+name: Company Name Resolve
+description: >-
+  Turn a company name into the identifiers other lookups need — registry number, jurisdiction
+  and official domain — with an explicit confidence band and honest refusal when the name is
+  ambiguous.
+category: company-data
+cost_class: paid_prepaid
+quota_window: none
+price_cents: 5
+is_free_tier: false
+avg_latency_ms: 2000
+data_source: >-
+  Composite — Serper.dev (licensed SERP, already live) for candidate discovery, DNS for
+  domain verification, and the official registry APIs Strale already operates for
+  identifier confirmation
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: composite-internal
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: multi
+
+input_schema:
+  type: object
+  required: []
+  properties:
+    company_name:
+      type: string
+      description: Company name as the caller has it (min 2 chars). Legal or trade name.
+    name:
+      type: string
+      description: Alias for company_name
+    query:
+      type: string
+      description: Alias for company_name
+    task:
+      type: string
+      description: Free-text alias for company_name
+    country:
+      type: string
+      description: >-
+        Optional ISO 3166-1 alpha-2 hint (e.g. "GB", "US", "DE"). Strongly recommended —
+        without it, resolution across jurisdictions is materially less confident.
+    domain_hint:
+      type: string
+      description: Optional known domain, used to confirm rather than discover the match
+  anyOf:
+    - required: [company_name]
+    - required: [name]
+    - required: [query]
+    - required: [task]
+
+output_schema:
+  type: object
+  example:
+    query: Monzo Bank
+    country: GB
+    confidence: high
+    resolved:
+      legal_name: MONZO BANK LIMITED
+      jurisdiction: GB
+      registry: UK Companies House
+      registry_id: "09446231"
+      registry_id_type: company_number
+      domain: monzo.com
+      domain_verified: true
+      next_capability: uk-company-data
+    candidates:
+      - legal_name: MONZO BANK LIMITED
+        jurisdiction: GB
+        registry_id: "09446231"
+        score: 0.96
+    candidate_count: 1
+  properties:
+    query: { type: string }
+    country: { type: ["string", "null"] }
+    confidence:
+      type: string
+      description: 'One of: high | medium | ambiguous | none. "ambiguous" and "none" leave `resolved` null.'
+    resolved:
+      type: ["object", "null"]
+      description: The single confident match, or null when confidence is ambiguous/none
+    candidates:
+      type: array
+      description: Scored candidates, always returned so the caller can disambiguate
+    candidate_count: { type: integer }
+
+test_fixtures:
+  # DRAFT fixture. Use a company whose registry ID you have independently verified.
+  # A second fixture asserting confidence == "ambiguous" on a deliberately ambiguous
+  # name (e.g. "Apple") is MANDATORY before launch — the refusal path is the product.
+  known_answer:
+    input:
+      company_name: Monzo Bank
+      country: GB
+    expected_fields:
+      - { field: confidence, operator: not_null, reliability: guaranteed }
+      - { field: candidates, operator: type, reliability: guaranteed, value: array }
+      - { field: candidate_count, operator: not_null, reliability: guaranteed }
+  health_check_input:
+    company_name: Monzo Bank
+    country: GB
+
+output_field_reliability:
+  query: guaranteed
+  country: guaranteed
+  confidence: guaranteed
+  candidates: guaranteed
+  candidate_count: guaranteed
+  resolved: common
+  "resolved.legal_name": common
+  "resolved.jurisdiction": common
+  "resolved.registry_id": common
+  "resolved.registry": common
+  "resolved.domain": rare
+  "resolved.domain_verified": rare
+  "resolved.next_capability": common
+
+limitations:
+  - title: Refuses rather than guesses — ambiguity is a successful outcome
+    text: >-
+      When no candidate clears the per-registry threshold the response is 200 with
+      `confidence: "ambiguous"`, `resolved: null` and the scored candidate list. This is
+      deliberate: registry name searches never rank by relevance, so returning a
+      best-effort single match produces confidently wrong companies. Callers must handle
+      the ambiguous case.
+    category: accuracy
+    severity: warning
+  - title: Country hint materially changes accuracy
+    text: >-
+      Without `country`, candidates are drawn across jurisdictions and the same trade name
+      may exist in several registries. Expect a lower confidence band and more candidates
+      when the hint is omitted.
+    category: accuracy
+    severity: warning
+  - title: Coverage is limited to registries Strale already operates
+    text: >-
+      Resolution can only return identifiers for jurisdictions with a live Strale registry
+      capability. For other countries the response may still resolve a domain but will
+      carry no registry_id.
+    category: coverage
+    severity: warning
+  - title: Organisation-level only — no personal contact data
+    text: >-
+      Returns company identifiers and the official domain. It does not infer, search for,
+      or return any individual's email address or direct phone number, by design.
+    category: legal
+    severity: info
+  - title: Domain verification confirms, it does not prove ownership
+    text: >-
+      `domain_verified` means the domain resolves and its content is consistent with the
+      resolved entity. It is not a trademark check and does not establish that the entity
+      owns the domain.
+    category: accuracy
+    severity: info

--- a/manifests-drafts/domain-email-provider-detect.yaml
+++ b/manifests-drafts/domain-email-provider-detect.yaml
@@ -1,0 +1,166 @@
+# DRAFT — NOT FOR THE ONBOARDING PIPELINE
+#
+# Queue rank 4. Demand: the email cluster is the volume leader and the only
+# month-over-month grower. 30d: email-validate 422 calls / 100%, email-deliverability-check
+# 136 / 100%, lead-email-verify the #1 solution (57 calls, EUR11.40). Adjacency
+# keyword-suggest -> email-validate 13 pairs.
+# See docs/strategy/2026-08-demand-mined-build-queue.md §5 rank 4.
+#
+# Zero-maintenance class (DNS only, no vendor, no key, no external cost) — therefore a
+# candidate for factory dark-launch under DEC-20260812-A: invisible + non-x402 until the
+# first green week.
+#
+# VERIFICATION DEBT — close before building:
+#   1. The provider fingerprint list is the entire product and is NOT yet sourced. It must
+#      be a versioned, in-repo table of MX-suffix -> provider with a stated last-reviewed
+#      date, not a hardcoded if-chain. Decide where it lives and who reviews it.
+#   2. Decide the unknown-provider contract. Recommendation: return provider "unknown"
+#      with the raw MX hosts, never a guess. A wrong provider label is worse than none.
+#   3. Confirm reuse of the existing mx-lookup primitive rather than a second DNS path.
+#   4. Check overlap with email-deliverability-check — if that capability already returns
+#      MX hosts, this must be positioned as the classification layer, not a duplicate.
+#      If the overlap is total, this becomes a field addition, not a new capability.
+
+slug: domain-email-provider-detect
+name: Domain Email Provider Detect
+description: >-
+  Identify which email platform a domain uses by classifying its MX records — Google Workspace,
+  Microsoft 365, Proofpoint, Mimecast, Zoho, self-hosted and others — with the raw records shown.
+category: web-intelligence
+cost_class: free_computed
+quota_window: none
+price_cents: 3
+is_free_tier: false
+avg_latency_ms: 250
+data_source: Public DNS MX records (no vendor, no external cost)
+data_source_type: computed
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: zero-maintenance
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: global
+
+input_schema:
+  type: object
+  required: []
+  properties:
+    domain:
+      type: string
+      description: Domain to inspect (e.g. "example.com"). Bare domain or URL.
+    url:
+      type: string
+      description: Alias for domain — the host is extracted
+    email:
+      type: string
+      description: Alias — the domain part after "@" is used. The local part is discarded, never stored.
+    query:
+      type: string
+      description: Alias for domain
+    task:
+      type: string
+      description: Free-text alias for domain
+  anyOf:
+    - required: [domain]
+    - required: [url]
+    - required: [email]
+    - required: [query]
+    - required: [task]
+
+output_schema:
+  type: object
+  example:
+    domain: example.com
+    provider: Google Workspace
+    provider_key: google_workspace
+    category: cloud_mailbox
+    confidence: high
+    mx_hosts:
+      - host: aspmx.l.google.com
+        priority: 1
+      - host: alt1.aspmx.l.google.com
+        priority: 5
+    has_mx: true
+    security_gateway: null
+    fingerprint_version: "2026-08-13"
+  properties:
+    domain: { type: string }
+    provider: { type: ["string", "null"] }
+    provider_key: { type: ["string", "null"] }
+    category:
+      type: ["string", "null"]
+      description: 'cloud_mailbox | security_gateway | hosting_bundled | self_hosted | none | unknown'
+    confidence:
+      type: string
+      description: 'high | medium | unknown. "unknown" means the MX suffix matched no fingerprint.'
+    mx_hosts:
+      type: array
+      description: Raw MX records with priorities, always returned so the caller can audit the call
+    has_mx: { type: boolean }
+    security_gateway:
+      type: ["string", "null"]
+      description: Set when a filtering layer fronts the mailbox provider (e.g. Proofpoint, Mimecast)
+    fingerprint_version: { type: string }
+
+test_fixtures:
+  # DRAFT fixture. google.com is stable but any large provider's MX can change —
+  # prefer asserting on shape (has_mx, mx_hosts array) over the provider string.
+  # A second fixture for a domain with NO MX records is mandatory before launch.
+  known_answer:
+    input:
+      domain: google.com
+    expected_fields:
+      - { field: domain, operator: equals, reliability: guaranteed, value: google.com }
+      - { field: has_mx, operator: not_null, reliability: guaranteed }
+      - { field: mx_hosts, operator: type, reliability: guaranteed, value: array }
+      - { field: confidence, operator: not_null, reliability: guaranteed }
+  health_check_input:
+    domain: example.com
+
+output_field_reliability:
+  domain: guaranteed
+  has_mx: guaranteed
+  mx_hosts: guaranteed
+  confidence: guaranteed
+  fingerprint_version: guaranteed
+  category: guaranteed
+  provider: common
+  provider_key: common
+  security_gateway: rare
+
+limitations:
+  - title: Says nothing about deliverability or authentication
+    text: >-
+      This identifies the mail platform only. It does not check SPF, DKIM or DMARC, does not
+      score deliverability, and does not verify that any mailbox exists. Use email-auth-check
+      for authentication posture and email-deliverability-check for deliverability.
+    category: coverage
+    severity: warning
+  - title: Unknown is a real answer, not a failure
+    text: >-
+      When the MX suffix matches no entry in the fingerprint table the response returns
+      `provider: null` and `confidence: "unknown"` with the raw MX hosts. It will not guess
+      a provider from a partial match.
+    category: accuracy
+    severity: warning
+  - title: A security gateway can mask the mailbox provider
+    text: >-
+      Domains fronted by a filtering service publish the gateway's MX records, not the
+      underlying mailbox platform's. In that case `security_gateway` is populated and
+      `provider` may be null — the real mailbox host is not visible in DNS.
+    category: accuracy
+    severity: warning
+  - title: Fingerprint table ages
+    text: >-
+      Classification depends on a maintained MX-suffix table, whose version is returned as
+      `fingerprint_version`. New or rebranded providers are unrecognised until the table is
+      reviewed.
+    category: freshness
+    severity: info
+  - title: No MX does not mean no email
+    text: >-
+      A domain with no MX records may still receive mail at its A record under legacy
+      fallback behaviour, or may simply not be used for mail. `has_mx: false` reports the
+      DNS fact and draws no conclusion.
+    category: accuracy
+    severity: info

--- a/manifests-drafts/mexican-company-data.yaml
+++ b/manifests-drafts/mexican-company-data.yaml
@@ -1,0 +1,195 @@
+# DRAFT — NOT FOR THE ONBOARDING PIPELINE
+#
+# Queue rank 1. Demand: 50 paid google-search calls in 30d from the top wallet,
+# template `"<CARRIER NAME>" 墨西哥 phone contact`, 100% success, zero Mexican
+# capability in the catalogue. See docs/strategy/2026-08-demand-mined-build-queue.md §2.1.
+#
+# VERIFICATION DEBT — close all of these before building:
+#   1. DENUE publishes NO rate limits and NO terms of use on
+#      https://www.inegi.org.mx/servicios/api_denue.html. Obtain both in writing
+#      (or record their absence) before launch. Same class as the AT Firmenbuch
+#      item in the 2026-08-12 catalogue strategy §5 V1.
+#   2. Field names below are taken from the API documentation page, not from a live
+#      response. Confirm `Telefono` / `Correo_e` / `Sitio_internet` are actually
+#      populated and not near-universally empty — the whole demand case rests on
+#      contact fields being present.
+#   3. Token acquisition is a free registration. Confirm it does not carry
+#      redistribution restrictions that conflict with reselling lookups.
+#   4. PERSONAL-DATA CALL — HUMAN DECISION, NOT ENGINEERING.
+#      DENUE covers ~6M establishments including sole traders ("personas físicas con
+#      actividad empresarial"), where the business phone is frequently a personal
+#      mobile. This is why processes_personal_data is true below. Petter must decide
+#      whether this ships, on the same footing as the standing email-finder refusal.
+#      Do NOT resolve this by reading the manifest.
+#   5. DEC-20260428-A preference order check: this is an official API (tier above
+#      per-call parsing), so no DEC-20260813-A analysis is required. Confirm anyway.
+
+slug: mexican-company-data
+name: Mexican Company Data
+description: >-
+  Look up Mexican businesses in INEGI's official DENUE establishment directory by name or
+  registry ID. Returns legal name, economic activity, size band, address, coordinates and
+  published business contact details.
+category: company-data
+cost_class: free_official
+quota_window: unknown
+price_cents: 5
+is_free_tier: false
+avg_latency_ms: 900
+data_source: INEGI DENUE (Directorio Estadístico Nacional de Unidades Económicas) API
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: government-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: true
+geography: MX
+
+input_schema:
+  type: object
+  required: []
+  properties:
+    company_name:
+      type: string
+      description: Business or trade name to search (min 3 chars). Uses the DENUE `Nombre` method.
+    name:
+      type: string
+      description: Alias for company_name
+    query:
+      type: string
+      description: Alias for company_name
+    task:
+      type: string
+      description: Free-text alias for company_name
+    denue_id:
+      type: string
+      description: DENUE establishment ID for an exact lookup (uses the `Ficha` method)
+    state:
+      type: string
+      description: >-
+        Optional Mexican state to scope the search — name or INEGI 2-digit code
+        (e.g. "Chihuahua", "08"). Omit to search nationally.
+    max_results:
+      type: number
+      description: "Max establishments to return (default 10, cap 25)"
+  anyOf:
+    - required: [company_name]
+    - required: [name]
+    - required: [query]
+    - required: [task]
+    - required: [denue_id]
+
+output_schema:
+  type: object
+  example:
+    query: AUTOFLETES CHIHUAHUA
+    state: null
+    result_count: 1
+    establishments:
+      - denue_id: "1234567"
+        name: AUTOFLETES CHIHUAHUA
+        legal_name: AUTOFLETES DE CHIHUAHUA SA DE CV
+        activity_class: Transporte de carga general
+        activity_code: "484121"
+        size_band: 51 a 100 personas
+        street: Avenida Tecnologico
+        exterior_number: "3900"
+        neighbourhood: Granjas
+        postal_code: "31160"
+        municipality: Chihuahua
+        state: Chihuahua
+        phone: "+52 614 000 0000"
+        email: contacto@example.mx
+        website: https://example.mx
+        latitude: 28.6353
+        longitude: -106.0889
+        contact_fields_present: true
+  properties:
+    query: { type: ["string", "null"] }
+    state: { type: ["string", "null"] }
+    result_count: { type: integer }
+    establishments:
+      type: array
+      description: >-
+        Matching establishments. Identity and location fields are guaranteed by DENUE;
+        contact fields are self-reported by the establishment and frequently absent.
+
+test_fixtures:
+  # DRAFT fixture — the pipeline regenerates expected_fields via --discover.
+  # Replace the input with a carrier verified present in DENUE before onboarding.
+  known_answer:
+    input:
+      company_name: AUTOFLETES CHIHUAHUA
+      max_results: 5
+    expected_fields:
+      - { field: result_count, operator: not_null, reliability: guaranteed }
+      - { field: establishments, operator: not_null, reliability: guaranteed }
+      - { field: establishments, operator: type, reliability: guaranteed, value: array }
+  health_check_input:
+    company_name: TRANSPORTES
+    state: Chihuahua
+    max_results: 3
+
+output_field_reliability:
+  query: guaranteed
+  state: guaranteed
+  result_count: guaranteed
+  establishments: guaranteed
+  "establishments[].denue_id": guaranteed
+  "establishments[].name": guaranteed
+  "establishments[].activity_class": guaranteed
+  "establishments[].size_band": guaranteed
+  "establishments[].state": guaranteed
+  "establishments[].municipality": guaranteed
+  "establishments[].latitude": common
+  "establishments[].longitude": common
+  "establishments[].legal_name": common
+  "establishments[].postal_code": common
+  "establishments[].phone": rare
+  "establishments[].email": rare
+  "establishments[].website": rare
+  "establishments[].contact_fields_present": guaranteed
+
+limitations:
+  - title: Contact details are self-reported and often missing
+    text: >-
+      Phone, email and website in DENUE are supplied by the establishment during census
+      collection and are absent for a large share of records. `contact_fields_present`
+      states per record whether any were returned. This capability will not find a
+      contact that DENUE does not hold — it does not search the open web to fill gaps.
+    category: coverage
+    severity: warning
+  - title: Establishments, not legal entities
+    text: >-
+      DENUE is a directory of physical establishments, not a company register. One legal
+      entity may appear as many establishments, and DENUE carries no RFC, no incorporation
+      date, no directors and no ownership. For legal-entity identity in Mexico this is not
+      a substitute for the Registro Público de Comercio.
+    category: coverage
+    severity: warning
+  - title: Name search is substring matching, not entity resolution
+    text: >-
+      The DENUE `Nombre` method matches on name text. Common words return many unrelated
+      establishments and abbreviations may miss entirely. Results are candidates for the
+      caller to disambiguate, not a confident single match.
+    category: accuracy
+    severity: warning
+  - title: Very small rural localities are excluded
+    text: >-
+      INEGI documents that DENUE omits establishments in very small rural localities.
+      Absence from DENUE is not evidence that a business does not exist.
+    category: coverage
+    severity: info
+  - title: Update cadence is periodic, not live
+    text: >-
+      DENUE is refreshed on INEGI's own census and update schedule (roughly twice yearly),
+      so records can lag reality by months. The API call is live; the underlying data is not.
+    category: freshness
+    severity: info
+  - title: May contain personal data for sole traders
+    text: >-
+      Establishments operated by sole traders can carry a personal mobile number or personal
+      email in the business contact fields. Callers are responsible for their own lawful
+      basis when processing these records.
+    category: legal
+    severity: warning

--- a/manifests-drafts/product-offers-lookup.yaml
+++ b/manifests-drafts/product-offers-lookup.yaml
@@ -1,0 +1,181 @@
+# DRAFT — NOT FOR THE ONBOARDING PIPELINE
+#
+# Queue rank 3. Demand: the retail-intelligence recipe is real and entirely broken.
+# Adjacency 30d: barcode-lookup -> google-search 20 pairs, serp-analyze -> barcode-lookup 13,
+# serp-analyze -> price-compare 12, url-to-markdown -> price-compare 6.
+# Completion 30d: product-search 0/5, price-compare 4/8, product-reviews-extract 5/42.
+# EUR10.60 of list price destroyed in 30d, dominated by HTTP 403 bot-blocks and 429s.
+# See docs/strategy/2026-08-demand-mined-build-queue.md §2.2 / §5 Rank 0.2.
+#
+# The point of this capability is DOCTRINAL as much as commercial: it replaces three
+# scraping-based capabilities that are failing against bot protection with one licensed
+# SERP call. Per DEC-20260428-A the preference order is official API > licensed bulk >
+# Tier-2 vendor > per-call parsing; Serper is a licensed SERP vendor already live in prod
+# and already backing google-search, so this moves the retail leg UP the preference order.
+#
+# VERIFICATION DEBT — close before building:
+#   1. The /shopping response shape has NOT been captured. Field names below are inferred
+#      from the /search and /news shapes already in the codebase. Capture a real response
+#      and let onboard.ts --discover regenerate expected_fields.
+#   2. Confirm /shopping is included in the current Serper plan and check its per-call
+#      cost — google-search economics do not automatically transfer. If /shopping bills
+#      differently, revisit price_cents.
+#   3. Merchant/pricing data is a Google-surfaced aggregation. Confirm the Serper terms
+#      permit re-serving it to customers, same check that was done for google-search.
+#   4. Decide the relationship to price-compare and product-search. If this ships, those
+#      two are delisting candidates (2026-08-12 §3d), not siblings. Do not run all three.
+
+slug: product-offers-lookup
+name: Product Offers Lookup
+description: >-
+  Find current retail offers for a product across merchants via a licensed SERP API. Returns
+  merchant, price, currency, rating and product link — no site scraping, no bot-blocked fetches.
+category: data-extraction
+cost_class: paid_prepaid
+quota_window: none
+price_cents: 10
+is_free_tier: false
+avg_latency_ms: 1500
+data_source: Serper.dev (licensed Google SERP API) — Shopping vertical
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: commercial-stable-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: global
+
+input_schema:
+  type: object
+  required: []
+  properties:
+    query:
+      type: string
+      description: Product name, model or search phrase (min 2 chars)
+    q:
+      type: string
+      description: Alias for query
+    product:
+      type: string
+      description: Alias for query
+    task:
+      type: string
+      description: Free-text alias for query
+    barcode:
+      type: string
+      description: >-
+        Optional UPC/EAN. When supplied without a query, it is used as the search term —
+        pairs with barcode-lookup, which is the observed upstream capability in this recipe.
+    country:
+      type: string
+      description: Optional ISO 3166 country to scope offers (e.g. "us", "se"). Affects currency.
+    language:
+      type: string
+      description: Optional interface language (e.g. "en", "sv")
+    num_results:
+      type: number
+      description: "Max offers to return (default 10, cap 20)"
+  anyOf:
+    - required: [query]
+    - required: [q]
+    - required: [product]
+    - required: [task]
+    - required: [barcode]
+
+output_schema:
+  type: object
+  example:
+    query: Sony WH-1000XM5
+    country: us
+    result_count: 2
+    currency_note: Currencies follow the scoped country and may differ between offers
+    offers:
+      - position: 1
+        title: Sony WH-1000XM5 Wireless Headphones
+        merchant: Example Electronics
+        price: 328.0
+        currency: USD
+        price_raw: "$328.00"
+        delivery: Free delivery
+        rating: 4.6
+        rating_count: 12043
+        url: https://example.com/p/wh1000xm5
+        image_url: null
+    price_range:
+      min: 328.0
+      max: 399.99
+      currency: USD
+  properties:
+    query: { type: string }
+    country: { type: ["string", "null"] }
+    result_count: { type: integer }
+    offers:
+      type: array
+      description: Ranked retail offers as surfaced by the Shopping vertical
+    price_range:
+      type: ["object", "null"]
+      description: Min/max across returned offers, only when all offers share one currency
+
+test_fixtures:
+  # DRAFT fixture — capture a real /shopping response first, then let --discover rewrite this.
+  # Do NOT assert on price values: they change hourly by design.
+  known_answer:
+    input:
+      query: Sony WH-1000XM5
+      num_results: 5
+    expected_fields:
+      - { field: query, operator: equals, reliability: guaranteed, value: Sony WH-1000XM5 }
+      - { field: result_count, operator: not_null, reliability: guaranteed }
+      - { field: offers, operator: type, reliability: guaranteed, value: array }
+  health_check_input:
+    query: usb c cable
+    num_results: 3
+
+output_field_reliability:
+  query: guaranteed
+  country: guaranteed
+  result_count: guaranteed
+  offers: guaranteed
+  currency_note: guaranteed
+  "offers[].title": guaranteed
+  "offers[].url": guaranteed
+  "offers[].position": guaranteed
+  "offers[].merchant": common
+  "offers[].price": common
+  "offers[].currency": common
+  "offers[].price_raw": common
+  "offers[].delivery": rare
+  "offers[].rating": rare
+  "offers[].rating_count": rare
+  "offers[].image_url": rare
+  price_range: common
+
+limitations:
+  - title: Prices are a point-in-time snapshot, not a quote
+    text: >-
+      Offers reflect what the Shopping vertical surfaced at call time. Prices, availability
+      and delivery terms change continuously and may already differ at the merchant. Never
+      present these as a binding price.
+    category: freshness
+    severity: warning
+  - title: Merchant coverage follows Google's index, not a complete market
+    text: >-
+      Only merchants participating in Google Shopping for the scoped country appear.
+      Absence of a merchant is not evidence they do not sell the product, and ordering
+      reflects Google's ranking rather than lowest price.
+    category: coverage
+    severity: warning
+  - title: Currencies can be mixed within one response
+    text: >-
+      When offers span countries the response can contain more than one currency. No
+      conversion is performed and `price_range` is omitted unless all offers share a
+      currency. Use currency-convert if a single basis is needed.
+    category: accuracy
+    severity: warning
+  - title: Not a replacement for merchant-site detail
+    text: >-
+      Returns the offer as listed, not product specifications, stock levels, variant-level
+      pricing, or reviews. It deliberately does not fetch merchant pages, which is why it
+      does not suffer the bot-blocking that affects page-fetch capabilities.
+    category: coverage
+    severity: info

--- a/manifests-drafts/sec-edgar-name-search.yaml
+++ b/manifests-drafts/sec-edgar-name-search.yaml
@@ -1,0 +1,187 @@
+# DRAFT — NOT FOR THE ONBOARDING PIPELINE
+#
+# Queue rank 5. Demand: us-company-data is the worst-performing capability with real
+# external traffic — 26 calls / 90d, 17 failed (35% completion). Verbatim errors:
+#   `'cik' or 'company_name' is required. Provide a CIK number or US company name.`  (x4)
+#   `No confident SEC EDGAR match for "Apple". The closest filing belongs to a
+#    different entity ("Apple Hospitality REIT, Inc...")`                             (x3)
+# 5 of 26 arrivals carry a name rather than a CIK. US is the weakest identity leg.
+# See docs/strategy/2026-08-demand-mined-build-queue.md §2.4 / §5 rank 5.
+#
+# Relationship to rank 2 (company-name-resolve): this is the US-specific primitive that
+# company-name-resolve would call for jurisdiction == US. Build order matters — if
+# company-name-resolve ships first with a weak US leg it inherits the "Apple" problem.
+# Consider building this one FIRST despite the lower rank.
+#
+# VERIFICATION DEBT — close before building:
+#   1. SEC fair-access policy is MANDATORY and enforced by IP block, not by 429. Requires
+#      a declared User-Agent carrying a real contact address and <=10 req/s. Confirm the
+#      exact current policy text at sec.gov before writing the client, and confirm which
+#      contact address Strale declares (this is a public disclosure — Moonlighter AB /
+#      @strale.io per project_legal_entity.md and project_email_domain.md).
+#   2. efts.sec.gov full-text search covers filings from 2001 onward ONLY. Entities whose
+#      last filing predates 2001 are invisible. Confirm the exact cutoff before writing
+#      the coverage limitation below.
+#   3. Response shape not captured. Field names are inferred; let onboard.ts --discover
+#      regenerate expected_fields from a live call.
+#   4. Decide whether this replaces the name path inside us-company-data or ships beside
+#      it. Shipping beside it without fixing us-company-data leaves the 35%-completion
+#      capability in the catalogue, which the readiness program treats as a broken promise.
+#      Recommendation: this becomes us-company-data's name path, and ships as a fix.
+
+slug: sec-edgar-name-search
+name: SEC EDGAR Name Search
+description: >-
+  Resolve a US company name to its SEC EDGAR identity — CIK, exact registrant name, ticker and
+  recent filing activity — scoring candidates and refusing rather than returning a wrong entity.
+category: company-data
+cost_class: free_official
+quota_window: rate_limited
+price_cents: 5
+is_free_tier: false
+avg_latency_ms: 1200
+data_source: SEC EDGAR full-text search (efts.sec.gov) and company_tickers.json — US government, public domain
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: government-api
+gdpr_art_22_classification: data_lookup
+processes_personal_data: false
+geography: US
+
+input_schema:
+  type: object
+  required: []
+  properties:
+    company_name:
+      type: string
+      description: US registrant name to resolve (min 2 chars)
+    name:
+      type: string
+      description: Alias for company_name
+    query:
+      type: string
+      description: Alias for company_name
+    task:
+      type: string
+      description: Free-text alias for company_name
+    ticker:
+      type: string
+      description: Optional ticker symbol — when supplied, used to confirm rather than discover
+    max_results:
+      type: number
+      description: "Max candidates to return (default 10, cap 20)"
+  anyOf:
+    - required: [company_name]
+    - required: [name]
+    - required: [query]
+    - required: [task]
+    - required: [ticker]
+
+output_schema:
+  type: object
+  example:
+    query: Apple
+    confidence: ambiguous
+    resolved: null
+    candidates:
+      - cik: "0000320193"
+        registrant_name: "Apple Inc."
+        ticker: AAPL
+        exchange: Nasdaq
+        score: 0.81
+        last_filing_date: "2026-08-01"
+        last_filing_form: "10-Q"
+      - cik: "0001418121"
+        registrant_name: "Apple Hospitality REIT, Inc."
+        ticker: APLE
+        exchange: NYSE
+        score: 0.74
+        last_filing_date: "2026-07-28"
+        last_filing_form: "10-Q"
+    candidate_count: 2
+    ambiguity_reason: "Two registrants scored within 0.10 — name alone does not disambiguate"
+  properties:
+    query: { type: string }
+    confidence:
+      type: string
+      description: 'high | medium | ambiguous | none. "ambiguous" and "none" leave `resolved` null.'
+    resolved:
+      type: ["object", "null"]
+      description: The single confident registrant, or null when ambiguous/none
+    candidates:
+      type: array
+      description: Scored registrant candidates, always returned
+    candidate_count: { type: integer }
+    ambiguity_reason:
+      type: ["string", "null"]
+      description: Present only when confidence is ambiguous — states why no single match was chosen
+
+test_fixtures:
+  # DRAFT fixture. Use an unambiguous registrant for known_answer.
+  # A SECOND fixture asserting confidence == "ambiguous" for input "Apple" is MANDATORY
+  # before launch — reproducing the recorded production failure is the point of this build.
+  known_answer:
+    input:
+      company_name: Tesla, Inc.
+    expected_fields:
+      - { field: confidence, operator: not_null, reliability: guaranteed }
+      - { field: candidates, operator: type, reliability: guaranteed, value: array }
+      - { field: candidate_count, operator: not_null, reliability: guaranteed }
+  health_check_input:
+    company_name: Microsoft Corporation
+
+output_field_reliability:
+  query: guaranteed
+  confidence: guaranteed
+  candidates: guaranteed
+  candidate_count: guaranteed
+  resolved: common
+  "resolved.cik": common
+  "resolved.registrant_name": common
+  "candidates[].cik": guaranteed
+  "candidates[].registrant_name": guaranteed
+  "candidates[].score": guaranteed
+  "candidates[].ticker": rare
+  "candidates[].exchange": rare
+  "candidates[].last_filing_date": common
+  "candidates[].last_filing_form": common
+  ambiguity_reason: rare
+
+limitations:
+  - title: SEC registrants only — not a US company register
+    text: >-
+      EDGAR contains entities that file with the SEC. The overwhelming majority of US
+      companies — private companies, LLCs, most small businesses — have never filed and do
+      not appear. Absence from EDGAR says nothing about whether a company exists. There is
+      no federal US company register; incorporation is state-level.
+    category: coverage
+    severity: warning
+  - title: Refuses on ambiguity rather than returning the closest name
+    text: >-
+      When two registrants score closely the response is 200 with `confidence: "ambiguous"`,
+      `resolved: null` and `ambiguity_reason`. This exists because EDGAR full-text search
+      ranks filings, not entities, and taking the top hit returns the wrong company — the
+      recorded production case was "Apple" resolving to Apple Hospitality REIT.
+    category: accuracy
+    severity: warning
+  - title: Full-text search covers filings from 2001 onward
+    text: >-
+      The EDGAR full-text index does not reach filings before roughly 2001. A registrant
+      that stopped filing before then may be unreachable by name even though its CIK exists.
+    category: coverage
+    severity: warning
+  - title: Subject to SEC fair-access rate limits
+    text: >-
+      SEC enforces a declared User-Agent and a request-rate ceiling, and blocks by IP rather
+      than returning 429. Under burst load this capability will queue or refuse rather than
+      risk the block, so latency is not guaranteed under concurrency.
+    category: availability
+    severity: warning
+  - title: Ticker and exchange are not always present
+    text: >-
+      Ticker mapping comes from a separate SEC file and covers listed registrants only.
+      Non-listed filers — funds, subsidiaries, private filers of Form D — resolve to a CIK
+      with no ticker.
+    category: coverage
+    severity: info


### PR DESCRIPTION
Read-only mining of production `failed_requests`, `transactions`, `discovery_hits` and `suggest_log` (30d/90d to 2026-08-13), turned into a ranked build queue with per-candidate demand evidence.

Extends `audit-output/parallel-audits-2026-08-12/catalog-buildout-strategy.md` rather than restating it. Its structural conclusions hold — fixes still beat builds, `failed_requests` is still unusable for ranking, concentration is still the dominant risk. **Three findings change its ranking.**

## Three corrections

**1. Rank #9 `package-download-stats` should be demoted, not built.** The 94 calls of workaround traffic that justified it (`npmjs.com` 26/26 failed, `pypistats.org` 24, `pepy.tech` 13) all target *Strale's own packages* — `strale-mcp`, `straleio`, `langchain-strale`. The caller is `is_free_tier = true`, `user_id IS NULL`, and silent since 2026-06-21. It is our own distribution-tracking ops agent, not a customer.

**2. New Rank 0 — the test scheduler is destroying paid calls.** `brazilian-company-data` took **3,592 internal test calls** against free upstream ReceitaWS in 90 days; the paying x402 customer's 12 failures are all `ReceitaWS returned HTTP 429`. Platform-wide internal load is **82,780 calls / 30d across 218 capabilities**:

| Capability | internal 30d | external 30d |
|---|---|---|
| `vat-validate` | 1,961 → VIES | **0** |
| `lei-lookup` | 1,998 → GLEIF | 3 |
| `polish-company-data` | 1,299 (899 failed) | **0** |
| `canadian-company-data` | 503 | **0** |

"Hourly free-only" scheduling (DEC-20260503-B) selects on `external_cost_cents = 0` — our cost — and does not account for **quota consumed at the upstream**. Test Infrastructure Cost Principle A covers billable calls; nothing covers rate-limited free ones. Sending ~4,000 requests/month to the European Commission's VIES service and GLEIF for capabilities nobody buys is a reputational exposure as well as a quality one.

**3. The paying customer's geography is LatAm, not the EU.** 50 paid `google-search` calls in 30d, one template, 100% success:

```
"AUTOFLETES CHIHUAHUA" 墨西哥 phone contact
"AUTO FLETES OMEGA" 墨西哥 phone contact
"CIMA TERMINAL SA DE CV" 墨西哥 phone contact
```

A company-by-company sweep of Mexican freight carriers for business contacts — paid, template-driven, and a workaround for a capability that does not exist. Plus `brazilian-company-data → email-validate` at 77 adjacency pairs. Geographic tokens across 90d: **Mexico 50 · UK 5 · US 3 · Brazil 3**. The one country with double-digit demand is the one with no registry capability, against ~20 EU registries that have earned €0.

## Headline

30d external revenue **€132.19**, **89.7% from one wallet** (up from 53% of the 90d window), with **€21.74 destroyed by failures on capabilities that already exist** — a 16.4% uplift needing no new source, licence, or maintenance surface.

`failed_requests` remains structurally unusable: 77 rows all-time, ~30 of them bot noise, and `x402-gateway-v2.ts` still returns bare 404s while 97.5% of revenue arrives over x402. The queue is therefore mined from *purchase and failure* data, not *miss* data — a weaker form of evidence, stated as such.

`discovery_hits` has **4.5 hours of data** and is reported for shape only: all registry/directory crawler traffic (`glimind-probe`, `aisec-registry-probe`, `mcpbeat`, `smithery-probe`, `x402-observatory`), **zero conversions** on the documented join key, and `src_tag` has exactly one value in the wild — `verify-test`, our own smoke check. No tagged directory submission has ever been fetched.

## Cheapest wins are merchandising, not building

Four capabilities have demand on record and zero calls. `google-news-search`, `serp-related-questions`, `email-auth-check` shipped dark 08-13 and are excluded from all "missing" lists. `email-auth-check` in particular has a verbatim `failed_requests` row from the same morning — task `"check email auth"` — plus two paid `dns-lookup` TXT calls on `_dmarc.*` domains.

`domain-contact-extract` is the sharp one: live, x402-enabled, five days old, **zero calls** — while the largest customer spends money on 52 Google searches doing the same job. Discovery failure, not demand failure.

## Draft manifests

Top 5 in **`manifests-drafts/`**, deliberately outside `manifests/`. Verified that every CI script resolves the manifest directory by exact path (`join(REPO_ROOT, "manifests")`), so nothing here is picked up.

| Draft | Source | Effort |
|---|---|---|
| `mexican-company-data` | INEGI DENUE API — official, free, token | M |
| `company-name-resolve` | Serper + DNS + existing registries | M |
| `product-offers-lookup` | Serper.dev `/shopping` — vendor already live | S |
| `domain-email-provider-detect` | DNS MX only, zero external cost | S |
| `sec-edgar-name-search` | SEC EDGAR full-text — official, free | S |

No executors exist. `expected_fields` and `output_field_reliability` are hand-written guesses that `onboard.ts --discover` would regenerate. Each file opens with a `# DRAFT` header listing its verification debt — unpublished DENUE rate limits and terms, uncaptured Serper `/shopping` response shape, SEC fair-access UA requirements, and per-registry match thresholds.

**`mexican-company-data` carries a personal-data judgement that is explicitly flagged as a human call, not an engineering one**: DENUE covers sole traders whose business phone is often a personal mobile. `processes_personal_data: true` is set and the limitation says so, but the ship/no-ship decision belongs to Petter on the same footing as the standing `email-finder` refusal.

## Method

Temporary scripts, `SELECT` only, `max_parallel_workers_per_gather = 0`, deleted after use. Internal accounts and health probes excluded on the same basis as `since-last-ext.ts`. Payer analysis is aggregate-only — wallet clusters and breadth distributions, no individual profiling. Repo writes are the doc and the drafts; no Notion writes, no DB writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
