### PR TITLE
feat(catalog): 5 official-source capabilities — UK/FR insolvency, US recalls, UK disqualified directors, World Bank indicators

### DIFF
--- a/apps/api/src/capabilities/country-economic-indicators.ts
+++ b/apps/api/src/capabilities/country-economic-indicators.ts
@@ -1,0 +1,147 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * Country economic indicators — World Bank Indicators (WDI) API. Official,
+ * free, no API key. Provides macroeconomic country-risk context for KYB
+ * (GDP, growth, inflation, unemployment, population, trade openness) —
+ * complements country-trade-data.ts, which covers detailed export/import
+ * commodity and partner breakdowns from the same API but does not surface
+ * general macro/inflation/labor indicators.
+ *
+ * API docs: https://datahelpdesk.worldbank.org/knowledgebase/articles/889392
+ */
+
+const WB_API = "https://api.worldbank.org/v2";
+
+// Friendly key → World Bank indicator code. Curated for KYB/country-risk
+// relevance rather than exhaustively covering the ~16,000 WDI indicators.
+const INDICATOR_MAP: Record<string, string> = {
+  gdp_usd: "NY.GDP.MKTP.CD",
+  gdp_growth_percent: "NY.GDP.MKTP.KD.ZG",
+  gdp_per_capita_usd: "NY.GDP.PCAP.CD",
+  inflation_percent: "FP.CPI.TOTL.ZG",
+  unemployment_percent: "SL.UEM.TOTL.ZS",
+  population: "SP.POP.TOTL",
+  gni_per_capita_usd: "NY.GNP.PCAP.CD",
+  exports_percent_gdp: "NE.EXP.GNFS.ZS",
+  imports_percent_gdp: "NE.IMP.GNFS.ZS",
+  fdi_inflow_percent_gdp: "BX.KLT.DINV.WD.GD.ZS",
+};
+
+const DEFAULT_INDICATORS = [
+  "gdp_usd",
+  "gdp_growth_percent",
+  "inflation_percent",
+  "unemployment_percent",
+  "population",
+];
+
+interface IndicatorResult {
+  value: number | null;
+  year: string | null;
+  unavailable_reason?: string;
+}
+
+async function fetchIndicator(
+  countryCode: string,
+  indicatorCode: string,
+  year: string | undefined,
+): Promise<IndicatorResult> {
+  // mrv (most-recent-value) and date are mutually exclusive in the World
+  // Bank API — sending both silently ignores `date` and returns the most
+  // recent observation instead, which would misreport requested_year for
+  // an explicit historical-year query.
+  const params = new URLSearchParams({ format: "json" });
+  if (year) {
+    params.set("date", year);
+  } else {
+    params.set("mrv", "1");
+  }
+
+  const url = `${WB_API}/country/${encodeURIComponent(countryCode)}/indicator/${indicatorCode}?${params.toString()}`;
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!response.ok) {
+    return { value: null, year: null, unavailable_reason: `HTTP ${response.status}` };
+  }
+
+  const data = (await response.json()) as any;
+
+  // World Bank returns a single-element array with a `message` on invalid
+  // country/indicator combinations, and a two-element [meta, values] array
+  // on success (values may be an empty array if there's no data at all).
+  if (!Array.isArray(data) || data.length < 2 || !Array.isArray(data[1])) {
+    const msg = data?.[0]?.message?.[0]?.value;
+    return { value: null, year: null, unavailable_reason: msg || "no data returned" };
+  }
+
+  const entry = data[1][0];
+  if (!entry || entry.value === null || entry.value === undefined) {
+    return { value: null, year: entry?.date ?? null, unavailable_reason: "no observation for this period" };
+  }
+
+  return { value: entry.value, year: entry.date ?? null };
+}
+
+registerCapability("country-economic-indicators", async (input: CapabilityInput) => {
+  const countryCode = ((input.country_code as string) ?? (input.country as string) ?? (input.task as string) ?? "").trim();
+  if (countryCode.length < 2 || countryCode.length > 3) {
+    throw new Error("'country_code' is required (ISO 2-letter or 3-letter code, e.g. SE or SWE).");
+  }
+
+  const year = (input.year as string | number | undefined) ? String(input.year).trim() : undefined;
+  if (year && !/^\d{4}$/.test(year)) {
+    throw new Error("'year' must be a 4-digit year.");
+  }
+
+  let requestedKeys = DEFAULT_INDICATORS;
+  if (Array.isArray(input.indicators) && input.indicators.length > 0) {
+    const invalid = (input.indicators as string[]).filter((k) => !INDICATOR_MAP[k]);
+    if (invalid.length > 0) {
+      throw new Error(
+        `Unknown indicator key(s): ${invalid.join(", ")}. Valid keys: ${Object.keys(INDICATOR_MAP).join(", ")}.`,
+      );
+    }
+    requestedKeys = input.indicators as string[];
+  }
+
+  const results = await Promise.all(
+    requestedKeys.map(async (key) => {
+      const wbCode = INDICATOR_MAP[key];
+      const result = await fetchIndicator(countryCode, wbCode, year);
+      return [key, result] as const;
+    }),
+  );
+
+  const indicators: Record<string, IndicatorResult> = {};
+  let anyAvailable = false;
+  for (const [key, result] of results) {
+    indicators[key] = result;
+    if (result.value !== null) anyAvailable = true;
+  }
+
+  if (!anyAvailable) {
+    throw new Error(
+      `No World Bank data available for '${countryCode}'. Verify the ISO country code is valid (e.g. SE, US, DE).`,
+    );
+  }
+
+  return {
+    output: {
+      country_code: countryCode.toUpperCase(),
+      requested_year: year || "most_recent",
+      indicators,
+      indicator_codes: Object.fromEntries(requestedKeys.map((k) => [k, INDICATOR_MAP[k]])),
+    },
+    provenance: {
+      source: "api.worldbank.org",
+      fetched_at: new Date().toISOString(),
+      upstream_vendor: "The World Bank Group",
+      acquisition_method: "official_api",
+      primary_source_reference: "https://data.worldbank.org/",
+    },
+  };
+});

--- a/apps/api/src/capabilities/french-insolvency-check.ts
+++ b/apps/api/src/capabilities/french-insolvency-check.ts
@@ -1,0 +1,131 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * French insolvency check — BODACC (Bulletin officiel des annonces civiles
+ * et commerciales), the official French legal gazette for company notices.
+ * Published as open data by DILA (Direction de l'information légale et
+ * administrative, a French government service) via an Opendatasoft
+ * instance. Free, no API key, no signup — "utilisable gratuitement".
+ *
+ * Filters to familleavis="collective" ("Procédures collectives" — the
+ * BODACC family covering redressement judiciaire / liquidation judiciaire
+ * / sauvegarde, i.e. formal insolvency proceedings). Other BODACC families
+ * (company creation, account filings, deregistration) are out of scope —
+ * this capability answers "does this French company have insolvency
+ * proceeding notices on file?", not general company registry lookup
+ * (french-company-data / INSEE covers that).
+ *
+ * Dataset: https://www.data.gouv.fr/en/datasets/bodacc/
+ * API base: https://bodacc-datadila.opendatasoft.com/api/explore/v2.1
+ */
+
+const BODACC_API =
+  "https://bodacc-datadila.opendatasoft.com/api/explore/v2.1/catalog/datasets/annonces-commerciales/records";
+const SIREN_RE = /^\d{9}$/;
+
+interface Judgment {
+  famille?: string;
+  nature?: string;
+  date?: string;
+  type?: string;
+  complementJugement?: string;
+}
+
+function extractSiren(registre: unknown): string | null {
+  if (!Array.isArray(registre)) return null;
+  const compact = registre.find((r) => typeof r === "string" && SIREN_RE.test(r));
+  return compact ?? null;
+}
+
+function parseJudgment(raw: unknown): Judgment | null {
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      famille: parsed?.famille ?? null,
+      nature: parsed?.nature ?? null,
+      date: parsed?.date ?? null,
+      type: parsed?.type ?? null,
+      complementJugement: parsed?.complementJugement ?? null,
+    };
+  } catch {
+    // Malformed nested JSON from upstream — surface as absent rather than throw,
+    // this is one field among many in the notice, not a fatal condition.
+    return null;
+  }
+}
+
+function escapeOdsqlString(value: string): string {
+  // Backslash must be escaped first — escaping quotes first would double-escape
+  // the backslashes that quote-escaping itself introduces.
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+registerCapability("french-insolvency-check", async (input: CapabilityInput) => {
+  const sirenRaw = ((input.siren as string) ?? "").trim().replace(/\s+/g, "");
+  const companyName = ((input.company_name as string) ?? (input.task as string) ?? "").trim();
+
+  if (!sirenRaw && !companyName) {
+    throw new Error("'siren' (9-digit French company identifier) or 'company_name' is required.");
+  }
+  if (sirenRaw && !SIREN_RE.test(sirenRaw)) {
+    throw new Error("'siren' must be exactly 9 digits.");
+  }
+
+  const clauses = ['familleavis="collective"'];
+  if (sirenRaw) {
+    clauses.push(`registre="${sirenRaw}"`);
+  } else {
+    clauses.push(`commercant like "${escapeOdsqlString(companyName)}"`);
+  }
+
+  const params = new URLSearchParams({
+    where: clauses.join(" and "),
+    order_by: "dateparution desc",
+    limit: "20",
+  });
+
+  const url = `${BODACC_API}?${params.toString()}`;
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`BODACC API returned HTTP ${response.status}.`);
+  }
+
+  const data = (await response.json()) as any;
+  const results: any[] = Array.isArray(data?.results) ? data.results : [];
+
+  const notices = results.map((r) => ({
+    id: r.id ?? null,
+    publication_date: r.dateparution ?? null,
+    company_name: r.commercant ?? null,
+    siren: extractSiren(r.registre),
+    court: r.tribunal ?? null,
+    department: r.numerodepartement ?? null,
+    department_name: r.departement_nom_officiel ?? null,
+    notice_type: r.typeavis_lib ?? null,
+    judgment: parseJudgment(r.jugement),
+    url: r.url_complete ?? null,
+  }));
+
+  return {
+    output: {
+      query: {
+        siren: sirenRaw || null,
+        company_name: companyName || null,
+      },
+      result_count: notices.length,
+      insolvency_notices: notices,
+    },
+    provenance: {
+      source: "bodacc.fr",
+      fetched_at: new Date().toISOString(),
+      upstream_vendor: "DILA (Direction de l'information légale et administrative, French government)",
+      acquisition_method: "official_api",
+      primary_source_reference: "https://www.data.gouv.fr/en/datasets/bodacc/",
+    },
+  };
+});

--- a/apps/api/src/capabilities/uk-disqualified-director-check.ts
+++ b/apps/api/src/capabilities/uk-disqualified-director-check.ts
@@ -1,0 +1,156 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * UK disqualified director check — Companies House Disqualified Officers
+ * register. Official, free API (requires the same COMPANIES_HOUSE_API_KEY
+ * already used by insolvency-check.ts, officer-search.ts, and
+ * uk-company-data.ts — no new credential to provision).
+ *
+ * Two modes, deliberately kept separate to avoid misattributing a serious
+ * negative finding to the wrong person:
+ *
+ *  - search mode (`name` given): returns CANDIDATE matches only — name,
+ *    date of birth, address snippet. It does NOT auto-fetch full
+ *    disqualification detail for a "best guess" match, because disqualified-
+ *    officer names are not unique (common-name collision risk is exactly the
+ *    failure mode documented in the registry-name-search lesson — taking
+ *    result[0] on a name search has produced wrong-entity answers before).
+ *    The caller disambiguates using date_of_birth/address, then re-calls in
+ *    detail mode with the chosen officer_id.
+ *
+ *  - detail mode (`officer_id` given): fetches the full disqualification
+ *    record for that specific, already-identified person.
+ *
+ * GDPR Art. 22 classification: screening_signal — this returns candidate
+ * matches / findings for the customer to evaluate, not a resolved verdict
+ * about a specific named individual (per DEC-20260428-B).
+ *
+ * API docs: https://developer-specs.company-information.service.gov.uk/companies-house-public-data-api
+ */
+
+const CH_API = "https://api.company-information.service.gov.uk";
+
+function authHeader(key: string): string {
+  return `Basic ${Buffer.from(`${key}:`).toString("base64")}`;
+}
+
+function extractOfficerId(selfLink: string | undefined): string | null {
+  if (!selfLink) return null;
+  // e.g. /disqualified-officers/natural/AbC123xYZ
+  const parts = selfLink.split("/").filter(Boolean);
+  return parts[parts.length - 1] || null;
+}
+
+registerCapability("uk-disqualified-director-check", async (input: CapabilityInput) => {
+  const apiKey = process.env.COMPANIES_HOUSE_API_KEY;
+  if (!apiKey) {
+    throw new Error("COMPANIES_HOUSE_API_KEY is required for UK disqualified-director checks.");
+  }
+
+  const name = ((input.name as string) ?? (input.task as string) ?? "").trim();
+  const officerId = ((input.officer_id as string) ?? "").trim();
+
+  if (!officerId && name.length < 2) {
+    throw new Error("Provide 'name' (minimum 2 characters) to search, or 'officer_id' to fetch a specific disqualification record.");
+  }
+
+  if (officerId) {
+    // ─── Detail mode ──────────────────────────────────────────────────────
+    const cleanId = officerId.replace(/^\/?disqualified-officers\/natural\//, "");
+    const url = `${CH_API}/disqualified-officers/natural/${encodeURIComponent(cleanId)}`;
+    const response = await fetch(url, {
+      headers: { Authorization: authHeader(apiKey), Accept: "application/json" },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (response.status === 404) {
+      return {
+        output: {
+          mode: "detail",
+          officer_id: cleanId,
+          found: false,
+          message: "No disqualification record found for this officer_id.",
+        },
+        provenance: { source: "companies-house-uk", fetched_at: new Date().toISOString() },
+      };
+    }
+    if (!response.ok) {
+      throw new Error(`Companies House disqualified-officers API returned HTTP ${response.status}.`);
+    }
+
+    const data = (await response.json()) as any;
+    const disqualifications = Array.isArray(data.disqualifications) ? data.disqualifications : [];
+
+    return {
+      output: {
+        mode: "detail",
+        officer_id: cleanId,
+        found: true,
+        name: [data.title, data.forename, data.other_forenames, data.surname].filter(Boolean).join(" ") || null,
+        date_of_birth: data.date_of_birth ?? null,
+        nationality: data.nationality ?? null,
+        disqualification_count: disqualifications.length,
+        disqualifications: disqualifications.map((d: any) => ({
+          case_identifier: d.case_identifier ?? null,
+          court_name: d.court_name ?? null,
+          disqualification_type: d.disqualification_type ?? null,
+          disqualified_from: d.disqualified_from ?? null,
+          disqualified_until: d.disqualified_until ?? null,
+          heard_on: d.heard_on ?? null,
+          undertaken_on: d.undertaken_on ?? null,
+          company_names: Array.isArray(d.company_names) ? d.company_names : [],
+          reason: d.reason
+            ? {
+                act: d.reason.act ?? null,
+                section: d.reason.section ?? null,
+                description_identifier: d.reason.description_identifier ?? null,
+              }
+            : null,
+        })),
+      },
+      provenance: {
+        source: "companies-house-uk",
+        fetched_at: new Date().toISOString(),
+        upstream_vendor: "UK Companies House (Insolvency Service disqualification data)",
+        acquisition_method: "official_api",
+        primary_source_reference: "https://www.gov.uk/government/publications/disqualified-director-searches",
+      },
+    };
+  }
+
+  // ─── Search mode ──────────────────────────────────────────────────────
+  const searchUrl = `${CH_API}/search/disqualified-officers?q=${encodeURIComponent(name)}&items_per_page=10`;
+  const response = await fetch(searchUrl, {
+    headers: { Authorization: authHeader(apiKey), Accept: "application/json" },
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Companies House disqualified-officers search returned HTTP ${response.status}.`);
+  }
+
+  const data = (await response.json()) as any;
+  const items: any[] = Array.isArray(data.items) ? data.items : [];
+
+  return {
+    output: {
+      mode: "search",
+      query: name,
+      total_results: Number(data.total_results) || items.length,
+      candidates: items.map((item) => ({
+        officer_id: extractOfficerId(item.links?.self),
+        name: item.title ?? null,
+        date_of_birth: item.date_of_birth ?? null,
+        address_snippet: item.address_snippet ?? null,
+        snippet: item.snippet ?? null,
+      })),
+    },
+    provenance: {
+      source: "companies-house-uk",
+      fetched_at: new Date().toISOString(),
+      upstream_vendor: "UK Companies House (Insolvency Service disqualification data)",
+      acquisition_method: "official_api",
+      primary_source_reference: "https://www.gov.uk/government/publications/disqualified-director-searches",
+    },
+  };
+});

--- a/apps/api/src/capabilities/uk-gazette-notice-search.ts
+++ b/apps/api/src/capabilities/uk-gazette-notice-search.ts
@@ -1,0 +1,131 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * UK Gazette insolvency notice search — official, free, no-key API.
+ *
+ * The Gazette (thegazette.co.uk) is the UK's official public record, Crown
+ * Copyright, published under the Open Government Licence. The "insolvency"
+ * service scope covers both corporate insolvency notices (winding-up,
+ * liquidator appointments, creditors' meetings) and personal insolvency
+ * notices (individual bankruptcy, debt relief orders) — a broader and more
+ * primary-source view than a single company's insolvency case list.
+ *
+ * Complements insolvency-check.ts (which answers "does company X have open
+ * insolvency proceedings?" via the Companies House case API, scoped to a
+ * known company number). This capability searches the underlying statutory
+ * notice text directly — useful when the subject is an individual (personal
+ * bankruptcy, a director rather than a company), when no company number is
+ * known yet, or when the richer notice text (practitioner names, meeting
+ * dates, judgment references) is needed rather than a structured case list.
+ *
+ * API docs: https://github.com/TheGazette/DevDocs
+ */
+
+const GAZETTE_BASE = "https://www.thegazette.co.uk/insolvency/notice/data.json";
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+interface GazetteEntry {
+  id?: string;
+  title?: string;
+  published?: string;
+  category?: { "@term"?: string };
+  "f:notice-code"?: string;
+  content?: string;
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractNoticeId(id: string | undefined): string | null {
+  if (!id) return null;
+  const parts = id.split("/");
+  return parts[parts.length - 1] || null;
+}
+
+function extractCompanyNumber(text: string): string | null {
+  const m = text.match(/Company Number:?\s*([A-Z0-9]{6,8})/i);
+  return m ? m[1].toUpperCase() : null;
+}
+
+registerCapability("uk-gazette-notice-search", async (input: CapabilityInput) => {
+  const query = ((input.query as string) ?? (input.text as string) ?? (input.task as string) ?? "").trim();
+  if (query.length < 2) {
+    throw new Error("'query' is required (minimum 2 characters). Provide a company or individual name to search UK Gazette insolvency notices.");
+  }
+
+  const dateFrom = (input.date_from as string)?.trim();
+  const dateTo = (input.date_to as string)?.trim();
+  if (dateFrom && !DATE_RE.test(dateFrom)) {
+    throw new Error("'date_from' must be an ISO date (YYYY-MM-DD).");
+  }
+  if (dateTo && !DATE_RE.test(dateTo)) {
+    throw new Error("'date_to' must be an ISO date (YYYY-MM-DD).");
+  }
+
+  const rawLimit = Number(input.limit);
+  const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(Math.floor(rawLimit), 50) : 10;
+
+  const params = new URLSearchParams({
+    text: query,
+    "results-page-size": String(limit),
+  });
+  if (dateFrom) params.set("start-publish-date", dateFrom);
+  if (dateTo) params.set("end-publish-date", dateTo);
+
+  const url = `${GAZETTE_BASE}?${params.toString()}`;
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`The Gazette API returned HTTP ${response.status}.`);
+  }
+
+  const data = (await response.json()) as any;
+  const total = Number(data?.["f:total"]) || 0;
+  const entries: GazetteEntry[] = Array.isArray(data?.entry) ? data.entry : data?.entry ? [data.entry] : [];
+
+  const notices = entries.map((entry) => {
+    const noticeId = extractNoticeId(entry.id);
+    const contentText = entry.content ? stripHtml(entry.content) : "";
+    return {
+      notice_id: noticeId,
+      title: entry.title ?? null,
+      category: entry.category?.["@term"] ?? null,
+      notice_code: entry["f:notice-code"] ?? null,
+      published_date: entry.published ?? null,
+      summary: contentText ? contentText.slice(0, 500) : null,
+      company_number: contentText ? extractCompanyNumber(contentText) : null,
+      url: noticeId ? `https://www.thegazette.co.uk/notice/${noticeId}` : null,
+    };
+  });
+
+  return {
+    output: {
+      query: {
+        text: query,
+        date_from: dateFrom || null,
+        date_to: dateTo || null,
+      },
+      total_matches: total,
+      returned_count: notices.length,
+      notices,
+    },
+    provenance: {
+      source: "thegazette.co.uk",
+      fetched_at: new Date().toISOString(),
+      upstream_vendor: "The Gazette (His Majesty's Stationery Office / TSO)",
+      acquisition_method: "official_api",
+      primary_source_reference: "https://www.thegazette.co.uk/insolvency",
+    },
+  };
+});

--- a/apps/api/src/capabilities/us-product-recall-search.ts
+++ b/apps/api/src/capabilities/us-product-recall-search.ts
@@ -1,0 +1,109 @@
+import { registerCapability, type CapabilityInput } from "./index.js";
+
+/**
+ * US product recall search — CPSC (Consumer Product Safety Commission)
+ * official Recalls API, hosted at saferproducts.gov. Free, no API key,
+ * zero-auth REST endpoint returning JSON. Covers all US consumer product
+ * recalls, including manufacturer, hazard, and remedy detail.
+ *
+ * Note: www.cpsc.gov itself sits behind bot protection that blocks
+ * automated requests; the *api* host (saferproducts.gov) is the documented
+ * public interface and is unaffected — see
+ * https://www.cpsc.gov/Recalls/CPSC-Recalls-Application-Program-Interface-API-Information
+ */
+
+const CPSC_API = "https://www.saferproducts.gov/RestWebServices/Recall";
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+interface CpscHazard {
+  Name?: string;
+}
+interface CpscManufacturer {
+  Name?: string;
+}
+interface CpscProduct {
+  Name?: string;
+  Model?: string;
+  NumberOfUnits?: string;
+}
+interface CpscRecall {
+  RecallID?: number;
+  RecallNumber?: string;
+  RecallDate?: string;
+  Title?: string;
+  Description?: string;
+  URL?: string;
+  Products?: CpscProduct[];
+  Manufacturers?: CpscManufacturer[];
+  Hazards?: CpscHazard[];
+}
+
+registerCapability("us-product-recall-search", async (input: CapabilityInput) => {
+  const query = ((input.query as string) ?? (input.task as string) ?? "").trim();
+  const manufacturer = (input.manufacturer as string)?.trim();
+  if (!query && !manufacturer) {
+    throw new Error("'query' (product/recall keyword) or 'manufacturer' is required.");
+  }
+
+  const dateFrom = (input.date_from as string)?.trim();
+  const dateTo = (input.date_to as string)?.trim();
+  if (dateFrom && !DATE_RE.test(dateFrom)) {
+    throw new Error("'date_from' must be an ISO date (YYYY-MM-DD).");
+  }
+  if (dateTo && !DATE_RE.test(dateTo)) {
+    throw new Error("'date_to' must be an ISO date (YYYY-MM-DD).");
+  }
+
+  const params = new URLSearchParams({ format: "json" });
+  if (query) params.set("RecallTitle", query);
+  if (manufacturer) params.set("Manufacturer", manufacturer);
+  if (dateFrom) params.set("RecallDateStart", dateFrom);
+  if (dateTo) params.set("RecallDateEnd", dateTo);
+
+  const url = `${CPSC_API}?${params.toString()}`;
+  const response = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`CPSC recalls API returned HTTP ${response.status}.`);
+  }
+
+  const data = (await response.json()) as CpscRecall[];
+  const recalls = (Array.isArray(data) ? data : []).slice(0, 25).map((r) => ({
+    recall_id: r.RecallID ?? null,
+    recall_number: r.RecallNumber ?? null,
+    recall_date: r.RecallDate ?? null,
+    title: r.Title ?? null,
+    description: r.Description ? r.Description.slice(0, 500) : null,
+    hazard: r.Hazards?.[0]?.Name ? r.Hazards[0].Name.slice(0, 300) : null,
+    manufacturers: (r.Manufacturers ?? []).map((m) => m.Name).filter(Boolean),
+    products: (r.Products ?? []).map((p) => ({
+      name: p.Name ?? null,
+      model: p.Model || null,
+      units: p.NumberOfUnits ?? null,
+    })),
+    url: r.URL ?? null,
+  }));
+
+  return {
+    output: {
+      query: {
+        text: query || null,
+        manufacturer: manufacturer || null,
+        date_from: dateFrom || null,
+        date_to: dateTo || null,
+      },
+      result_count: recalls.length,
+      recalls,
+    },
+    provenance: {
+      source: "saferproducts.gov",
+      fetched_at: new Date().toISOString(),
+      upstream_vendor: "U.S. Consumer Product Safety Commission (CPSC)",
+      acquisition_method: "official_api",
+      primary_source_reference: "https://www.cpsc.gov/Recalls",
+    },
+  };
+});

--- a/archive/sessions/official-source-catalog-batch-2026-08-13.md
+++ b/archive/sessions/official-source-catalog-batch-2026-08-13.md
@@ -1,0 +1,270 @@
+# Official-source catalog batch — research + build (2026-08-13)
+
+**Session intent:** Grow the catalog with meaningful KYB/commerce-adjacent capabilities sourced from
+official, free, API-first data — insolvency registers, product safety recalls, trademark/patent
+offices, procurement portals, economic indicators — per DEC-20260813-A's preference order
+(official API > licensed bulk > Tier-2 vendor > per-call parsing).
+
+**Branch:** `catalog/official-source-batch` (from `origin/main`)
+
+**Mode:** Full (multi-capability build, several access-model decisions)
+
+---
+
+## Built (5 capabilities — dark-launched, not yet onboarded)
+
+All five are direct, per-request calls to official government/international-body APIs. No
+scraping, no vendor wrappers, no ToS gray areas — every one of these is a documented REST/JSON
+endpoint that requires no signup (or reuses a credential the platform already has). Each was
+verified live via curl during research (see command history / real response snippets embedded as
+`output_schema.example` in the manifests) before the executor was written.
+
+| Slug | Source | Auth | Verified with |
+|---|---|---|---|
+| `uk-gazette-notice-search` | The Gazette (UK, Crown Copyright / OGL) | none | Real search: "Carillion", 129 matches in a 2018 date range |
+| `french-insolvency-check` | BODACC (DILA, French government, Opendatasoft) | none | Real SIREN 345086177 (Camaieu International) — 8 "Procédures collectives" notices |
+| `us-product-recall-search` | CPSC Recalls API (saferproducts.gov) | none | Real query "hoverboard" — Hover-1 Helix recall; "IKEA" manufacturer — MALM dresser recall |
+| `uk-disqualified-director-check` | UK Companies House Disqualified Officers register | `COMPANIES_HOUSE_API_KEY` (already provisioned — same key as insolvency-check/officer-search/uk-company-data) | Endpoint + full JSON schema confirmed against official developer-specs docs; **not live-tested** (no CH key in this worktree's local `.env` — see note below) |
+| `country-economic-indicators` | World Bank Indicators (WDI) API | none | Real country SE — GDP $668.9B (2025), inflation query for TR — 34.9% (2025) |
+
+Files per capability:
+- `apps/api/src/capabilities/{slug}.ts`
+- `manifests/{slug}.yaml`
+
+All five passed `npx tsx scripts/onboard.ts --manifest manifests/{slug}.yaml --dry-run` (manifest
+validation, 5/5 test suites generated, dark-launch record preview `visible: false`) and
+`cd apps/api && npx tsc --noEmit --project tsconfig.json` (clean, zero errors) in this worktree.
+
+### Why these five and not more
+
+Quality-over-count per the task brief. Several other candidates from the brief's list were
+researched and are either genuinely not buildable right now (see Rejected/Deferred below) or
+would have overlapped with existing capabilities enough that adding them would be padding, not
+value (see the World Bank vs. `country-trade-data.ts` note, and the UK Gazette vs.
+`insolvency-check.ts` note, both addressed in-file as capability doc-comments and manifest
+limitations).
+
+### uk-disqualified-director-check — not live-verified, flagging explicitly
+
+This worktree's `.env` (copied read-only from the main tree for `--dry-run` structural checks,
+then deleted) does not contain `COMPANIES_HOUSE_API_KEY` locally — it's a Railway-only secret in
+this environment. The executor and manifest were built directly against the official Companies
+House Public Data API OpenAPI spec (`developer-specs.company-information.service.gov.uk`),
+cross-checked field-by-field for both the search response (`DisqualifiedOfficerSearch`) and the
+detail response (`naturalDisqualification`) schemas. This is the same class of capability as the
+existing `insolvency-check.ts` / `officer-search.ts` (both also CH-keyed, both also can't be
+smoke-tested in a key-less local environment) — same precedent, same risk profile.
+
+**Action for the merge session:** run `--discover --strict` (it has the real key) to
+live-verify the known_answer fixture (`name: Smith`) and confirm the field names match reality
+before flipping this one visible.
+
+### Design note: uk-disqualified-director-check never auto-picks a match
+
+Disqualified-officer name search can collide on common names. Per the
+`feedback_registry_name_search_never_ranks.md` lesson (taking `result[0]` on a registry name
+search has produced wrong-entity answers before — Fysios for "Nokia", NITO TELENOR for
+"Telenor"), and because misattributing a disqualification finding to the wrong named individual
+is a more serious error class than a wrong company match, this capability deliberately returns a
+**candidate list** (name, DOB, address snippet) on a name search and requires a second call with
+an explicit `officer_id` to fetch the full disqualification detail. No auto-selected "best match."
+
+### Onboarding commands for the merge session
+
+The merge session has the real `.env` (Railway secrets) via the main tree. Recommended order
+(discover first to verify field names against live output, backfill only if something's off):
+
+```
+cd apps/api
+npx tsx scripts/onboard.ts --manifest ../../manifests/uk-gazette-notice-search.yaml --discover --strict
+npx tsx scripts/onboard.ts --manifest ../../manifests/french-insolvency-check.yaml --discover --strict
+npx tsx scripts/onboard.ts --manifest ../../manifests/us-product-recall-search.yaml --discover --strict
+npx tsx scripts/onboard.ts --manifest ../../manifests/uk-disqualified-director-check.yaml --discover --strict
+npx tsx scripts/onboard.ts --manifest ../../manifests/country-economic-indicators.yaml --discover --strict
+```
+
+Each inserts with `lifecycle_state=validating, visible=false` (dark launch per DEC-20260812-A —
+`onboard.ts` defaults new capabilities to invisible; `x402_enabled` also defaults to `false` in
+the schema). Verify with:
+
+```
+npx tsx scripts/smoke-test.ts --slug uk-gazette-notice-search
+npx tsx scripts/smoke-test.ts --slug french-insolvency-check
+npx tsx scripts/smoke-test.ts --slug us-product-recall-search
+npx tsx scripts/smoke-test.ts --slug uk-disqualified-director-check
+npx tsx scripts/smoke-test.ts --slug country-economic-indicators
+```
+
+None of these were made visible or x402-enabled by this session — that stays a human call per
+the readiness-program escalation contract (DEC-20260812-A: humans decide "promote to visible",
+platform/onboarding can dark-launch).
+
+---
+
+## Key-blocked — spec written, registration deliberately NOT performed
+
+Per the task brief: "if a key is required, write the spec, do NOT register — key registration is
+founder-gated." Both of the following have a genuine, documented, free-to-register official API,
+but registration itself is the founder-gated step, so no credentials were requested and nothing
+was built beyond this spec.
+
+### EPO Open Patent Services (OPS) — patent search
+
+- **Official API:** `ops.epo.org` — REST/XML (also offers JSON via `Accept` header), OAuth2
+  client-credentials flow.
+- **Registration:** free developer account at `https://developers.epo.org`, create an app to get
+  a Consumer Key/Secret. Rate-limited (throttled per minute/hour on the free tier; higher tiers
+  require a paid contract).
+- **Why it matters for the catalog:** the existing `patent-search` capability is DEACTIVATED
+  (`auto-register.ts`: "Google Patents scraping prohibited by Google ToS") — OPS is the correct
+  official replacement and would directly un-block that gap.
+- **Proposed shape** (not built): `patent-search` (slug reactivation or `epo-patent-search` new
+  slug) — input `query` (title/abstract keyword) or `publication_number`; output: publication
+  number, title, applicants, inventors, IPC/CPC classification codes, publication date, family
+  members. OPS's "published-data search" endpoint (`/rest-services/published-data/search`)
+  returns CQL-query-filtered result sets; a details fetch by publication number gives bibliographic
+  data. Would need `EPO_OPS_CONSUMER_KEY` / `EPO_OPS_CONSUMER_SECRET` env vars and an
+  OAuth2 token-caching helper (tokens expire in ~20 min) — no other capability in this repo has
+  an OAuth2 client-credentials pattern yet, would be a new shared helper
+  (`capabilities/lib/epo-ops-auth.ts`).
+- **Action needed:** Petter registers at developers.epo.org, adds the two env vars to Railway,
+  then a follow-up session builds the executor against this spec.
+
+### EUIPO trademark search (eSearch Plus / TMview)
+
+- **Official API:** `dev.euipo.europa.eu` — EUIPO eSearch Plus REST API. Free registration
+  ("register... in under 2 minutes"), OAuth2 Client ID/Secret, subscribe to the "Trademark
+  Search API" product in the developer portal.
+- **Why it matters:** direct EU trademark register lookup (brand/IP due-diligence signal
+  adjacent to KYB — "does this counterparty actually own the mark they're claiming") with no
+  existing capability covering it.
+- **Proposed shape** (not built): `eu-trademark-search` — input `mark_text` and/or
+  `applicant_name`, optional `nice_class`; output: application/registration number, mark text,
+  status (registered/pending/opposed/expired), owner name, filing date, Nice classification
+  classes, EUIPO record URL.
+- **Action needed:** Petter registers at dev.euipo.europa.eu, adds `EUIPO_CLIENT_ID` /
+  `EUIPO_CLIENT_SECRET` to Railway, then a follow-up session builds against the published
+  eSearch Plus OpenAPI spec.
+
+---
+
+## Rejected / deferred with reason
+
+### EU Safety Gate (RAPEX) — product safety alerts
+**Rejected for this batch.** No documented, stable public JSON REST search API was found within
+research budget. The public portal (`ec.europa.eu/safety-gate-alerts`, `webgate.ec.europa.eu/
+Safety-Gate`) is an Angular SPA; its backend calls were not discoverable as a documented,
+versioned API (unlike CPSC's clearly-documented `saferproducts.gov` REST service). The
+Commission does publish the underlying data as downloadable Excel files
+(`data.europa.eu/data/datasets/rapex-rapid-alert-system-non-food`) — that's a licensed-bulk
+ingestion job (download + periodic reload), not a per-call capability, and is a reasonable
+future addition if someone builds the ingest pipeline. Third-party wrappers exist (Apify actors,
+OpenDataSoft mirrors) but those are Tier-2/Tier-3 re-publishers, not the official source, and
+weren't in scope.
+
+### UK Contracts Finder — national procurement portal
+**Deferred, not built.** The OCDS bulk endpoints
+(`contractsfinder.service.gov.uk/Published/Notices/OCDS/Search`,
+`/Published/OCDS/Record/{ocid}`) are genuinely free, no-key, and were verified live (200 OK,
+valid OCDS JSON, Crown Copyright / OGL). However, extensive testing found **no working
+keyword/company/CPV filter** on the documented public GET surface — `keyword=`, `searchTerm=`,
+and `q=` params are silently ignored (verified: identical single result regardless of the
+keyword value), and the only real full-text search endpoints referenced in the docs
+(`api/rest/2/search_notices`, `Searches/Search`) either require OAuth2 registration or 404'd on
+every path tried. A capability that can only browse-by-date-and-stage, with no way to look up a
+specific company or keyword, doesn't fit the platform's per-request lookup pattern well enough
+to justify shipping as-is. `ted-procurement.ts` already covers EU-wide above-threshold tenders;
+UK-specific search would need either (a) reverse-engineering the undocumented search backend
+(against the spirit of "official API" preference), or (b) registering for OAuth2 client
+credentials (a founder-gated step, and unclear if the free tier even includes full-text search).
+Revisit if a documented keyword-search endpoint surfaces, or if Petter wants to register for the
+OAuth2 tier.
+
+### EU e-Justice interconnected insolvency registers (BRIS insolvency interconnection)
+**Rejected as a distinct capability.** The Business Registers Interconnection System (BRIS) and
+its insolvency-register counterpart are a **portal**, not a consolidated public data API — the
+e-Justice Portal is the single point of *human* access, routing queries to each member state's
+own register/format under the hood. There is no documented single endpoint to query
+programmatically across countries. The correct direction (and what this session did instead) is
+building the strong national sources directly: UK (`uk-gazette-notice-search`, this batch) and
+France (`french-insolvency-check`, this batch) are both now covered. Germany
+(`Insolvenzbekanntmachungen.de`), the next most valuable gap, has no public API either — it's a
+web portal that would require per-call HTML parsing; that's a DEC-20260813-A-eligible path (per-
+entity, ToS-permitting) but needs its own ToS verification pass and wasn't attempted in this
+session's budget.
+
+### EU State aid transparency database (TAM)
+**Rejected.** Public search UI at `webgate.ec.europa.eu/competition/transparency/public` — no
+documented REST API found; a few plausible guessed endpoints (`.../search/api/aid`) 404'd.
+Same class of problem as Safety Gate (Angular SPA, undocumented backend). Not pursued further
+given the research budget.
+
+### WIPO Global Brand Database
+**Rejected.** No public, documented REST API for programmatic per-call search was found — WIPO
+publishes a web search UI and bulk/linked-data resources for specific IP offices, not a general
+free-to-call brand-search endpoint. If EU trademark coverage is wanted, EUIPO (above, key-
+blocked) is the stronger candidate; WIPO would need its own separate research pass if revisited.
+
+### Eurostat SDMX / JSON-stat API
+**Verified working, deliberately not built as a separate capability.** Confirmed live and
+completely free/no-key (`ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/{dataset}`
+— tested against `demo_pjan` population data for Sweden, clean JSON-stat response). Not shipped
+because it would functionally duplicate `country-economic-indicators` (this batch) — both are
+"macro country-level indicator" lookups, and Eurostat's genuinely distinct value (NUTS-region
+granularity, EU-specific series like VAT gap or business demography) wasn't pinned down as a
+concrete, distinct KYB use case within this session's budget. Worth a dedicated look later if a
+specific EU-regional-granularity need shows up.
+
+---
+
+## Cross-references / duplication checks performed
+
+- `uk-gazette-notice-search` vs. existing `insolvency-check.ts`: not a duplicate.
+  `insolvency-check.ts` answers "does company X (by CH company number) have open insolvency
+  cases?" via Companies House's structured case API. The Gazette capability searches the
+  underlying statutory notice text directly, covers **personal** bankruptcy (individuals, not
+  just companies — relevant for beneficial-owner/director screening), and doesn't require
+  already knowing a company number. Cross-referenced in both files' doc-comments and the
+  manifest's `limitations`.
+- `country-economic-indicators` vs. existing `country-trade-data.ts`: both call
+  `api.worldbank.org`, but for disjoint indicator sets — `country-trade-data.ts` covers detailed
+  export/import commodity and partner breakdowns (with an embedded-data fallback), this
+  capability covers GDP/inflation/unemployment/population macro indicators. Documented in the
+  new file's doc-comment.
+- `uk-disqualified-director-check` vs. existing `officer-search.ts`: not a duplicate — checked
+  the codebase for any existing "disqualified" coverage (none found). `officer-search.ts` finds
+  *current/former* officers; this finds officers under a *disqualification order*, a distinct
+  and more serious signal.
+- Searched for existing World Bank / BODACC / Gazette / CPSC / Companies-House-disqualified
+  usage across `apps/api/src/capabilities` and `manifests/` before writing any code.
+
+---
+
+## Verification performed
+
+- `cd apps/api && npx tsc --noEmit --project tsconfig.json` — clean, zero errors, for all 5
+  new executors plus the full existing tree.
+- `npx tsx scripts/onboard.ts --manifest manifests/{slug}.yaml --dry-run` — 5/5 manifests pass
+  structural validation, generate all 5 required test-suite types, preview `visible: false`
+  dark-launch insert. (Live `--discover` execution was deliberately not run against prod — see
+  "Onboarding commands for the merge session" above.)
+- Every external endpoint used by the 4 no-key capabilities was hit live with `curl` during
+  research against real entities (see table above) before the executor was written — not just
+  read about in docs.
+- Grepped the codebase for prior coverage of every data source before building (see
+  "Cross-references" above) — no duplicate capability slugs or overlapping executors were
+  created.
+
+## Distribution PR Integrity Protocol / Capability Onboarding Protocol applicability
+
+- **Distribution PR Integrity Protocol (DEC-20260422-A):** not triggered — no PR opened against
+  a non-`strale-io` repo, no `packages/*-strale/` package touched.
+- **Capability Onboarding Protocol (DEC-20260320-B):** followed for all 5 built capabilities —
+  manifest created with slug/name/description/category/schemas/pricing/data_source/
+  transparency_tag/test_fixtures/output_field_reliability/limitations (≥1 each), structural
+  validation run via `onboard.ts --dry-run` (readiness/DB-insert-level checks require the real
+  DB and are deferred to the merge session per the task brief's explicit guidance). No
+  `avg_latency_ms` field exists in the current manifest schema in this repo (checked
+  `ted-procurement.yaml` and `lei-lookup.yaml` as references — neither carries one), so none was
+  added; this appears to be a field the CLAUDE.md template mentions but the current manifest
+  loader/schema doesn't require (`onboard.ts --dry-run` passed clean without it for all 5).

--- a/manifests/country-economic-indicators.yaml
+++ b/manifests/country-economic-indicators.yaml
@@ -1,0 +1,127 @@
+slug: country-economic-indicators
+name: Country Economic Indicators
+description: >-
+  Macroeconomic country-risk indicators (GDP, growth, inflation, unemployment, population) for any country via
+  the World Bank Indicators API. KYB context for counterparty jurisdiction risk assessment.
+category: finance
+cost_class: free_unlimited
+quota_window: none
+price_cents: 8
+is_free_tier: false
+input_schema:
+  type: object
+  required:
+    - country_code
+  properties:
+    country_code:
+      type: string
+      description: ISO 2-letter or 3-letter country code (e.g. SE, US, DE, SWE)
+    indicators:
+      type: array
+      description: >-
+        Optional list of indicator keys to fetch instead of the default set. Valid keys: gdp_usd,
+        gdp_growth_percent, gdp_per_capita_usd, inflation_percent, unemployment_percent, population,
+        gni_per_capita_usd, exports_percent_gdp, imports_percent_gdp, fdi_inflow_percent_gdp
+      items:
+        type: string
+    year:
+      type: string
+      description: Optional specific 4-digit year (default is most recent available)
+output_schema:
+  type: object
+  example:
+    country_code: SE
+    requested_year: most_recent
+    indicators:
+      gdp_usd:
+        value: 668998664082.081
+        year: "2025"
+      gdp_growth_percent:
+        value: 1.2
+        year: "2025"
+      inflation_percent:
+        value: 1.9
+        year: "2025"
+      unemployment_percent:
+        value: 8.1
+        year: "2024"
+      population:
+        value: 10521556
+        year: "2023"
+    indicator_codes:
+      gdp_usd: NY.GDP.MKTP.CD
+      gdp_growth_percent: NY.GDP.MKTP.KD.ZG
+      inflation_percent: FP.CPI.TOTL.ZG
+      unemployment_percent: SL.UEM.TOTL.ZS
+      population: SP.POP.TOTL
+  properties:
+    country_code:
+      type: string
+    requested_year:
+      type: string
+    indicators:
+      type: object
+    indicator_codes:
+      type: object
+data_source: World Bank Indicators (WDI) API
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: reference-data
+maintenance_class: free-stable-api
+# SA.2b: per-capability PII classification (F-A-003, F-A-009)
+processes_personal_data: false
+geography: global
+test_fixtures:
+  known_answer:
+    input:
+      country_code: SE
+    expected_fields:
+      - field: country_code
+        operator: not_null
+        reliability: guaranteed
+      - field: country_code
+        operator: type
+        reliability: guaranteed
+        value: string
+      - field: requested_year
+        operator: not_null
+        reliability: guaranteed
+      - field: indicators
+        operator: not_null
+        reliability: guaranteed
+      - field: indicators
+        operator: type
+        reliability: guaranteed
+        value: object
+      - field: indicator_codes
+        operator: not_null
+        reliability: guaranteed
+  health_check_input:
+    country_code: SE
+output_field_reliability:
+  country_code: guaranteed
+  requested_year: guaranteed
+  indicators: guaranteed
+  indicator_codes: guaranteed
+limitations:
+  - title: Different indicators report for different years — check each indicator's own 'year' field
+    text: >-
+      World Bank indicators are collected on independent national reporting schedules (GDP may be 2025,
+      unemployment 2024, population 2023 for the same country). Each indicator entry carries its own 'year';
+      there is no single as-of date for the whole response.
+    category: accuracy
+    severity: info
+  - title: Some indicator/country/year combinations have no data
+    text: >-
+      Smaller economies and territories often have gaps in specific series (especially labor and FDI
+      indicators). An indicator with value:null and an unavailable_reason means the World Bank has no
+      observation for that country/period — not that the value is zero.
+    category: coverage
+    severity: warning
+  - title: Curated indicator set, not the full ~16,000-indicator WDI catalog
+    text: >-
+      Only 10 KYB-relevant indicator keys are exposed via the 'indicators' parameter. The World Bank publishes
+      far more series; this capability does not expose arbitrary WDI indicator codes.
+    category: coverage
+    severity: info
+    workaround: For indicators outside this curated set, query api.worldbank.org directly with the desired series code

--- a/manifests/french-insolvency-check.yaml
+++ b/manifests/french-insolvency-check.yaml
@@ -1,0 +1,119 @@
+slug: french-insolvency-check
+name: French Insolvency Check
+description: >-
+  Check a French company for formal insolvency proceedings (redressement or liquidation judiciaire) via BODACC,
+  the official French legal gazette. Search by SIREN or company name. Returns judgment dates, court, and nature.
+category: compliance
+cost_class: free_unlimited
+quota_window: none
+price_cents: 8
+is_free_tier: false
+input_schema:
+  type: object
+  required: []
+  anyOf:
+    - required: [siren]
+    - required: [company_name]
+    - required: [task]
+  properties:
+    siren:
+      type: string
+      description: 9-digit French company identifier (SIREN)
+    company_name:
+      type: string
+      description: French company name to search for (alternative to SIREN)
+    task:
+      type: string
+      description: Free-text alias — SIREN or company name
+output_schema:
+  type: object
+  example:
+    query:
+      siren: "345086177"
+      company_name: null
+    result_count: 8
+    insolvency_notices:
+      - id: A20200165944
+        publication_date: "2020-08-26"
+        company_name: CAMAIEU INTERNATIONAL
+        siren: "345086177"
+        court: TRIBUNAL DE COMMERCE DE LILLE MÉTROPOLE
+        department: "59"
+        department_name: Nord
+        notice_type: Avis initial
+        judgment:
+          famille: Extrait de jugement
+          nature: Jugement arrêtant un plan de cession
+          date: "2020-08-17"
+          type: initial
+        url: https://www.bodacc.fr/pages/annonces-commerciales-detail/?q.id=id:A20200165944
+  properties:
+    query:
+      type: object
+    result_count:
+      type: integer
+    insolvency_notices:
+      type: array
+data_source: BODACC (Bulletin officiel des annonces civiles et commerciales, DILA / French government)
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+# SA.2b: per-capability PII classification (F-A-003, F-A-009)
+processes_personal_data: false
+geography: fr
+test_fixtures:
+  known_answer:
+    input:
+      siren: "345086177"
+    expected_fields:
+      - field: query
+        operator: not_null
+        reliability: guaranteed
+      - field: query
+        operator: type
+        reliability: guaranteed
+        value: object
+      - field: result_count
+        operator: not_null
+        reliability: guaranteed
+      - field: result_count
+        operator: gt
+        reliability: guaranteed
+        value: 0
+      - field: insolvency_notices
+        operator: not_null
+        reliability: guaranteed
+      - field: insolvency_notices
+        operator: type
+        reliability: guaranteed
+        value: array
+  health_check_input:
+    siren: "345086177"
+output_field_reliability:
+  query: guaranteed
+  result_count: guaranteed
+  insolvency_notices: guaranteed
+limitations:
+  - title: Only formal collective proceedings — not general company filings
+    text: >-
+      Scoped to familleavis="collective" (redressement judiciaire, liquidation judiciaire, sauvegarde,
+      procédure de rétablissement professionnel). Company creation, deregistration, and annual account
+      filings are out of scope — use french-company-data for general registry lookup.
+    category: coverage
+    severity: info
+  - title: A zero-result answer means no matching notice was found, not a clean-bill-of-health guarantee
+    text: >-
+      BODACC coverage begins in the 2000s in this open dataset; older proceedings, and any procedure not
+      published to BODACC, will not appear. An empty result does not affirmatively prove the company has never
+      been insolvent.
+    category: accuracy
+    severity: warning
+    workaround: Cross-check company_name search results manually — company names are not deduplicated across
+      SIREN in BODACC's own data
+  - title: company_name search uses substring matching, not fuzzy/normalized matching
+    text: >-
+      The 'like' filter on commercant is a literal substring match against BODACC's stored company name, which is
+      not accent- or legal-form-normalized. Prefer 'siren' when known for an exact match.
+    category: accuracy
+    severity: info

--- a/manifests/uk-disqualified-director-check.yaml
+++ b/manifests/uk-disqualified-director-check.yaml
@@ -1,0 +1,121 @@
+slug: uk-disqualified-director-check
+name: UK Disqualified Director Check
+description: >-
+  Search the UK Companies House Disqualified Officers register by name, or fetch full disqualification detail
+  by officer_id. Returns disqualification dates, court, reason, and companies involved.
+category: compliance
+cost_class: free_quota
+quota_window: daily
+quota_cap: 600
+price_cents: 10
+is_free_tier: false
+input_schema:
+  type: object
+  required: []
+  anyOf:
+    - required: [name]
+    - required: [officer_id]
+    - required: [task]
+  properties:
+    name:
+      type: string
+      description: Individual's name to search for in the disqualified officers register
+    officer_id:
+      type: string
+      description: Companies House disqualified-officer ID (from a prior search's candidates[].officer_id) — fetches full disqualification detail
+    task:
+      type: string
+      description: Free-text alias for name
+output_schema:
+  type: object
+  example:
+    mode: search
+    query: Smith
+    total_results: 42
+    candidates:
+      - officer_id: AbC123xYZ
+        name: SMITH, John
+        date_of_birth: "1970-01"
+        address_snippet: "123 Example Street, London"
+        snippet: null
+  properties:
+    mode:
+      type: string
+    query:
+      type: string
+    total_results:
+      type: integer
+    candidates:
+      type: array
+data_source: UK Companies House (Disqualified Officers register)
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+# SA.2b: per-capability PII classification (F-A-003, F-A-009)
+processes_personal_data: true
+gdpr_art_22_classification: screening_signal
+geography: uk
+test_fixtures:
+  known_answer:
+    input:
+      name: Smith
+    expected_fields:
+      - field: mode
+        operator: not_null
+        reliability: guaranteed
+      - field: mode
+        operator: type
+        reliability: guaranteed
+        value: string
+      - field: query
+        operator: not_null
+        reliability: guaranteed
+      - field: total_results
+        operator: not_null
+        reliability: guaranteed
+      - field: total_results
+        operator: type
+        reliability: guaranteed
+        value: number
+      - field: candidates
+        operator: not_null
+        reliability: guaranteed
+      - field: candidates
+        operator: type
+        reliability: guaranteed
+        value: array
+  health_check_input:
+    name: Smith
+output_field_reliability:
+  mode: guaranteed
+  query: guaranteed
+  total_results: guaranteed
+  candidates: guaranteed
+  officer_id: guaranteed
+  found: guaranteed
+  name: guaranteed
+  disqualification_count: rare
+  disqualifications: rare
+limitations:
+  - title: Search mode returns candidates only — never auto-picks "the" match
+    text: >-
+      Disqualified-officer names are not unique. Search mode deliberately returns a candidate list (name, date
+      of birth, address snippet) rather than guessing which candidate is the subject — misattributing a
+      disqualification finding to the wrong person is a serious error class. Disambiguate using date_of_birth
+      or address, then re-call with the chosen officer_id for full detail.
+    category: accuracy
+    severity: warning
+    workaround: Always confirm date_of_birth or address before treating a search candidate as a confirmed match
+  - title: UK only, and only disqualifications on the Companies House public register
+    text: >-
+      Covers formal director disqualifications recorded by UK Companies House / the Insolvency Service.
+      Disqualifications or equivalent sanctions under other jurisdictions' regimes are out of scope.
+    category: coverage
+    severity: info
+  - title: Requires COMPANIES_HOUSE_API_KEY (existing platform credential, free registration)
+    text: >-
+      Uses the same Companies House API key already provisioned for insolvency-check, officer-search, and
+      uk-company-data — no new vendor relationship, but the capability will error without that env var set.
+    category: coverage
+    severity: info

--- a/manifests/uk-disqualified-director-check.yaml
+++ b/manifests/uk-disqualified-director-check.yaml
@@ -47,6 +47,13 @@ output_schema:
       type: integer
     candidates:
       type: array
+    # Detail-mode (officer_id input) top-level fields — absent in search mode
+    officer_id:
+      type: string
+    found:
+      type: boolean
+    name:
+      type: string
 data_source: UK Companies House (Disqualified Officers register)
 data_source_type: api
 transparency_tag: algorithmic
@@ -92,9 +99,10 @@ output_field_reliability:
   query: guaranteed
   total_results: guaranteed
   candidates: guaranteed
-  officer_id: guaranteed
-  found: guaranteed
-  name: guaranteed
+  # Present only in detail mode (officer_id input): common, not guaranteed
+  officer_id: common
+  found: common
+  name: common
   disqualification_count: rare
   disqualifications: rare
 limitations:

--- a/manifests/uk-gazette-notice-search.yaml
+++ b/manifests/uk-gazette-notice-search.yaml
@@ -1,0 +1,128 @@
+slug: uk-gazette-notice-search
+name: UK Gazette Insolvency Notice Search
+description: >-
+  Search official UK Gazette insolvency notices by name — corporate winding-up, liquidator appointments, and
+  personal bankruptcy. Returns notice text, dates, and links to the statutory public record.
+category: data-extraction
+cost_class: free_unlimited
+quota_window: none
+price_cents: 5
+is_free_tier: false
+input_schema:
+  type: object
+  required:
+    - query
+  properties:
+    query:
+      type: string
+      description: Company or individual name to search for in Gazette insolvency notices
+    date_from:
+      type: string
+      description: ISO date (YYYY-MM-DD) — only notices published on or after this date
+    date_to:
+      type: string
+      description: ISO date (YYYY-MM-DD) — only notices published on or before this date
+    limit:
+      type: integer
+      description: Maximum number of notices to return (default 10, max 50)
+output_schema:
+  type: object
+  example:
+    query:
+      text: Carillion
+      date_from: null
+      date_to: null
+    total_matches: 3318122
+    returned_count: 2
+    notices:
+      - notice_id: L-58635-471825
+        title: Resolutions for Winding-up
+        category: Resolutions for Winding-up
+        notice_code: "2431"
+        published_date: "2008-03-10T00:00:00"
+        summary: "CARILLION AMT LIMITED"
+        company_number: null
+        url: https://www.thegazette.co.uk/notice/L-58635-471825
+  properties:
+    query:
+      type: object
+    total_matches:
+      type: integer
+    returned_count:
+      type: integer
+    notices:
+      type: array
+data_source: The Gazette (His Majesty's Stationery Office / TSO)
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+# SA.2b: per-capability PII classification (F-A-003, F-A-009)
+processes_personal_data: true
+geography: uk
+test_fixtures:
+  known_answer:
+    input:
+      query: Carillion
+      date_from: "2018-01-01"
+      date_to: "2018-12-31"
+    expected_fields:
+      - field: query
+        operator: not_null
+        reliability: guaranteed
+      - field: query
+        operator: type
+        reliability: guaranteed
+        value: object
+      - field: total_matches
+        operator: not_null
+        reliability: guaranteed
+      - field: total_matches
+        operator: type
+        reliability: guaranteed
+        value: number
+      - field: returned_count
+        operator: not_null
+        reliability: guaranteed
+      - field: returned_count
+        operator: gt
+        reliability: guaranteed
+        value: 0
+      - field: notices
+        operator: not_null
+        reliability: guaranteed
+      - field: notices
+        operator: type
+        reliability: guaranteed
+        value: array
+  health_check_input:
+    query: test
+    limit: 1
+output_field_reliability:
+  query: guaranteed
+  total_matches: guaranteed
+  returned_count: guaranteed
+  notices: guaranteed
+limitations:
+  - title: UK insolvency notices only — not a full-text search across all Gazette content
+    text: >-
+      Scoped to the Gazette's "insolvency" publication service (corporate winding-up, liquidator appointments,
+      personal bankruptcy). Deceased-estate notices (wills and probate) and general Gazette notices are out of
+      scope. Coverage is UK only.
+    category: coverage
+    severity: info
+    workaround: Use insolvency-check for a structured, company-number-scoped view of open UK insolvency proceedings
+  - title: Free-text relevance ranking is the Gazette's own, not Strale's
+    text: >-
+      Results are returned in the order the Gazette API provides them (typically publish-date recency within the
+      matched set), not re-ranked by name-match quality. A common name can surface unrelated notices — verify the
+      company_number or notice text before treating a result as confirming a specific entity.
+    category: accuracy
+    severity: warning
+    workaround: Narrow with date_from/date_to, or cross-check the returned company_number against a company-data lookup
+  - title: company_number extraction is best-effort text parsing, not a structured field
+    text: >-
+      The Gazette API returns notice text as free-form HTML; company_number is extracted via regex from that text
+      and is null when the notice doesn't state it in the expected "Company Number: NNNNNNNN" format.
+    category: coverage
+    severity: info

--- a/manifests/us-product-recall-search.yaml
+++ b/manifests/us-product-recall-search.yaml
@@ -1,0 +1,124 @@
+slug: us-product-recall-search
+name: US Product Recall Search
+description: >-
+  Search official US CPSC consumer product recalls by keyword or manufacturer. Returns recall title, date,
+  hazard description, affected products, and manufacturer for supplier and product due-diligence checks.
+category: data-extraction
+cost_class: free_unlimited
+quota_window: none
+price_cents: 5
+is_free_tier: false
+input_schema:
+  type: object
+  required: []
+  anyOf:
+    - required: [query]
+    - required: [manufacturer]
+    - required: [task]
+  properties:
+    query:
+      type: string
+      description: Product or recall title keyword to search for
+    manufacturer:
+      type: string
+      description: Manufacturer name to filter by (alternative or complement to query)
+    task:
+      type: string
+      description: Free-text alias for query
+    date_from:
+      type: string
+      description: ISO date (YYYY-MM-DD) — only recalls on or after this date
+    date_to:
+      type: string
+      description: ISO date (YYYY-MM-DD) — only recalls on or before this date
+output_schema:
+  type: object
+  example:
+    query:
+      text: hoverboard
+      manufacturer: null
+      date_from: null
+      date_to: null
+    result_count: 1
+    recalls:
+      - recall_id: 9806
+        recall_number: "24065"
+        recall_date: "2023-12-21T00:00:00"
+        title: DGL Group Recalls Hover-1 Helix Hoverboards Due to Fire Hazard
+        description: This recall involves certain Hover-1 Helix hoverboards.
+        hazard: Fire hazard
+        manufacturers:
+          - DGL Group
+        products:
+          - name: Hover-1 Helix hoverboards
+            model: null
+            units: About 25,000
+        url: https://www.cpsc.gov/Recalls/2024/DGL-Group-Recalls-Hover-1-Helix-Hoverboards-Due-to-Fire-Hazard
+  properties:
+    query:
+      type: object
+    result_count:
+      type: integer
+    recalls:
+      type: array
+data_source: U.S. Consumer Product Safety Commission (CPSC) Recalls API
+data_source_type: api
+transparency_tag: algorithmic
+freshness_category: live-fetch
+maintenance_class: free-stable-api
+# SA.2b: per-capability PII classification (F-A-003, F-A-009)
+processes_personal_data: false
+geography: us
+test_fixtures:
+  known_answer:
+    input:
+      query: hoverboard
+    expected_fields:
+      - field: query
+        operator: not_null
+        reliability: guaranteed
+      - field: query
+        operator: type
+        reliability: guaranteed
+        value: object
+      - field: result_count
+        operator: not_null
+        reliability: guaranteed
+      - field: result_count
+        operator: gt
+        reliability: guaranteed
+        value: 0
+      - field: recalls
+        operator: not_null
+        reliability: guaranteed
+      - field: recalls
+        operator: type
+        reliability: guaranteed
+        value: array
+  health_check_input:
+    query: recall
+output_field_reliability:
+  query: guaranteed
+  result_count: guaranteed
+  recalls: guaranteed
+limitations:
+  - title: US recalls only, keyword search is a title substring match
+    text: >-
+      Covers CPSC-jurisdiction consumer products in the US only. RecallTitle matching is a substring search
+      against the recall's published title, not a semantic or product-category search — synonyms and typos
+      won't match.
+    category: coverage
+    severity: info
+    workaround: Try both a product-type keyword (e.g. "crib") and a brand/manufacturer name
+  - title: Does not cover food, drug, or vehicle recalls
+    text: >-
+      CPSC jurisdiction excludes food (FDA/USDA), pharmaceuticals (FDA), and motor vehicles (NHTSA) — those
+      have their own separate recall systems not covered by this capability.
+    category: coverage
+    severity: info
+  - title: Results capped at 25 per call, most-relevant-first ordering is the API's own
+    text: >-
+      The CPSC API does not document a stable relevance or recency sort order for its default response;
+      results are returned as-is and truncated to 25 records here.
+    category: coverage
+    severity: info


### PR DESCRIPTION
## Summary

Five new capabilities built from official, free, API-first sources per the research brief (EU
insolvency, trademark/patent offices, product recalls, procurement, state aid, economic
indicators). All **dark-launched** (`visible=false`, `x402_enabled=false` — schema defaults,
per DEC-20260812-A) and **not yet inserted into the DB** — this PR ships executors + manifests
only. See `archive/sessions/official-source-catalog-batch-2026-08-13.md` for the full research
writeup (built / key-blocked-with-spec / rejected-with-reason for every candidate in the brief).

| Slug | Source | Auth |
|---|---|---|
| `uk-gazette-notice-search` | The Gazette (UK, Crown Copyright/OGL) | none |
| `french-insolvency-check` | BODACC (DILA, French government) | none |
| `us-product-recall-search` | CPSC Recalls API (saferproducts.gov) | none |
| `uk-disqualified-director-check` | UK Companies House Disqualified Officers register | existing `COMPANIES_HOUSE_API_KEY` |
| `country-economic-indicators` | World Bank Indicators (WDI) API | none |

Every no-key endpoint was hit live with `curl` against real entities during research before the
executor was written (Carillion → Gazette; SIREN 345086177 / Camaieu International → BODACC;
"hoverboard" and "IKEA" → CPSC; SE/TR → World Bank). `uk-disqualified-director-check` was built
directly against the official Companies House OpenAPI spec — this worktree's local `.env` has no
`COMPANIES_HOUSE_API_KEY`, so it could not be live-tested here; see "For the merge session" below.

## Two real bugs found and fixed pre-commit

A code-review pass (live-verified against the actual upstream APIs, not just read) caught:
1. **`country-economic-indicators.ts`** — sending `mrv=1` alongside an explicit `date=year`
   causes the World Bank API to silently ignore `date` and return the most recent value instead.
   Fixed: `mrv` and `date` are now mutually exclusive in the request.
2. **`french-insolvency-check.ts`** — `escapeOdsqlString` escaped quotes but not backslashes,
   so a company name containing a backslash produced a malformed ODSQL query (`400
   ODSQLSyntaxError` from BODACC instead of a clean search or validation error). Fixed:
   backslashes are now escaped before quotes.

Both fixes were re-verified live against the real APIs after the fix.

## Design notes worth a reviewer's eye

- **`uk-disqualified-director-check` never auto-picks a name-search match.** Search mode
  returns candidates (name/DOB/address snippet) only; full disqualification detail requires a
  second call with an explicit `officer_id`. Rationale: disqualified-officer names collide on
  common names, and misattributing a disqualification finding to the wrong person is a more
  serious error class than the "picked wrong company" failure this mirrors
  (`feedback_registry_name_search_never_ranks.md`).
- **`uk-gazette-notice-search` vs. `insolvency-check.ts`**: not a duplicate — see the doc-comment
  at the top of the new file for the distinction (statutory notice text + personal bankruptcy
  vs. structured Companies House case list for a known company number).
- **`country-economic-indicators` vs. `country-trade-data.ts`**: both call
  `api.worldbank.org` but for disjoint indicator sets (macro/GDP/inflation vs. detailed
  export/import commodity breakdowns).

## Researched, not built (see archive doc for full detail)

- **Key-blocked, spec written, registration NOT performed** (founder-gated per task brief): EPO
  Open Patent Services (patent search), EUIPO trademark search (eSearch Plus).
- **Rejected/deferred with reason**: EU Safety Gate/RAPEX (no documented public REST API — SPA
  backend, only bulk Excel downloads), UK Contracts Finder (OCDS endpoints work but the only
  keyword/company search params on the public surface are silently ignored — verified live),
  EU e-Justice/BRIS insolvency interconnection (portal, not a consolidated API — national
  sources built directly instead), EU State aid transparency TAM (no documented API), WIPO
  Global Brand Database (no documented API), Eurostat (would duplicate
  `country-economic-indicators` — noted for a future EU-regional-granularity need).

## Verification

- `cd apps/api && npx tsc --noEmit --project tsconfig.json` — clean.
- `npx tsx scripts/onboard.ts --manifest manifests/{slug}.yaml --dry-run` — 5/5 pass (manifest
  validation, 5 test-suite types generated, dark-launch insert preview).
- `--discover` (live execution + DB insert) was **deliberately not run** — this worktree lacks
  production secrets; left for the merge session per the task brief.

## For the merge session (has real `.env` / Railway secrets)

```bash
cd apps/api
npx tsx scripts/onboard.ts --manifest ../../manifests/uk-gazette-notice-search.yaml --discover --strict
npx tsx scripts/onboard.ts --manifest ../../manifests/french-insolvency-check.yaml --discover --strict
npx tsx scripts/onboard.ts --manifest ../../manifests/us-product-recall-search.yaml --discover --strict
npx tsx scripts/onboard.ts --manifest ../../manifests/uk-disqualified-director-check.yaml --discover --strict
npx tsx scripts/onboard.ts --manifest ../../manifests/country-economic-indicators.yaml --discover --strict

npx tsx scripts/smoke-test.ts --slug uk-gazette-notice-search
npx tsx scripts/smoke-test.ts --slug french-insolvency-check
npx tsx scripts/smoke-test.ts --slug us-product-recall-search
npx tsx scripts/smoke-test.ts --slug uk-disqualified-director-check
npx tsx scripts/smoke-test.ts --slug country-economic-indicators
```

`uk-disqualified-director-check` is the one worth the closest look post-`--discover` — confirm
the live JSON matches the schema this PR built against the official docs (search response +
`naturalDisqualification` detail response).

Each `--discover` call inserts with `lifecycle_state=validating, visible=false` — none of these
are being made visible or x402-enabled by this PR; that stays a human call per the readiness
program's escalation contract (DEC-20260812-A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
