### PR TITLE
fix(x402): PAYMENT-REQUIRED header on v2 paths (canonical v2 clients require it)

### DIFF
--- a/apps/api/src/lib/x402-v2-challenge.test.ts
+++ b/apps/api/src/lib/x402-v2-challenge.test.ts
@@ -204,6 +204,49 @@ describe("build402 (gateway challenge builder)", () => {
   });
 });
 
+describe("PAYMENT-REQUIRED header contract (v2 paths)", () => {
+  // @x402/core's client reads the PAYMENT-REQUIRED header first and its
+  // body fallback is v1-only (client/index.js getPaymentRequiredResponse):
+  // a header-less v2 challenge throws "Invalid payment required response"
+  // in every canonical v2 client. Found live-verifying the x402 example
+  // template (2026-08-13). This pins that our encoded header round-trips
+  // through the SDK's own client-side reader.
+  it("the SDK client accepts the encoded v2 challenge via the header path", { timeout: 60_000 }, async () => {
+    const { build402 } = await loadRoutes();
+    const { encodePaymentRequiredHeader } = await import("@x402/core/http");
+    const { x402HTTPClient, x402Client } = await import("@x402/core/client");
+    const { body } = build402(
+      "IBAN Validate", "Validate an IBAN.", 0.054,
+      "https://api.strale.io/x402/v2/iban-validate",
+      null, "GET", null,
+      2,
+    );
+    const encoded = encodePaymentRequiredHeader(body as never);
+    const httpClient = new x402HTTPClient(new x402Client());
+    const parsed = httpClient.getPaymentRequiredResponse(
+      (name: string) => (name.toUpperCase() === "PAYMENT-REQUIRED" ? encoded : null),
+      undefined,
+    );
+    expect(parsed.x402Version).toBe(2);
+    expect(parsed.accepts).toHaveLength(1);
+    expect((parsed.accepts[0] as Record<string, unknown>).amount).toBeDefined();
+  });
+
+  it("the SDK client still parses the legacy v1 body without any header", { timeout: 60_000 }, async () => {
+    const { build402 } = await loadRoutes();
+    const { x402HTTPClient, x402Client } = await import("@x402/core/client");
+    const { body } = build402(
+      "IBAN Validate", "Validate an IBAN.", 0.054,
+      "https://api.strale.io/x402/iban-validate",
+      null, "GET", null,
+      1,
+    );
+    const httpClient = new x402HTTPClient(new x402Client());
+    const parsed = httpClient.getPaymentRequiredResponse(() => null, body as never);
+    expect(parsed.x402Version).toBe(1);
+  });
+});
+
 describe("verifyX402PaymentOnly version branching", () => {
   it("v1 payload → v1-shaped requirements (bare network, maxAmountRequired)", async () => {
     const { verifyX402PaymentOnly } = await loadGateway();

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -37,6 +37,7 @@ import {
   type X402VerifiedPayment,
 } from "../lib/x402-gateway.js";
 import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
+import { encodePaymentRequiredHeader } from "@x402/core/http";
 import { extractClientMeta, recordDiscoveryHit } from "../lib/attribution.js";
 import { rateLimitByIp } from "../lib/rate-limit.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
@@ -960,9 +961,18 @@ x402GatewayV2.on(["GET", "POST"], ["/solutions/:slug", "/v2/solutions/:slug"], a
         sol.inputSchema, "POST", sol.outputSchema,
         challengeVersion,
       );
-      // No Payment-Required header: the body is the canonical source. Emitting a
-      // v1-encoded header trips v2-only header decoders (e.g. @agentcash/discovery)
-      // which never fall back to body parsing once any header is present.
+      // Legacy paths: no Payment-Required header — the v1 body is the
+      // canonical source, and a v1-encoded header trips v2-only header
+      // decoders (e.g. @agentcash/discovery) which never fall back to body
+      // parsing once any header is present. v2 paths: the header is
+      // REQUIRED — @x402/core's client reads PAYMENT-REQUIRED first and its
+      // body fallback is v1-only, so canonical v2 clients cannot pay a
+      // header-less v2 challenge (found live-verifying the x402 example
+      // template, 2026-08-13). A v2-encoded header doesn't retrigger the
+      // @agentcash issue: that decoder chokes on v1 encodings, not v2.
+      if (challengeVersion === 2) {
+        c.header("PAYMENT-REQUIRED", encodePaymentRequiredHeader(body as never));
+      }
       return c.json(body, 402);
     }
 
@@ -993,6 +1003,9 @@ x402GatewayV2.on(["GET", "POST"], ["/solutions/:slug", "/v2/solutions/:slug"], a
       // strictly and would otherwise surface a parse error instead).
       const failBody = { ...solRebuild.body } as Record<string, unknown>;
       failBody.error = `Payment verification failed: ${verification.error ?? "unknown reason"}`;
+      if (challengeVersion === 2) {
+        c.header("PAYMENT-REQUIRED", encodePaymentRequiredHeader(failBody as never));
+      }
       return c.json(failBody, 402);
     }
     verified = verification.verified;
@@ -1175,7 +1188,10 @@ x402GatewayV2.on(["GET", "POST"], ["/:slug", "/v2/:slug"], async (c) => {
         cap.inputSchema, cap.x402Method, cap.outputSchema,
         challengeVersion,
       );
-      // See note on the solutions handler above — no Payment-Required header.
+      // See the solutions handler note: header only on v2 paths.
+      if (challengeVersion === 2) {
+        c.header("PAYMENT-REQUIRED", encodePaymentRequiredHeader(body as never));
+      }
       return c.json(body, 402);
     }
 
@@ -1206,6 +1222,9 @@ x402GatewayV2.on(["GET", "POST"], ["/:slug", "/v2/:slug"], async (c) => {
       // Spec-shaped failure — see the solutions handler.
       const failBody = { ...capRebuild.body } as Record<string, unknown>;
       failBody.error = `Payment verification failed: ${verification.error ?? "unknown reason"}`;
+      if (challengeVersion === 2) {
+        c.header("PAYMENT-REQUIRED", encodePaymentRequiredHeader(failBody as never));
+      }
       return c.json(failBody, 402);
     }
     verified = verification.verified;


### PR DESCRIPTION
## Summary
- @x402/core's `getPaymentRequiredResponse` reads the `PAYMENT-REQUIRED` header first; its body fallback only accepts `x402Version: 1`. A header-less v2 challenge therefore throws in every canonical v2 client — meaning the /x402/v2/* paths shipped in #200 were registered on x402scan but unpayable via @x402/fetch. Found by the agent-templates session live-verifying the x402 buyer example (#204).
- v2-path 402s (initial challenge + verify-failure) now set `PAYMENT-REQUIRED` with the SDK's own `encodePaymentRequiredHeader`. Legacy paths stay header-less: their v1 body is covered by the client's fallback, and the historical @agentcash conflict was with v1-encoded headers specifically.

## Verification
- New test pins the round-trip through the SDK's actual client-side reader (`x402HTTPClient.getPaymentRequiredResponse`) for both generations. 14/14 in the challenge test file; tsc clean.
- Post-deploy: curl -i /x402/v2/vat-validate → header present and decodes; legacy path headerless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)