### PR TITLE
fix(x402): read PAYMENT-SIGNATURE header — v2 payments were invisible

### DIFF
--- a/apps/api/src/lib/x402-gateway.ts
+++ b/apps/api/src/lib/x402-gateway.ts
@@ -584,10 +584,22 @@ export function extractPayerAddress(verified: X402VerifiedPayment): string | nul
 
 /**
  * Extract the x402 payment header from a request.
- * Checks both X-PAYMENT (standard) and Payment (legacy) headers.
+ *
+ * Header names by protocol generation (@x402/core client,
+ * encodePaymentSignatureHeader): v2 clients send PAYMENT-SIGNATURE, v1
+ * clients send X-PAYMENT ("Payment" is a pre-v1 legacy name). Missing
+ * PAYMENT-SIGNATURE made every canonical v2 payment invisible — the paid
+ * retry just received a fresh challenge. Found by the first real-wallet
+ * v2 settlement test (2026-08-14); the payload generations are
+ * disambiguated downstream by parsePaymentPayload, not by header name.
  */
 export function extractPaymentHeader(headers: Headers): string | null {
-  return headers.get("x-payment") ?? headers.get("payment") ?? null;
+  return (
+    headers.get("payment-signature") ??
+    headers.get("x-payment") ??
+    headers.get("payment") ??
+    null
+  );
 }
 
 /**

--- a/apps/api/src/lib/x402-v2-challenge.test.ts
+++ b/apps/api/src/lib/x402-v2-challenge.test.ts
@@ -247,6 +247,20 @@ describe("PAYMENT-REQUIRED header contract (v2 paths)", () => {
   });
 });
 
+describe("extractPaymentHeader header-name coverage", () => {
+  // v2 clients send PAYMENT-SIGNATURE (@x402/core encodePaymentSignatureHeader
+  // switches on payload.x402Version); v1 sends X-PAYMENT. Missing the v2
+  // name made every canonical v2 payment invisible — the paid retry got a
+  // fresh challenge. Found by the first real-wallet settlement test.
+  it("reads PAYMENT-SIGNATURE (v2), X-PAYMENT (v1), and legacy Payment", async () => {
+    const { extractPaymentHeader } = await loadGateway();
+    expect(extractPaymentHeader(new Headers({ "PAYMENT-SIGNATURE": "abc" }))).toBe("abc");
+    expect(extractPaymentHeader(new Headers({ "X-PAYMENT": "def" }))).toBe("def");
+    expect(extractPaymentHeader(new Headers({ Payment: "ghi" }))).toBe("ghi");
+    expect(extractPaymentHeader(new Headers())).toBeNull();
+  });
+});
+
 describe("verifyX402PaymentOnly version branching", () => {
   it("v1 payload → v1-shaped requirements (bare network, maxAmountRequired)", async () => {
     const { verifyX402PaymentOnly } = await loadGateway();


### PR DESCRIPTION
## Summary
- @x402/core's client transmits v2 payment payloads in a `PAYMENT-SIGNATURE` header (`encodePaymentSignatureHeader` switches on payload version; v1 uses `X-PAYMENT`). Our `extractPaymentHeader` read only `x-payment`/`payment`, so canonical v2 payments were never seen — the paid retry received a fresh 402 challenge.
- Found by the first real-wallet v2 settlement test against production (April test wallet, recovered today). This was invisible to all prior testing because our tests inject payloads directly and the earlier example-template run misread its zero-balance failure as reaching verification.
- One-line reader fix + header-name coverage test. Payload version handling downstream is already correct (discriminated-union parse).

## Verification
- 15/15 challenge tests; tsc clean.
- Post-merge: re-run the real-wallet buy (examples/x402-autonomous-buyer) against prod → expect HTTP 200 + on-chain settlement tx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)