### PR TITLE
chore(glama): list both maintainer GitHub accounts

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "maintainers": [
-    "petterlindstrom79"
+    "petterlindstrom79",
+    "petterlindstrom"
   ]
 }


### PR DESCRIPTION
The Glama claim was failing because glama.json listed only `petterlindstrom79` (the strale-io org member / CLI identity) while the browser used for claiming is signed in as `petterlindstrom` (the older personal account). Glama matches the authorizing GitHub account against this list. Listing both makes the claim work from either identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)