### PR TITLE
chore(mcp): 0.2.6 — ship corrected tool descriptions

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strale-mcp",
   "mcpName": "io.github.strale-io/strale",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "MCP server for Strale — pre-flight check any paid API before your agent pays, plus 250+ business data, compliance, and validation tools for Claude, Cursor, Windsurf, and any MCP client",
   "type": "module",
   "main": "./dist/server.js",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/strale-io/strale",
     "source": "github"
   },
-  "version": "0.2.4",
+  "version": "0.2.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "strale-mcp",
-      "version": "0.2.4",
+      "version": "0.2.6",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -74,7 +74,7 @@ export interface StraleClientOptions {
 
 // Attribution client identifier — package name/version, sent as
 // X-Strale-Client on every API call this package makes.
-const STRALE_CLIENT_ID = "strale-mcp/0.2.5";
+const STRALE_CLIENT_ID = "strale-mcp/0.2.6";
 
 // ─── HTTP helpers ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
0.2.5 went out with the pre-#208 descriptions (retired SQS score, stale counts, 5-of-11 free tier). This bumps the version so the corrections in #208 and #209 actually reach users on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)