### PR TITLE
fix(company-enrich): tolerate model prose around the JSON it returns

### DIFF
--- a/apps/api/src/capabilities/company-enrich.test.ts
+++ b/apps/api/src/capabilities/company-enrich.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for company-enrich's `hasSubstance` billing guard.
+ *
+ * This is the half of the 2026-08-14 fix that decides whether €0.50 is
+ * charged. Making the JSON parser tolerant (see lib/llm-json.test.ts) means
+ * an all-null extraction now parses cleanly, so without this guard the
+ * openai.com call would have started *succeeding* — returning an object of
+ * nulls, billing for it, and violating the `guaranteed` / not_null contract
+ * in manifests/company-enrich.yaml. A throw is never charged (DEC-14).
+ *
+ * The guard is deliberately lenient: one populated field is enough. It
+ * catches the "extracted nothing" corner, not every partial result.
+ */
+
+import { describe, it, expect } from "vitest";
+import { hasSubstance } from "./company-enrich.js";
+
+const ALL_NULL = {
+  company_name: null,
+  industry: null,
+  employee_estimate: null,
+  hq_location: null,
+  description: null,
+  social_links: { linkedin: null, twitter: null, github: null },
+  tech_stack: null,
+  founded_year: null,
+  website: "https://openai.com",
+};
+
+describe("hasSubstance — rejects", () => {
+  it("the all-null shape the openai.com call produced", () => {
+    expect(hasSubstance(ALL_NULL)).toBe(false);
+  });
+
+  it("an object carrying only fields we fill in ourselves", () => {
+    // `website` is set by the executor, never by the model — it must not
+    // count as substance or the guard would never fire.
+    expect(hasSubstance({ website: "https://openai.com" })).toBe(false);
+  });
+
+  it("empty and whitespace-only strings", () => {
+    expect(hasSubstance({ ...ALL_NULL, company_name: "" })).toBe(false);
+    expect(hasSubstance({ ...ALL_NULL, description: "   " })).toBe(false);
+  });
+
+  it("an empty tech_stack array", () => {
+    expect(hasSubstance({ ...ALL_NULL, tech_stack: [] })).toBe(false);
+  });
+
+  it("undefined fields and a wholly empty object", () => {
+    expect(hasSubstance({ company_name: undefined })).toBe(false);
+    expect(hasSubstance({})).toBe(false);
+  });
+});
+
+describe("hasSubstance — accepts", () => {
+  it("any single populated substantive field", () => {
+    expect(hasSubstance({ ...ALL_NULL, company_name: "OpenAI" })).toBe(true);
+    expect(hasSubstance({ ...ALL_NULL, industry: "AI Research" })).toBe(true);
+    expect(hasSubstance({ ...ALL_NULL, tech_stack: ["Python"] })).toBe(true);
+  });
+
+  it("a non-empty employee_estimate that is not a string", () => {
+    expect(hasSubstance({ ...ALL_NULL, employee_estimate: 500 })).toBe(true);
+  });
+
+  it("a fully populated result", () => {
+    expect(
+      hasSubstance({
+        company_name: "Google",
+        industry: "Technology",
+        description: "Search and cloud.",
+        hq_location: "Mountain View, United States",
+        employee_estimate: "1000+",
+        tech_stack: ["Google Cloud"],
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/capabilities/company-enrich.ts
+++ b/apps/api/src/capabilities/company-enrich.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { assertTargetAllowed } from "../lib/tos-blocklist.js";
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { validateUrl } from "../lib/url-validator.js";
+import { extractJsonObject } from "./lib/llm-json.js";
 
 const EXTRACTION_PROMPT = `You are a company intelligence extraction system.
 
@@ -22,7 +23,41 @@ From the provided web page content, extract as much of the following as possible
   "website": "string"
 }
 
-Return ONLY valid JSON. If a field cannot be determined, use null.`;
+Return ONLY valid JSON. If a field cannot be determined, use null.
+Do not add any explanation before or after the JSON — if the page contains
+nothing usable, return the object with every field null and say nothing else.`;
+
+/**
+ * The fields `manifests/company-enrich.yaml` declares `guaranteed`. If the
+ * model returns null for every one of them the extraction found nothing, and
+ * returning the shell would bill €0.50 for an object of nulls that also
+ * violates the declared not_null contract. Fail loudly instead — the executor
+ * throws, and DEC-14 means an execution that throws is never charged.
+ *
+ * Keep this list in sync with that manifest's `output_field_reliability`.
+ * Duplicating it here is a stopgap: `lib/null-field-ratio.ts` already derives
+ * the same thing generically from `capability.outputFieldReliability`, but it
+ * is wired into the test runner only, not the live execute path in do.ts.
+ * Generalising that guard would cover every AI-synthesis capability at once.
+ */
+const SUBSTANTIVE_FIELDS = [
+  "company_name",
+  "industry",
+  "description",
+  "hq_location",
+  "employee_estimate",
+  "tech_stack",
+] as const;
+
+export function hasSubstance(parsed: Record<string, unknown>): boolean {
+  return SUBSTANTIVE_FIELDS.some((field) => {
+    const value = parsed[field];
+    if (value === null || value === undefined) return false;
+    if (typeof value === "string") return value.trim().length > 0;
+    if (Array.isArray(value)) return value.length > 0;
+    return true;
+  });
+}
 
 async function scrapeUrl(url: string): Promise<string> {
   // F-0-006: Browserless fetches the URL from its own network, so our
@@ -138,17 +173,20 @@ registerCapability("company-enrich", async (input: CapabilityInput) => {
 
   const responseText =
     response.content[0].type === "text" ? response.content[0].text : "";
-  const jsonStr = responseText
-    .trim()
-    .replace(/^```(?:json)?\s*\n?/i, "")
-    .replace(/\n?```\s*$/i, "")
-    .trim();
 
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(jsonStr);
-  } catch {
-    throw new Error(`Failed to parse enrichment result. Raw: ${responseText.slice(0, 300)}`);
+  const parsed = extractJsonObject(responseText);
+  if (!parsed) {
+    throw new Error(
+      `Failed to parse enrichment result for ${domain}. Raw: ${responseText.slice(0, 300)}`,
+    );
+  }
+
+  if (!hasSubstance(parsed)) {
+    throw new Error(
+      `No company information could be extracted from ${websiteUrl}. The page was ` +
+        `reachable but contained no usable company details — it may be JavaScript-only, ` +
+        `bot-protected, or a placeholder. Retrying will not help for this domain.`,
+    );
   }
 
   // Ensure website field

--- a/apps/api/src/capabilities/lib/llm-json.test.ts
+++ b/apps/api/src/capabilities/lib/llm-json.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for `extractJsonObject`.
+ *
+ * Regression origin: a 2026-08-14 x402 call to company-enrich for
+ * openai.com failed with "Failed to parse enrichment result" even though
+ * the model had returned a well-formed fenced JSON object. The old parser
+ * stripped the fence with anchored regexes (/^```(json)?/ and /```\s*$/),
+ * so any commentary after the closing fence left both the fence and the
+ * prose in the string handed to JSON.parse.
+ *
+ * The "prose after the closing fence" case is the one that shipped the
+ * incident, and it correlates with empty extractions: a model that found
+ * nothing tends to explain itself afterwards. It is pinned first.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractJsonObject } from "./llm-json.js";
+
+const ALL_NULL_BODY = `{
+  "company_name": null,
+  "industry": null,
+  "employee_estimate": null,
+  "hq_location": null,
+  "description": null,
+  "social_links": { "linkedin": null, "twitter": null, "github": null },
+  "tech_stack": null,
+  "founded_year": null,
+  "website": "https://openai.com"
+}`;
+
+describe("extractJsonObject — shapes that broke production", () => {
+  it("recovers JSON when the model appends a note after the closing fence", () => {
+    const raw = [
+      "```json",
+      ALL_NULL_BODY,
+      "```",
+      "",
+      "Note: the page content appeared to be a JavaScript shell, so no",
+      "company details could be determined.",
+    ].join("\n");
+
+    const parsed = extractJsonObject(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.website).toBe("https://openai.com");
+    expect(parsed!.company_name).toBeNull();
+  });
+
+  it("recovers JSON when the model adds a preamble before the fence", () => {
+    const raw = `Here is the extracted data:\n\n\`\`\`json\n${ALL_NULL_BODY}\n\`\`\``;
+    expect(extractJsonObject(raw)?.website).toBe("https://openai.com");
+  });
+
+  it("prefers the fenced block when the preamble itself contains braces", () => {
+    // This is the case the fenced candidate exists for: brace-scanning the
+    // whole string would stop at the `{}` in the prose and never reach the
+    // real object. Without the fence-first pass this returns the wrong
+    // object, so it pins why that pass is not redundant machinery.
+    const raw = [
+      "I could not find some fields, so I used {} for those:",
+      "```json",
+      ALL_NULL_BODY,
+      "```",
+    ].join("\n");
+
+    expect(extractJsonObject(raw)?.website).toBe("https://openai.com");
+  });
+
+  it("handles the plain fenced block the old parser already managed", () => {
+    const raw = `\`\`\`json\n${ALL_NULL_BODY}\n\`\`\``;
+    expect(extractJsonObject(raw)?.website).toBe("https://openai.com");
+  });
+
+  it("handles a bare object with no fence at all", () => {
+    expect(extractJsonObject(ALL_NULL_BODY)?.website).toBe("https://openai.com");
+  });
+
+  it("handles a fence with no json language tag", () => {
+    const raw = `\`\`\`\n${ALL_NULL_BODY}\n\`\`\``;
+    expect(extractJsonObject(raw)?.website).toBe("https://openai.com");
+  });
+});
+
+describe("extractJsonObject — brace scanning", () => {
+  it("does not over-capture when trailing prose contains a brace", () => {
+    const raw = `{"company_name":"Acme"}\n\nUse {placeholder} for missing values.`;
+    expect(extractJsonObject(raw)).toEqual({ company_name: "Acme" });
+  });
+
+  it("keeps nested objects intact", () => {
+    const raw = `{"a":{"b":{"c":1}},"d":2}`;
+    expect(extractJsonObject(raw)).toEqual({ a: { b: { c: 1 } }, d: 2 });
+  });
+
+  it("ignores braces inside string values", () => {
+    const raw = `{"description":"We use {{mustache}} templates","industry":"SaaS"}`;
+    expect(extractJsonObject(raw)).toEqual({
+      description: "We use {{mustache}} templates",
+      industry: "SaaS",
+    });
+  });
+
+  it("ignores escaped quotes inside string values", () => {
+    const raw = String.raw`{"description":"They call it \"the platform\"","industry":"SaaS"}`;
+    expect(extractJsonObject(raw)?.industry).toBe("SaaS");
+  });
+});
+
+describe("extractJsonObject — returns null rather than partial data", () => {
+  it("rejects output truncated mid-object", () => {
+    const raw = '```json\n{"company_name":"Acme","industry":"Sa';
+    expect(extractJsonObject(raw)).toBeNull();
+  });
+
+  it("rejects prose with no JSON in it", () => {
+    expect(extractJsonObject("I could not access that website.")).toBeNull();
+  });
+
+  it("rejects empty output", () => {
+    expect(extractJsonObject("")).toBeNull();
+    expect(extractJsonObject("   \n  ")).toBeNull();
+  });
+
+  it("unwraps a single-object array rather than failing", () => {
+    // The scanner starts at the first `{`, so an array wrapper is stepped
+    // over. Deliberate: one object in a list is still the answer.
+    expect(extractJsonObject('[{"company_name":"Acme"}]')).toEqual({
+      company_name: "Acme",
+    });
+  });
+});

--- a/apps/api/src/capabilities/lib/llm-json.ts
+++ b/apps/api/src/capabilities/lib/llm-json.ts
@@ -1,0 +1,88 @@
+/**
+ * Tolerant JSON extraction for LLM responses.
+ *
+ * Models asked for "ONLY valid JSON" comply most of the time, but the
+ * failure modes are predictable: a ```json fence around the object, prose
+ * before it ("Here is the extracted data:"), or — most commonly when the
+ * page yielded nothing — a note appended *after* the closing fence
+ * explaining what could not be found.
+ *
+ * The naive strip-the-fence-and-parse approach only survives the first of
+ * those. A 2026-08-14 company-enrich call on openai.com returned a
+ * well-formed fenced object and still 500'd, because anchored fence
+ * stripping (/```\s*$/) can't remove a fence that isn't last.
+ *
+ * Brace matching here is a real scanner rather than /\{[\s\S]*\}/ — the
+ * greedy regex runs to the last `}` in the string, which over-captures
+ * whenever trailing prose contains one.
+ */
+
+/**
+ * Return the first balanced `{...}` span in `text`, respecting string
+ * literals and escapes. Returns null when there is no `{`, or when the
+ * object never closes (i.e. the model output was cut off mid-object).
+ */
+function sliceBalancedObject(text: string): string | null {
+  const start = text.indexOf("{");
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+
+    if (ch === '"') inString = true;
+    else if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+
+  return null; // unbalanced — truncated output, nothing safe to salvage
+}
+
+/**
+ * Parse a JSON object out of a raw LLM response.
+ *
+ * Tries the contents of a fenced block first (the fence is the model's own
+ * delimiter, so it beats brace-scanning the whole string when commentary
+ * surrounds it), then falls back to the raw text.
+ *
+ * Returns null when no complete object can be recovered — callers should
+ * treat that as an extraction failure, never as an empty result.
+ */
+export function extractJsonObject(raw: string): Record<string, unknown> | null {
+  const text = raw.trim();
+  if (!text) return null;
+
+  const candidates: string[] = [];
+
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenced) candidates.push(fenced[1]);
+
+  candidates.push(text);
+
+  for (const candidate of candidates) {
+    const span = sliceBalancedObject(candidate);
+    if (!span) continue;
+    try {
+      // `span` always starts at `{` and is brace-balanced, so a successful
+      // parse is necessarily a plain object.
+      return JSON.parse(span) as Record<string, unknown>;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- A production x402 call for `openai.com` (2026-08-14 07:22Z) failed with `Failed to parse enrichment result`. The model had returned a **well-formed** fenced JSON object — the parser was the bug. The closing-fence strip was anchored to `$`, so when the model appended an explanatory note *after* the fence, neither the fence nor the prose was removed and `JSON.parse` choked. Confirmed against the old code: it throws `Unexpected non-whitespace character after JSON at position 62`, the production error class.
- The two symptoms were one thing: the extraction came back all-null, and a model that found nothing tends to explain itself afterwards — which is what broke the parse.
- New `capabilities/lib/llm-json.ts` takes the fenced block when present, else brace-scans the raw text with a string/escape-aware scanner (not `/\{[\s\S]*\}/`, which runs to the last brace and over-captures on trailing prose). Truncated output returns `null` rather than partial data.
- **Fixing the parse alone would have made this call start *succeeding*** — returning an object of nulls and billing €0.50 for it, while violating the `guaranteed`/`not_null` contract in `manifests/company-enrich.yaml`. So `hasSubstance` throws when no declared-guaranteed field survived; a throw is never charged (DEC-14).

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit` | pass |
| `vitest run` (full suite) | 1191 passed, 33 skipped, 0 failed |
| New tests | 22 (14 parser + 8 billing guard) |
| Regression direction (DEC-20260504-A r2) | verified — the pinned shape **fails** against the un-applied fix, passes with it |
| `validate-capability --slug company-enrich` | 19/19 |
| `checkReadiness("company-enrich")` | `ready: true`, no issues |
| `smoke-test --slug company-enrich` | 9/10 — see below |

**Smoke step 2 (live execution) could not run.** `ALLOW_MATRIX` refuses `paid_prepaid` capabilities from `internal_test` context by design, to avoid burning vendor credits outside customer-initiated paths. Not a defect in this change, but it means **the end-to-end path is unverified locally** — and a local run would prove little anyway, since local Browserless is v2 and prod is v1. The parse logic itself is fully unit-covered.

**Re-run `company-enrich` for `openai.com` in prod after deploy** to see which branch it lands in: a real enrichment, or the new clean "no company information could be extracted" error. Both are correct outcomes; which one occurs tells us whether openai.com is scrapeable from prod.

Note on suite stability: the `test/integration/*.smoke` tests flip between pass and fail across local runs (they need a reachable `postgres.railway.internal` and a live server). Observed 3-fail, 0-fail, 6-fail, 0-fail across four runs, always in those files, never in the touched area. Reported number above is from a clean run.

## Reviewer findings

Six-lens review (technical + product) run in parallel on the diff. **No HIGH findings.** Two MEDIUMs were fixed in-branch rather than deferred; the rest are recorded here for your call.

**Fixed after review:**
- The billing guard had zero test coverage — it is the path that decides whether €0.50 is charged. Exported `hasSubstance` and added 8 tests (`company-enrich.test.ts`).
- Error text said "the page returned no usable content", but the scrape had already succeeded by then. Reworded to say the page was reachable but contained nothing extractable, and that retrying will not help.

**MEDIUM — deferred, your call:**
1. **Six sibling capabilities still carry the identical fragile pattern**: `web-extract.ts:149`, `pii-redact.ts:74`, `pdf-extract.ts:86`, `invoice-extract.ts:165`, `annual-report-extract.ts:265`, `llm-output-validate.ts:23`. `browserless-extract.ts:76` also uses the greedy `/\{[\s\S]*\}/`, and it backs ~47 country-registry capabilities. Both reviewers judged deferring correct — bundling six paid capabilities into an incident fix is the scope creep this gate exists to catch — but the class is *not* fixed by this PR. Follow-up task raised separately.
2. **`SUBSTANTIVE_FIELDS` duplicates the manifest's `output_field_reliability`** and nothing fails if they drift. `lib/null-field-ratio.ts` already derives this generically from `capability.outputFieldReliability`, but it is wired into the test runner only, not the live execute path in `do.ts`. Generalising it there would cover every AI-synthesis capability at once and delete this list. Flagged in a code comment.
3. **The guard is lenient**: one populated field passes, so a mostly-null result still bills. Deliberate — it catches "extracted nothing", not every partial result — but it is narrower than the manifest contract it cites.
4. **Both new errors map to `error_code: "execution_failed"`**, so an agent cannot mechanically tell "retry" (transient parse fault) from "give up on this domain" (terminal). The message text now distinguishes them; the code does not.
5. **`Raw: ${responseText.slice(0, 300)}` echoes model output** derived from a scraped third-party page into the customer-facing error, which persists to `transactions.error` and the token-issued shareable audit record. Pre-existing, and I deliberately kept it: that field is exactly how this bug was diagnosed, and dropping it would blind the same investigation next time. The stricter option is to log it server-side and return a clean message.
6. **`manifests/company-enrich.yaml` has no limitation covering the new hard-fail.** Customers now get an outright failure on JS-only/bot-protected sites where they previously got a (contract-violating) 200. Not added here because per the onboarding pipeline a manifest `limitations` edit does not propagate to the DB row via `--backfill` — it needs delete + re-onboard, which is a bigger operation than this PR should carry.

## Test plan

1. Merge and deploy.
2. Call `company-enrich` with `{"domain": "openai.com"}` in prod. Expect either a populated enrichment or the new `No company information could be extracted from https://openai.com…` error — **not** a parse failure, and **not** an object of nulls.
3. Spot-check a known-good domain (`google.com`, the known_answer fixture) still returns `industry`, `tech_stack`, `description`, `hq_location`.
4. Watch `transactions.error` for `company-enrich` over the next few days — a shift from parse failures to "no company information" errors is the fix working, not a new problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
