### PR TITLE
test(french-insolvency): cover the company_name entry point

### DIFF
--- a/manifests/french-insolvency-check.yaml
+++ b/manifests/french-insolvency-check.yaml
@@ -88,6 +88,29 @@ test_fixtures:
         operator: type
         reliability: guaranteed
         value: array
+  # Real coverage of the name-search path (the anyOf allows
+  # siren | company_name | task; known_answer covers siren only).
+  # Verified live 2026-08-14: company_name "Camaieu" returned 8 BODACC
+  # procedures collectives notices.
+  #
+  # NOTE: this does NOT satisfy Gate 5, which counts only known_answer and
+  # schema_check suites (see lib/gate5-path-coverage.ts). The manifest format
+  # allows a single known_answer fixture, so no dual-entry-point capability
+  # can currently pass that gate — spanish-company-data and
+  # norwegian-company-data are both live at 19/20 for the same reason.
+  # Fixing that needs a pipeline change (per-entry-point fixture arrays),
+  # tracked separately.
+  edge_case:
+    input:
+      company_name: "Camaieu"
+    expected_fields:
+      - field: result_count
+        operator: not_null
+        reliability: guaranteed
+      - field: query
+        operator: not_null
+        reliability: guaranteed
+
   health_check_input:
     siren: "345086177"
 output_field_reliability:


### PR DESCRIPTION
Adds an `edge_case` fixture for the name-search path, verified live (`company_name: Camaieu` → 8 BODACC notices).

**Honest scope note:** this does *not* close Gate 5. That gate counts only `known_answer`/`schema_check` suites, and the manifest format supports a single `known_answer` fixture — so **no dual-entry-point capability can currently pass it**. Verified: `spanish-company-data` and `norwegian-company-data` are both live at 19/20 with the same failure. That's a pre-existing pipeline limitation, not a regression from this capability, and the real fix (per-entry-point fixture arrays) is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)