### PR TITLE
fix(capabilities): actionable errors for identifier-only registry lookups

### DIFF
--- a/apps/api/src/capabilities/au-company-data.ts
+++ b/apps/api/src/capabilities/au-company-data.ts
@@ -153,14 +153,14 @@ registerCapability("au-company-data", async (input: CapabilityInput) => {
     (input.abn as string) ?? (input.task as string) ?? "";
   if (typeof rawInput !== "string" || !rawInput.trim()) {
     throw new Error(
-      "'abn' is required. Provide an Australian Business Number (11 digits).",
+      "'abn' is required. Provide an 11-digit Australian Business Number. Look one up by company name at the official ABN Lookup search: https://abr.business.gov.au/.",
     );
   }
 
   const abn = cleanAbn(rawInput.trim());
   if (!abn) {
     throw new Error(
-      `Invalid ABN format: "${rawInput.trim()}". ABN must be exactly 11 digits.`,
+      `Invalid ABN format: "${rawInput.trim()}". ABN must be exactly 11 digits — look one up by company name at the official ABN Lookup search: https://abr.business.gov.au/.`,
     );
   }
 

--- a/apps/api/src/capabilities/austrian-company-data.ts
+++ b/apps/api/src/capabilities/austrian-company-data.ts
@@ -38,13 +38,13 @@ registerCapability("austrian-company-data", async (input: CapabilityInput) => {
     "";
   if (typeof rawInput !== "string" || !rawInput.trim()) {
     throw new Error(
-      "'vat_number' is required. Provide an Austrian UID-Nummer (e.g. ATU14189108). Firmenbuchnummer (FN) is not accepted by the upstream API; use the VAT format.",
+      "'vat_number' is required. Provide an Austrian UID-Nummer (e.g. ATU14189108). Firmenbuchnummer (FN) is not accepted by the upstream API; look up the UID-Nummer by company name at the Austrian Federal Economic Chamber directory: https://firmen.wko.at/.",
     );
   }
   const normalised = normaliseAtIdentifier(rawInput.trim());
   if (!normalised) {
     throw new Error(
-      `'${rawInput.trim()}' is not a valid Austrian UID-Nummer. Expected format: ATU + 8 digits (e.g. ATU14189108).`,
+      `'${rawInput.trim()}' is not a valid Austrian UID-Nummer. Expected format: ATU + 8 digits (e.g. ATU14189108). Look one up by company name at https://firmen.wko.at/.`,
     );
   }
   const __etResult = await executeOpenapiCapability(

--- a/apps/api/src/capabilities/brazilian-company-data.ts
+++ b/apps/api/src/capabilities/brazilian-company-data.ts
@@ -72,14 +72,18 @@ async function fetchByCnpj(cnpj: string): Promise<Record<string, unknown>> {
 registerCapability("brazilian-company-data", async (input: CapabilityInput) => {
   const raw = (input.cnpj as string) ?? (input.company_name as string) ?? (input.task as string) ?? "";
   if (typeof raw !== "string" || !raw.trim()) {
-    throw new Error("'cnpj' is required. Provide a CNPJ number (14 digits). Name search is not supported — use a CNPJ.");
+    throw new Error(
+      "'cnpj' is required. Provide a CNPJ number (14 digits, e.g. 11222333000181). Neither ReceitaWS nor Brazil's official registry supports name search — the CNPJ is printed on the company's invoices, contracts, or NF-e documents; verify a candidate at Receita Federal's public consultation page: https://solucoes.receita.fazenda.gov.br/Servicos/cnpjreva/cnpjreva_solicitacao.asp.",
+    );
   }
 
   const trimmed = raw.trim();
   const cnpj = findCnpj(trimmed);
 
   if (!cnpj) {
-    throw new Error("A valid CNPJ number is required (14 digits, e.g. 11222333000181). Name search is not supported by ReceitaWS.");
+    throw new Error(
+      "A valid CNPJ number is required (14 digits, e.g. 11222333000181). Name search is not supported by ReceitaWS or Brazil's official registry — find the CNPJ on the company's invoices/contracts, or verify a candidate at Receita Federal's public consultation page: https://solucoes.receita.fazenda.gov.br/Servicos/cnpjreva/cnpjreva_solicitacao.asp.",
+    );
   }
 
   const output = await fetchByCnpj(cnpj);

--- a/apps/api/src/capabilities/bulgarian-company-data.ts
+++ b/apps/api/src/capabilities/bulgarian-company-data.ts
@@ -37,13 +37,13 @@ registerCapability("bulgarian-company-data", async (input: CapabilityInput) => {
     "";
   if (typeof rawInput !== "string" || !rawInput.trim()) {
     throw new Error(
-      "'vat_number' is required. Provide a Bulgarian UIC/EIK (9 digits, optionally BG-prefixed; e.g. 831902088 or BG831902088).",
+      "'vat_number' is required. Provide a Bulgarian UIC/EIK (9 digits, optionally BG-prefixed; e.g. 831902088 or BG831902088). Look one up by company name at the official Commercial Register: https://portal.registryagency.bg/.",
     );
   }
   const normalised = normaliseBgIdentifier(rawInput.trim());
   if (!normalised) {
     throw new Error(
-      `'${rawInput.trim()}' is not a valid Bulgarian UIC/EIK. Expected format: 9 digits, optionally with BG prefix (e.g. 831902088).`,
+      `'${rawInput.trim()}' is not a valid Bulgarian UIC/EIK. Expected format: 9 digits, optionally with BG prefix (e.g. 831902088). Look one up by company name at https://portal.registryagency.bg/.`,
     );
   }
   const __etResult = await executeOpenapiCapability(

--- a/apps/api/src/capabilities/croatian-company-data.ts
+++ b/apps/api/src/capabilities/croatian-company-data.ts
@@ -143,13 +143,17 @@ async function fetchDetail(
 registerCapability("croatian-company-data", async (input: CapabilityInput) => {
   const raw = (input.oib as string) ?? (input.mbs as string) ?? (input.task as string) ?? "";
   if (typeof raw !== "string" || !raw.trim()) {
-    throw new Error("'oib' (11 digits) or 'mbs' (court registry number) is required.");
+    throw new Error(
+      "'oib' (11 digits) or 'mbs' (court registry number) is required. Look one up by company name at the Croatian Court Register public search: https://sudreg.pravosudje.hr/registar/.",
+    );
   }
 
   const trimmed = raw.trim();
   const identifier = extractOibOrMbs(trimmed);
   if (!identifier) {
-    throw new Error(`'${trimmed}' is not a valid Croatian OIB (11 digits) or MBS (numeric court registry number).`);
+    throw new Error(
+      `'${trimmed}' is not a valid Croatian OIB (11 digits) or MBS (numeric court registry number). Look one up by company name at https://sudreg.pravosudje.hr/registar/.`,
+    );
   }
 
   const token = await getAccessToken();

--- a/apps/api/src/capabilities/cypriot-company-data.ts
+++ b/apps/api/src/capabilities/cypriot-company-data.ts
@@ -141,13 +141,13 @@ registerCapability("cypriot-company-data", async (input: CapabilityInput) => {
     "";
   if (typeof rawInput !== "string" || !rawInput.trim()) {
     throw new Error(
-      "'vat_number' or 'identifier' is required. Provide a Cypriot VAT (CY-prefix or bare 8-digit-plus-letter) or company number (C-prefix, e.g. C165).",
+      "'vat_number' or 'identifier' is required. Provide a Cypriot VAT (CY-prefix or bare 8-digit-plus-letter) or company number (C-prefix, e.g. C165). Look one up by company name at the Registrar of Companies (DRCOR) public search: https://efiling.drcor.mcit.gov.cy/DrcorPublic/SearchForm.aspx?sc=1&lang=EN.",
     );
   }
   const normalised = normaliseCyIdentifier(rawInput.trim());
   if (!normalised) {
     throw new Error(
-      `'${rawInput.trim()}' is not a valid Cypriot identifier. Expected: CY + 8 digits + 1 letter (VAT), 8 digits + 1 letter (bare VAT), or C + digits (company number).`,
+      `'${rawInput.trim()}' is not a valid Cypriot identifier. Expected: CY + 8 digits + 1 letter (VAT), 8 digits + 1 letter (bare VAT), or C + digits (company number). Look one up by company name at https://efiling.drcor.mcit.gov.cy/DrcorPublic/SearchForm.aspx?sc=1&lang=EN.`,
     );
   }
   const __etResult = await executeOpenapiCapability(

--- a/apps/api/src/capabilities/dutch-company-data.ts
+++ b/apps/api/src/capabilities/dutch-company-data.ts
@@ -32,13 +32,13 @@ registerCapability("dutch-company-data", async (input: CapabilityInput) => {
     "";
   if (typeof rawInput !== "string" || !rawInput.trim()) {
     throw new Error(
-      "'vat_number' is required. Provide a Dutch VAT/BTW number (NL + 9 digits + B + 2 digits, e.g. NL803441526B01). KvK numbers are not accepted by the upstream API.",
+      "'vat_number' is required. Provide a Dutch VAT/BTW number (NL + 9 digits + B + 2 digits, e.g. NL803441526B01). KvK numbers are not accepted by the upstream API; look up the VAT/BTW number by company name at the official KVK business register search: https://www.kvk.nl/zoeken/.",
     );
   }
   const normalised = normaliseNlIdentifier(rawInput.trim());
   if (!normalised) {
     throw new Error(
-      `'${rawInput.trim()}' is not a valid Dutch VAT/BTW number. Expected format: NL + 9 digits + B + 2 digits (e.g. NL803441526B01).`,
+      `'${rawInput.trim()}' is not a valid Dutch VAT/BTW number. Expected format: NL + 9 digits + B + 2 digits (e.g. NL803441526B01). Look one up by company name at https://www.kvk.nl/zoeken/.`,
     );
   }
   const __etResult = await executeOpenapiCapability(

--- a/apps/api/src/capabilities/greek-company-data.ts
+++ b/apps/api/src/capabilities/greek-company-data.ts
@@ -195,7 +195,7 @@ registerCapability("greek-company-data", async (input: CapabilityInput) => {
     (typeof afmInput !== "string" || !afmInput.trim())
   ) {
     throw new Error(
-      "Provide either 'gemi_number' (Greek GEMI registry number) or 'afm' (Greek tax ID, 9 digits).",
+      "Provide either 'gemi_number' (Greek GEMI registry number) or 'afm' (Greek tax ID, 9 digits). Look either one up by company name at the official GEMI public search: https://publicity.businessportal.gr/.",
     );
   }
 
@@ -206,7 +206,7 @@ registerCapability("greek-company-data", async (input: CapabilityInput) => {
     const arGemi = normaliseGemiNumber(gemiInput);
     if (!arGemi) {
       throw new Error(
-        `'gemi_number' must be 6-14 digits. Received: "${gemiInput}".`,
+        `'gemi_number' must be 6-14 digits. Received: "${gemiInput}". Look one up by company name at https://publicity.businessportal.gr/.`,
       );
     }
     company = await fetchByGemiNumber(arGemi);
@@ -216,7 +216,9 @@ registerCapability("greek-company-data", async (input: CapabilityInput) => {
   } else if (typeof afmInput === "string" && afmInput.trim()) {
     const afm = normaliseAfm(afmInput);
     if (!afm) {
-      throw new Error(`'afm' must be exactly 9 digits. Received: "${afmInput}".`);
+      throw new Error(
+        `'afm' must be exactly 9 digits. Received: "${afmInput}". Look one up by company name at https://publicity.businessportal.gr/.`,
+      );
     }
     company = await searchByAfm(afm);
     if (!company) {

--- a/apps/api/src/capabilities/hungarian-company-data.ts
+++ b/apps/api/src/capabilities/hungarian-company-data.ts
@@ -31,13 +31,13 @@ registerCapability("hungarian-company-data", async (input: CapabilityInput) => {
     "";
   if (typeof rawInput !== "string" || !rawInput.trim()) {
     throw new Error(
-      "'vat_number' is required. Provide a Hungarian VAT (HU + 8 digits, e.g. HU10537914). Cégjegyzékszám is not accepted by the upstream API.",
+      "'vat_number' is required. Provide a Hungarian VAT (HU + 8 digits, e.g. HU10537914). Cégjegyzékszám is not accepted by the upstream API; look up the VAT by company name at the official company registry search: https://www.e-cegjegyzek.hu/.",
     );
   }
   const normalised = normaliseHuIdentifier(rawInput.trim());
   if (!normalised) {
     throw new Error(
-      `'${rawInput.trim()}' is not a valid Hungarian VAT. Expected format: HU + 8 digits (e.g. HU10537914).`,
+      `'${rawInput.trim()}' is not a valid Hungarian VAT. Expected format: HU + 8 digits (e.g. HU10537914). Look one up by company name at https://www.e-cegjegyzek.hu/.`,
     );
   }
   const __etResult = await executeOpenapiCapability(

--- a/apps/api/src/capabilities/italian-company-data.ts
+++ b/apps/api/src/capabilities/italian-company-data.ts
@@ -57,13 +57,13 @@ registerCapability("italian-company-data", async (input: CapabilityInput) => {
     "";
   if (typeof rawInput !== "string" || !rawInput.trim()) {
     throw new Error(
-      "'vat_number' or 'codice_fiscale' is required. Provide an Italian codice fiscale / P.IVA (11 digits, e.g. 00484960588). IT-prefix VAT format is also accepted (e.g. IT00484960588).",
+      "'vat_number' or 'codice_fiscale' is required. Provide an Italian codice fiscale / P.IVA (11 digits, e.g. 00484960588). IT-prefix VAT format is also accepted (e.g. IT00484960588). Look one up by company name at the official Business Register search: https://www.registroimprese.it/.",
     );
   }
   const normalised = normaliseItIdentifier(rawInput.trim());
   if (!normalised) {
     throw new Error(
-      `'${rawInput.trim()}' is not a valid Italian codice fiscale / P.IVA. Expected format: 11 digits (e.g. 00484960588).`,
+      `'${rawInput.trim()}' is not a valid Italian codice fiscale / P.IVA. Expected format: 11 digits (e.g. 00484960588). Look one up by company name at https://www.registroimprese.it/.`,
     );
   }
   const __etResult = await executeOpenapiCapability(

--- a/apps/api/src/capabilities/luxembourgish-company-data.ts
+++ b/apps/api/src/capabilities/luxembourgish-company-data.ts
@@ -32,13 +32,13 @@ registerCapability(
       "";
     if (typeof rawInput !== "string" || !rawInput.trim()) {
       throw new Error(
-        "'vat_number' is required. Provide a Luxembourgish VAT (LU + 8 digits, e.g. LU18513414). RCS B-prefix company numbers are not accepted by the upstream API.",
+        "'vat_number' is required. Provide a Luxembourgish VAT (LU + 8 digits, e.g. LU18513414). RCS B-prefix company numbers are not accepted by the upstream API; look up the VAT by company name at the Luxembourg Business Registers public search: https://www.lbr.lu/.",
       );
     }
     const normalised = normaliseLuIdentifier(rawInput.trim());
     if (!normalised) {
       throw new Error(
-        `'${rawInput.trim()}' is not a valid Luxembourgish VAT. Expected format: LU + 8 digits (e.g. LU18513414).`,
+        `'${rawInput.trim()}' is not a valid Luxembourgish VAT. Expected format: LU + 8 digits (e.g. LU18513414). Look one up by company name at https://www.lbr.lu/.`,
       );
     }
     const __etResult = await executeOpenapiCapability(

--- a/apps/api/src/capabilities/maltese-company-data.ts
+++ b/apps/api/src/capabilities/maltese-company-data.ts
@@ -31,13 +31,13 @@ registerCapability("maltese-company-data", async (input: CapabilityInput) => {
     "";
   if (typeof rawInput !== "string" || !rawInput.trim()) {
     throw new Error(
-      "'vat_number' is required. Provide a Maltese VAT (MT + 8 digits, e.g. MT12826209). MFSA C-prefix company numbers are not accepted by the upstream API.",
+      "'vat_number' is required. Provide a Maltese VAT (MT + 8 digits, e.g. MT12826209). MFSA C-prefix company numbers are not accepted by the upstream API; look up the VAT by company name at the Malta Business Registry: https://mbr.mt/.",
     );
   }
   const normalised = normaliseMtIdentifier(rawInput.trim());
   if (!normalised) {
     throw new Error(
-      `'${rawInput.trim()}' is not a valid Maltese VAT. Expected format: MT + 8 digits (e.g. MT12826209).`,
+      `'${rawInput.trim()}' is not a valid Maltese VAT. Expected format: MT + 8 digits (e.g. MT12826209). Look one up by company name at https://mbr.mt/.`,
     );
   }
   const __etResult = await executeOpenapiCapability(

--- a/apps/api/src/capabilities/portuguese-company-data.ts
+++ b/apps/api/src/capabilities/portuguese-company-data.ts
@@ -40,13 +40,13 @@ registerCapability("portuguese-company-data", async (input: CapabilityInput) => 
     "";
   if (typeof rawInput !== "string" || !rawInput.trim()) {
     throw new Error(
-      "'vat_number' or 'nipc' is required. Provide a Portuguese NIPC (9 digits, e.g. 504499777). PT-prefix VAT format is also accepted (e.g. PT504499777).",
+      "'vat_number' or 'nipc' is required. Provide a Portuguese NIPC (9 digits, e.g. 504499777). PT-prefix VAT format is also accepted (e.g. PT504499777). Look one up by company name at the official commercial registry publications portal: https://publicacoes.mj.pt/.",
     );
   }
   const normalised = normalisePtIdentifier(rawInput.trim());
   if (!normalised) {
     throw new Error(
-      `'${rawInput.trim()}' is not a valid Portuguese NIPC. Expected format: 9 digits (e.g. 504499777).`,
+      `'${rawInput.trim()}' is not a valid Portuguese NIPC. Expected format: 9 digits (e.g. 504499777). Look one up by company name at https://publicacoes.mj.pt/.`,
     );
   }
   const __etResult = await executeOpenapiCapability(

--- a/apps/api/src/capabilities/slovak-company-data.ts
+++ b/apps/api/src/capabilities/slovak-company-data.ts
@@ -155,7 +155,9 @@ function deriveStatus(
 registerCapability("slovak-company-data", async (input: CapabilityInput) => {
   const raw = ((input.ico as string) ?? (input.company_number as string) ?? "").toString().trim();
   if (!raw) {
-    throw new Error("'ico' is required. Provide a Slovak IČO (8 digits).");
+    throw new Error(
+      "'ico' is required. Provide a Slovak IČO (8 digits). Look one up by company name at the official Register of Legal Persons (RPO) search: https://rpo.statistics.sk/.",
+    );
   }
   // normalizeIco zero-pads 1-7 digit numeric input to 8. Real Slovak IČOs go
   // as low as 5 significant digits (e.g. 00151653), so we tolerate short
@@ -164,7 +166,7 @@ registerCapability("slovak-company-data", async (input: CapabilityInput) => {
   const ico = normalizeIco(raw);
   if (!ico || stripped.length < 4) {
     throw new Error(
-      `'${raw}' is not a valid IČO. Slovak IČO is 8 digits (zero-padded).`,
+      `'${raw}' is not a valid IČO. Slovak IČO is 8 digits (zero-padded). Look one up by company name at https://rpo.statistics.sk/.`,
     );
   }
 

--- a/apps/api/src/capabilities/swedish-company-data.ts
+++ b/apps/api/src/capabilities/swedish-company-data.ts
@@ -233,7 +233,7 @@ registerCapability(
       "";
     if (typeof rawInput !== "string" || !rawInput.trim()) {
       throw new Error(
-        "'org_number' is required. Provide a 10-digit Swedish organisationsnummer (e.g. 556703-7485).",
+        "'org_number' is required. Provide a 10-digit Swedish organisationsnummer (e.g. 556703-7485). Name lookup is not supported by Bolagsverket's HVD API; look one up by company name at the official Swedish Companies Registration Office: https://www.bolagsverket.se/.",
       );
     }
 
@@ -245,7 +245,7 @@ registerCapability(
 
     if (!normalised) {
       throw new Error(
-        `'${trimmed}' is not a valid Swedish organisationsnummer. Provide 10 digits, optionally with a hyphen (e.g. 556703-7485). Name lookup is not supported by Bolagsverket's HVD API.`,
+        `'${trimmed}' is not a valid Swedish organisationsnummer. Provide 10 digits, optionally with a hyphen (e.g. 556703-7485). Name lookup is not supported by Bolagsverket's HVD API; look one up by company name at https://www.bolagsverket.se/.`,
       );
     }
 


### PR DESCRIPTION
## Problem

Agents call these registry capabilities holding a company **name**; the registries index by **identifier**. The error text told callers the identifier format but never how to obtain that identifier from a name — a dead end. `brazilian-company-data` alone failed 36/60 calls in 24h on exactly this shape:

> `'cnpj' is required. Provide a CNPJ number (14 digits). Name search is not supported — use a CNPJ.`

An audit found ~15 capabilities with the same shape. This PR fixes the error text (and only the error text) on all 15.

## What changed

Each identifier-required error now states (1) the identifier + format, (2) a concrete next step — an official public registry search URL, curl-verified 200 — to resolve name → identifier. No input schemas, pricing, or business logic changed.

**`au-company-data` note:** the task brief for this PR assumed a working sibling — `australian-company-data` — that does name search. That capability is **deactivated** in `auto-register.ts` ("duplicate of au-company-data ... Browserless scrape of abr.business.gov.au violates Tier 1 per DEC-20260428-A") and is never loaded at runtime (`auto-register-skip-deactivated`). Pointing to it would be a fabricated pointer per the ground rule in the task brief, so `au-company-data`'s error instead points to the official ABR public search (`https://abr.business.gov.au/`). Flagging this discrepancy rather than silently following the brief.

**`brazilian-company-data` note:** verified per the task's explicit warning — ReceitaWS has no `?name=` endpoint (confirmed: no name field on the official Receita Federal CNPJ consultation form either). No compliant name-search path exists for Brazil. The error now points to the official Receita Federal CNPJ consultation page and explains that the CNPJ is normally sourced from the company's own invoices/contracts — an honest answer, not an overclaim.

## Evidence table

| slug | old message | new message (abbreviated) | pointer named | URL verified |
|---|---|---|---|---|
| brazilian-company-data | `'cnpj' is required. Provide a CNPJ number (14 digits). Name search is not supported — use a CNPJ.` | `...Neither ReceitaWS nor Brazil's official registry supports name search — the CNPJ is printed on the company's invoices, contracts, or NF-e documents; verify a candidate at Receita Federal's public consultation page: https://solucoes.receita.fazenda.gov.br/...` | Receita Federal CNPJ consultation page (official, not a name-search fix) | 200 |
| au-company-data | `'abn' is required. Provide an Australian Business Number (11 digits).` | `...Look one up by company name at the official ABN Lookup search: https://abr.business.gov.au/.` | ABR public search (NOT the deactivated `australian-company-data` sibling — see note above) | 200 |
| austrian-company-data | `'vat_number' is required. Provide an Austrian UID-Nummer... Firmenbuchnummer (FN) is not accepted...` | `...look up the UID-Nummer by company name at the Austrian Federal Economic Chamber directory: https://firmen.wko.at/.` | firmen.wko.at (official WKO directory) | 200 |
| bulgarian-company-data | `'vat_number' is required. Provide a Bulgarian UIC/EIK (9 digits...)` | `...Look one up by company name at the official Commercial Register: https://portal.registryagency.bg/.` | Bulgarian Commercial Register (official) | 200 |
| cypriot-company-data | `'vat_number' or 'identifier' is required. Provide a Cypriot VAT... or company number...` | `...Look one up by company name at the Registrar of Companies (DRCOR) public search: https://efiling.drcor.mcit.gov.cy/...` | DRCOR public search (official; same source cypriot-company-data already uses for legal_representatives) | 200 |
| croatian-company-data | `'oib' (11 digits) or 'mbs' (court registry number) is required.` | `...Look one up by company name at the Croatian Court Register public search: https://sudreg.pravosudje.hr/registar/.` | Sudski registar (official) | 200 |
| dutch-company-data | `'vat_number' is required. Provide a Dutch VAT/BTW number... KvK numbers are not accepted...` | `...look up the VAT/BTW number by company name at the official KVK business register search: https://www.kvk.nl/zoeken/.` | KVK search (official) | 200 |
| greek-company-data | `Provide either 'gemi_number' (Greek GEMI registry number) or 'afm' (Greek tax ID, 9 digits).` | `...Look either one up by company name at the official GEMI public search: https://publicity.businessportal.gr/.` | GEMI public search (official) | 200 |
| hungarian-company-data | `'vat_number' is required. Provide a Hungarian VAT... Cégjegyzékszám is not accepted...` | `...look up the VAT by company name at the official company registry search: https://www.e-cegjegyzek.hu/.` | e-cégjegyzék (official) | 200 |
| italian-company-data | `'vat_number' or 'codice_fiscale' is required. Provide an Italian codice fiscale / P.IVA (11 digits...)` | `...Look one up by company name at the official Business Register search: https://www.registroimprese.it/.` | Registro Imprese (official public search page — distinct from the banned Strale-side scrape of the same site) | 200 |
| luxembourgish-company-data | `'vat_number' is required. Provide a Luxembourgish VAT... RCS B-prefix company numbers are not accepted...` | `...look up the VAT by company name at the Luxembourg Business Registers public search: https://www.lbr.lu/.` | LBR (official) | 200 |
| maltese-company-data | `'vat_number' is required. Provide a Maltese VAT... MFSA C-prefix company numbers are not accepted...` | `...look up the VAT by company name at the Malta Business Registry: https://mbr.mt/.` | MBR (official) | 200 |
| portuguese-company-data | `'vat_number' or 'nipc' is required. Provide a Portuguese NIPC (9 digits...)` | `...Look one up by company name at the official commercial registry publications portal: https://publicacoes.mj.pt/.` | Ministério da Justiça publications portal (official) | 200 |
| slovak-company-data | `'ico' is required. Provide a Slovak IČO (8 digits).` | `...Look one up by company name at the official Register of Legal Persons (RPO) search: https://rpo.statistics.sk/.` | RPO public search (official; same register slovak-company-data's own API queries) | 200 |
| swedish-company-data | `'org_number' is required. Provide a 10-digit Swedish organisationsnummer... Name lookup is not supported by Bolagsverket's HVD API.` | `...Name lookup is not supported by Bolagsverket's HVD API; look one up by company name at the official Swedish Companies Registration Office: https://www.bolagsverket.se/.` | Bolagsverket (official) | 200 |

All 15 files also got the matching "invalid format" throw site (the second guard, fired when a name lands in an identifier field) updated with the same pointer — visible in the diff.

## Live verification (7 of 15, exceeds the 3-capability requirement)

Executed against the actual committed code via direct executor invocation (validation fires before any network call, so no external credentials needed):

```
[brazilian-company-data] input={"company_name":"Petrobras"}
  -> A valid CNPJ number is required (14 digits, e.g. 11222333000181). Name search is not supported by
     ReceitaWS or Brazil's official registry — find the CNPJ on the company's invoices/contracts, or verify
     a candidate at Receita Federal's public consultation page:
     https://solucoes.receita.fazenda.gov.br/Servicos/cnpjreva/cnpjreva_solicitacao.asp.

[au-company-data] input={"company_name":"Wesfarmers"}
  -> 'abn' is required. Provide an 11-digit Australian Business Number. Look one up by company name at the
     official ABN Lookup search: https://abr.business.gov.au/.

[swedish-company-data] input={"company_name":"Volvo"}
  -> 'org_number' is required. Provide a 10-digit Swedish organisationsnummer (e.g. 556703-7485). Name
     lookup is not supported by Bolagsverket's HVD API; look one up by company name at the official Swedish
     Companies Registration Office: https://www.bolagsverket.se/.

[croatian-company-data] input={"company_name":"INA"}
  -> 'oib' (11 digits) or 'mbs' (court registry number) is required. Look one up by company name at the
     Croatian Court Register public search: https://sudreg.pravosudje.hr/registar/.

[austrian-company-data] input={"vat_number":"OMV"}
  -> 'OMV' is not a valid Austrian UID-Nummer. Expected format: ATU + 8 digits (e.g. ATU14189108). Look one
     up by company name at https://firmen.wko.at/.

[dutch-company-data] input={"vat_number":"Heineken"}
  -> 'Heineken' is not a valid Dutch VAT/BTW number. Expected format: NL + 9 digits + B + 2 digits (e.g.
     NL803441526B01). Look one up by company name at https://www.kvk.nl/zoeken/.

[slovak-company-data] input={"ico":"Slovnaft"}
  -> 'Slovnaft' is not a valid IČO. Slovak IČO is 8 digits (zero-padded). Look one up by company name at
     https://rpo.statistics.sk/.
```

## Verification

- `cd apps/api && npx tsc --noEmit --project tsconfig.json` — clean, no errors.
- `npx vitest run` — **92 test files passed, 3 skipped (95 total); 1199 tests passed, 33 skipped, 0 failed.** No dedicated unit tests exist for these 15 capability files, so no test updates were needed.
- No manifests, DB rows, pricing, or input schemas touched — error strings and their surrounding comments only, matching every changed diff hunk.

## Scope notes

- `australian-company-data.ts` was **not** touched: it's not in the target list, and it's deactivated (Tier-1 scraping violation) — editing a dead file's error text has no runtime effect and risks looking like reactivation. See the au-company-data note above for how the cross-reference gap was actually closed.
- All 15 target capabilities were in scope and none were skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
