### PR TITLE
docs(claude): shared-checkout concurrency rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,6 +462,40 @@ scheduler excludes them from all runs (test-runner.ts line 117). They are never 
 12. Save session summary to `handoff/_general/from-code/`
 13. Contradiction check if decisions were made
 
+### Shared-Checkout Rule (concurrency safety)
+
+**This checkout is shared.** Several Claude Code sessions and background agents
+run against the same working tree at once. Git branch switching is not
+concurrency-safe here.
+
+**The failure mode:** an agent runs `git checkout <branch>` in the main tree
+while another process holds file locks (tsc, vitest, npm, an editor). On
+Windows git's delete-then-rewrite sequence fails partway — the old files are
+unlinked, the new ones never written. ~1,000 tracked files vanish from disk
+while the index still lists them, always in `apps/api/**` and `packages/**`
+where node holds handles. Hit three times on 2026-08-14.
+
+**Rules:**
+
+1. **Any agent that edits files MUST be launched with `isolation: "worktree"`.**
+   An agent working in the shared checkout will eventually collide with the
+   main loop or another agent. This is the actual prevention.
+2. **Agents must never `git checkout` a branch in the main tree.** If an agent
+   without worktree isolation needs a branch, it should create its own worktree
+   (`git worktree add`) rather than moving the shared one.
+3. **Before branch-switching in the main tree, check `git status`** for another
+   session's uncommitted work. Uncommitted changes travel across branch
+   switches and can end up staged onto the wrong branch.
+4. **Never "fix" phantom breakage.** If files that are committed suddenly
+   ENOENT, that is this bug, not a real deletion. Run
+   `node scripts/guard-tree-integrity.mjs` (or just any Bash command, if the
+   PostToolUse hook is wired) and re-check before diagnosing further.
+
+The guard at `scripts/guard-tree-integrity.mjs` auto-repairs the damage and is
+wired as a PostToolUse/Bash hook in `.claude/settings.json` (gitignored — each
+machine opts in). It only ever restores tracked-and-deleted paths, so it cannot
+discard work. It is a safety net, not a substitute for rule 1.
+
 ### Report Filing Convention
 
 Large investigative/audit/session reports (AUDIT-*, FIX_PHASE_*, SESSION_*, RESOLUTION_REPORT, REVIEW_FINDINGS_*, *_INVENTORY, *_RESEARCH, checklists tied to a specific incident, etc.) route to `archive/sessions/` (flat layout — see existing entries for naming convention), never to the repo root. Root stays reserved for genuine top-level canon (README, CLAUDE.md, LICENSE, WORKTREES.md-style structural docs, live-use checklists still actively referenced). Note: `AGENTS.md` is currently untracked in this repo pending its own resolution — it is not yet part of this convention's tracked surface.


### PR DESCRIPTION
Records the branch-switch corruption mode diagnosed today (root cause of the phantom mass deletions) and the rules that prevent it. Companion to #218, which added the auto-repair guard.

Primary rule: **agents that edit files must be launched with worktree isolation.** The guard is the safety net; isolation is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)