### PR TITLE
docs(catalog): mexican-company-data spec - blocked on DENUE token registration

### DIFF
--- a/handoff/_general/from-code/2026-08-14-mexican-company-data-token-blocked.md
+++ b/handoff/_general/from-code/2026-08-14-mexican-company-data-token-blocked.md
@@ -1,0 +1,89 @@
+Intent: Build mexican-company-data from INEGI DENUE, excluding sole-trader contact fields per Petter's product decision
+
+## Outcome: build blocked before it started — DENUE API requires a registered token
+
+Per the session's own instructions ("If it needs a token that must be registered, STOP
+and write the spec instead — key registration is founder-gated, do not sign up for
+anything"), this session verified the DENUE access model, confirmed a token is required,
+confirmed nothing resembling a token exists anywhere in the repo/`.env`, and stopped
+before writing an executor or touching the DB. **No capability was created. No DB rows
+were inserted or modified.**
+
+## What was verified
+
+1. **Source access model.** Fetched
+   https://www.inegi.org.mx/servicios/api_denue.html directly (2026-08-14). Confirmed:
+   - Endpoint: `https://www.inegi.org.mx/app/api/denue/v1/consulta/Nombre/{name}/{entidad}/{start}/{end}/{token}`
+     and `.../consulta/Ficha/{id}/{token}`.
+   - A token is required for every call — the docs state it is "obtained by registering"
+     (`Número único que permite hacer consultas, el cual se puede obtener al
+     registrarse`), at https://inegi.org.mx/app/desarrolladores/generatoken/Usuarios/token_Verify,
+     emailed to the address supplied at signup.
+   - No rate limits and no terms of use / redistribution terms are published on the
+     docs page. Recorded the absence rather than obtaining anything in writing (same
+     class as the AT Firmenbuch item, 2026-08-12 catalogue strategy §5 V1).
+   - Confirmed empirically: an unauthenticated call
+     (`curl https://www.inegi.org.mx/app/api/denue/v1/consulta/Nombre/AUTOFLETES/0/1/10/`)
+     returns HTTP 501 "Consulta incorrecta" — the token is enforced, not optional.
+   - Checked `.env`, the whole repo, and grepped for `denue`/`inegi` — no token or prior
+     integration exists anywhere.
+2. **Persona física / persona moral classification.** DENUE's documented response
+   fields (`Nombre`, `Razon_social`, `Clase_actividad`, `Estrato`, `Telefono`,
+   `Correo_e`, `Sitio_internet`, address fields, `Latitud`/`Longitud`) contain no
+   explicit legal-form flag. The only available signal is pattern-matching
+   `Razon_social` for a corporate suffix (SA DE CV, S DE RL, SC, SAPI DE CV, AC, etc.),
+   which the task instructions explicitly forbid using ("do not guess"). Per Petter's
+   own conditional in the task ("If DENUE does not let you distinguish persona física
+   from persona moral reliably, omit contact fields entirely"), this resolves to:
+   **omit `phone`/`email`/`website` from the output for every record**, not a
+   sole-trader-only exclusion. Documented in the manifest as a `legal`-category
+   limitation.
+
+## What was done
+
+- Updated `manifests-drafts/mexican-company-data.yaml` (still in `manifests-drafts/`,
+  not promoted to `manifests/` — it cannot be, no executor exists):
+  - Closed verification-debt items 1 and 5 from the prior draft's header.
+  - Recorded item 2 (contact-field population rates) and item 3 (redistribution
+    terms) as blocked on the token — cannot be checked without registering.
+  - Added the persona física finding (new item 6) and resolved it per Petter's
+    conditional: contact fields removed from `output_schema.example`,
+    `output_field_reliability`, and description; a new `limitations` entry
+    ("Contact fields withheld for all records") replaces the two prior
+    contact-related limitation entries.
+  - Added an explicit action item for Petter: register at the INEGI URL above, add
+    the token to the environment (suggested name `DENUE_API_TOKEN`), confirm no
+    redistribution restriction in the post-signup terms, then re-verify contact-field
+    population rates live before the executor is written.
+- No executor file was created (`apps/api/src/capabilities/mexican-company-data.ts`
+  does not exist).
+- No manifest was moved into `manifests/`, no `onboard.ts` run (dry-run or otherwise —
+  there is nothing to onboard without an executor), no DB writes of any kind.
+- No account was created and no registration form was submitted anywhere.
+
+## Capability Onboarding Protocol (DEC-20260320-B) — not triggered
+
+No executor, no manifest promotion, no DB row: the protocol's "creates, modifies, or
+onboards a capability" trigger did not fire. Nothing to report against readiness check,
+structural validation, or smoke test — none were run because there is nothing to run
+them against.
+
+## Next step (for whoever picks this up once a token exists)
+
+1. Petter registers at https://inegi.org.mx/app/desarrolladores/generatoken/Usuarios/token_Verify,
+   sets `DENUE_API_TOKEN` (or similar) on Railway + local `.env`.
+2. Re-run the population-rate check (item 2) with a real authenticated call against a
+   known carrier (e.g. one of the 50 names in the demand doc) before trusting the
+   €0.05 pricing / value framing.
+3. Write the executor following the Capability Onboarding Protocol and the manifest at
+   `manifests-drafts/mexican-company-data.yaml` (promote to `manifests/` once the
+   executor exists), keeping the contact-field omission exactly as specified — do not
+   reintroduce `phone`/`email`/`website` without a documented DENUE legal-form field.
+4. Dark-launch per DEC-20260812-A (`visible=false`, `x402_enabled=false`) until a green
+   week of real signal.
+
+## PR
+
+Branch `catalog/mexican-company-data` off `origin/main`. This PR contains only the
+manifest-draft update and this handoff file — no code, no DB changes. Opened as a
+findings/spec PR per the task's explicit stop condition, not a capability-ship PR.

--- a/manifests-drafts/mexican-company-data.yaml
+++ b/manifests-drafts/mexican-company-data.yaml
@@ -4,32 +4,77 @@
 # template `"<CARRIER NAME>" 墨西哥 phone contact`, 100% success, zero Mexican
 # capability in the catalogue. See docs/strategy/2026-08-demand-mined-build-queue.md §2.1.
 #
-# VERIFICATION DEBT — close all of these before building:
-#   1. DENUE publishes NO rate limits and NO terms of use on
-#      https://www.inegi.org.mx/servicios/api_denue.html. Obtain both in writing
-#      (or record their absence) before launch. Same class as the AT Firmenbuch
-#      item in the 2026-08-12 catalogue strategy §5 V1.
-#   2. Field names below are taken from the API documentation page, not from a live
-#      response. Confirm `Telefono` / `Correo_e` / `Sitio_internet` are actually
-#      populated and not near-universally empty — the whole demand case rests on
-#      contact fields being present.
-#   3. Token acquisition is a free registration. Confirm it does not carry
-#      redistribution restrictions that conflict with reselling lookups.
-#   4. PERSONAL-DATA CALL — HUMAN DECISION, NOT ENGINEERING.
+# ============================================================================
+# BUILD BLOCKED 2026-08-14 — DENUE requires a registered API token.
+# No executor was written and nothing was inserted to the DB this session.
+# See handoff/_general/from-code/2026-08-14-mexican-company-data-token-blocked.md
+# for the full session record. Verification findings below; action item for
+# Petter at the bottom.
+# ============================================================================
+#
+# VERIFICATION DEBT — status as of 2026-08-14:
+#   1. CLOSED. Confirmed by direct fetch of https://www.inegi.org.mx/servicios/api_denue.html
+#      (2026-08-14): the page states NO rate limits and NO terms of use / licensing /
+#      redistribution terms for the DENUE API. It is described only as part of INEGI's
+#      "iniciativa de datos de libre acceso" (open-data initiative). Absence recorded,
+#      not obtained in writing — same class as the AT Firmenbuch item in the 2026-08-12
+#      catalogue strategy §5 V1.
+#   2. BLOCKED ON TOKEN. Cannot confirm `Telefono` / `Correo_e` / `Sitio_internet`
+#      population rates without a live authenticated call. An unauthenticated probe
+#      (`curl .../consulta/Nombre/AUTOFLETES/0/1/10/` with no token, 2026-08-14) returns
+#      HTTP 501 "Consulta incorrecta. Por favor, verifica los parámetros del método
+#      solicitado." — confirming the token is enforced, not optional. Re-run this check
+#      once a token exists, before trusting the demand case in the queue doc.
+#   3. HARD STOP — TOKEN REQUIRES REGISTRATION.
+#      DENUE's own documentation: "Número único que permite hacer consultas, el cual se
+#      puede obtener al registrarse" (obtained by registering). Registration is at
+#      https://inegi.org.mx/app/desarrolladores/generatoken/Usuarios/token_Verify and the
+#      token is emailed to the address supplied at signup. Per this session's build
+#      instructions, key registration is founder-gated and this agent must not sign up
+#      for anything. Redistribution-restriction question (original item 3) is therefore
+#      also still open — cannot be answered without registering to read the post-signup
+#      terms.
+#   4. PERSONAL-DATA CALL — RESOLVED BY PETTER (2026-08-14), see decision below.
 #      DENUE covers ~6M establishments including sole traders ("personas físicas con
 #      actividad empresarial"), where the business phone is frequently a personal
-#      mobile. This is why processes_personal_data is true below. Petter must decide
-#      whether this ships, on the same footing as the standing email-finder refusal.
-#      Do NOT resolve this by reading the manifest.
-#   5. DEC-20260428-A preference order check: this is an official API (tier above
-#      per-call parsing), so no DEC-20260813-A analysis is required. Confirm anyway.
+#      mobile. Decision: build it, but exclude contact fields for sole traders where
+#      classification is reliable; omit contact fields entirely where it is not (see
+#      the persona física finding below — that is the branch that applies here).
+#   5. CLOSED. This is an official government API — DEC-20260428-A tier above
+#      per-call parsing — so no DEC-20260813-A per-call-parsing analysis applies.
+#   6. NEW — persona física / persona moral classification finding (2026-08-14):
+#      DENUE's documented response fields (`Nombre`, `Razon_social`, `Clase_actividad`,
+#      `Estrato`, `Telefono`, `Correo_e`, `Sitio_internet`, address, `Latitud`/`Longitud`)
+#      contain NO explicit legal-form flag. The only available signal is an informal
+#      heuristic — checking `Razon_social` for a corporate-suffix token (SA DE CV, S DE
+#      RL, S DE RL DE CV, SC, SAPI DE CV, AC, etc.) — which is pattern-matching on a
+#      free-text field, not a documented classification, and can misfire both ways
+#      (a sole trader can register a `Razon_social` with no suffix that still isn't a
+#      company, and rare legal forms won't match a suffix list). Per this session's
+#      explicit instruction not to guess the classification: the resolution is to omit
+#      `phone` / `email` / `website` for ALL records, not attempt a persona
+#      física/moral split. This is captured in `output_field_reliability` and
+#      `limitations` below. Re-open this only if a future session finds a documented
+#      DENUE field for legal form (not found in the public API docs as of this session).
+#
+# ACTION ITEM FOR PETTER: register at
+# https://inegi.org.mx/app/desarrolladores/generatoken/Usuarios/token_Verify, add the
+# resulting token to the environment (suggest `DENUE_API_TOKEN`), and confirm no
+# redistribution restriction surfaces in the post-signup terms. Once that's done, item 2
+# above needs a live re-check (real phone/email population rates) before this manifest's
+# `price_cents` and contact-field framing can be trusted, then the executor at
+# `apps/api/src/capabilities/mexican-company-data.ts` can be written following the
+# Capability Onboarding Protocol and this manifest.
 
 slug: mexican-company-data
 name: Mexican Company Data
 description: >-
   Look up Mexican businesses in INEGI's official DENUE establishment directory by name or
-  registry ID. Returns legal name, economic activity, size band, address, coordinates and
-  published business contact details.
+  registry ID. Returns legal name, economic activity, size band, address and coordinates.
+  Business contact details (phone/email/website) are withheld — see the persona física
+  finding in the header comment; DENUE does not expose a reliable legal-form field to
+  distinguish sole traders from companies, so contact fields are omitted for every record
+  rather than guessed.
 category: company-data
 cost_class: free_official
 quota_window: unknown
@@ -98,12 +143,8 @@ output_schema:
         postal_code: "31160"
         municipality: Chihuahua
         state: Chihuahua
-        phone: "+52 614 000 0000"
-        email: contacto@example.mx
-        website: https://example.mx
         latitude: 28.6353
         longitude: -106.0889
-        contact_fields_present: true
   properties:
     query: { type: ["string", "null"] }
     state: { type: ["string", "null"] }
@@ -111,8 +152,11 @@ output_schema:
     establishments:
       type: array
       description: >-
-        Matching establishments. Identity and location fields are guaranteed by DENUE;
-        contact fields are self-reported by the establishment and frequently absent.
+        Matching establishments. Identity and location fields are guaranteed by DENUE.
+        `phone` / `email` / `website` are deliberately not returned — DENUE mixes sole
+        traders and companies with no documented legal-form field, so contact data (which
+        is personal data for sole traders) is withheld for every record rather than
+        guessed at classification. See limitations.
 
 test_fixtures:
   # DRAFT fixture — the pipeline regenerates expected_fields via --discover.
@@ -145,19 +189,23 @@ output_field_reliability:
   "establishments[].longitude": common
   "establishments[].legal_name": common
   "establishments[].postal_code": common
-  "establishments[].phone": rare
-  "establishments[].email": rare
-  "establishments[].website": rare
-  "establishments[].contact_fields_present": guaranteed
+  # phone / email / website intentionally absent from output — see limitations
+  # "Contact fields withheld for all records" below. Do not re-add without a
+  # documented DENUE legal-form field to gate them on.
 
 limitations:
-  - title: Contact details are self-reported and often missing
+  - title: Contact fields withheld for all records
     text: >-
-      Phone, email and website in DENUE are supplied by the establishment during census
-      collection and are absent for a large share of records. `contact_fields_present`
-      states per record whether any were returned. This capability will not find a
-      contact that DENUE does not hold — it does not search the open web to fill gaps.
-    category: coverage
+      DENUE includes sole traders ("personas físicas con actividad empresarial") whose
+      business phone/email is frequently a personal number, alongside registered
+      companies. DENUE's API exposes no documented field that reliably distinguishes the
+      two — the only available signal is pattern-matching `Razon_social` for a corporate
+      suffix (SA DE CV, S DE RL, SC, etc.), which is a guess, not a classification, and
+      was rejected on that basis. This capability therefore never returns `Telefono` /
+      `Correo_e` / `Sitio_internet` for any establishment, sole trader or company. Use
+      `denue_id` with the source `Ficha` method directly against INEGI if you need
+      contact fields and can make your own lawful-basis determination.
+    category: legal
     severity: warning
   - title: Establishments, not legal entities
     text: >-
@@ -186,10 +234,3 @@ limitations:
       so records can lag reality by months. The API call is live; the underlying data is not.
     category: freshness
     severity: info
-  - title: May contain personal data for sole traders
-    text: >-
-      Establishments operated by sole traders can carry a personal mobile number or personal
-      email in the business contact fields. Callers are responsible for their own lawful
-      basis when processing these records.
-    category: legal
-    severity: warning


### PR DESCRIPTION
## Summary

Blocked, not shipped. This PR closes the verification debt on the `mexican-company-data` spec and documents why the build stopped before an executor was written — **no capability was created, no DB rows were touched.**

## Why blocked

Per the task's own instruction: *"If it needs a token that must be registered, STOP and write the spec instead — key registration is founder-gated, do not sign up for anything."*

Verified directly against INEGI's docs (https://www.inegi.org.mx/servicios/api_denue.html, fetched 2026-08-14):

- Every DENUE call requires a token: *"Número único que permite hacer consultas, el cual se puede obtener al registrarse"* — obtained by registering at https://inegi.org.mx/app/desarrolladores/generatoken/Usuarios/token_Verify, emailed to the signup address.
- Confirmed empirically — an unauthenticated call returns HTTP 501:
  ```
  $ curl https://www.inegi.org.mx/app/api/denue/v1/consulta/Nombre/AUTOFLETES/0/1/10/
  "Consulta incorrecta. Por favor, verifica los parámetros del método solicitado."
  ```
- No rate limits or terms of use are published on the docs page — recorded the absence.
- Grepped the repo and `.env` for `denue`/`inegi` — no existing token anywhere.

This is a hard stop per instructions, not a judgment call. No account was created and no registration form was submitted.

## Persona física / persona moral finding (resolves the open product question)

The prior draft flagged the sole-trader contact-field question as a human decision. Petter's decision this session: build it, exclude contact fields for sole traders **if reliably distinguishable**, otherwise omit contact fields entirely rather than guess.

Verified: DENUE's documented response fields (`Nombre`, `Razon_social`, `Clase_actividad`, `Estrato`, `Telefono`, `Correo_e`, `Sitio_internet`, address, `Latitud`/`Longitud`) have **no explicit legal-form field**. The only available signal is pattern-matching `Razon_social` for a corporate suffix (SA DE CV, S DE RL, SC, SAPI DE CV, AC…), which is a guess, not a classification, and is explicitly disallowed by the task instructions.

**Resolution applied to the manifest:** `phone` / `email` / `website` are omitted from the output for every establishment, sole trader or company — not a sole-trader-only exclusion. See the new "Contact fields withheld for all records" limitation in the manifest.

## What changed

- `manifests-drafts/mexican-company-data.yaml` — verification-debt header updated (2 items closed, 2 blocked-on-token, persona física item added and resolved), `output_schema`/`output_field_reliability`/`limitations`/description updated to drop contact fields from the output shape, explicit action item added for Petter.
- `handoff/_general/from-code/2026-08-14-mexican-company-data-token-blocked.md` — full session record.

Still in `manifests-drafts/`, not promoted to `manifests/` (no executor exists to onboard).

## Capability Onboarding Protocol (DEC-20260320-B)

Not triggered — no executor, no manifest promotion, no DB write. Nothing to run readiness/structural-validation/smoke-test checks against.

## Next step for Petter

1. Register at https://inegi.org.mx/app/desarrolladores/generatoken/Usuarios/token_Verify, add the token to the environment (suggested `DENUE_API_TOKEN`), confirm no redistribution restriction in the post-signup terms.
2. Once available, re-verify `Telefono`/`Correo_e`/`Sitio_internet` population rates with a live authenticated call — the whole demand case in `docs/strategy/2026-08-demand-mined-build-queue.md` §2.1 rests on contact fields being present, and this PR removes contact fields from the output entirely, so that value proposition needs re-examining regardless (the capability's value becomes identity/address/activity/coordinates only, not contact discovery).
3. Then the executor can be written following the Capability Onboarding Protocol and this manifest, dark-launched per DEC-20260812-A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
