### PR TITLE
fix(discovery): wire search_tags into ranking; fix domain-contact-extract vocabulary mismatch

### DIFF
--- a/apps/api/src/lib/suggest.ts
+++ b/apps/api/src/lib/suggest.ts
@@ -191,6 +191,7 @@ async function loadCatalog(): Promise<CatalogItem[]> {
           category: solutions.category,
           priceCents: solutions.priceCents,
           geography: solutions.geography,
+          searchTags: solutions.searchTags,
         })
         .from(solutions)
         .where(eq(solutions.isActive, true))
@@ -222,10 +223,17 @@ async function loadCatalog(): Promise<CatalogItem[]> {
         const stepNames = steps
           .map((s) => s.capabilityName ?? s.capabilitySlug)
           .join(", ");
+        // search_tags are hand-authored vocabulary bridges (the words agents
+        // actually type, which don't always appear in the name/description
+        // prose) — fold them into both the embedding text and the token set
+        // so they influence ranking rather than sitting unused in the API
+        // response. See suggest.ts capItems mapping below for the same fix
+        // on the capability side.
+        const tagText = sol.searchTags && sol.searchTags.length > 0 ? sol.searchTags.join(", ") : "";
         const embeddingText = sol.agentDescription
-          ? `${sol.name}. ${sol.agentDescription}. ${sol.description}. Category: ${sol.category}. Geography: ${sol.geography}. Includes: ${stepNames}.`
-          : `${sol.name}. ${sol.description}. Category: ${sol.category}. Geography: ${sol.geography}. Includes: ${stepNames}.`;
-        const tokenText = `${sol.name} ${sol.description} ${sol.agentDescription ?? ""} ${sol.category} ${sol.geography} ${sol.slug} ${steps.map((s) => s.capabilitySlug).join(" ")}`;
+          ? `${sol.name}. ${sol.agentDescription}. ${sol.description}. Category: ${sol.category}. Geography: ${sol.geography}. Includes: ${stepNames}.${tagText ? ` Also known as: ${tagText}.` : ""}`
+          : `${sol.name}. ${sol.description}. Category: ${sol.category}. Geography: ${sol.geography}. Includes: ${stepNames}.${tagText ? ` Also known as: ${tagText}.` : ""}`;
+        const tokenText = `${sol.name} ${sol.description} ${sol.agentDescription ?? ""} ${sol.category} ${sol.geography} ${sol.slug} ${steps.map((s) => s.capabilitySlug).join(" ")} ${tagText}`;
 
         return {
           type: "solution" as const,
@@ -259,6 +267,7 @@ async function loadCatalog(): Promise<CatalogItem[]> {
           priceCents: capabilities.priceCents,
           isFreeTier: capabilities.isFreeTier,
           geography: capabilities.geography,
+          searchTags: capabilities.searchTags,
         })
         .from(capabilities)
         .where(
@@ -274,8 +283,16 @@ async function loadCatalog(): Promise<CatalogItem[]> {
 
       const capItems: CatalogItem[] = capRows.map((cap) => {
         const slugWords = cap.slug.replace(/-/g, " ");
-        const embeddingText = `${cap.name}. ${cap.description}. Category: ${cap.category}. Also known as: ${slugWords}.`;
-        const tokenText = `${cap.name} ${cap.description} ${cap.category} ${cap.slug}`;
+        // search_tags (manifest field `search_tags`) previously flowed all
+        // the way to the API response and to this catalog item but was never
+        // read by embeddingText/tokenText — a capability's discoverability
+        // depended on name+description+category+slug only, so hand-authored
+        // vocabulary bridges (e.g. "email address", "phone number", "KYB")
+        // had zero effect on ranking. Fold them in here.
+        const tagWords = cap.searchTags && cap.searchTags.length > 0 ? cap.searchTags.join(", ") : "";
+        const alsoKnownAs = tagWords ? `${slugWords}, ${tagWords}` : slugWords;
+        const embeddingText = `${cap.name}. ${cap.description}. Category: ${cap.category}. Also known as: ${alsoKnownAs}.`;
+        const tokenText = `${cap.name} ${cap.description} ${cap.category} ${cap.slug} ${tagWords}`;
 
         return {
           type: "capability" as const,

--- a/manifests/company-enrich.yaml
+++ b/manifests/company-enrich.yaml
@@ -7,6 +7,14 @@ description: >-
   Enrich company data from a domain, email, or company name. Scrapes the company website to extract: industry, employee
   estimate, HQ location, description, social links, tech stack.
 category: data-extraction
+search_tags:
+  - company info
+  - company lookup
+  - company profile
+  - find company details
+  - company background
+  - company research
+  - tech stack lookup
 cost_class: paid_prepaid
 quota_window: none
 price_cents: 50

--- a/manifests/domain-contact-extract.yaml
+++ b/manifests/domain-contact-extract.yaml
@@ -1,9 +1,24 @@
 slug: domain-contact-extract
 name: Domain Contact Extract
 description: >-
-  Extract a company's public organisational contact channels (role emails, phone numbers, address, social links) from
-  its own website. No personnel discovery.
+  Find a company's contact info — email address, phone number, and mailing address — by extracting it from the
+  company's own website given its domain. Returns role emails (info@, sales@, support@), phone numbers, postal
+  address, contact-page URL, and social links. Organisation-level contacts only, not a specific person's email
+  address (see email-finder) and not employee discovery.
 category: web-intelligence
+search_tags:
+  - contact info
+  - company email
+  - company contact
+  - find email
+  - find phone number
+  - get email address
+  - get phone number
+  - business contact details
+  - contact page
+  - website scrape
+  - extract emails from website
+  - company phone number
 cost_class: free_unlimited
 quota_window: none
 price_cents: 5

--- a/manifests/email-finder.yaml
+++ b/manifests/email-finder.yaml
@@ -4,6 +4,14 @@ description: >-
   Infer a person's most likely work email address from their name and a company domain, ranked by confidence.
   Evidence-linked, never claims verification.
 category: web-intelligence
+search_tags:
+  - find email
+  - get email address
+  - person email address
+  - work email finder
+  - guess email address
+  - email address format
+  - find someone's email
 cost_class: free_unlimited
 quota_window: none
 price_cents: 5

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -677,10 +677,15 @@ export function registerStraleTools(
       }
 
       // Match solutions
+      // search_tags are hand-authored vocabulary bridges (the words agents
+      // actually type, which don't always appear in the name/description);
+      // fold them into the matched text so this fallback path — used when
+      // the typeahead API is unreachable or a category filter is set — sees
+      // the same signal the primary /v1/suggest/typeahead path now does.
       const matchedSolutions = solutions
         .filter((s) => {
           if (catFilter && !s.category.toLowerCase().includes(catFilter)) return false;
-          return localMatchScore(`${s.name} ${s.description} ${s.slug} ${s.category}`) > 0;
+          return localMatchScore(`${s.name} ${s.description} ${s.slug} ${s.category} ${(s.search_tags ?? []).join(" ")}`) > 0;
         })
         .map((s) => ({
           type: "solution" as const,
@@ -698,7 +703,7 @@ export function registerStraleTools(
       const matchedCaps = capabilities
         .filter((c) => {
           if (catFilter && !c.category.toLowerCase().includes(catFilter)) return false;
-          return localMatchScore(`${c.name} ${c.description} ${c.slug} ${c.category}`) > 0;
+          return localMatchScore(`${c.name} ${c.description} ${c.slug} ${c.category} ${(c.search_tags ?? []).join(" ")}`) > 0;
         })
         .map((c) => {
           let inputFields = "Accepts: task (string) — describe what you need in natural language";


### PR DESCRIPTION
## Problem

The platform's one paying customer runs `google-search` (paid, €0.10/call) to
get company phone/contact info — 52 times in 30 days, per
`docs/strategy/2026-08-demand-mined-build-queue.md` — while
`domain-contact-extract` does exactly this job, is live, x402-enabled, and
zero external cost. It has had **zero real customer calls** since shipping
2026-08-08 (verified read-only against prod: the only `domain-contact-extract`
transactions are `user_id = system@strale.internal`, `input: {}` — the hourly
free-tier health probe, not customers; see §"DB evidence" below).

## Mechanism (diagnosed, not guessed)

Three discovery surfaces exist. All three rank on the **same narrow token
set**, and none of them read `search_tags`:

1. **`POST /v1/suggest`** and **`GET /v1/suggest/typeahead`** —
   `apps/api/src/lib/suggest.ts`, `loadCatalog()`. Builds one `tokenText` /
   `embeddingText` per capability/solution from
   `` `${name} ${description} ${category} ${slug}` `` (capabilities:
   line ~270 before this PR) and `` `${name} ${description} ${agentDescription}
   ${category} ${geography} ${slug} ${stepSlugs}` `` (solutions). `search_tags`
   is not in the `capRows`/`solRows` SELECT and never touches either string.
   Both `typeahead()` (keyword scoring) and `suggest()`'s embedding +
   Claude-rerank path consume these same fields, so the gap affects both
   the free keyword path and the Voyage/Claude path.
2. **`GET /v1/capabilities`** / **`GET /v1/solutions`** —
   `apps/api/src/routes/capabilities.ts:30,94`, `solutions.ts:33,77`. These
   *do* select and return `search_tags` in the JSON payload — but the route
   has no `q` query param at all, so nothing server-side ever searches it;
   it's returned data, not a matched field.
3. **MCP `strale_search`** — `packages/mcp-server/src/tools.ts:564-660`
   calls `/v1/suggest/typeahead` first (inherits gap #1), and falls back to
   local keyword matching (`localMatchScore`, line ~668) when that's
   unreachable or a `category` filter is set. The fallback matched against
   `` `${name} ${description} ${slug} ${category}` `` only — `search_tags`
   is on the `Capability`/`Solution` TS types (populated from the same
   `/v1/capabilities` response) but was never appended to the matched text.

**Net effect:** `search_tags` is fully inert. It's authored in some
manifests, backfilled to prod for ~80% of the catalog by
`apps/api/scripts/seed-search-tags.ts` (a separate one-off script, not the
`onboard.ts` pipeline), returned in two public API responses — and consumed
by zero ranking code. A capability's discoverability depends entirely on
`name` + `description` + `category` + `slug`.

**Compounding gap on `domain-contact-extract` specifically:**
`seed-search-tags.ts`'s `CATEGORY_TAGS` map (line 31) has no entry for
`web-intelligence` — the category `domain-contact-extract` and `email-finder`
are both in — so neither capability got even the generic
`["data extraction", "lookup", "data"]` boilerplate every `data-extraction`
capability has. In prod, `domain-contact-extract.search_tags = []`.

## DB evidence (read-only, SELECT only, no writes performed)

Mined from prod via a temporary local script (`postgres` package, read-only
`DATABASE_URL`), deleted after use — not committed.

`google-search` inputs, 90d, contact-intent filter — verbatim, the recurring
pattern:
```
"AUTOFLETES CHIHUAHUA" 墨西哥 phone contact          (×50, one wallet, template-driven)
Trucao Auto Pecas Brazil phone number contact
Haney's Comfort Living Furniture New Castle PA owner phone contact
```
"phone" and "contact" are the load-bearing words. The pre-PR description
("phone numbers... from its own website") technically contained "phone
numbers" as a substring of the concept, but ranking is exact-token, and
`search_tags` — the field meant to carry exactly this kind of vocabulary
bridge — was never read.

`domain-contact-extract` all-time transactions: 20 rows, **all**
`user_id = system@strale.internal`, `input: {}`, roughly hourly cadence —
the free-tier health probe (this capability's `cost_class: free_unlimited`
makes it eligible for DEC-20260503-B's hourly free-only scheduler). Zero
customer transactions confirmed.

`failed_requests` (checked per the task's ask): 77 rows all-time, confirmed
mostly non-signal (Arbor multi-agent-roundtable prompts, marketplace
liveness probes, deliberate negative-test slugs like `zzz-no-such-cap`) —
matches the demand doc's own characterization. One row, `"company-lookup"`
(2026-07-19, €0.50 bid), is a related but distinct gap (name→identity
resolution across registries — doc's Rank #2 `company-name-resolve`, a
genuine capability gap, not a wording fix) and is out of scope here.

`suggest_log` (90d, 300 most-recent rows): only 6 zero-result queries, none
in the contact/email/phone family (`reminder`, `itinerary`, `rewrite`,
`logging`, `relocation visa immigration` — coverage gaps, already documented
in `search-aliases.ts`'s module docstring, not description bugs). The
contact-family queries in `suggest_log` are dominated by `email validation`
(→ `email-validate`, works fine) — there isn't yet a `suggest_log` sample of
someone typing "find company contact info" into the search box, because the
one customer who wants this is going straight to `google-search` via their
own pipeline, not through Strale's search UI. The google-search transaction
log is the actual demand signal here, not `suggest_log`.

## Fix

**Code** (`apps/api/src/lib/suggest.ts`, `packages/mcp-server/src/tools.ts`):
wire `search_tags` into all three ranking paths above — select it in
`loadCatalog()`'s capability/solution queries, fold into `tokenText` (keyword
path) and `embeddingText` (embedding path), and fold into the MCP local
fallback's matched string. This makes `search_tags` a real signal for the
first time, for the whole catalog, not just the capabilities touched below.

**Manifests** — description + `search_tags`, verified against the executor
(no new claims):

- **`manifests/domain-contact-extract.yaml`** — description now leads with
  "contact info", "email address", "phone number" (the mined vocabulary)
  instead of only "organisational contact channels". Every claim checked
  against `apps/api/src/capabilities/domain-contact-extract.ts` (role
  emails, phone numbers, postal address, contact-page URL, social links,
  organisation-level only, no personnel discovery — all unchanged, just
  reordered/re-worded). Added `search_tags`.
- **`manifests/email-finder.yaml`**, **`manifests/company-enrich.yaml`** —
  `search_tags` only, no description change (both already read fine). Same
  `web-intelligence`-has-no-`CATEGORY_TAGS`-entry gap; `email-finder` is the
  capability `domain-contact-extract`'s own manifest points callers to for
  person-level lookups (its first limitation), so it's the same discovery
  family and was equally undiscovered by tag.

**Not changed:** pricing, input schemas, x402/visibility gating. No DB
writes.

## Before/after

**Live prod, before this PR** (public endpoints, GET/POST only, no auth, no
writes):

```
POST /v1/suggest {"query":"find company contact info"}
→ recommendation: kyc-sweden (Nordic KYC solution, €1.50)
→ domain-contact-extract: not in recommendation or alternatives

GET /v1/suggest/typeahead?q=find+company+contact+info&limit=10
→ 10 results, all solutions (kyc-sweden, verify-us-company, domain-intel,
  competitor-snapshot, vendor-risk-assess, lead-enrich, prospect-profile,
  enhanced-due-diligence, contact-verify, vendor-onboard)
→ domain-contact-extract: absent from top 10 (79 total matches)

GET /v1/suggest/typeahead?q=get+email+for+a+company+domain&limit=10
→ domain-contact-extract: absent from top 10 (324 total matches)

GET /v1/suggest/typeahead?q=extract+phone+number+from+website&limit=10
→ domain-contact-extract: rank #4 of 10 (121 total matches)
  (the one query where the old description's "phone numbers... website"
  already overlapped enough to place)
```

**Local replay of the ranking algorithm** (capabilities-only — I did not
deploy this branch, so I can't hit the live endpoint post-fix; instead I
copied `tokenize()` verbatim and replayed `typeahead()`'s token-scoring
against the real production capability catalog fetched via
`GET /v1/capabilities`, with `domain-contact-extract`'s row overlaid with
this PR's new description + `search_tags`). This isolates the description/
tag effect from solutions' fixed `+3` bonus and the embedding/Claude-rerank
path, neither of which I can exercise offline — **treat this as evidence the
mechanism works, not a promise about the live endpoint's exact output**,
which also includes solutions, alias terms, and (when `VOYAGE_API_KEY` /
`ANTHROPIC_API_KEY` are set) semantic + LLM re-ranking on top of this token
layer:

| Query | Before (capability rank) | After (capability rank) |
|---|---|---|
| "find company contact info" | #2 of 58 (score 2) | **#1 of 59 (score 4)** |
| "get email for a company domain" | #6 of 63 (score 2) | **#2 of 63 (score 3)** |
| "extract phone number from website" | #1 of 62 (score 3) | #1 of 63 (score 4, wider margin) |
| "company email address lookup" | #21 of 96 (score 2) | #8 of 134 (score 3) |
| "find business phone contact" | #2 of 15 (score 2) | **#1 of 30 (score 4)** |

Caveat on the real endpoint: solutions get a flat `+3` "solutions-first"
bonus whenever they score `>0` at all (`typeahead()`, `suggest.ts`), which is
why solutions dominate the live "before" results above even though this
fix doesn't touch that bonus. For "find company contact info" specifically,
`domain-contact-extract`'s new score (4) is now competitive with top
solutions' typical score (~4 = 1 token match + 3 bonus), so I'd expect it to
start appearing in the live results list post-deploy rather than being
structurally invisible — but I have not verified that empirically against a
deployed build, and solutions may still outrank it for broad phrasing. I'm
confident about the specific/narrower queries (rows 2, 3, 5 above) where
`domain-contact-extract` now wins outright against other capabilities.

## Apply commands (human-run — no DB writes performed by this PR)

**`onboard.ts --backfill` does not apply here.** Verified by reading
`apps/api/scripts/onboard.ts`'s `backfill()` (line 1023) — its own inline
comment states: *"Today the backfill path writes only test suites, PII
classification, field reliability, and limitations"* (line 1062).
`description` and `search_tags` are Class-4-adjacent fields the backfill
path does not touch at all — running `--backfill` on these three slugs
would be a no-op for the fields this PR actually changed. `seed-search-tags.ts`
is the script that writes `search_tags` today, but it seeds by category
table, not manifest, so it can't pick up hand-authored per-capability tags
either. Raw SQL is the correct apply path until one of those scripts is
extended to read manifest `search_tags`/`description` (a follow-up, not
done here — out of scope for a discoverability fix).

```sql
UPDATE capabilities
SET description = 'Find a company''s contact info — email address, phone number, and mailing address — by extracting it from the company''s own website given its domain. Returns role emails (info@, sales@, support@), phone numbers, postal address, contact-page URL, and social links. Organisation-level contacts only, not a specific person''s email address (see email-finder) and not employee discovery.',
    search_tags = ARRAY['contact info','company email','company contact','find email','find phone number','get email address','get phone number','business contact details','contact page','website scrape','extract emails from website','company phone number']
WHERE slug = 'domain-contact-extract';

UPDATE capabilities
SET search_tags = ARRAY['find email','get email address','person email address','work email finder','guess email address','email address format','find someone''s email']
WHERE slug = 'email-finder';

UPDATE capabilities
SET search_tags = ARRAY['company info','company lookup','company profile','find company details','company background','company research','tech stack lookup']
WHERE slug = 'company-enrich';
```

After running, `GET /v1/capabilities` should show the new `search_tags` for
these three slugs, and (since `suggest.ts`'s catalog cache TTL is 10 minutes)
`/v1/suggest/typeahead` should reflect the new ranking within 10 minutes of
the SQL running, without a deploy — though the code fix in this PR (reading
`search_tags` at all) does require deploying this branch first.

## Verification

- `tsc --noEmit` clean on `apps/api` and `packages/mcp-server` (re-verified
  after rebase onto `origin/main`).
- No test harness exercises `suggest.ts`'s `loadCatalog()` or the MCP
  fallback matcher today (`git grep` found none) — this is a change to
  existing, already-untested ranking logic, not a new money/compliance code
  path, so the Audit-Follow-up Test Coverage Protocol's trigger (cert-audit
  finding, wallet/audit-trail/spend-cap code) does not apply.
- Did not run `onboard.ts` (would touch prod) or `seed-search-tags.ts`
  (bulk-overwrites all capabilities' tags, out of scope, and per its own
  docstring is "idempotent — overwrites existing tags" for the *whole*
  catalog, not a target for this PR's 3-capability change).

## Scope not covered (explicitly out of scope for this task)

- **`related_capabilities` hint in successful responses** (demand doc §5,
  rank 0.6) — a different fix (post-call upsell), not a description/
  search_tags problem. Not attempted here.
- **`x402-gateway-v2.ts` writing to `failed_requests`** (demand doc §7,
  rank 0.7) — instrumentation gap, unrelated to discovery ranking.
- Broader sweep beyond the 3 capabilities above: I looked for other
  live+x402 capabilities with zero/near-zero external calls
  (`web-intelligence`/`data-extraction`/`company-data` categories, read-only
  DB query) but found the low-call-count capabilities are mostly genuine
  narrow-niche registries (Croatian/Greek/Slovenian company data etc.) with
  no comparable mined-vocabulary evidence of a wording mismatch — adding
  tags there would be guessing, not diagnosis, so I didn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
