### PR TITLE
fix(health): a correct refusal is not a capability fault

### DIFF
--- a/apps/api/src/capabilities/french-company-data.ts
+++ b/apps/api/src/capabilities/french-company-data.ts
@@ -1,7 +1,7 @@
-import Anthropic from "@anthropic-ai/sdk";
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { deriveVatFR } from "../lib/vat-derivation.js";
 import { classifyNameMatch } from "../lib/company-name-match.js";
+import { extractCompanyName } from "./lib/browserless-extract.js";
 
 // French company data via recherche-entreprises.api.gouv.fr — FREE, no auth
 const API = "https://recherche-entreprises.api.gouv.fr";
@@ -25,19 +25,6 @@ function findSiren(input: string): string | null {
   return match && SIREN_RE.test(match[0]) ? match[0] : null;
 }
 
-async function extractCompanyName(text: string): Promise<string> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is required.");
-  const client = new Anthropic({ apiKey });
-  const r = await client.messages.create({
-    model: "claude-haiku-4-5-20251001",
-    max_tokens: 100,
-    messages: [{ role: "user", content: `Extract the French company name from this request. Return ONLY the company name, nothing else.\n\nRequest: "${text}"` }],
-  });
-  const name = r.content[0].type === "text" ? r.content[0].text.trim().replace(/^["']|["']$/g, "") : "";
-  if (!name) throw new Error(`Could not identify a company name from: "${text}".`);
-  return name;
-}
 
 async function fetchResults(query: string, perPage: number): Promise<any[]> {
   const url = `${API}/search?q=${encodeURIComponent(query)}&page=1&per_page=${perPage}`;
@@ -171,7 +158,7 @@ registerCapability("french-company-data", async (input: CapabilityInput) => {
   if (siren) {
     output = await lookupBySiren(siren);
   } else {
-    const query = await extractCompanyName(trimmed);
+    const query = await extractCompanyName(trimmed, "French");
     const resolved = await lookupByName(query);
     output = resolved.output;
     output.match_confidence = resolved.matchConfidence;

--- a/apps/api/src/capabilities/lib/browserless-extract.ts
+++ b/apps/api/src/capabilities/lib/browserless-extract.ts
@@ -1,4 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
+import { CapabilityRefusalError } from "../../lib/capability-refusal.js";
 
 /**
  * Shared Browserless scraping + Claude extraction utility for company registries.
@@ -115,7 +116,7 @@ export async function extractCompanyName(
       : "";
 
   if (!name || name === NO_NAME_SENTINEL || looksLikeRefusal(name)) {
-    throw new Error(
+    throw new CapabilityRefusalError(
       `Could not identify a specific ${country} company name in the request. ` +
         `Provide the company's registration number, or a more specific company name.`,
     );

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -1,6 +1,6 @@
-import Anthropic from "@anthropic-ai/sdk";
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { classifyNameMatch } from "../lib/company-name-match.js";
+import { extractCompanyName } from "./lib/browserless-extract.js";
 
 // UK VAT validation is handled by vat-validate.ts (which routes GB → HMRC v2),
 // not by this Identity capability. Companies House (the source for this
@@ -29,19 +29,6 @@ function getApiKey(): string {
   return key;
 }
 
-async function extractCompanyName(text: string): Promise<string> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is required.");
-  const client = new Anthropic({ apiKey });
-  const r = await client.messages.create({
-    model: "claude-haiku-4-5-20251001",
-    max_tokens: 100,
-    messages: [{ role: "user", content: `Extract the UK/British company name from this request. Return ONLY the company name, nothing else.\n\nRequest: "${text}"` }],
-  });
-  const name = r.content[0].type === "text" ? r.content[0].text.trim().replace(/^["']|["']$/g, "") : "";
-  if (!name) throw new Error(`Could not identify a company name from: "${text}".`);
-  return name;
-}
 
 export interface UkNameResolution {
   companyNumber: string;
@@ -216,7 +203,7 @@ registerCapability("uk-company-data", async (input: CapabilityInput) => {
   let nameResolution: UkNameResolution | null = null;
 
   if (!companyNumber) {
-    const name = await extractCompanyName(trimmed);
+    const name = await extractCompanyName(trimmed, "UK");
     nameResolution = await searchCompany(name);
     companyNumber = nameResolution.companyNumber;
   }

--- a/apps/api/src/lib/capability-refusal.test.ts
+++ b/apps/api/src/lib/capability-refusal.test.ts
@@ -81,6 +81,60 @@ function realRefusals(): Array<{ label: string; err: unknown }> {
   return out;
 }
 
+/**
+ * Four capabilities still carry their own `pickByName` rather than the shared
+ * one. Their wording happens to match the pattern list today, so they are
+ * classified correctly — but nothing was enforcing that, which is the same
+ * silence that let the taxonomy's tie pattern sit broken. Swept here until the
+ * duplicates are consolidated, so a wording tweak in any of them fails a test
+ * instead of quietly re-arming the breaker for that one capability.
+ */
+async function duplicatedRefusals(): Promise<Array<{ label: string; err: unknown }>> {
+  const out: Array<{ label: string; err: unknown }> = [];
+  const capture = (label: string, fn: () => unknown) => {
+    try {
+      fn();
+      throw new Error(`expected ${label} to refuse, but it returned`);
+    } catch (err) {
+      out.push({ label, err });
+    }
+  };
+
+  const ca = await import("../capabilities/canadian-company-data.js");
+  const fr = await import("../capabilities/french-company-data.js");
+  const ie = await import("../capabilities/irish-company-data.js");
+  const uk = await import("../capabilities/uk-company-data.js");
+
+  // Two indistinguishable candidates each — the ambiguity refusal, which is
+  // the shape the taxonomy pattern was missing.
+  capture("canadian pickByName", () =>
+    ca.pickByName("Total", [
+      { name: "TOTAL", corpId: "1" },
+      { name: "Total", corpId: "2" },
+    ] as never),
+  );
+  capture("french pickByName", () =>
+    fr.pickByName("Total", [
+      { nom_complet: "TOTAL", siren: "111111111" },
+      { nom_complet: "Total", siren: "222222222" },
+    ] as never),
+  );
+  capture("irish pickByName", () =>
+    ie.pickByName("Kerry", [
+      { company_name: "KERRY", company_num: "1" },
+      { company_name: "Kerry", company_num: "2" },
+    ] as never),
+  );
+  capture("uk pickByName", () =>
+    uk.pickByName("HSBC", [
+      { title: "HSBC", company_number: "00000001" },
+      { title: "hsbc", company_number: "00000002" },
+    ]),
+  );
+
+  return out;
+}
+
 describe("refusals are recognised as such", () => {
   it("every real refusal site throws the typed error", () => {
     for (const { label, err } of realRefusals()) {
@@ -104,6 +158,27 @@ describe("refusals are recognised as such", () => {
       expect(isUserInputError((err as Error).message), `${label} must not trip the breaker`).toBe(
         true,
       );
+    }
+  });
+});
+
+describe("the four un-consolidated duplicates are classified too", () => {
+  it("each is recognised by all three consumers", async () => {
+    const { classifyTransactionFailure, CALLER_ATTRIBUTABLE } = await import(
+      "./transaction-failure-taxonomy.js"
+    );
+    const { categorizeError } = await import("./quality-capture.js");
+    const dupes = await duplicatedRefusals();
+    expect(dupes.length, "all four duplicates must refuse on an ambiguous pair").toBe(4);
+
+    for (const { label, err } of dupes) {
+      const msg = (err as Error).message;
+      expect(isUserInputError(msg), `${label}: breaker`).toBe(true);
+      expect(
+        CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(msg)),
+        `${label}: quality floor`,
+      ).toBe(true);
+      expect(categorizeError(msg), `${label}: quality signal`).toBe("capability_refusal");
     }
   });
 });
@@ -144,10 +219,10 @@ describe("the circuit breaker ignores refusals but not faults", () => {
 });
 
 describe("the quality signal does not treat a refusal as a fault", () => {
-  it("classifies a refusal as client_refusal, not internal_error", async () => {
+  it("classifies a refusal as capability_refusal, not internal_error", async () => {
     const { categorizeError } = await import("./quality-capture.js");
     for (const { label, err } of realRefusals()) {
-      expect(categorizeError(err as Error), label).toBe("client_refusal");
+      expect(categorizeError(err as Error), label).toBe("capability_refusal");
     }
   });
 
@@ -167,7 +242,7 @@ describe("the quality signal does not treat a refusal as a fault", () => {
     const err = new CapabilityRefusalError(
       'Ambiguous UK company name "Timeout Ltd": 2 distinct registered entities.',
     );
-    expect(categorizeError(err)).toBe("client_refusal");
+    expect(categorizeError(err)).toBe("capability_refusal");
   });
 });
 

--- a/apps/api/src/lib/capability-refusal.test.ts
+++ b/apps/api/src/lib/capability-refusal.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression tests for the 2026-08-14 "a refusal is not a fault" defect.
+ *
+ * Reproduced in production minutes after the refusal behaviour shipped: three
+ * identical `/v1/do` calls to `french-company-data` with
+ * `{"company_name":"Total"}` each returned the intended refusal, and the third
+ * opened the circuit breaker against a capability with 25 prior successes
+ * (`state=open, consecutive_failures=3`). Every caller then received
+ * `capability_unavailable`.
+ *
+ * Two accounting paths were counting refusals as ill health — the breaker, and
+ * the quality signal feeding the quarantine/deactivation floor. Both are
+ * covered here, in both directions: refusals must be ignored, and genuine
+ * upstream faults must still register.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  CapabilityRefusalError,
+  isCapabilityRefusal,
+  isRefusalMessage,
+} from "./capability-refusal.js";
+import { isUserInputError } from "./circuit-breaker.js";
+import { pickByName, assertSingleResultMatch } from "./company-name-match.js";
+
+/**
+ * The real messages, produced by the real primitives.
+ *
+ * Deliberately not a list of hand-copied strings: the failure mode this guards
+ * against is someone rewording a refusal and silently re-arming the breaker,
+ * and a test that restates the strings would be reworded in the same commit.
+ * Same arrangement tos-blocklist.test.ts uses for the ToS marker.
+ */
+function realRefusals(): Array<{ label: string; err: unknown }> {
+  const out: Array<{ label: string; err: unknown }> = [];
+  const capture = (label: string, fn: () => unknown) => {
+    try {
+      fn();
+      throw new Error(`expected ${label} to refuse, but it returned`);
+    } catch (err) {
+      out.push({ label, err });
+    }
+  };
+
+  type C = { title: string; number: string };
+  const byTitle = (c: C) => c.title;
+  const byNumber = (c: C) => c.number;
+  const opts = { subjectLabel: "French", disambiguationHint: "Provide the SIREN." };
+
+  capture("pickByName — several equally-good matches", () =>
+    pickByName(
+      "Total",
+      [
+        { title: "TOTAL", number: "111111111" },
+        { title: "Total", number: "222222222" },
+      ],
+      byTitle,
+      byNumber,
+      opts,
+    ),
+  );
+
+  capture("pickByName — nothing matched", () =>
+    pickByName(
+      "Zzzqqx Holdings",
+      [{ title: "Unrelated Trading Ltd", number: "333333333" }],
+      byTitle,
+      byNumber,
+      opts,
+    ),
+  );
+
+  capture("assertSingleResultMatch — unrelated entity returned", () =>
+    assertSingleResultMatch("Bank", "Nordea Danmark", {
+      jurisdictionLabel: "Danish",
+      sourceDescription: "cvrapi.dk",
+      disambiguationHint: "Provide the CVR number (8 digits).",
+    }),
+  );
+
+  return out;
+}
+
+describe("refusals are recognised as such", () => {
+  it("every real refusal site throws the typed error", () => {
+    for (const { label, err } of realRefusals()) {
+      expect(err, label).toBeInstanceOf(CapabilityRefusalError);
+    }
+  });
+
+  it("every real refusal message is recognisable from the string alone", () => {
+    // /v1/do persists only the message on the async and x402 paths, so the
+    // type cannot be relied on there.
+    for (const { label, err } of realRefusals()) {
+      expect(isRefusalMessage((err as Error).message), label).toBe(true);
+    }
+  });
+
+  it("catches wording drift at the throw sites", () => {
+    // The guard the whole arrangement rests on: if someone rewords a refusal
+    // out of the pattern list, this fails rather than silently re-arming the
+    // breaker in production.
+    for (const { label, err } of realRefusals()) {
+      expect(isUserInputError((err as Error).message), `${label} must not trip the breaker`).toBe(
+        true,
+      );
+    }
+  });
+});
+
+describe("the circuit breaker ignores refusals but not faults", () => {
+  it("skips the refusals that opened the breaker in production", () => {
+    // Verbatim from capability_health / transactions on 2026-08-14.
+    const observed = [
+      'Ambiguous French company name "Total": 9 distinct registered entities are exact matches — TOTAL (542051180). Provide the SIREN for an exact lookup.',
+      "Could not identify a specific Canadian company name in the request. Provide the company's registration number, or a more specific company name.",
+    ];
+    for (const msg of observed) {
+      expect(isUserInputError(msg), msg.slice(0, 40)).toBe(true);
+    }
+  });
+
+  it("still trips on genuine upstream faults", () => {
+    const faults = [
+      "Corporations Canada API returned HTTP 503",
+      "fetch failed: ETIMEDOUT",
+      "Unexpected token < in JSON at position 0",
+      "Browserless returned a 500",
+    ];
+    for (const msg of faults) {
+      expect(isUserInputError(msg), `${msg} must still trip`).toBe(false);
+      expect(isCapabilityRefusal(msg), `${msg} is not a refusal`).toBe(false);
+    }
+  });
+
+  it("N consecutive refusals leave the breaker untouched", () => {
+    // recordFailure returns early for anything isUserInputError matches, so
+    // the guarantee is exactly that predicate holding for every refusal.
+    const refusal = 'Ambiguous UK company name "HSBC": 4 distinct registered entities.';
+    for (let i = 0; i < 10; i++) {
+      expect(isUserInputError(refusal)).toBe(true);
+    }
+  });
+});
+
+describe("the quality signal does not treat a refusal as a fault", () => {
+  it("classifies a refusal as client_refusal, not internal_error", async () => {
+    const { categorizeError } = await import("./quality-capture.js");
+    for (const { label, err } of realRefusals()) {
+      expect(categorizeError(err as Error), label).toBe("client_refusal");
+    }
+  });
+
+  it("still classifies genuine faults into their fault buckets", async () => {
+    const { categorizeError } = await import("./quality-capture.js");
+    expect(categorizeError("upstream returned 503")).toBe("upstream_error");
+    expect(categorizeError("request timed out")).toBe("upstream_timeout");
+    expect(categorizeError("rate limit exceeded")).toBe("rate_limited");
+    expect(categorizeError(null)).toBeNull();
+  });
+
+  it("does not let a company name push a refusal into a fault bucket", async () => {
+    const { categorizeError } = await import("./quality-capture.js");
+    // The refusal quotes the caller's query back. "Timeout Ltd" is a plausible
+    // company name, and matching on substrings would file this as an upstream
+    // timeout — which is why the refusal check runs first.
+    const err = new CapabilityRefusalError(
+      'Ambiguous UK company name "Timeout Ltd": 2 distinct registered entities.',
+    );
+    expect(categorizeError(err)).toBe("client_refusal");
+  });
+});
+
+describe("isCapabilityRefusal", () => {
+  it("recognises the typed error", () => {
+    expect(isCapabilityRefusal(new CapabilityRefusalError("Ambiguous X"))).toBe(true);
+  });
+
+  it("recognises a structurally-tagged object across a module boundary", () => {
+    // The async paths can re-import modules; instanceof is not guaranteed.
+    expect(isCapabilityRefusal({ isCapabilityRefusal: true, message: "x" })).toBe(true);
+  });
+
+  it("recognises a bare message", () => {
+    expect(isCapabilityRefusal("No confident Danish registry match for \"Bank\".")).toBe(true);
+  });
+
+  it("does not fire on ordinary errors, null or undefined", () => {
+    expect(isCapabilityRefusal(new Error("upstream exploded"))).toBe(false);
+    expect(isCapabilityRefusal(null)).toBe(false);
+    expect(isCapabilityRefusal(undefined)).toBe(false);
+    expect(isCapabilityRefusal("")).toBe(false);
+  });
+});

--- a/apps/api/src/lib/capability-refusal.test.ts
+++ b/apps/api/src/lib/capability-refusal.test.ts
@@ -171,6 +171,47 @@ describe("the quality signal does not treat a refusal as a fault", () => {
   });
 });
 
+describe("the quality floor does not count refusals against completion", () => {
+  it("classifies every real refusal as caller-attributable", async () => {
+    const { classifyTransactionFailure, CALLER_ATTRIBUTABLE } = await import(
+      "./transaction-failure-taxonomy.js"
+    );
+    for (const { label, err } of realRefusals()) {
+      const cls = classifyTransactionFailure((err as Error).message);
+      expect(CALLER_ATTRIBUTABLE.has(cls), `${label} classified ${cls}`).toBe(true);
+    }
+  });
+
+  it("classifies the ambiguity refusal the old pattern silently missed", async () => {
+    const { classifyTransactionFailure } = await import("./transaction-failure-taxonomy.js");
+    // The list intended to cover this with "distinct .* entities match", but
+    // the real message says "entities ARE EXACT matches" — no literal
+    // "entities match" to hit — so every ambiguity refusal was landing in
+    // `internal` ("our bug until proven otherwise") and counting against the
+    // completion rate the floor quarantines on.
+    const real =
+      'Ambiguous French company name "Total": 9 distinct registered entities are exact matches — TOTAL (542051180). Provide the SIREN for an exact lookup.';
+    expect(classifyTransactionFailure(real)).toBe("caller_input");
+  });
+
+  it("still counts genuine faults against the capability", async () => {
+    const { classifyTransactionFailure, CALLER_ATTRIBUTABLE } = await import(
+      "./transaction-failure-taxonomy.js"
+    );
+    const faults: Array<[string, string]> = [
+      ["Corporations Canada API returned HTTP 503", "upstream"],
+      ["Request timed out after 10000ms", "timeout"],
+      ["Cannot read properties of undefined (reading 'x')", "internal"],
+      ["Vendor quota exceeded", "upstream"],
+    ];
+    for (const [msg, expected] of faults) {
+      const cls = classifyTransactionFailure(msg);
+      expect(cls, msg).toBe(expected);
+      expect(CALLER_ATTRIBUTABLE.has(cls), `${msg} must still count`).toBe(false);
+    }
+  });
+});
+
 describe("isCapabilityRefusal", () => {
   it("recognises the typed error", () => {
     expect(isCapabilityRefusal(new CapabilityRefusalError("Ambiguous X"))).toBe(true);

--- a/apps/api/src/lib/capability-refusal.ts
+++ b/apps/api/src/lib/capability-refusal.ts
@@ -20,11 +20,17 @@
  *   1. `circuit-breaker.ts` — three consecutive trips the breaker and suspends
  *      the capability for everyone. Threshold 3, so three agents each asking
  *      for a generic name is enough.
- *   2. `quality-capture.ts` → `quality-aggregation.ts` → `jobs/quality-floor.ts`
- *      — a refusal was categorised `internal_error`, and success rate counts
- *      any non-null `error_type` against the capability. Below 70% quarantines
- *      it and below 30% deactivates it (DEC-20260812-A). That one is slower
- *      than the breaker and considerably harder to undo.
+ *   2. `jobs/quality-floor.ts` — the quarantine/deactivate engine, which reads
+ *      `transactions.error` directly and classifies it through
+ *      `transaction-failure-taxonomy.ts`. Its `CALLER_ATTRIBUTABLE` set exists
+ *      for exactly this, and half the refusals were already meant to be in it,
+ *      but the tie-refusal pattern never matched the message it was written
+ *      for. Below 70% completion quarantines, below 30% proposes deactivation
+ *      (DEC-20260812-A) — slower than the breaker and much harder to undo.
+ *   3. `quality-capture.ts` → `quality-aggregation.ts` — the trust and quality
+ *      surfaces, where a refusal was categorised `internal_error` and counted
+ *      against success rate. Not the floor: an earlier version of this comment
+ *      claimed it was, which is what hid (2) until the wiring was traced.
  *
  * Nothing here changes what the caller sees. A refusal is still an error, still
  * names the disambiguator, and is still unbilled per DEC-14. Only the health
@@ -80,7 +86,17 @@ export function isCapabilityRefusal(err: unknown): boolean {
   return isRefusalMessage(message);
 }
 
-/** Message-only form, for the paths that never see the error object. */
+/**
+ * Message-only form, for the paths that never see the error object.
+ *
+ * Anchored at the start rather than matched anywhere in the string. Every
+ * refusal site opens with one of these phrases, and several unrelated errors in
+ * the same capabilities quote the caller's query back verbatim — `No French
+ * company found matching "${query}"`. A company name beginning "Ambiguous" is
+ * contrived but not impossible, and would otherwise file an ordinary not-found
+ * as a refusal. Both outcomes happen to be caller-attributable, so nothing
+ * breaks either way; anchoring just keeps the bucket meaning what it says.
+ */
 export function isRefusalMessage(message: string): boolean {
-  return REFUSAL_MESSAGE_PATTERNS.some((p) => message.includes(p));
+  return REFUSAL_MESSAGE_PATTERNS.some((p) => message.startsWith(p));
 }

--- a/apps/api/src/lib/capability-refusal.ts
+++ b/apps/api/src/lib/capability-refusal.ts
@@ -1,0 +1,86 @@
+/**
+ * Refusals: the capability worked, the request was unanswerable as asked.
+ *
+ * A registry name search that returns nine equally-good "Total" matches has
+ * not failed. It reached the upstream, got an answer, and understood it well
+ * enough to know the answer is ambiguous. Handing back an arbitrary one of the
+ * nine would be the failure — that is the wrong-company class documented in
+ * `company-name-match.ts`, and refusing is the fix for it.
+ *
+ * The health machinery could not tell the difference. Reproduced in production
+ * on 2026-08-14, minutes after the refusal behaviour shipped: three identical
+ * `/v1/do` calls to `french-company-data` with `{"company_name":"Total"}` each
+ * returned the intended refusal, and the third opened the circuit breaker
+ * (`state=open, consecutive_failures=3`) against a capability with 25 prior
+ * successes. Every caller then got `capability_unavailable`.
+ *
+ * Two separate accounting paths treat a refusal as evidence of ill health, and
+ * both are wired to this module:
+ *
+ *   1. `circuit-breaker.ts` — three consecutive trips the breaker and suspends
+ *      the capability for everyone. Threshold 3, so three agents each asking
+ *      for a generic name is enough.
+ *   2. `quality-capture.ts` → `quality-aggregation.ts` → `jobs/quality-floor.ts`
+ *      — a refusal was categorised `internal_error`, and success rate counts
+ *      any non-null `error_type` against the capability. Below 70% quarantines
+ *      it and below 30% deactivates it (DEC-20260812-A). That one is slower
+ *      than the breaker and considerably harder to undo.
+ *
+ * Nothing here changes what the caller sees. A refusal is still an error, still
+ * names the disambiguator, and is still unbilled per DEC-14. Only the health
+ * accounting changes.
+ */
+
+/**
+ * Thrown by a capability when the request cannot be answered as asked and the
+ * caller has to change something — an ambiguous company name, a name matching
+ * nothing, input that names no entity at all.
+ *
+ * Not for upstream faults. A 503, a timeout or a parse failure is a real
+ * failure and must keep tripping the breaker.
+ */
+export class CapabilityRefusalError extends Error {
+  /** Discriminator that survives structured cloning and `instanceof` across
+   *  module-instance boundaries, which the async execution paths can cross. */
+  readonly isCapabilityRefusal = true;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "CapabilityRefusalError";
+  }
+}
+
+/**
+ * Message fragments that identify a refusal when only a string survives.
+ *
+ * `/v1/do` records failures through `recordFailure(slug, errorMessage)` and
+ * `recordQuality({ error })`, and on the async and x402 paths the original
+ * error object is long gone by then — only its message is persisted. So the
+ * type alone cannot carry this; the message has to be recognisable too.
+ *
+ * These are exact prefixes of the messages the refusal sites already emit, so
+ * no caller-facing text changed to accommodate the machine. `assertRefusalsAreRecognised`
+ * in `capability-refusal.test.ts` builds real errors from the real primitives
+ * and fails if a wording change ever drifts out of this list — the same
+ * arrangement `tos-blocklist.test.ts` uses for the ToS refusal marker.
+ */
+export const REFUSAL_MESSAGE_PATTERNS = [
+  "Ambiguous ", // pickByName: several equally-good registry matches
+  "No confident ", // pickByName / assertSingleResultMatch: nothing matched well enough
+  "Could not identify a specific ", // extractCompanyName: input names no company
+] as const;
+
+/** Does this error — object or bare message — represent a refusal? */
+export function isCapabilityRefusal(err: unknown): boolean {
+  if (err instanceof CapabilityRefusalError) return true;
+  if (typeof err === "object" && err !== null && "isCapabilityRefusal" in err) {
+    return (err as { isCapabilityRefusal?: unknown }).isCapabilityRefusal === true;
+  }
+  const message = typeof err === "string" ? err : err instanceof Error ? err.message : "";
+  return isRefusalMessage(message);
+}
+
+/** Message-only form, for the paths that never see the error object. */
+export function isRefusalMessage(message: string): boolean {
+  return REFUSAL_MESSAGE_PATTERNS.some((p) => message.includes(p));
+}

--- a/apps/api/src/lib/circuit-breaker.ts
+++ b/apps/api/src/lib/circuit-breaker.ts
@@ -5,6 +5,7 @@ import { logHealthEvent } from "./health-monitor.js";
 import { categorizeFailureReason, isRetryableFailure } from "./trust-helpers.js";
 import { fireAndForget } from "./fire-and-forget.js";
 import { log } from "./log.js";
+import { REFUSAL_MESSAGE_PATTERNS } from "./capability-refusal.js";
 
 // Circuit breaker states
 type CircuitState = "closed" | "open" | "half_open";
@@ -175,6 +176,11 @@ const USER_INPUT_ERROR_PATTERNS = [
   // (28 arrived in 16 days) would take the capability down for everyone.
   // Kept in sync with TOS_REFUSAL_MARKER by tos-blocklist.test.ts.
   "Terms of Service prohibit automated access",
+  // Registry name-search refusals: the capability reached the upstream and
+  // understood the answer well enough to know it was ambiguous or unmatched.
+  // Kept in sync with the throw sites by capability-refusal.test.ts, which
+  // builds real errors from the real primitives rather than restating strings.
+  ...REFUSAL_MESSAGE_PATTERNS,
 ];
 
 /** Exported so tests can assert the pattern list stays in sync with its producers. */

--- a/apps/api/src/lib/company-name-match.ts
+++ b/apps/api/src/lib/company-name-match.ts
@@ -18,6 +18,7 @@
  * entity, which a caller cannot detect. Score the candidates and refuse when
  * nothing matches well.
  */
+import { CapabilityRefusalError } from "./capability-refusal.js";
 
 export type MatchConfidence = "exact" | "high" | "low";
 
@@ -200,7 +201,7 @@ export function pickByName<T>(
       return { id, matchedName, matchConfidence: label };
     }
     const listing = [...bucket.entries()].slice(0, 5).map(([id, n]) => `${n} (${id})`).join("; ");
-    throw new Error(
+    throw new CapabilityRefusalError(
       `Ambiguous ${opts.subjectLabel} name "${query}": ${bucket.size} distinct registered ` +
         `entities are ${label === "exact" ? "exact" : "close"} matches — ${listing}. ${opts.disambiguationHint}`,
     );
@@ -210,7 +211,7 @@ export function pickByName<T>(
   if (winner) return winner;
 
   const closest = candidates.map(getName).filter((n): n is string => !!n).slice(0, 3).join(", ");
-  throw new Error(
+  throw new CapabilityRefusalError(
     `No confident ${opts.subjectLabel} match for "${query}". The search is fuzzy and returned only ` +
       `unrelated entities${closest ? ` (closest: ${closest})` : ""}. ${opts.disambiguationHint}`,
   );
@@ -246,7 +247,7 @@ export function assertSingleResultMatch(
   const { match_confidence } = classifyNameMatch(query, returnedName ?? "");
   if (match_confidence === "low") {
     const named = returnedName ? ` ("${returnedName}")` : "";
-    throw new Error(
+    throw new CapabilityRefusalError(
       `No confident ${opts.jurisdictionLabel} registry match for "${query}". ` +
         `${opts.sourceDescription} returned an unrelated entity${named}${opts.extraClause ?? ""}. ` +
         `${opts.disambiguationHint}`,

--- a/apps/api/src/lib/quality-aggregation.ts
+++ b/apps/api/src/lib/quality-aggregation.ts
@@ -95,6 +95,15 @@ async function computeCapabilityQuality(
         tq.error_type,
         tq.created_at,
         CASE
+          -- A refusal carries no weight as health evidence. The capability
+          -- reached its upstream and understood the answer well enough to know
+          -- it was ambiguous — that is not a malfunction, and a refusal has no
+          -- output, so counting it would drag down success rate, schema
+          -- conformance and field completeness alike. Zero weight rather than
+          -- a WHERE filter: filtering changed the query plan badly enough to
+          -- time out /v1/capabilities. This is pure arithmetic on rows already
+          -- scanned. See lib/capability-refusal.ts.
+          WHEN tq.error_type = 'client_refusal' THEN 0
           WHEN tq.created_at >= NOW() - INTERVAL '7 days' THEN 3.0
           ELSE 1.0
         END AS weight

--- a/apps/api/src/lib/quality-aggregation.ts
+++ b/apps/api/src/lib/quality-aggregation.ts
@@ -103,7 +103,7 @@ async function computeCapabilityQuality(
           -- a WHERE filter: filtering changed the query plan badly enough to
           -- time out /v1/capabilities. This is pure arithmetic on rows already
           -- scanned. See lib/capability-refusal.ts.
-          WHEN tq.error_type = 'client_refusal' THEN 0
+          WHEN tq.error_type = 'capability_refusal' THEN 0
           WHEN tq.created_at >= NOW() - INTERVAL '7 days' THEN 3.0
           ELSE 1.0
         END AS weight
@@ -136,6 +136,9 @@ async function computeCapabilityQuality(
           THEN ROUND(SUM(field_completeness_pct::numeric * weight) / SUM(weight), 2)
           ELSE NULL
         END AS avg_field_completeness_pct,
+        -- Counts refusals, unlike the weighted rates above. So an all-refusal
+        -- window reads total_30d > 0 with the rates NULL: "we have traffic, and
+        -- none of it is evidence either way" — not "insufficient data".
         COUNT(*)::text AS total_30d
       FROM quality_rows
     ),

--- a/apps/api/src/lib/quality-capture.ts
+++ b/apps/api/src/lib/quality-capture.ts
@@ -134,7 +134,7 @@ export function categorizeError(
   // caller asked about, and an unlucky company name would otherwise land in
   // one of them ("Timeout Ltd" is a real kind of name).
   if (isCapabilityRefusal(error)) {
-    return "client_refusal";
+    return "capability_refusal";
   }
 
   if (msg.includes("timeout") || msg.includes("timed out") || msg.includes("etimedout")) {

--- a/apps/api/src/lib/quality-capture.ts
+++ b/apps/api/src/lib/quality-capture.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { logError } from "./log.js";
+import { isCapabilityRefusal } from "./capability-refusal.js";
 
 /**
  * Quality signal data collected during capability execution.
@@ -119,13 +120,22 @@ function validateSchema(
 /**
  * Categorize an error into a standard error_type bucket.
  */
-function categorizeError(
+/** Exported for testing — the refusal branch is the one worth pinning down,
+ *  since misclassifying it feeds the quarantine/deactivation floor. */
+export function categorizeError(
   error: Error | string | null | undefined,
 ): string | null {
   if (!error) return null;
 
   const msg =
     typeof error === "string" ? error.toLowerCase() : error.message.toLowerCase();
+
+  // Checked before the fault buckets: a refusal often mentions the entity the
+  // caller asked about, and an unlucky company name would otherwise land in
+  // one of them ("Timeout Ltd" is a real kind of name).
+  if (isCapabilityRefusal(error)) {
+    return "client_refusal";
+  }
 
   if (msg.includes("timeout") || msg.includes("timed out") || msg.includes("etimedout")) {
     return "upstream_timeout";

--- a/apps/api/src/lib/transaction-failure-taxonomy.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.ts
@@ -22,6 +22,7 @@
  * Ordering matters and is pinned by tests both directions.
  */
 import { TOS_REFUSAL_MARKER } from "./tos-blocklist.js";
+import { REFUSAL_MESSAGE_PATTERNS } from "./capability-refusal.js";
 
 export type TransactionFailureClass =
   | "caller_input"   // bad/missing input, wrong identifier, unresolvable name
@@ -74,8 +75,18 @@ const CALLER_INPUT_RE = new RegExp(
     "this url points to a pdf",
     "this url points to an image",
     "could not repair json",
-    "no confident .* match",         // scored name resolution refusals
-    "distinct .* entities match",    // tie refusals
+    // Registry name-search refusals. Sourced from capability-refusal.ts so
+    // this list, the circuit breaker's and the throw sites cannot drift apart
+    // — they are three consumers of one definition.
+    //
+    // These were partly here already, but "distinct .* entities match" never
+    // fired: the message reads "N distinct registered entities are exact
+    // matches", so there is no literal "entities match" for it to hit. Every
+    // ambiguity refusal was therefore classified `internal` — "OUR bug until
+    // proven otherwise" — and counted against the capability's completion
+    // rate, which is what the quality floor quarantines on. Verified against
+    // the real strings, not the intent.
+    ...REFUSAL_MESSAGE_PATTERNS.map((p) => p.trim()),
   ].join("|"),
   "i",
 );


### PR DESCRIPTION
## Summary

A capability that **correctly refuses** an ambiguous request was being recorded as a capability failure.

Reproduced in production on 2026-08-14, minutes after the refusal behaviour shipped: three identical `/v1/do` calls to `french-company-data` with `{"company_name":"Total"}` each returned the intended refusal, and the third opened the circuit breaker against a capability with **25 prior successes**. Every caller then received `capability_unavailable`.

A registry search returning nine equally-good "Total" matches has not failed. It reached the upstream and understood the answer well enough to know it was ambiguous. Returning an arbitrary one of the nine would be the failure — refusing is the fix for it. The breaker exists to catch an upstream that is broken or unreachable; a refusal is evidence of the opposite.

This matters now because #224, #227 and #229 made refusals common across nine registry capabilities. The breaker threshold is 3.

## Three consumers, one definition

The concept already existed in two places, so no third taxonomy was invented — `lib/capability-refusal.ts` is the single definition all three read.

| Path | Before | After |
|---|---|---|
| `circuit-breaker.ts` | Already skipped `USER_INPUT_ERROR_PATTERNS`; refusals matched none of them | Patterns sourced from the shared module |
| `transaction-failure-taxonomy.ts` → quality floor | **Half-guarded, never fired** — see below | All refusal shapes → `caller_input` |
| `quality-capture.ts` → trust/quality surfaces | Categorised `internal_error`, counted against success rate | `capability_refusal`, zero weight |

## The floor bug was already written, and had never fired

The taxonomy intended to cover this — it lists `"distinct .* entities match"` for tie refusals. The real message reads "N distinct registered entities **are exact** matches", so there is no literal `entities match` to hit. Every ambiguity refusal classified `internal` — *"OUR bug until proven otherwise"* — and counted against the completion rate the floor quarantines below 70% and proposes deactivation below 30% (DEC-20260812-A). `"Could not identify a specific ..."` was absent entirely.

That path is slower than the breaker and much harder to undo.

## Reviewer findings — all fixed in-branch

**HIGH — the two capabilities the incident happened in were still exposed.** `french-company-data.ts` and `uk-company-data.ts` each carried their own pre-#230 copy of `extractCompanyName`, lacking the sentinel and prose guard, throwing `"Could not identify a company name from"` — not the shared `"a specific"` — so it matched nothing on any consumer. Live on two counts: model prose leaked to callers inside `No French company found matching "I cannot identify a French company name…"`, and three in a row would **re-open the breaker on `french-company-data`**, the original incident reachable through a path this PR hadn't closed. Both duplicates deleted; they now call the shared function, as `canadian-company-data` already did.

**MEDIUM — four local `pickByName` copies had no test guarantee.** Canadian, French, Irish and UK keep their own. Their wording matches by construction today, but nothing enforced it — the same silence that let the tie pattern sit broken. All four are now swept by the sync test against all three consumers. Consolidation is deliberately left as follow-up: a behaviour-preserving refactor across four registries doesn't belong in a health-accounting fix.

**Also fixed:** the module docstring still misdescribed the floor path (that claim is what hid the defect); `isRefusalMessage` now anchors with `startsWith`, since several unrelated errors in these files quote the caller's query verbatim and a company name starting "Ambiguous" would otherwise misfile an ordinary not-found; `client_refusal` renamed `capability_refusal` (every other name here is from the capability's point of view); `total_30d`'s divergence from the weighted rates documented.

**Confirmed clean by the reviewer:** the zero-weight arithmetic genuinely excludes refusals from numerator *and* denominator of all three rates; the three-way `isCapabilityRefusal` check is justified because async/x402 paths persist only the message; `capabilities/lib/` → `../../lib/` is the established import pattern; no genuine 5xx/timeout/quota template can produce these substrings; and `routes/do.ts` has zero diff lines, so DEC-14 unbilled-on-failure is provably untouched.

## Corrections to my own work

- My first commit claimed the floor consumes `quality-aggregation`'s success rate. **It does not** — it reads `transactions` directly through the taxonomy. Tracing that instead of asserting it is what found the never-firing pattern.
- My first attempt filtered refusals in the aggregation `WHERE` clause; that changed the query plan and timed out `/v1/capabilities`, `/v1/verify` and `/v1/transactions`. Caught by baselining against unmodified `main` rather than blaming the usual remote-DB flakiness, then bisecting. Replaced with zero-weighting — arithmetic over rows already scanned.

## Caller-facing behaviour is unchanged

Same message naming the disambiguator, same unbilled failure per DEC-14. Only the health accounting moves.

## Verification

- `tsc --noEmit` clean.
- `vitest run src/lib` + all affected capability tests — **786 passed, 4 skipped, 56 files**.
- 17 tests in `capability-refusal.test.ts`. **Verified in both directions:** with the fix disabled, 5 fail.
- The taxonomy's 16 existing pinning tests pass untouched — a 503, a timeout, a quota error and an ordinary exception all still count against the capability.
- The sync test builds real errors from the real primitives rather than restating strings, so rewording a refusal fails a test instead of silently re-arming the breaker.

Full-suite runs are unreliable here (remote DB, 10s timeouts) — a clean-`main` baseline run also blew a 10-minute budget. CI is the authoritative signal.

## Test plan

- `cd apps/api && npx vitest run src/lib/capability-refusal.test.ts src/lib/quality-floor.test.ts`
- After deploy: three `/v1/do` calls to `french-company-data` with `{"company_name":"Total"}` should each return the ambiguity refusal, and `capability_health` for that slug should stay `state=closed, consecutive_failures=0`.