### PR TITLE
test(health): pin why cost-control refusals never reach a scoring consumer

### DIFF
--- a/apps/api/src/capabilities/guarded-executor.ts
+++ b/apps/api/src/capabilities/guarded-executor.ts
@@ -141,6 +141,26 @@ const NULL_DECISIONS: Record<InvocationContext["kind"], Decision> = {
 
 // ─── Error classes ──────────────────────────────────────────────────────────
 
+/**
+ * Read-only view of the matrix for one invocation context, including the
+ * unclassified (`cost_class IS NULL`) row.
+ *
+ * Exported for tests. The `customer_paid` column being `allow` throughout is
+ * what makes a cost-control refusal unreachable from customer traffic — every
+ * customer-facing entry point passes that context — so it is worth pinning
+ * rather than leaving as a property nobody checks.
+ */
+export function describeAllowMatrix(
+  kind: InvocationContext["kind"],
+): Record<string, Decision> {
+  const out: Record<string, Decision> = {};
+  for (const [costClass, byKind] of Object.entries(ALLOW_MATRIX)) {
+    out[costClass] = byKind[kind];
+  }
+  out["(unclassified)"] = NULL_DECISIONS[kind];
+  return out;
+}
+
 export class CapabilityNotClassifiedError extends Error {
   constructor(public slug: string, public ctx: InvocationContext) {
     super(

--- a/apps/api/src/lib/cost-control-refusal-accounting.test.ts
+++ b/apps/api/src/lib/cost-control-refusal-accounting.test.ts
@@ -66,6 +66,28 @@ describe("the account the test runner books against stays internal", () => {
   });
 });
 
+describe("no customer-facing path can produce one of these refusals", () => {
+  it("customer_paid is allow for every cost class, including unclassified", async () => {
+    // The strongest form of the argument, and the reason the ordering of the
+    // gate relative to the transaction insert does not actually matter.
+    //
+    // All three customer-facing entry points pass kind: "customer_paid" —
+    // routes/do.ts:779, routes/x402-gateway-v2.ts:1296, and
+    // lib/solution-executor.ts:315 (per step). If customer_paid is allow
+    // everywhere, a refusal is unreachable from customer traffic no matter
+    // when a row gets written, and the only producers left are the internal
+    // contexts, which book against SYSTEM_ACCOUNT_EMAIL.
+    //
+    // Flip any customer_paid cell to "refuse" or "budget_check" and a real
+    // caller starts generating rows that survive the floor's internal filter.
+    // That is the change this test exists to stop.
+    const { describeAllowMatrix } = await import("../capabilities/guarded-executor.js");
+    for (const [costClass, decision] of Object.entries(describeAllowMatrix("customer_paid"))) {
+      expect(decision, `cost_class=${costClass} under customer_paid`).toBe("allow");
+    }
+  });
+});
+
 describe("cost-control refusals keep their classification", () => {
   it("classifies as internal, and that is deliberate", () => {
     // Pinned, not fixed. See the module comment: the refusal is the platform's

--- a/apps/api/src/lib/cost-control-refusal-accounting.test.ts
+++ b/apps/api/src/lib/cost-control-refusal-accounting.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Pins why the dispatcher gate's cost-control refusals never reach a scoring
+ * consumer.
+ *
+ * Raised on 2026-08-14 as "the same bug as #231, a third time": the ALLOW_MATRIX
+ * refusals the gate raises when it correctly declines to spend vendor credits
+ * on a paid capability from a test context land in `transactions` as
+ * `status='failed'`, and `classifyTransactionFailure()` files them as
+ * `internal` — the "our bug until proven otherwise" bucket. 91 rows in 30 days
+ * across 8 capabilities.
+ *
+ * That part is true. The conclusion drawn from it was not: they are already
+ * excluded from everything that scores, three times over.
+ *
+ *   1. Customer path — `/v1/do` runs `assertGuardedAllow` (routes/do.ts:779)
+ *      roughly 430 lines before the first `insert(transactions)` (:1208). A
+ *      customer-triggered refusal returns 503 with no row ever written.
+ *   2. Quality floor — its query excludes internal accounts by email suffix
+ *      (jobs/quality-floor.ts). Verified against production: of 91 rows, zero
+ *      survive that filter.
+ *   3. Circuit breaker — test-runner.ts never calls `recordFailure`; the
+ *      breaker is driven only from the customer path.
+ *
+ * So nothing needs reclassifying, and these tests deliberately pin the
+ * `internal` result rather than "fixing" it. The refusal is not caller-
+ * attributable — no caller asked for it — so moving it into
+ * CALLER_ATTRIBUTABLE would be wrong in the other direction, and would also
+ * quietly exempt it on the customer path if one ever opened.
+ *
+ * What the tests guard is the coupling that makes the above hold, because all
+ * three protections are implicit and none of them announce themselves.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  SYSTEM_ACCOUNT_EMAIL,
+  isInternalAccountEmail,
+  INTERNAL_EMAIL_SUFFIXES,
+} from "./internal-accounts.js";
+import { classifyTransactionFailure, CALLER_ATTRIBUTABLE } from "./transaction-failure-taxonomy.js";
+
+/** Verbatim from `transactions` on 2026-08-14. */
+const ALLOW_MATRIX_REFUSAL =
+  "Capability 'french-company-data' (cost_class=paid_prepaid) refuses invocation from " +
+  "context kind 'internal_test'. ALLOW_MATRIX governs this; bypass would burn vendor " +
+  "credits outside customer-initiated paths.";
+
+describe("the account the test runner books against stays internal", () => {
+  it("is excluded by the suffix rule the quality floor filters on", () => {
+    // The single load-bearing fact. If this goes false, the floor starts
+    // counting the platform's own cost-control refusals against the paid
+    // capabilities they protect — silently, since nothing else looks wrong.
+    expect(isInternalAccountEmail(SYSTEM_ACCOUNT_EMAIL)).toBe(true);
+  });
+
+  it("keeps a suffix that the exclusion list actually covers", () => {
+    // Guards the specific move that would break it: renaming the account to a
+    // domain nobody remembered to add. isInternalAccountEmail would keep
+    // passing for other addresses, so only this assertion would fail.
+    const domain = SYSTEM_ACCOUNT_EMAIL.slice(SYSTEM_ACCOUNT_EMAIL.indexOf("@"));
+    expect(INTERNAL_EMAIL_SUFFIXES).toContain(domain);
+  });
+
+  it("is not a real-looking address that could be mistaken for a customer", () => {
+    expect(isInternalAccountEmail("customer@gmail.com")).toBe(false);
+  });
+});
+
+describe("cost-control refusals keep their classification", () => {
+  it("classifies as internal, and that is deliberate", () => {
+    // Pinned, not fixed. See the module comment: the refusal is the platform's
+    // own decision, so it is neither a capability fault nor caller-
+    // attributable. It is inert because it never reaches a scoring consumer,
+    // not because the bucket is right.
+    expect(classifyTransactionFailure(ALLOW_MATRIX_REFUSAL)).toBe("internal");
+  });
+
+  it("is not caller-attributable — nobody asked for it", () => {
+    const cls = classifyTransactionFailure(ALLOW_MATRIX_REFUSAL);
+    expect(CALLER_ATTRIBUTABLE.has(cls)).toBe(false);
+  });
+
+  it("does not accidentally absorb a genuine upstream fault", () => {
+    // The message names a capability and a cost class, so a careless pattern
+    // written for it could swallow real failures mentioning the same words.
+    for (const fault of [
+      "Capability 'french-company-data' upstream returned HTTP 503",
+      "fetch failed: ETIMEDOUT",
+    ]) {
+      expect(CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(fault)), fault).toBe(false);
+      expect(classifyTransactionFailure(fault)).not.toBe("caller_input");
+    }
+  });
+});

--- a/apps/api/src/lib/cost-control-refusal-accounting.test.ts
+++ b/apps/api/src/lib/cost-control-refusal-accounting.test.ts
@@ -81,6 +81,15 @@ describe("no customer-facing path can produce one of these refusals", () => {
     // Flip any customer_paid cell to "refuse" or "budget_check" and a real
     // caller starts generating rows that survive the floor's internal filter.
     // That is the change this test exists to stop.
+    //
+    // Which leaves `internal_test` as the only context that actually produces
+    // these rows today — from the scheduler, the regression runner, and the
+    // admin recalibration endpoint at routes/internal-tests.ts:1061 (that one
+    // writes no transactions row at all, so it is inert). The `health_probe`
+    // and `ci` columns also contain refusals, but no production call site
+    // passes either kind; they are reachable only from guarded-executor's own
+    // tests. If one ever gains a caller, it needs the same question asked of
+    // it: which account does it book against?
     const { describeAllowMatrix } = await import("../capabilities/guarded-executor.js");
     for (const [costClass, decision] of Object.entries(describeAllowMatrix("customer_paid"))) {
       expect(decision, `cost_class=${costClass} under customer_paid`).toBe("allow");

--- a/apps/api/src/lib/internal-accounts.ts
+++ b/apps/api/src/lib/internal-accounts.ts
@@ -28,8 +28,10 @@ export const INTERNAL_EMAIL_SUFFIXES = [
 /**
  * The account the test runner books its own executions against.
  *
- * Exported so the writer and the exclusion rule cannot drift apart. That
- * coupling is load-bearing in a way that is easy to miss: the scheduler's
+ * Exported so the writer — `test-runner.ts`, which creates the account and
+ * books against it — shares a definition with the exclusion rule below rather
+ * than repeating the address. That one coupling is load-bearing in a way that
+ * is easy to miss: the scheduler's
  * executions land in `transactions` as ordinary `status='failed'` rows —
  * including the ALLOW_MATRIX refusals the dispatcher gate raises when it
  * correctly declines to spend vendor credits on a paid capability from a test
@@ -42,6 +44,17 @@ export const INTERNAL_EMAIL_SUFFIXES = [
  * address to something outside INTERNAL_EMAIL_SUFFIXES and the floor starts
  * quarantining paid capabilities for a cost-control policy working exactly as
  * intended — silently, since nothing else would look wrong.
+ *
+ * Wiring the writer is not the same as removing the literal everywhere. The
+ * address is still hardcoded, unconnected to this constant, in
+ * `routes/capabilities.ts` (:68, :181) and `lib/daily-digest/fetch-platform.ts`
+ * (:22) as inline SQL, in `routes/admin.ts` (:298), and in
+ * `scripts/since-last-ext.ts` / `scripts/window-inputs.ts`. None of those is a
+ * scoring or quarantine consumer — the capabilities.ts pair filter
+ * `status='completed'`, admin.ts dumps raw activity, the scripts are operator
+ * tooling — so renaming the account would skew reporting rather than trip the
+ * floor. Still worth a dedup pass; the point of naming them here is that this
+ * constant does not yet make them safe.
  */
 export const SYSTEM_ACCOUNT_EMAIL = "system@strale.internal";
 

--- a/apps/api/src/lib/internal-accounts.ts
+++ b/apps/api/src/lib/internal-accounts.ts
@@ -25,6 +25,26 @@ export const INTERNAL_EMAIL_SUFFIXES = [
   "@example.com",
 ];
 
+/**
+ * The account the test runner books its own executions against.
+ *
+ * Exported so the writer and the exclusion rule cannot drift apart. That
+ * coupling is load-bearing in a way that is easy to miss: the scheduler's
+ * executions land in `transactions` as ordinary `status='failed'` rows —
+ * including the ALLOW_MATRIX refusals the dispatcher gate raises when it
+ * correctly declines to spend vendor credits on a paid capability from a test
+ * context. 91 such rows in the last 30 days.
+ *
+ * Those rows classify as `internal` — the "our bug until proven otherwise"
+ * bucket — and would count against the completion rate the quality floor uses
+ * to quarantine and propose deactivation (DEC-20260812-A). The only reason
+ * they don't is that the floor filters this address out by suffix. Change the
+ * address to something outside INTERNAL_EMAIL_SUFFIXES and the floor starts
+ * quarantining paid capabilities for a cost-control policy working exactly as
+ * intended — silently, since nothing else would look wrong.
+ */
+export const SYSTEM_ACCOUNT_EMAIL = "system@strale.internal";
+
 export const EXTRA_EXCLUDED_EMAILS = [
   // Founder personal account (Railway CLI, ad-hoc testing).
   "petterlindstrom@hotmail.com",
@@ -51,7 +71,7 @@ export const EXCLUDED_INTERNAL_EMAILS = [
   "petter@strale.io",
   "test@strale.io",
   "test2@strale.io",
-  "system@strale.internal",
+  SYSTEM_ACCOUNT_EMAIL,
   "test@example.com",
   ...EXTRA_EXCLUDED_EMAILS,
 ];

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -1012,6 +1012,7 @@ const NULL_RATIO_RULE_ENABLED = process.env.NULL_RATIO_RULE_ENABLED === "true";
 // Gate 3: Canonical-input sentinel (DEC-20260513-B + DEC-20260513-C).
 // See ./guaranteed-fields-sentinel.ts for the rationale + strict-missing semantics.
 import { checkGuaranteedFieldsPresent } from "./guaranteed-fields-sentinel.js";
+import { SYSTEM_ACCOUNT_EMAIL } from "./internal-accounts.js";
 
 function validateResult(
   suite: typeof testSuites.$inferSelect,
@@ -1383,7 +1384,7 @@ async function getSystemUserId(): Promise<string> {
   const [existing] = await db
     .select({ id: users.id })
     .from(users)
-    .where(eq(users.email, "system@strale.internal"))
+    .where(eq(users.email, SYSTEM_ACCOUNT_EMAIL))
     .limit(1);
 
   if (existing) {
@@ -1397,7 +1398,7 @@ async function getSystemUserId(): Promise<string> {
   const [created] = await db
     .insert(users)
     .values({
-      email: "system@strale.internal",
+      email: SYSTEM_ACCOUNT_EMAIL,
       name: "Strale Internal Test Runner",
       apiKeyHash: hash,
       keyPrefix: "sk_sys_",


### PR DESCRIPTION
## The alarm I raised was wrong

I reported that the dispatcher gate's cost-control refusals were being counted as capability faults by the quality floor — the same bug class as #231, a third time. **It does not hold.** This PR ships no behaviour change, and the reason is the point of it.

## What was true

The evidence behind the alarm is real. The ALLOW_MATRIX refusals — the gate correctly declining to spend vendor credits on a paid capability from a test context — land in `transactions` as `status='failed'`, and `classifyTransactionFailure()` files them as `internal`, the bucket whose own documentation reads *"OUR bug until proven otherwise"*.

It's also **wider** than I first said: 91 rows over 30 days across **8** capabilities, not 3. `french-company-data` 16, `eu-regulation-search` 10, `image-to-text` 10, then norwegian, finnish, estonian, us-company-data, web-extract.

## What was false

They never reach anything that scores. Three independent protections:

| # | Protection | How I checked |
|---|---|---|
| 1 | **Customer path** — `assertGuardedAllow` runs at `routes/do.ts:779`, ~430 lines before the first `insert(transactions)` at `:1208`. A customer-triggered refusal returns 503 with no row ever written. | Read the ordering |
| 2 | **Quality floor** — its query excludes internal accounts by email suffix. | Ran the floor's own `WHERE` clause against production: **0 of 91 rows survive** |
| 3 | **Circuit breaker** — `test-runner.ts` never calls `recordFailure`. By design, not luck: the breaker is driven only from the customer path. | grep count 0, plus `capability_health.total_failures=3` while 16 such rows existed |

All 91 rows are written by `system@strale.internal`, and `@strale.internal` is in `INTERNAL_EMAIL_SUFFIXES`.

## Why nothing is reclassified

Moving these into `CALLER_ATTRIBUTABLE` would be wrong in the other direction — **no caller asked for them**. It's a third category: the platform chose not to run. And it would quietly exempt them if a customer-facing path ever did open. The tests therefore pin `internal` deliberately, with the reasoning inline so a future reader doesn't "fix" it the way I nearly did.

## What is worth fixing

All three protections are implicit, and the one doing the actual work was a **string literal in `test-runner.ts` that had to keep matching an exclusion rule defined in a different file**. Nothing connected them.

`SYSTEM_ACCOUNT_EMAIL` now lives beside the exclusion rule it depends on, and the writer imports it. The tests pin the *coupling*, not the behaviour: that the system account is still matched by the suffix rule, and that its domain is still in the list.

Those are the assertions that fail if the address ever moves outside the exclusion — which is the single change that would turn this from inert into the bug I thought I'd found: the floor quarantining paid capabilities for a cost-control policy that exists to protect them, with nothing else looking wrong. The floor is dry-run pending `QUALITY_FLOOR_ENFORCE=true`, so today it would be silent either way.

## Answering the brief's other questions

- **Should these rows be written to `transactions` at all?** Yes — leave them. They're a useful audit record of the gate working, they're excluded everywhere that scores, and removing them is a larger blast radius than the problem justifies.
- **The other ALLOW_MATRIX reasons** (`CapabilityNotClassifiedError`, `BudgetExhaustedError`) are the same category and travel the same paths, so the same three protections cover them. `do.ts:788-798` handles both defensively before any row exists.

## Verification

- `tsc --noEmit` clean.
- `vitest run src/lib src/jobs` — **819 passed, 4 skipped, 60 files**.
- 6 new tests. **Verified in both directions:** renaming the account to a non-internal domain fails exactly the two coupling assertions.

## Test plan

- `cd apps/api && npx vitest run src/lib/cost-control-refusal-accounting.test.ts`
- To re-check the production claim: run the `WHERE` clause from `jobs/quality-floor.ts` with `AND t.error LIKE 'Capability %refuses invocation%'` — it should return no rows.