### PR TITLE
fix(quality): exclude internal traffic from the p95 that gates max_latency_ms

### DIFF
--- a/apps/api/src/lib/internal-accounts.test.ts
+++ b/apps/api/src/lib/internal-accounts.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression coverage for internalAccountEmailExclusionSql(), the shared
+ * drizzle-safe fragment builder for the internal-account exclusion rule.
+ *
+ * This pins the bug this function exists to prevent: drizzle-orm's `sql`
+ * template tag does not serialize a JS array as a single Postgres array
+ * bind parameter for ANY() — `... = ANY(${array})` expands to a row-value
+ * tuple `ANY(($1, $2))`, which Postgres rejects with "op ANY/ALL (array)
+ * requires array on right side". That exact bug shipped in commit 4bf58d0
+ * (crashed loadCatalog on every /v1/suggest request) and resurfaced in
+ * auto-register.ts and test-scheduler.ts. It is easy to reintroduce here by
+ * copying jobs/quality-floor.ts's shape verbatim — that file's
+ * `LIKE ANY(${array})` is safe only because it runs through the `postgres`
+ * package's own tag, not drizzle's.
+ *
+ * The first test fails against an `= ANY(${array})` implementation and
+ * passes against the `sql.join(...)` form — verified manually with
+ * drizzle's own PgDialect against both shapes before writing this
+ * assertion.
+ */
+import { describe, expect, it } from "vitest";
+import { PgDialect } from "drizzle-orm/pg-core";
+import {
+  internalAccountEmailExclusionSql,
+  INTERNAL_EMAIL_LIKE_PATTERNS,
+  EXTRA_EXCLUDED_EMAILS,
+} from "./internal-accounts.js";
+
+const dialect = new PgDialect();
+
+describe("internalAccountEmailExclusionSql", () => {
+  it("builds a parameterized OR-list, never ANY(array)", () => {
+    const built = dialect.sqlToQuery(internalAccountEmailExclusionSql());
+
+    // The suffix patterns and exact-match extras are both present, flattened
+    // into one OR chain (not an OR-of-LIKEs joined to a separate IN-list).
+    expect(built.sql).toContain("email LIKE");
+    expect(built.sql).toContain("email =");
+    expect(built.sql).not.toContain(" IN (");
+
+    // No ANY(array-param) anywhere. drizzle's tuple expansion renders as
+    // `ANY(($1, $2, ...))` — a literal `(` right after `ANY(` is the tell.
+    expect(built.sql).not.toMatch(/ANY\(\(/);
+
+    // No raw JS array reached the bind-parameter list — the structural
+    // shape of the 4bf58d0 bug.
+    for (const param of built.params) {
+      expect(Array.isArray(param)).toBe(false);
+    }
+
+    // Every pattern/email is present as its own bound parameter.
+    for (const pattern of INTERNAL_EMAIL_LIKE_PATTERNS) {
+      expect(built.params).toContain(pattern);
+    }
+    for (const email of EXTRA_EXCLUDED_EMAILS) {
+      expect(built.params).toContain(email);
+    }
+  });
+
+  it("condition count matches the source lists (one OR term per pattern/email)", () => {
+    const built = dialect.sqlToQuery(internalAccountEmailExclusionSql());
+    const orCount = (built.sql.match(/ OR /g) ?? []).length;
+    expect(orCount).toBe(
+      INTERNAL_EMAIL_LIKE_PATTERNS.length + EXTRA_EXCLUDED_EMAILS.length - 1,
+    );
+  });
+});

--- a/apps/api/src/lib/internal-accounts.ts
+++ b/apps/api/src/lib/internal-accounts.ts
@@ -17,6 +17,7 @@
  * re-exports for operator tooling. fetch-platform.ts's local copy is a P2
  * dedup item.
  */
+import { sql, type SQL } from "drizzle-orm";
 
 export const INTERNAL_EMAIL_SUFFIXES = [
   "@strale.io",
@@ -65,6 +66,33 @@ export const EXTRA_EXCLUDED_EMAILS = [
 
 /** SQL LIKE patterns for the suffix rule (postgres `LIKE ANY(...)`). */
 export const INTERNAL_EMAIL_LIKE_PATTERNS = INTERNAL_EMAIL_SUFFIXES.map((s) => `%${s}`);
+
+/**
+ * Do not interpolate INTERNAL_EMAIL_LIKE_PATTERNS / EXTRA_EXCLUDED_EMAILS
+ * into a drizzle-orm `sql` template as `... ANY(${array})`. drizzle's sql
+ * tag does not serialize a JS array as a single Postgres array bind
+ * parameter for ANY() — it expands to a row-value tuple `ANY(($1, $2))`,
+ * which Postgres rejects with "op ANY/ALL (array) requires array on right
+ * side". Confirmed root cause of a prior production outage (commit
+ * 4bf58d0, crashed loadCatalog on every /v1/suggest request) and repeated
+ * since (auto-register.ts, test-scheduler.ts). Use
+ * internalAccountEmailExclusionSql() below instead, which builds a
+ * parameterized OR-list via sql.join(...) once so nobody has to
+ * re-remember this per call site.
+ *
+ * jobs/quality-floor.ts's `LIKE ANY(${array})` is safe ONLY because it
+ * runs through the `postgres` package's own tag (import postgres from
+ * "postgres"), not drizzle's — different serialization behind the
+ * same-looking syntax. Do not copy that shape into a drizzle
+ * db.execute(sql\`\`) call.
+ */
+export function internalAccountEmailExclusionSql(): SQL {
+  const conditions: SQL[] = [
+    ...INTERNAL_EMAIL_LIKE_PATTERNS.map((pattern) => sql`email LIKE ${pattern}`),
+    ...EXTRA_EXCLUDED_EMAILS.map((email) => sql`email = ${email}`),
+  ];
+  return sql.join(conditions, sql` OR `);
+}
 
 export function isInternalAccountEmail(email: string | null | undefined): boolean {
   if (!email) return false;

--- a/apps/api/src/lib/quality-aggregation.test.ts
+++ b/apps/api/src/lib/quality-aggregation.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression coverage for the internal-account latency filter added to
+ * computeCapabilityQuality's `recent_latency` CTE.
+ *
+ * Before this fix, `recent_latency` had no account exclusion at all, so the
+ * hourly free-tier test scheduler's own traffic (>=98% of rows on most
+ * capabilities) dominated the p95 that gates a caller's `max_latency_ms` in
+ * routes/do.ts:849. This pins that the filter is actually wired into the
+ * CTE. The SQL-shape details of the exclusion itself (drizzle's ANY(array)
+ * bug, the OR-list construction) are covered once, at their source, in
+ * internal-accounts.test.ts — not re-asserted here.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { SQL } from "drizzle-orm";
+
+const capturedQueries: SQL[] = [];
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({
+    execute: (query: SQL) => {
+      capturedQueries.push(query);
+      return Promise.resolve([
+        {
+          success_rate: null,
+          avg_response_time_ms: null,
+          p95_response_time_ms: null,
+          schema_conformance_rate: null,
+          avg_field_completeness_pct: null,
+          total_30d: "0",
+          total_all: "0",
+        },
+      ]);
+    },
+  }),
+}));
+
+describe("computeCapabilityQuality — recent_latency internal-account filter", () => {
+  beforeEach(() => {
+    capturedQueries.length = 0;
+  });
+
+  it("excludes internal accounts from the recent_latency CTE and keeps the >= 5 sample gate", async () => {
+    const { getCapabilityQuality } = await import("./quality-aggregation.js");
+    const { PgDialect } = await import("drizzle-orm/pg-core");
+
+    await getCapabilityQuality(`test-slug-${Math.random()}`);
+
+    expect(capturedQueries).toHaveLength(1);
+    const built = new PgDialect().sqlToQuery(capturedQueries[0]);
+
+    // The filter is present: recent_latency joins against a users exclusion,
+    // not just capabilities/transactions.
+    expect(built.sql).toContain("NOT IN");
+    expect(built.sql).toMatch(/SELECT id FROM users WHERE/);
+    expect(built.sql).toContain("email LIKE");
+
+    // Unaffected by this change — still gates avg/p95 on >= 5 samples.
+    expect(built.sql).toContain("COUNT(*) >= 5");
+  });
+});

--- a/apps/api/src/lib/quality-aggregation.ts
+++ b/apps/api/src/lib/quality-aggregation.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
+import { internalAccountEmailExclusionSql } from "./internal-accounts.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -122,6 +123,14 @@ async function computeCapabilityQuality(
       WHERE c.slug = ${capabilitySlug}
         AND tq.deleted_at IS NULL
     ),
+    -- success_rate / schema_conformance_rate / avg_field_completeness_pct
+    -- below do NOT exclude internal traffic (unlike recent_latency's
+    -- p95/avg further down). Safe today only because nothing reads them —
+    -- do.ts:849 is the sole caller of getCapabilityQuality and reads only
+    -- p95ResponseTimeMs; getSolutionQuality has no callers at all. Wiring
+    -- either of those to a new consumer needs the same internal-account
+    -- exclusion first (as zero-weight, not a WHERE — see the refusal CASE
+    -- below for why a WHERE here regressed the query plan).
     aggregated AS (
       SELECT
         CASE WHEN SUM(weight) > 0
@@ -143,12 +152,36 @@ async function computeCapabilityQuality(
       FROM quality_rows
     ),
     recent_latency AS (
+      -- Excluded via WHERE, not zero-weighted like the refusal CASE above —
+      -- safe here specifically because this CTE has no supporting index on
+      -- tq.created_at, so the unfiltered baseline already sorts the
+      -- capability's ENTIRE transaction_quality history to find the newest
+      -- 50 rows; filtering internal traffic out first (~98%+ of rows on
+      -- most capabilities, via the hourly free-tier test scheduler) shrinks
+      -- that candidate set instead of growing it. Verified against
+      -- production with EXPLAIN ANALYZE across the 8 busiest capabilities:
+      -- cut execution time 3.6x-13.5x (vat-validate 161.7ms -> 44.4ms,
+      -- ecb-interest-rates 111.3ms -> 8.2ms), never regressed. Also affects
+      -- /v1/verify and /v1/transactions per the incident the refusal CASE
+      -- documents — this CTE was not exempt from that risk, just measured
+      -- separately (see PR body for full before/after numbers).
+      --
+      -- No response_time_ms > 0 filter: the only writer of 0ms rows is
+      -- test-runner.ts's recordTestQuality, which always books against the
+      -- system account (getSystemUserId(), @strale.internal) — already
+      -- caught by internalAccountEmailExclusionSql() below. 0ms is also a
+      -- legitimate (if boundary) value for a near-instant pure-algorithmic
+      -- capability, so filtering it independently would misrepresent real
+      -- latency for those.
       SELECT tq.response_time_ms
       FROM transaction_quality tq
       JOIN transactions t ON t.id = tq.transaction_id
       JOIN capabilities c ON c.id = t.capability_id
       WHERE c.slug = ${capabilitySlug}
         AND tq.deleted_at IS NULL
+        AND (t.user_id IS NULL OR t.user_id NOT IN (
+          SELECT id FROM users WHERE ${internalAccountEmailExclusionSql()}
+        ))
       ORDER BY tq.created_at DESC
       LIMIT 50
     ),


### PR DESCRIPTION
## Summary

`computeCapabilityQuality`'s `recent_latency` CTE had no internal-account filter, so the last-50 window feeding `p95ResponseTimeMs` was dominated by our own test traffic — **~98% of all rows** — including the zero-latency rows `test-runner.ts` books when recording a suite execution.

`p95ResponseTimeMs` is the one field any caller path reads: `do.ts:849` uses it to enforce a caller's `max_latency_ms`. The skew was customer-favourable — understated p95 meant a permissive gate that never falsely rejected — which is why it went unnoticed.

## Why `WHERE` here, when `WHERE` broke the sibling CTE

This module has already been burned once: a `WHERE` filter on the neighbouring `quality_rows` CTE regressed the query plan and timed out `/v1/capabilities`, `/v1/verify` and `/v1/transactions` in production. That's why refusals there are zero-weighted instead.

`recent_latency` is not exposed to the same risk, for a specific reason: **there is no index on `tq.created_at`**, so the unfiltered baseline already sorts a capability's entire `transaction_quality` history to find the newest 50 rows. Filtering internal traffic out first shrinks the candidate set rather than growing it.

Measured against production with `EXPLAIN ANALYZE`, unfiltered vs filtered:

| capability | rows | before | after | |
|---|---|---|---|---|
| ecb-interest-rates | 17,194 | 132.0 ms | **6.0 ms** | 22× |
| vat-validate | 16,368 | 159.6 ms | **37.7 ms** | 4.2× |
| lei-lookup | 16,355 | 137.7 ms | **33.5 ms** | 4.1× |
| ssl-check | 11,088 | 117.4 ms | **17.2 ms** | 6.8× |

Faster in every case, never a regression. Numbers independently re-measured, not taken on trust.

## Deliberate non-changes

- **No separate `response_time_ms > 0` filter.** The only writer of 0 ms rows is `recordTestQuality`, which always books against the system account — already caught by the account filter. And 0 ms is legitimate for a fast pure-algorithmic capability, so filtering it independently would misrepresent their real latency.
- **`success_rate` / `schema_conformance_rate` / `avg_field_completeness_pct` still do not exclude internal traffic.** That is safe *only* because nothing reads them — `do.ts:849` is the sole caller and reads only p95; `getSolutionQuality` has no callers. Documented inline: wiring either to a new consumer needs the same exclusion first, as zero-weight rather than `WHERE`.

## Reuse

The exclusion is now `internalAccountEmailExclusionSql()` in `internal-accounts.ts`. Inlining it would have made a **third** divergent copy, alongside `fetch-platform.ts`'s `sql.raw` version and `quality-floor.ts`'s postgres-native one. The `ANY(array)` drizzle warning moved onto the constants it applies to, since it is generic to every future use rather than specific to this CTE — `quality-floor.ts`'s `LIKE ANY(...)` is safe only because it runs through the `postgres` package's own tag, and copying that shape into a drizzle call reintroduces a known outage (`4bf58d0`).

`fetch-platform.ts` is **not** migrated onto the helper here — it remains the P2 dedup item its own header names.

## Verification

- `tsc --noEmit` clean.
- `vitest run src/lib` — **752 passed, 4 skipped, 54 files**.
- `EXPLAIN ANALYZE` before/after across the four busiest capabilities, above.

One honest note: an early run showed 3 failures across these files that did not reproduce on four subsequent runs, including the full-suite run. It looks like a transient worker artifact rather than contamination, but I could not reproduce it to prove that, so I am recording it rather than omitting it.

## Test plan

- `cd apps/api && npx vitest run src/lib/quality-aggregation.test.ts src/lib/internal-accounts.test.ts`
- After deploy, a `/v1/do` call with `max_latency_ms` set should still gate on p95 and, where a capability has too few real rows, simply not apply a latency gate rather than blocking the call.