### PR TITLE
fix(company-data): consolidate four duplicated pickByName implementations

### DIFF
--- a/apps/api/src/capabilities/canadian-company-data.ts
+++ b/apps/api/src/capabilities/canadian-company-data.ts
@@ -1,7 +1,7 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { extractCompanyName } from "./lib/browserless-extract.js";
 import { safeFetch } from "../lib/safe-fetch.js";
-import { classifyNameMatch } from "../lib/company-name-match.js";
+import { pickByName as pickByNameShared } from "../lib/company-name-match.js";
 
 // Canada — Corporations Canada (ISED)
 //
@@ -225,46 +225,31 @@ async function searchByName(query: string): Promise<CaNameCandidate[]> {
 
 /**
  * The site search returns a page of candidates, not a single best guess —
- * same discipline as uk-company-data.ts's pickByName (the #161 wrong-company
- * class): score every candidate by name, refuse when several distinct
- * corporations tie at the same confidence, and refuse when nothing genuinely
- * matches rather than silently returning the first row.
+ * same discipline as the shared pickByName (the #161 wrong-company class):
+ * score every candidate by name, refuse when several distinct corporations
+ * tie at the same confidence, and refuse when nothing genuinely matches
+ * rather than silently returning the first row.
+ *
+ * Thin field-mapping wrapper: the bucket/score/refuse logic itself now lives
+ * once in company-name-match.ts (consolidated 2026-08-14, was duplicated
+ * four ways — see that module's pickByName doc comment). Kept as an exported
+ * `pickByName(query, candidates)` two-argument function, same shape as
+ * before, so canadian-company-data.test.ts and the executor below don't need
+ * to change, and so the Canadian-specific wording (which differs from the
+ * other three registries' wording — see the shared function's doc comment)
+ * is declared exactly once, here.
  */
 export function pickByName(query: string, candidates: CaNameCandidate[]): CaNameResolution {
-  const exact = new Map<string, string>();
-  const high = new Map<string, string>();
-  for (const c of candidates) {
-    if (!c.corpId || !c.name) continue;
-    const { match_confidence } = classifyNameMatch(query, c.name);
-    if (match_confidence === "exact" && !exact.has(c.corpId)) exact.set(c.corpId, c.name);
-    else if (match_confidence === "high" && !high.has(c.corpId)) high.set(c.corpId, c.name);
-  }
-
-  const pickUnambiguous = (bucket: Map<string, string>, label: "exact" | "high"): CaNameResolution | null => {
-    if (bucket.size === 0) return null;
-    if (bucket.size === 1) {
-      const [corpId, matchedName] = bucket.entries().next().value!;
-      return { corpId, matchedName, matchConfidence: label };
-    }
-    const listing = [...bucket.entries()].slice(0, 5).map(([id, n]) => `${n} (${id})`).join("; ");
-    throw new Error(
-      `Ambiguous Canadian company name "${query}": ${bucket.size} distinct registered ` +
-        `entities are ${label === "exact" ? "exact" : "close"} matches — ${listing}. ` +
-        `Provide the corporation number (older corporations have fewer than 7 digits) or the ` +
-        `9-digit business number to disambiguate.`,
-    );
-  };
-
-  const winner = pickUnambiguous(exact, "exact") ?? pickUnambiguous(high, "high");
-  if (winner) return winner;
-
-  const closest = candidates.slice(0, 3).map((c) => c.name).filter(Boolean).join(", ");
-  throw new Error(
-    `No confident Canadian federal registry match for "${query}". The Corporations Canada site ` +
-      `search is fuzzy and returned only unrelated entities${closest ? ` (closest: ${closest})` : ""}. ` +
-      `Provide the corporation number (older corporations have fewer than 7 digits) or the ` +
-      `9-digit business number for an exact lookup.`,
-  );
+  const resolved = pickByNameShared(query, candidates, (c) => c.name, (c) => c.corpId, {
+    subjectLabel: "Canadian company",
+    disambiguationHint:
+      "Provide the corporation number (older corporations have fewer than 7 digits) or the 9-digit business number to disambiguate.",
+    noMatchLabel: "Canadian federal registry",
+    searchDescription: "The Corporations Canada site search",
+    noMatchHint:
+      "Provide the corporation number (older corporations have fewer than 7 digits) or the 9-digit business number for an exact lookup.",
+  });
+  return { corpId: resolved.id, matchedName: resolved.matchedName, matchConfidence: resolved.matchConfidence };
 }
 
 registerCapability("canadian-company-data", async (input: CapabilityInput) => {

--- a/apps/api/src/capabilities/french-company-data.ts
+++ b/apps/api/src/capabilities/french-company-data.ts
@@ -1,6 +1,6 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { deriveVatFR } from "../lib/vat-derivation.js";
-import { classifyNameMatch } from "../lib/company-name-match.js";
+import { pickByName as pickByNameShared } from "../lib/company-name-match.js";
 import { extractCompanyName } from "./lib/browserless-extract.js";
 
 // French company data via recherche-entreprises.api.gouv.fr — FREE, no auth
@@ -93,48 +93,29 @@ export interface FrNameResolution {
  * wrong-company class already fixed for NO/FI/EE/DE/CH). Score every
  * candidate in the page (max per_page = 25, API-enforced) and refuse when
  * nothing genuinely matches, same discipline as the sibling registries.
+ *
+ * Thin field-mapping wrapper: the bucket/score/refuse logic itself now lives
+ * once in company-name-match.ts (consolidated 2026-08-14, was duplicated
+ * four ways — see that module's pickByName doc comment). The shared function
+ * hands back the winning candidate itself (`resolved.candidate`), so this
+ * wrapper only renames it to the `{ company, matchConfidence }` shape
+ * french-company-data.test.ts already exercises — no second scan needed.
  */
 export function pickByName(query: string, results: any[]): FrNameResolution {
-  const exact = new Map<string, any>();
-  const high = new Map<string, any>();
-  for (const c of results) {
-    const name = c?.nom_complet || c?.nom_raison_sociale;
-    const siren = c?.siren;
-    if (typeof name !== "string" || !name || !siren) continue;
-    const { match_confidence } = classifyNameMatch(query, name);
-    if (match_confidence === "exact" && !exact.has(siren)) exact.set(siren, c);
-    else if (match_confidence === "high" && !high.has(siren)) high.set(siren, c);
-  }
-
-  const pickUnambiguous = (bucket: Map<string, any>, label: "exact" | "high"): FrNameResolution | null => {
-    if (bucket.size === 0) return null;
-    if (bucket.size === 1) {
-      return { company: bucket.values().next().value!, matchConfidence: label };
-    }
-    const listing = [...bucket.values()]
-      .slice(0, 5)
-      .map((c) => `${c.nom_complet || c.nom_raison_sociale} (${c.siren})`)
-      .join("; ");
-    throw new Error(
-      `Ambiguous French company name "${query}": ${bucket.size} distinct registered ` +
-        `entities are ${label === "exact" ? "exact" : "close"} matches — ${listing}. ` +
-        `Provide the SIREN (9 digits) or SIRET (14 digits) to disambiguate.`,
-    );
-  };
-
-  const winner = pickUnambiguous(exact, "exact") ?? pickUnambiguous(high, "high");
-  if (winner) return winner;
-
-  const closest = results
-    .slice(0, 3)
-    .map((c) => c?.nom_complet || c?.nom_raison_sociale)
-    .filter(Boolean)
-    .join(", ");
-  throw new Error(
-    `No confident French registry match for "${query}". recherche-entreprises.api.gouv.fr's search is ` +
-      `fuzzy and returned only unrelated entities${closest ? ` (closest: ${closest})` : ""}. ` +
-      `Provide the SIREN (9 digits) or SIRET (14 digits) for an exact lookup.`,
+  const resolved = pickByNameShared(
+    query,
+    results,
+    (c) => c?.nom_complet || c?.nom_raison_sociale,
+    (c) => c?.siren,
+    {
+      subjectLabel: "French company",
+      disambiguationHint: "Provide the SIREN (9 digits) or SIRET (14 digits) to disambiguate.",
+      noMatchLabel: "French registry",
+      searchDescription: "recherche-entreprises.api.gouv.fr's search",
+      noMatchHint: "Provide the SIREN (9 digits) or SIRET (14 digits) for an exact lookup.",
+    },
   );
+  return { company: resolved.candidate, matchConfidence: resolved.matchConfidence };
 }
 
 async function lookupByName(query: string): Promise<{ output: Record<string, unknown>; matchConfidence: "exact" | "high" }> {

--- a/apps/api/src/capabilities/irish-company-data.ts
+++ b/apps/api/src/capabilities/irish-company-data.ts
@@ -1,5 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
-import { classifyNameMatch } from "../lib/company-name-match.js";
+import { pickByName as pickByNameShared } from "../lib/company-name-match.js";
 
 /**
  * Irish company data via the CRO Open Data Portal CKAN datastore API.
@@ -90,6 +90,14 @@ async function lookupByCroNumber(croNumber: string): Promise<CroRecord> {
  * NO/FI/EE/DE/CH. Score every candidate by name and refuse when nothing
  * genuinely matches; a status preference is not a substitute for a name
  * match, so it is not applied as a tiebreaker.
+ *
+ * Thin field-mapping wrapper: the bucket/score/refuse logic itself now lives
+ * once in company-name-match.ts (consolidated 2026-08-14, was duplicated
+ * four ways — see that module's pickByName doc comment). The shared function
+ * hands back the winning candidate itself (`resolved.candidate`), so this
+ * wrapper only renames it to the `{ record, matchConfidence }` shape
+ * irish-company-data.test.ts already exercises — no second scan needed. No
+ * status tiebreak is reintroduced here either.
  */
 export interface IeNameResolution {
   record: CroRecord;
@@ -97,35 +105,20 @@ export interface IeNameResolution {
 }
 
 export function pickByName(name: string, records: CroRecord[]): IeNameResolution {
-  const exact = new Map<number, CroRecord>();
-  const high = new Map<number, CroRecord>();
-  for (const r of records) {
-    if (typeof r?.company_name !== "string" || !r.company_name) continue;
-    const { match_confidence } = classifyNameMatch(name, r.company_name);
-    if (match_confidence === "exact" && !exact.has(r.company_num)) exact.set(r.company_num, r);
-    else if (match_confidence === "high" && !high.has(r.company_num)) high.set(r.company_num, r);
-  }
-
-  const pickUnambiguous = (bucket: Map<number, CroRecord>, label: "exact" | "high"): IeNameResolution | null => {
-    if (bucket.size === 0) return null;
-    if (bucket.size === 1) return { record: bucket.values().next().value!, matchConfidence: label };
-    const listing = [...bucket.values()].slice(0, 5).map((r) => `${r.company_name} (${r.company_num})`).join("; ");
-    throw new Error(
-      `Ambiguous Irish company name "${name}": ${bucket.size} distinct registered ` +
-        `entities are ${label === "exact" ? "exact" : "close"} matches — ${listing}. ` +
-        `Provide the CRO number (5-6 digits) to disambiguate.`,
-    );
-  };
-
-  const winner = pickUnambiguous(exact, "exact") ?? pickUnambiguous(high, "high");
-  if (winner) return winner;
-
-  const closest = records.slice(0, 3).map((r) => r.company_name).filter(Boolean).join(", ");
-  throw new Error(
-    `No confident Irish registry match for "${name}". The CRO Open Data Portal's search is fuzzy ` +
-      `and returned only unrelated entities${closest ? ` (closest: ${closest})` : ""}. ` +
-      `Provide the CRO number (5-6 digits) for an exact lookup.`,
+  const resolved = pickByNameShared(
+    name,
+    records,
+    (r) => r?.company_name,
+    (r) => (r?.company_num != null ? String(r.company_num) : undefined),
+    {
+      subjectLabel: "Irish company",
+      disambiguationHint: "Provide the CRO number (5-6 digits) to disambiguate.",
+      noMatchLabel: "Irish registry",
+      searchDescription: "The CRO Open Data Portal's search",
+      noMatchHint: "Provide the CRO number (5-6 digits) for an exact lookup.",
+    },
   );
+  return { record: resolved.candidate, matchConfidence: resolved.matchConfidence };
 }
 
 // Fetches the candidate page and delegates to pickByName above for the

--- a/apps/api/src/capabilities/uk-company-data.ts
+++ b/apps/api/src/capabilities/uk-company-data.ts
@@ -1,5 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
-import { classifyNameMatch } from "../lib/company-name-match.js";
+import { pickByName as pickByNameShared } from "../lib/company-name-match.js";
 import { extractCompanyName } from "./lib/browserless-extract.js";
 
 // UK VAT validation is handled by vat-validate.ts (which routes GB → HMRC v2),
@@ -44,40 +44,21 @@ export interface UkNameResolution {
  * already fixed for NO/FI/EE/DE/CH/FR/IE). Pull a page of candidates
  * (items_per_page=20; Companies House caps at 100) and score every one by
  * name; refuse when nothing genuinely matches.
+ *
+ * Thin field-mapping wrapper: the bucket/score/refuse logic itself now lives
+ * once in company-name-match.ts (consolidated 2026-08-14, was duplicated
+ * four ways — see that module's pickByName doc comment). Kept as an exported
+ * `pickByName(query, items)` two-argument function, same shape as before, so
+ * uk-company-data.test.ts and the executor below don't need to change.
  */
 export function pickByName(query: string, items: Array<{ title?: string; company_number?: string }>): UkNameResolution {
-  const exact = new Map<string, string>();
-  const high = new Map<string, string>();
-  for (const item of items) {
-    if (typeof item.title !== "string" || !item.title || !item.company_number) continue;
-    const { match_confidence } = classifyNameMatch(query, item.title);
-    if (match_confidence === "exact" && !exact.has(item.company_number)) exact.set(item.company_number, item.title);
-    else if (match_confidence === "high" && !high.has(item.company_number)) high.set(item.company_number, item.title);
-  }
-
-  const pickUnambiguous = (bucket: Map<string, string>, label: "exact" | "high"): UkNameResolution | null => {
-    if (bucket.size === 0) return null;
-    if (bucket.size === 1) {
-      const [companyNumber, matchedName] = bucket.entries().next().value!;
-      return { companyNumber, matchedName, matchConfidence: label };
-    }
-    const listing = [...bucket.entries()].slice(0, 5).map(([num, n]) => `${n} (${num})`).join("; ");
-    throw new Error(
-      `Ambiguous UK company name "${query}": ${bucket.size} distinct registered ` +
-        `entities are ${label === "exact" ? "exact" : "close"} matches — ${listing}. ` +
-        `Provide the Companies House number (8 digits) to disambiguate.`,
-    );
-  };
-
-  const winner = pickUnambiguous(exact, "exact") ?? pickUnambiguous(high, "high");
-  if (winner) return winner;
-
-  const closest = items.slice(0, 3).map((i) => i.title).filter(Boolean).join(", ");
-  throw new Error(
-    `No confident Companies House match for "${query}". The search is fuzzy and returned only ` +
-      `unrelated entities${closest ? ` (closest: ${closest})` : ""}. ` +
-      `Provide the Companies House number (8 digits) for an exact lookup.`,
-  );
+  const resolved = pickByNameShared(query, items, (item) => item?.title, (item) => item?.company_number, {
+    subjectLabel: "UK company",
+    disambiguationHint: "Provide the Companies House number (8 digits) to disambiguate.",
+    noMatchLabel: "Companies House",
+    noMatchHint: "Provide the Companies House number (8 digits) for an exact lookup.",
+  });
+  return { companyNumber: resolved.id, matchedName: resolved.matchedName, matchConfidence: resolved.matchConfidence };
 }
 
 async function searchCompany(name: string): Promise<UkNameResolution> {

--- a/apps/api/src/lib/capability-refusal.test.ts
+++ b/apps/api/src/lib/capability-refusal.test.ts
@@ -82,14 +82,26 @@ function realRefusals(): Array<{ label: string; err: unknown }> {
 }
 
 /**
- * Four capabilities still carry their own `pickByName` rather than the shared
- * one. Their wording happens to match the pattern list today, so they are
- * classified correctly — but nothing was enforcing that, which is the same
- * silence that let the taxonomy's tie pattern sit broken. Swept here until the
- * duplicates are consolidated, so a wording tweak in any of them fails a test
- * instead of quietly re-arming the breaker for that one capability.
+ * canadian-company-data.ts, french-company-data.ts, irish-company-data.ts
+ * and uk-company-data.ts used to each carry a fully independent `pickByName`
+ * — the bucket/score/refuse logic duplicated four ways, throwing a plain
+ * `Error` that was classified correctly only by wording coincidence (nothing
+ * enforced it, the same silence that let the taxonomy's tie pattern sit
+ * broken). Consolidated 2026-08-14 onto the shared `pickByName` in
+ * company-name-match.ts: each of the four capability files now keeps only a
+ * thin field-mapping wrapper — same exported `pickByName(query, candidates)`
+ * signature, same caller-facing wording, but the bucket/score/refuse logic
+ * and the CapabilityRefusalError throw live once, in the shared function.
+ *
+ * Still swept here, but for a different reason than before: not because the
+ * logic is duplicated (it isn't, any more), but because these four wrappers
+ * are the only callers exercising the shared function's `noMatchLabel` /
+ * `searchDescription` / `noMatchHint` overrides end-to-end. A future edit to
+ * any of the four wrappers, or to the shared function's override handling,
+ * fails here instead of only surfacing as a caller-facing wording change in
+ * production.
  */
-async function duplicatedRefusals(): Promise<Array<{ label: string; err: unknown }>> {
+async function consolidatedRegistryRefusals(): Promise<Array<{ label: string; err: unknown }>> {
   const out: Array<{ label: string; err: unknown }> = [];
   const capture = (label: string, fn: () => unknown) => {
     try {
@@ -162,14 +174,25 @@ describe("refusals are recognised as such", () => {
   });
 });
 
-describe("the four un-consolidated duplicates are classified too", () => {
+describe("the four consolidated registries are classified too", () => {
+  it("each still refuses on an ambiguous pair, as the typed error", async () => {
+    const dupes = await consolidatedRegistryRefusals();
+    expect(dupes.length, "all four wrappers must refuse on an ambiguous pair").toBe(4);
+    for (const { label, err } of dupes) {
+      // Pre-consolidation these threw a plain Error, recognised only by
+      // wording. Now they throw the typed error like every other refusal
+      // site — this is the actual point of the consolidation.
+      expect(err, label).toBeInstanceOf(CapabilityRefusalError);
+    }
+  });
+
   it("each is recognised by all three consumers", async () => {
     const { classifyTransactionFailure, CALLER_ATTRIBUTABLE } = await import(
       "./transaction-failure-taxonomy.js"
     );
     const { categorizeError } = await import("./quality-capture.js");
-    const dupes = await duplicatedRefusals();
-    expect(dupes.length, "all four duplicates must refuse on an ambiguous pair").toBe(4);
+    const dupes = await consolidatedRegistryRefusals();
+    expect(dupes.length, "all four wrappers must refuse on an ambiguous pair").toBe(4);
 
     for (const { label, err } of dupes) {
       const msg = (err as Error).message;

--- a/apps/api/src/lib/company-name-match.test.ts
+++ b/apps/api/src/lib/company-name-match.test.ts
@@ -209,7 +209,12 @@ describe("pickByName", () => {
       { title: "Totally Unrelated Ltd", number: "99999999" },
     ];
     const r = pickByName("HSBC Holdings plc", candidates, byTitle, byNumber, opts);
-    expect(r).toEqual({ id: "00617987", matchedName: "HSBC Holdings plc", matchConfidence: "exact" });
+    expect(r).toEqual({
+      id: "00617987",
+      matchedName: "HSBC Holdings plc",
+      matchConfidence: "exact",
+      candidate: candidates[0],
+    });
   });
 
   it("refuses when two distinct entities tie at the same confidence", () => {

--- a/apps/api/src/lib/company-name-match.ts
+++ b/apps/api/src/lib/company-name-match.ts
@@ -149,10 +149,18 @@ export function classifyNameMatch(
     : { match_confidence: "low", is_exact_match: false };
 }
 
-export interface NameSearchResolution {
+export interface NameSearchResolution<T = unknown> {
   id: string;
   matchedName: string;
   matchConfidence: "exact" | "high";
+  /**
+   * The winning candidate itself, not just its name/id. Added so callers who
+   * need the full record (french-company-data.ts, irish-company-data.ts —
+   * both keep a `{ company/record, matchConfidence }` return shape) don't
+   * have to re-scan the candidate list a second time to recover it; the
+   * bucket already held the full object while scoring.
+   */
+  candidate: T;
 }
 
 /**
@@ -162,45 +170,73 @@ export interface NameSearchResolution {
  * see this module's header comment) — score every candidate with
  * classifyNameMatch and refuse rather than take candidates[0].
  *
- * uk-company-data.ts independently grew an identically-shaped `pickByName`
- * (PR #224, branch fix/name-match-confidence, open/unmerged as of
- * 2026-08-14) for the same Companies House endpoint. That version could not
- * be imported here: it lives on an unmerged branch, and — more durably —
- * capability executor files deliberately do not import from one another (see
- * this module's header: these primitives were lifted out of a capability
- * file specifically so registry capabilities share them via this lib instead
- * of reaching across the capability boundary). This is that shared version,
- * generalized over the candidate shape so officer-search.ts and
- * uk-filing-events.ts (both Companies House name-search callers) can use it
- * without duplicating the bucket/refuse logic a third and fourth time. When
- * #224 lands, uk-company-data.ts's own pickByName can be consolidated onto
- * this one.
+ * uk-company-data.ts, canadian-company-data.ts, french-company-data.ts and
+ * irish-company-data.ts each grew an identically-shaped local `pickByName`
+ * independently (PR #224, 2026-08-14): the bucket/score/refuse logic was
+ * genuinely duplicated four ways, and each copy threw a plain `Error` rather
+ * than the typed `CapabilityRefusalError` — classified correctly only by
+ * wording coincidence (see capability-refusal.ts's header). Consolidated
+ * onto this function 2026-08-14: each of the four capability files now keeps
+ * only a thin field-mapping wrapper around this — same exported
+ * `pickByName(query, candidates)` two-argument signature its own test file
+ * already exercises, same caller-facing wording, but the bucket/score/refuse
+ * logic and the CapabilityRefusalError throw live here exactly once.
+ * officer-search.ts and uk-filing-events.ts call this directly (no per-file
+ * wrapper needed there — their candidate shape is already Companies House's
+ * raw item shape).
+ *
+ * The four registries' wording is NOT uniform between the two refusal
+ * messages: the "no confident match" refusal names the SOURCE ("Companies
+ * House", "Canadian federal registry", "Irish registry", "French registry")
+ * while the "ambiguous" refusal names the SUBJECT of the search ("UK
+ * company", "Canadian company", ...), and the two messages' trailing hints
+ * differ in suffix ("...to disambiguate." vs "...for an exact lookup.") even
+ * though they name the same identifier. `noMatchLabel` / `searchDescription`
+ * / `noMatchHint` exist so a caller can reproduce that without forking the
+ * function — they default to `subjectLabel` / "The search" /
+ * `disambiguationHint` respectively, which is exactly officer-search.ts's
+ * and uk-filing-events.ts's existing (unchanged) behaviour.
  */
 export function pickByName<T>(
   query: string,
   candidates: T[],
   getName: (c: T) => string | null | undefined,
   getId: (c: T) => string | null | undefined,
-  opts: { subjectLabel: string; disambiguationHint: string },
-): NameSearchResolution {
-  const exact = new Map<string, string>();
-  const high = new Map<string, string>();
+  opts: {
+    subjectLabel: string;
+    disambiguationHint: string;
+    /** Label for the "No confident X match" refusal. Defaults to subjectLabel. */
+    noMatchLabel?: string;
+    /** "${x} is fuzzy and returned only unrelated entities" preamble in the
+     *  no-match refusal. Defaults to "The search". */
+    searchDescription?: string;
+    /** Trailing hint for the no-match refusal. Defaults to disambiguationHint. */
+    noMatchHint?: string;
+  },
+): NameSearchResolution<T> {
+  // Buckets hold the full candidate, not just its name — the winner is
+  // handed back as `candidate` below with no second scan needed to recover
+  // the record a caller like french/irish-company-data.ts actually wants.
+  const exact = new Map<string, T>();
+  const high = new Map<string, T>();
   for (const c of candidates) {
     const name = getName(c);
     const id = getId(c);
     if (!name || !id) continue;
     const { match_confidence } = classifyNameMatch(query, name);
-    if (match_confidence === "exact" && !exact.has(id)) exact.set(id, name);
-    else if (match_confidence === "high" && !high.has(id)) high.set(id, name);
+    if (match_confidence === "exact" && !exact.has(id)) exact.set(id, c);
+    else if (match_confidence === "high" && !high.has(id)) high.set(id, c);
   }
 
-  const pickUnambiguous = (bucket: Map<string, string>, label: "exact" | "high"): NameSearchResolution | null => {
+  const pickUnambiguous = (bucket: Map<string, T>, label: "exact" | "high"): NameSearchResolution<T> | null => {
     if (bucket.size === 0) return null;
     if (bucket.size === 1) {
-      const [id, matchedName] = bucket.entries().next().value!;
-      return { id, matchedName, matchConfidence: label };
+      const [id, candidate] = bucket.entries().next().value!;
+      // getName(candidate) is non-null here — that's exactly the condition
+      // that put it in the bucket above.
+      return { id, matchedName: getName(candidate)!, matchConfidence: label, candidate };
     }
-    const listing = [...bucket.entries()].slice(0, 5).map(([id, n]) => `${n} (${id})`).join("; ");
+    const listing = [...bucket.entries()].slice(0, 5).map(([id, c]) => `${getName(c)} (${id})`).join("; ");
     throw new CapabilityRefusalError(
       `Ambiguous ${opts.subjectLabel} name "${query}": ${bucket.size} distinct registered ` +
         `entities are ${label === "exact" ? "exact" : "close"} matches — ${listing}. ${opts.disambiguationHint}`,
@@ -212,8 +248,11 @@ export function pickByName<T>(
 
   const closest = candidates.map(getName).filter((n): n is string => !!n).slice(0, 3).join(", ");
   throw new CapabilityRefusalError(
-    `No confident ${opts.subjectLabel} match for "${query}". The search is fuzzy and returned only ` +
-      `unrelated entities${closest ? ` (closest: ${closest})` : ""}. ${opts.disambiguationHint}`,
+    `No confident ${opts.noMatchLabel ?? opts.subjectLabel} match for "${query}". ${
+      opts.searchDescription ?? "The search"
+    } is fuzzy and returned only unrelated entities${closest ? ` (closest: ${closest})` : ""}. ${
+      opts.noMatchHint ?? opts.disambiguationHint
+    }`,
   );
 }
 


### PR DESCRIPTION
## Summary
- Consolidate `canadian-company-data.ts`, `french-company-data.ts`, `irish-company-data.ts`, `uk-company-data.ts`'s four independently-grown `pickByName` implementations onto the shared `pickByName` in `apps/api/src/lib/company-name-match.ts`. Each duplicate threw a plain `Error` instead of the typed `CapabilityRefusalError` — classified correctly today only by wording coincidence (see `capability-refusal.ts`'s header on the 2026-08-14 incident this pattern already caused elsewhere).
- Extend the shared `pickByName` with three optional overrides (`noMatchLabel`, `searchDescription`, `noMatchHint`) because the four registries' wording was never uniform: the "ambiguous" message names the search SUBJECT ("UK company") while the "no confident match" message names the SOURCE ("Companies House"), and the two messages' trailing hints differ in suffix ("...to disambiguate." vs "...for an exact lookup."). Defaults reproduce `officer-search.ts`'s and `uk-filing-events.ts`'s existing (unchanged) behaviour exactly.
- Each capability file keeps a thin field-mapping wrapper — same exported two-argument `pickByName(query, candidates)` signature its own `.test.ts` already exercises — so no caller-facing behaviour changes except the refusal's *type*.
- The shared bucket now stores the winning candidate itself (not just its name), so french/irish's wrappers read `resolved.candidate` directly instead of re-scanning the array a second time (finding from the reuse/simplification review pass).
- `capability-refusal.test.ts`'s sweep is renamed and its rationale rewritten: it no longer guards "four duplicated implementations" (there's only one implementation left) — it guards the four wrappers' wiring into the shared function's new overrides.

## Message preservation (verbatim, byte-for-byte)
| Registry | Ambiguous refusal | No-confident-match refusal |
|---|---|---|
| Canadian | `Ambiguous Canadian company name "X": N distinct registered entities are {exact\|close} matches — LIST. Provide the corporation number (older corporations have fewer than 7 digits) or the 9-digit business number to disambiguate.` | `No confident Canadian federal registry match for "X". The Corporations Canada site search is fuzzy and returned only unrelated entities (closest: ...). Provide the corporation number (older corporations have fewer than 7 digits) or the 9-digit business number for an exact lookup.` |
| French | `Ambiguous French company name "X": N distinct registered entities are {exact\|close} matches — LIST. Provide the SIREN (9 digits) or SIRET (14 digits) to disambiguate.` | `No confident French registry match for "X". recherche-entreprises.api.gouv.fr's search is fuzzy and returned only unrelated entities (closest: ...). Provide the SIREN (9 digits) or SIRET (14 digits) for an exact lookup.` |
| Irish | `Ambiguous Irish company name "X": N distinct registered entities are {exact\|close} matches — LIST. Provide the CRO number (5-6 digits) to disambiguate.` | `No confident Irish registry match for "X". The CRO Open Data Portal's search is fuzzy and returned only unrelated entities (closest: ...). Provide the CRO number (5-6 digits) for an exact lookup.` |
| UK | `Ambiguous UK company name "X": N distinct registered entities are {exact\|close} matches — LIST. Provide the Companies House number (8 digits) to disambiguate.` | `No confident Companies House match for "X". The search is fuzzy and returned only unrelated entities (closest: ...). Provide the Companies House number (8 digits) for an exact lookup.` |

Every string above is unchanged before/after (only the thrown error's *type* changed, plain `Error` → `CapabilityRefusalError`). Proof: all four pre-existing `.test.ts` files, which assert these exact strings via regex, pass **unmodified**.

## Verification
- `npx tsc --noEmit` — clean
- `npx vitest run` on `company-name-match.test.ts`, `capability-refusal.test.ts`, all four capability `.test.ts` files, plus `officer-search.test.ts` + `uk-filing-events.test.ts` (the two pre-existing direct callers of the shared function) — **111/111 passed**, re-run after merging `origin/main` (through #233)
- `npx tsx scripts/validate-capability.ts --slug <slug>` for all four: canadian-company-data and uk-company-data **20/20**; french-company-data and irish-company-data **19/20** — Gate 5 ("company_name entry point fixture coverage") is a **pre-existing gap**, confirmed unrelated to this PR by re-running validate-capability against the unmodified code via `git stash`
- `npx tsx scripts/smoke-test.ts --slug <slug>` for all four — structural steps all pass; live-execution step for french/uk-company-data is blocked by the pre-existing ALLOW_MATRIX cost-class guard (`paid_prepaid` capabilities refuse `internal_test` invocation to avoid burning vendor credits), unrelated to this change
- Directly executed all four name paths against the consolidated code with real inputs:
  - `canadian-company-data({"company_name":"Shopify"})` -> `company_name: "SHOPIFY INC."`, `corporation_number: "4261607"`, `status: "Active"`, `match_confidence: "exact"` — matches the capability's DB `known_answer` fixture (added since this PR started) exactly, field for field
  - `french-company-data({"company_name":"Danone"})` -> `company_name: "DANONE"`, `siren: "552032534"`, `match_confidence: "exact"`
  - `irish-company-data({"company_name":"Stripe Payments Europe"})` -> `company_name: "STRIPE PAYMENTS EUROPE, LIMITED"`, `cro_number: "513174"`, `match_confidence: "exact"` — matches the known fixture used in `irish-company-data.test.ts`
  - `uk-company-data` live call in this sandbox failed only on a missing `COMPANIES_HOUSE_API_KEY` env var (not present in this dev environment) — unrelated to the diff; its `pickByName` wrapper is covered by the unit tests above against real captured Companies House data (Tesco PLC, HSBC, etc.)
- Identifier/number paths (`findRegistryNumber`, `findSiren`/`lookupBySiren`, `findCro`/`lookupByCroNumber`, `findCompanyNumber`, `fetchCompany`/`fetchOfficers`, `fetchCorporationJson`) are untouched — every diff hunk is scoped to the `pickByName` function and its import in each file

## Reviewer findings — six-lens pass (done inline)
**Technical (senior dev / security / architect / CTO):** clean. Bucket now stores the full candidate `T` (typechecked); `getName(candidate)!` non-null assertion is justified (candidate only enters the bucket when `getName` was truthy); no SSRF/SQL/secrets/auth surface touched; opts extension is a proportionate generalization tied to genuine pre-existing wording variance, not speculative; no conflict with any active Decision.

**Product (PM / UX / founder):** clean. Directly addresses the root cause of the 2026-08-14 refusal-misclassification incident pattern; every caller-facing error string is unchanged; no wire-shape changes.

No HIGH or MEDIUM findings from either pass.

## Cross-repo
None — no capability categories, endpoints, auth flow, or pricing changed.

## Test plan
- Call `POST /v1/do` with an ambiguous/generic `company_name` against each of the four registries and confirm the refusal text is unchanged from before this PR.
- Confirm identifier-path calls (`corporation_number`/`siren`/`cro_number`/`company_number`) are unaffected.
