### PR TITLE
fix(dk): stop the test scheduler claiming the vendor's entire free allowance

### DIFF
--- a/apps/api/scripts/check-cost-class-coherence.mjs
+++ b/apps/api/scripts/check-cost-class-coherence.mjs
@@ -137,6 +137,10 @@ const THROTTLED_HOST_RULES = [
   { host: "api.gdeltproject.org", reason: "GDELT enforces a documented per-IP request interval." },
   { host: "api.gopluslabs.io", reason: "GoPlus Labs' free tier (no access token) is rate-limited." },
   {
+    host: "cvrapi.dk",
+    reason: "cvrapi.dk's unauthenticated free tier has a documented daily lookup quota.",
+  },
+  {
     host: "api.company-information.service.gov.uk",
     reason: "UK Companies House's public API is rate-limited.",
   },

--- a/apps/api/src/lib/danish-quota-headroom.test.ts
+++ b/apps/api/src/lib/danish-quota-headroom.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Block 0083 — the test scheduler must not be entitled to a vendor's entire
+ * free allowance.
+ *
+ * cvrapi.dk documents 50 free lookups per day. quota_cap was also 50, so the
+ * scheduler could consume all of it and the one genuinely external call in the
+ * 30-day window to 2026-08-15 failed with "quota exceeded". Only
+ * internal_test/ci contexts are budget-checked — customer_paid is always ALLOW
+ * — so the budget exists to stop US, not to protect customers after the fact.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { runMigration0083_danishQuotaHeadroom } from "./startup-migrations.js";
+
+function makeStub(count: number) {
+  const captured: unknown[] = [];
+  return {
+    captured,
+    async execute(q: unknown) {
+      captured.push(q);
+      return { count };
+    },
+  };
+}
+
+describe("Block 0083 — danish-company-data quota headroom", () => {
+  it("cuts the test budget and reports the reservation", async () => {
+    const stub = makeStub(1);
+    const r = await runMigration0083_danishQuotaHeadroom(stub as never);
+    expect(r.rows_affected).toBe(1);
+    expect(r.outcome).toMatch(/50 to 20/);
+  });
+
+  it("is idempotent — a redeploy after retuning is a no-op", async () => {
+    const stub = makeStub(0);
+    const r = await runMigration0083_danishQuotaHeadroom(stub as never);
+    expect(r.rows_affected).toBe(0);
+    expect(r.outcome).toMatch(/no change/);
+  });
+
+  it("guards on the old value so an operator's retune survives", async () => {
+    const stub = makeStub(1);
+    await runMigration0083_danishQuotaHeadroom(stub as never);
+    const text = JSON.stringify(stub.captured[0]);
+    expect(text).toContain("quota_cap");
+    expect(text, "must only touch rows still at the old value").toContain("50");
+  });
+
+  it("binds no Date or Buffer (DEC-20260504-A bind-encoder shape)", async () => {
+    const stub = makeStub(1);
+    await runMigration0083_danishQuotaHeadroom(stub as never);
+    for (const q of stub.captured) {
+      const chunks = (q as { queryChunks?: unknown[] }).queryChunks ?? [];
+      expect(chunks.filter((c) => c instanceof Date || Buffer.isBuffer(c))).toEqual([]);
+    }
+  });
+
+  it("the manifest reserves headroom rather than claiming the vendor's whole allowance", () => {
+    // The actual invariant. A future edit that raises quota_cap back to the
+    // documented limit re-creates the outage this block fixed.
+    const y = readFileSync("../../manifests/danish-company-data.yaml", "utf8");
+    const cap = Number(/^quota_cap:\s*(\d+)/m.exec(y)?.[1]);
+    const vendor = Number(/^\s*value:\s*(\d+)/m.exec(y.slice(y.indexOf("known_rate_limit")))?.[1]);
+    expect(vendor, "vendor limit must be declared").toBe(50);
+    expect(cap, "test budget must leave room for customers").toBeLessThan(vendor);
+  });
+});

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1157,7 +1157,7 @@ describe("startup-migrations — phase-b5 slug lists (invariants)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 25 blocks in historical order", () => {
+  it("exports the expected 26 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1189,6 +1189,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0080_cyDirectors",
       "runMigration0081_attribution",
       "runMigration0082_reclassifyThrottledFreeUnlimited",
+      "runMigration0083_danishQuotaHeadroom",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1545,6 +1545,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0080_cyDirectors,
   runMigration0081_attribution,
   runMigration0082_reclassifyThrottledFreeUnlimited,
+  runMigration0083_danishQuotaHeadroom,
 ];
 
 /**
@@ -1789,6 +1790,52 @@ export async function runMigration0082_reclassifyThrottledFreeUnlimited(
       updateCount === 0
         ? `no rows to reclassify (all ${PHASE_C1_THROTTLED_UPSTREAM_RECLASSIFY.length} slugs already non-free_unlimited)`
         : `reclassified ${updateCount} cap(s) from free_unlimited to free_quota (of ${PHASE_C1_THROTTLED_UPSTREAM_RECLASSIFY.length} target slugs)`,
+    rows_affected: updateCount,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+/**
+ * Block 0083 — reserve customer headroom in danish-company-data's test budget.
+ *
+ * cvrapi.dk documents exactly 50 free lookups per day. quota_cap was also 50,
+ * so the scheduler was entitled to the entire vendor allowance and customers
+ * got whatever was left, which was nothing. Measured in the week to
+ * 2026-08-15: 12-31 upstream-consuming executions a day, our own budget
+ * refusing 12-15 of them, and cvrapi.dk still returning "quota exceeded" 2-4
+ * times a day. The single genuinely external call in the 30-day window failed
+ * with exactly that error.
+ *
+ * Only internal_test/ci contexts are budget-checked — customer_paid is always
+ * ALLOW in the ALLOW_MATRIX — so the budget cannot protect customers from us;
+ * it can only stop us before we exhaust the shared pool. Setting it to 20
+ * leaves 30/day for real callers, comfortably above the observed 12/day
+ * baseline for a full suite cycle.
+ *
+ * Guarded on the old value so an operator who has since retuned it is left
+ * alone, and so a redeploy is a no-op.
+ */
+export async function runMigration0083_danishQuotaHeadroom(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const result = await tx.execute(sql`
+    UPDATE capabilities
+       SET quota_cap = 20,
+           updated_at = NOW()
+     WHERE slug = 'danish-company-data'
+       AND cost_class = 'free_quota'
+       AND quota_cap = 50
+  `);
+  const updateCount = (result as { count?: number }).count ?? 0;
+
+  return {
+    block: "0083_danish_quota_headroom",
+    outcome:
+      updateCount === 0
+        ? "no change (danish-company-data quota_cap already retuned or capability absent)"
+        : "danish-company-data test budget cut from 50 to 20, reserving 30/day of the vendor's 50 for customers",
     rows_affected: updateCount,
     duration_ms: Date.now() - startedAt,
   };

--- a/manifests/danish-company-data.yaml
+++ b/manifests/danish-company-data.yaml
@@ -17,11 +17,31 @@ category: data-extraction
 price_cents: 5
 is_free_tier: false
 # Phase A0b cost-class: cvrapi.dk unauthenticated free tier, IP-quota-limited.
-# Empirical floor ~50/day; documented limit higher but conservative cap chosen
-# until we observe one clean cycle. See apps/api/src/capabilities/danish-company-data.ts:5-10.
+#
+# The previous note here read "empirical floor ~50/day; documented limit higher
+# but conservative cap chosen". That had it backwards. cvrapi.dk documents
+# exactly 50 free lookups per day — "Du har 50 gratis opslag om dagen" — so a
+# cap of 50 was not conservative, it allocated the entire vendor allowance to
+# our own test scheduler and left nothing for paying callers.
+#
+# That is what happened. In the week to 2026-08-15 the scheduler ran 12-31
+# upstream-consuming executions a day, our own budget refused 12-15 of them,
+# and cvrapi.dk still returned "quota exceeded" 2-4 times a day. The one
+# genuinely external call in the 30-day window failed with exactly that error.
+# Tests and customers draw on the same 50; only tests are budget-checked
+# (customer_paid is always ALLOW in the ALLOW_MATRIX), so tests can consume the
+# lot and customers meet the wall.
+#
+# The cap now reserves headroom rather than claiming the whole allowance: 20
+# for testing against a documented 50, leaving 30/day for real callers. 20 sits
+# comfortably above the observed 12/day baseline for a full suite cycle.
+known_rate_limit:
+  value: 50
+  unit: per_day
+  source_url: https://cvrapi.dk/documentation
 cost_class: free_quota
 quota_window: daily
-quota_cap: 50
+quota_cap: 20
 input_schema:
   type: object
   # No field is individually required: a CVR number OR a company name is


### PR DESCRIPTION
## Summary

cvrapi.dk documents **exactly 50 free lookups per day** — *"Du har 50 gratis opslag om dagen"*. `quota_cap` was also **50**, so the test scheduler was entitled to the whole vendor allowance and customers got whatever was left. Which was nothing.

The manifest comment had it backwards:

> *"empirical floor ~50/day; documented limit higher but conservative cap chosen"*

The documented limit is not higher. It is 50. So the cap was never conservative — it allocated the entire pool to ourselves, and the comment recorded a belief that made that look safe.

## The evidence

Week to 2026-08-15, `danish-company-data`:

| day | upstream-consuming runs | our budget refused | **cvrapi.dk quota hit** |
|---|---|---|---|
| 08-15 | 17 | 12 | **4** |
| 08-14 | 17 | 12 | **4** |
| 08-13 | 20 | 15 | **2** |
| 08-12 | 31 | 15 | **2** |
| 08-08..11 | 12 | 0 | 0 |

The single genuinely external call in the 30-day window failed with *"The Danish business registry API quota has been temporarily exceeded."*

Only `internal_test`/`ci` contexts are budget-checked — `customer_paid` is always ALLOW in the ALLOW_MATRIX — so the budget **cannot protect customers from us after the fact**. It can only stop us before we drain the shared pool.

## The fix

- `quota_cap` **50 → 20**, reserving **30/day for real callers**. 20 sits comfortably above the observed 12/day baseline for a full suite cycle.
- Declares `known_rate_limit: {value: 50, unit: per_day, source_url: …}` using the schema #238 added, so the number has a citation instead of a folk memory.
- Adds `cvrapi.dk` to `THROTTLED_HOST_RULES`, so a future manifest touching that host must declare a limit rather than inheriting this silently.
- **Block 0083** applies the cap to the database — a manifest edit does not propagate, since `onboard.ts` never writes `cost_class` (#235's finding). Guarded on the old value, so an operator retune survives and a redeploy is a no-op.

## Verification

- `tsc --noEmit` clean; `check-cost-class-coherence.mjs` clean across all manifests.
- `vitest run src/lib src/jobs` — **888 passed, 4 skipped, 68 files**.
- **Verified in both directions.** The load-bearing test asserts `quota_cap` stays strictly below the declared vendor limit; setting it back to 50 fails exactly that test, which is the edit that would recreate the outage.
- The canonical BLOCKS-list guard correctly caught the new block and was updated deliberately (25 → 26).

## Method note

This came out of re-measuring with `isInternalAccountEmail` rather than a hand-rolled filter. The original triage counted `test2@strale.io` as a customer and produced a list of five broken capabilities; with the canonical rule, three had no external failure at all. This is one of the two that survived.

## Test plan

- `cd apps/api && npx vitest run src/lib/danish-quota-headroom.test.ts`
- After deploy: `SELECT quota_cap FROM capabilities WHERE slug='danish-company-data'` should read **20**, and cvrapi.dk "quota exceeded" errors should stop appearing in `test_results`.