### PR TITLE
fix(llm-cost-calculate): refresh the price table and make its decay visible

### DIFF
--- a/apps/api/src/capabilities/llm-cost-calculate.test.ts
+++ b/apps/api/src/capabilities/llm-cost-calculate.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The price table decays silently, and that is the actual defect.
+ *
+ * A real x402 caller asked `llm-cost-calculate` for `claude-sonnet-4-5` and was
+ * turned away: the table was stamped "updated Feb 2025" and stopped at
+ * `claude-3.5-sonnet`. Eighteen months of new models were missing and nothing
+ * anywhere said so — no test failed, no monitor fired, the capability reported
+ * itself healthy while being useless for current work.
+ *
+ * The refresh is the easy half. These tests are the half that matters: they
+ * make the next eighteen months of decay visible while it is still cheap.
+ */
+
+import { describe, it, expect } from "vitest";
+import { __pricingMeta } from "./llm-cost-calculate.js";
+
+const { PRICING, MODEL_ALIASES, PRICING_SOURCES, PRICING_VERIFIED_ON, PRICING_MAX_AGE_DAYS } =
+  __pricingMeta;
+
+describe("the request that exposed the staleness", () => {
+  it("prices claude-sonnet-4-5, the model the caller actually asked for", () => {
+    const p = PRICING["claude-sonnet-4-5"];
+    expect(p, "the exact string a paying caller sent must resolve").toBeDefined();
+    // $3/$15 per MTok, per the Anthropic pricing page.
+    expect(p.inputPer1K).toBeCloseTo(0.003);
+    expect(p.outputPer1K).toBeCloseTo(0.015);
+  });
+
+  it("covers the current generation of each vendor, not just the newest one", () => {
+    for (const model of ["claude-sonnet-5", "claude-opus-5", "gpt-5.5", "gemini-3.5-flash"]) {
+      expect(PRICING[model], `${model} must be priced`).toBeDefined();
+    }
+  });
+});
+
+describe("staleness is visible before a caller finds it", () => {
+  it("the table has been verified within PRICING_MAX_AGE_DAYS", () => {
+    // The whole point. When this fails, re-check the three vendor pages and
+    // move PRICING_VERIFIED_ON — do not just bump the date. A green test with
+    // a stale table is exactly the state that produced the original failure.
+    const verified = new Date(PRICING_VERIFIED_ON);
+    expect(Number.isNaN(verified.getTime()), "PRICING_VERIFIED_ON must parse").toBe(false);
+    const ageDays = (Date.now() - verified.getTime()) / 86_400_000;
+    expect(
+      ageDays,
+      `price table last verified ${Math.round(ageDays)} days ago — re-check ${Object.values(
+        PRICING_SOURCES,
+      ).join(", ")} and update PRICING_VERIFIED_ON`,
+    ).toBeLessThan(PRICING_MAX_AGE_DAYS);
+  });
+
+  it("every priced model names a vendor that has a source URL", () => {
+    // Stops a model being added with no traceable origin — an unsourced price
+    // is worse than a missing one, because the output still looks authoritative.
+    for (const [model, p] of Object.entries(PRICING)) {
+      expect(PRICING_SOURCES[p.vendor], `${model} cites an unknown vendor`).toBeTruthy();
+    }
+  });
+
+  it("distinguishes verified rows from carried-over ones", () => {
+    // Carried-over rows are allowed, but they must be marked. Silence is what
+    // let the old table pass as current.
+    const carried = Object.entries(PRICING).filter(([, p]) => p.unverified);
+    expect(carried.length, "some rows are carried over unverified").toBeGreaterThan(0);
+    for (const [, p] of carried) expect(p.unverified).toBe(true);
+  });
+});
+
+describe("nothing that worked before breaks", () => {
+  it("resolves the old dotted spellings through aliases", () => {
+    for (const [alias, target] of Object.entries(MODEL_ALIASES)) {
+      expect(PRICING[target], `alias ${alias} points at missing ${target}`).toBeDefined();
+    }
+  });
+
+  it("keeps the previously supported models priced", () => {
+    for (const model of ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo", "claude-3-opus", "gemini-1.5-pro"]) {
+      expect(PRICING[model], `${model} was supported before and must stay`).toBeDefined();
+    }
+  });
+
+  it("leaves gpt-4o's price unchanged — it was never wrong", () => {
+    // The old table was incomplete, not inaccurate. Re-verified: still
+    // $2.50/$10.00 per MTok.
+    expect(PRICING["gpt-4o"].inputPer1K).toBeCloseTo(0.0025);
+    expect(PRICING["gpt-4o"].outputPer1K).toBeCloseTo(0.01);
+  });
+});
+
+describe("the numbers are structurally sane", () => {
+  it("every price is positive and output costs at least input", () => {
+    for (const [model, p] of Object.entries(PRICING)) {
+      expect(p.inputPer1K, `${model} input`).toBeGreaterThan(0);
+      expect(p.outputPer1K, `${model} output`).toBeGreaterThan(0);
+      expect(p.outputPer1K, `${model}: output should not be cheaper than input`).toBeGreaterThanOrEqual(
+        p.inputPer1K,
+      );
+    }
+  });
+
+  it("context is a positive number or explicitly null, never zero or guessed", () => {
+    for (const [model, p] of Object.entries(PRICING)) {
+      if (p.context === null) continue;
+      expect(p.context, `${model} context`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/api/src/capabilities/llm-cost-calculate.ts
+++ b/apps/api/src/capabilities/llm-cost-calculate.ts
@@ -1,21 +1,135 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 
-// Pricing per 1K tokens (USD) — updated Feb 2025
-const PRICING: Record<string, { inputPer1K: number; outputPer1K: number; context: number }> = {
-  "gpt-4o": { inputPer1K: 0.0025, outputPer1K: 0.01, context: 128000 },
-  "gpt-4o-mini": { inputPer1K: 0.00015, outputPer1K: 0.0006, context: 128000 },
-  "gpt-4-turbo": { inputPer1K: 0.01, outputPer1K: 0.03, context: 128000 },
-  "gpt-4": { inputPer1K: 0.03, outputPer1K: 0.06, context: 8192 },
-  "gpt-3.5-turbo": { inputPer1K: 0.0005, outputPer1K: 0.0015, context: 16385 },
-  "claude-3-opus": { inputPer1K: 0.015, outputPer1K: 0.075, context: 200000 },
-  "claude-3-sonnet": { inputPer1K: 0.003, outputPer1K: 0.015, context: 200000 },
-  "claude-3-haiku": { inputPer1K: 0.00025, outputPer1K: 0.00125, context: 200000 },
-  "claude-3.5-sonnet": { inputPer1K: 0.003, outputPer1K: 0.015, context: 200000 },
-  "claude-3.5-haiku": { inputPer1K: 0.0008, outputPer1K: 0.004, context: 200000 },
-  "gemini-1.5-pro": { inputPer1K: 0.00125, outputPer1K: 0.005, context: 2000000 },
-  "gemini-1.5-flash": { inputPer1K: 0.000075, outputPer1K: 0.0003, context: 1000000 },
-  "mistral-large": { inputPer1K: 0.002, outputPer1K: 0.006, context: 128000 },
-  "llama-3-70b": { inputPer1K: 0.00059, outputPer1K: 0.00079, context: 8192 },
+// ─── Model pricing ──────────────────────────────────────────────────────────
+//
+// USD per 1,000 tokens. Vendors publish per 1,000,000, so every figure here is
+// theirs divided by 1000.
+//
+// The previous table was stamped "updated Feb 2025" and went eighteen months
+// without a refresh. A real caller asked for `claude-sonnet-4-5` and was turned
+// away by a catalogue that stopped at `claude-3.5-sonnet`. Nothing signalled
+// the staleness, which is why PRICING_VERIFIED_ON exists and is asserted on in
+// llm-cost-calculate.test.ts.
+//
+// Worth knowing for the next refresh: the old entries were not wrong. gpt-4o at
+// $2.50/$10.00 per MTok is still current, as are gpt-4o-mini and gpt-3.5-turbo.
+// The table had simply stopped growing, so the failure mode was missing models
+// rather than bad numbers — which is exactly the kind of decay no test catches.
+const PRICING_SOURCES = {
+  openai: "https://developers.openai.com/api/docs/pricing",
+  anthropic: "https://platform.claude.com/docs/en/about-claude/pricing",
+  google: "https://ai.google.dev/gemini-api/docs/pricing",
+} as const;
+
+/** Last date every non-legacy row below was checked against its vendor page. */
+const PRICING_VERIFIED_ON = "2026-08-15";
+
+/** How long before the staleness test starts failing. */
+const PRICING_MAX_AGE_DAYS = 180;
+
+type Vendor = keyof typeof PRICING_SOURCES;
+
+interface ModelPrice {
+  inputPer1K: number;
+  outputPer1K: number;
+  /** Documented context window, or null where the vendor publishes none. */
+  context: number | null;
+  vendor: Vendor;
+  /** Vendor lists it as retired; still priced so existing callers keep working. */
+  retired?: true;
+  /** Carried from the Feb 2025 table and NOT re-verified in this pass. */
+  unverified?: true;
+}
+
+const PRICING: Record<string, ModelPrice> = {
+  // ── OpenAI ──
+  "gpt-5.6-sol": { inputPer1K: 0.005, outputPer1K: 0.03, context: null, vendor: "openai" },
+  "gpt-5.6-terra": { inputPer1K: 0.002, outputPer1K: 0.012, context: null, vendor: "openai" },
+  "gpt-5.6-luna": { inputPer1K: 0.0002, outputPer1K: 0.0012, context: null, vendor: "openai" },
+  "gpt-5.5": { inputPer1K: 0.005, outputPer1K: 0.03, context: 272000, vendor: "openai" },
+  "gpt-5.5-pro": { inputPer1K: 0.03, outputPer1K: 0.18, context: 272000, vendor: "openai" },
+  "gpt-5.4": { inputPer1K: 0.0025, outputPer1K: 0.015, context: 272000, vendor: "openai" },
+  "gpt-5.4-pro": { inputPer1K: 0.03, outputPer1K: 0.18, context: 272000, vendor: "openai" },
+  "gpt-5.4-mini": { inputPer1K: 0.00075, outputPer1K: 0.0045, context: null, vendor: "openai" },
+  "gpt-5.4-nano": { inputPer1K: 0.0002, outputPer1K: 0.00125, context: null, vendor: "openai" },
+  "gpt-5.2": { inputPer1K: 0.00175, outputPer1K: 0.014, context: null, vendor: "openai" },
+  "gpt-5.1": { inputPer1K: 0.00125, outputPer1K: 0.01, context: null, vendor: "openai" },
+  "gpt-5": { inputPer1K: 0.00125, outputPer1K: 0.01, context: null, vendor: "openai" },
+  "gpt-5-mini": { inputPer1K: 0.00025, outputPer1K: 0.002, context: null, vendor: "openai" },
+  "gpt-5-nano": { inputPer1K: 0.00005, outputPer1K: 0.0004, context: null, vendor: "openai" },
+  "o3": { inputPer1K: 0.002, outputPer1K: 0.008, context: null, vendor: "openai" },
+  "o3-pro": { inputPer1K: 0.02, outputPer1K: 0.08, context: null, vendor: "openai" },
+  "o1": { inputPer1K: 0.015, outputPer1K: 0.06, context: null, vendor: "openai" },
+  "o1-pro": { inputPer1K: 0.15, outputPer1K: 0.6, context: null, vendor: "openai" },
+  "gpt-4o": { inputPer1K: 0.0025, outputPer1K: 0.01, context: 128000, vendor: "openai" },
+  "gpt-4o-mini": { inputPer1K: 0.00015, outputPer1K: 0.0006, context: 128000, vendor: "openai" },
+  "gpt-3.5-turbo": { inputPer1K: 0.0005, outputPer1K: 0.0015, context: 16385, vendor: "openai" },
+
+  // ── Anthropic ── (API model names; dotted spellings aliased below)
+  "claude-fable-5": { inputPer1K: 0.01, outputPer1K: 0.05, context: 1000000, vendor: "anthropic" },
+  "claude-opus-5": { inputPer1K: 0.005, outputPer1K: 0.025, context: 1000000, vendor: "anthropic" },
+  "claude-opus-4-8": { inputPer1K: 0.005, outputPer1K: 0.025, context: 1000000, vendor: "anthropic" },
+  "claude-opus-4-7": { inputPer1K: 0.005, outputPer1K: 0.025, context: 1000000, vendor: "anthropic" },
+  "claude-opus-4-6": { inputPer1K: 0.005, outputPer1K: 0.025, context: 1000000, vendor: "anthropic" },
+  "claude-opus-4-5": { inputPer1K: 0.005, outputPer1K: 0.025, context: 200000, vendor: "anthropic" },
+  "claude-sonnet-5": { inputPer1K: 0.002, outputPer1K: 0.01, context: 1000000, vendor: "anthropic" },
+  "claude-sonnet-4-6": { inputPer1K: 0.003, outputPer1K: 0.015, context: 1000000, vendor: "anthropic" },
+  "claude-sonnet-4-5": { inputPer1K: 0.003, outputPer1K: 0.015, context: 200000, vendor: "anthropic" },
+  "claude-haiku-4-5": { inputPer1K: 0.001, outputPer1K: 0.005, context: 200000, vendor: "anthropic" },
+  "claude-opus-4-1": { inputPer1K: 0.015, outputPer1K: 0.075, context: 200000, vendor: "anthropic", retired: true },
+  "claude-sonnet-4": { inputPer1K: 0.003, outputPer1K: 0.015, context: 200000, vendor: "anthropic", retired: true },
+  "claude-haiku-3-5": { inputPer1K: 0.0008, outputPer1K: 0.004, context: 200000, vendor: "anthropic", retired: true },
+
+  // ── Google ──
+  "gemini-3.7-flash": { inputPer1K: 0.00075, outputPer1K: 0.00375, context: null, vendor: "google" },
+  "gemini-3.6-flash": { inputPer1K: 0.00075, outputPer1K: 0.00375, context: null, vendor: "google" },
+  "gemini-3.5-flash": { inputPer1K: 0.0015, outputPer1K: 0.009, context: null, vendor: "google" },
+  "gemini-3.5-flash-lite": { inputPer1K: 0.0003, outputPer1K: 0.0025, context: null, vendor: "google" },
+  "gemini-3.1-flash-lite": { inputPer1K: 0.00025, outputPer1K: 0.0015, context: null, vendor: "google" },
+  "gemini-3.1-pro-preview": { inputPer1K: 0.002, outputPer1K: 0.012, context: null, vendor: "google" },
+  "gemini-2.5-pro": { inputPer1K: 0.00125, outputPer1K: 0.01, context: null, vendor: "google" },
+  "gemini-2.5-flash": { inputPer1K: 0.0003, outputPer1K: 0.0025, context: 1000000, vendor: "google" },
+  "gemini-2.5-flash-lite": { inputPer1K: 0.0001, outputPer1K: 0.0004, context: null, vendor: "google" },
+
+  // ── Carried over, NOT re-verified on 2026-08-15 ──
+  // Kept so existing callers keep working, but their vendors' current pages
+  // were not consulted in this pass. Marked rather than silently presented as
+  // current — an unverified price that looks authoritative is the failure this
+  // whole refresh exists to correct.
+  "claude-3-opus": { inputPer1K: 0.015, outputPer1K: 0.075, context: 200000, vendor: "anthropic", unverified: true },
+  "claude-3-sonnet": { inputPer1K: 0.003, outputPer1K: 0.015, context: 200000, vendor: "anthropic", unverified: true },
+  "claude-3-haiku": { inputPer1K: 0.00025, outputPer1K: 0.00125, context: 200000, vendor: "anthropic", unverified: true },
+  "gpt-4-turbo": { inputPer1K: 0.01, outputPer1K: 0.03, context: 128000, vendor: "openai", unverified: true },
+  "gpt-4": { inputPer1K: 0.03, outputPer1K: 0.06, context: 8192, vendor: "openai", unverified: true },
+  "gemini-1.5-pro": { inputPer1K: 0.00125, outputPer1K: 0.005, context: 2000000, vendor: "google", unverified: true },
+  "gemini-1.5-flash": { inputPer1K: 0.000075, outputPer1K: 0.0003, context: 1000000, vendor: "google", unverified: true },
+  "mistral-large": { inputPer1K: 0.002, outputPer1K: 0.006, context: 128000, vendor: "openai", unverified: true },
+  "llama-3-70b": { inputPer1K: 0.00059, outputPer1K: 0.00079, context: 8192, vendor: "openai", unverified: true },
+};
+
+/**
+ * Older spellings kept resolvable so nothing that worked before breaks. The
+ * dotted forms predate this table adopting the vendors' real API naming — and
+ * the caller who triggered this refresh used the API form, `claude-sonnet-4-5`.
+ */
+const MODEL_ALIASES: Record<string, string> = {
+  "claude-3.5-sonnet": "claude-sonnet-4-5",
+  "claude-3.5-haiku": "claude-haiku-3-5",
+  "claude-sonnet-4.5": "claude-sonnet-4-5",
+  "claude-sonnet-4.6": "claude-sonnet-4-6",
+  "claude-opus-4.5": "claude-opus-4-5",
+  "claude-opus-4.1": "claude-opus-4-1",
+  "claude-haiku-4.5": "claude-haiku-4-5",
+  "claude-haiku-3.5": "claude-haiku-3-5",
+};
+
+/** Exported for the staleness and coverage tests. */
+export const __pricingMeta = {
+  PRICING,
+  MODEL_ALIASES,
+  PRICING_SOURCES,
+  PRICING_VERIFIED_ON,
+  PRICING_MAX_AGE_DAYS,
 };
 
 function estimateTokens(text: string): number {
@@ -23,9 +137,14 @@ function estimateTokens(text: string): number {
 }
 
 registerCapability("llm-cost-calculate", async (input: CapabilityInput) => {
-  const model = ((input.model as string) ?? "gpt-4o").trim().toLowerCase();
+  const requested = ((input.model as string) ?? "gpt-4o").trim().toLowerCase();
+  const model = MODEL_ALIASES[requested] ?? requested;
   const pricing = PRICING[model];
-  if (!pricing) throw new Error(`Unknown model '${model}'. Supported: ${Object.keys(PRICING).join(", ")}`);
+  if (!pricing) {
+    throw new Error(
+      `Unknown model '${requested}'. Supported: ${Object.keys(PRICING).join(", ")}`,
+    );
+  }
 
   // Accept either text or token count directly
   let inputTokens: number;


### PR DESCRIPTION
## Summary

A paying x402 caller asked for **`claude-sonnet-4-5`** and was turned away. The table was stamped *"updated Feb 2025"* and stopped at `claude-3.5-sonnet` — eighteen months of models missing, with nothing signalling it. No test failed, no monitor fired. The capability reported itself healthy while being useless for current work.

## Two things it turned out not to be

**Not a pricing error.** `gpt-4o` at $2.50/$10.00 per MTok is still current, as are `gpt-4o-mini` and `gpt-3.5-turbo`. The table had simply stopped *growing* — the decay mode is missing models, not wrong numbers, which is exactly the kind nothing catches.

**Not really about price at all.** `claude-sonnet-4-5` costs precisely what `claude-3.5-sonnet` already cost. The table used dotted spellings; the caller used the vendor's real API name. Model keys are now the API form, with old spellings aliased so nothing that worked before breaks.

## What changed

Refreshed against each vendor's own pricing page, cited in `PRICING_SOURCES`:

- **OpenAI** — gpt-5.6 family, gpt-5.5/5.4/5.2/5.1/5 and mini/nano/pro variants, o1/o3 series
- **Anthropic** — Opus 4.5→5, Sonnet 4.5→5, Haiku 4.5, Fable 5; retired models kept priced
- **Google** — Gemini 2.5 through 3.7

Rows I could not re-source are marked **`unverified`** rather than presented as current. An unsourced price that looks authoritative is worse than a missing one — that's the failure this refresh exists to correct.

## The staleness check is the actual deliverable

`PRICING_VERIFIED_ON` plus a 180-day ceiling turns the next eighteen months of decay into a failing test rather than a turned-away customer. The failure message names the three vendor pages to re-check, because a test that only says "stale" invites bumping the date instead of doing the work.

## Verification

End-to-end execution, not just unit tests:

| input | result |
|---|---|
| `claude-sonnet-4-5` (the original failing request) | **$0.000033** |
| `claude-3.5-sonnet` (alias) | **$0.000033** — identical, back-compat holds |
| `gpt-5.5`, 1000 in / 500 out | **$0.02** — matches hand-check ($0.005 + $0.015) |
| unknown model | clean error listing supported models |

- `tsc --noEmit` clean.
- 10/10 new tests; **1190 pass** across `src/capabilities` and `src/lib`.
- Three files fail to *collect* under full parallel load via a `vite:dynamic-import-vars` issue in `auto-register.ts`. Pre-existing and unrelated — each passes in isolation (verified).

## Method note

This came out of re-triaging with `isInternalAccountEmail` rather than a hand-rolled filter. The original list of "five broken capabilities" counted `test2@strale.io` as a customer; with the canonical rule, three had no external failure at all. This is one of the two that survived — and the only one that was genuinely customer-visible.

## Test plan

- `cd apps/api && npx vitest run src/capabilities/llm-cost-calculate.test.ts`
- After deploy: `POST /v1/do` with `{"capability_slug":"llm-cost-calculate","inputs":{"model":"claude-sonnet-4-5","prompt_text":"hello"}}` should return a cost rather than "Unknown model".