### PR TITLE
feat(mcp): tell refused agents about the route they can actually take

### DIFF
--- a/apps/api/src/routes/mcp-conversion.test.ts
+++ b/apps/api/src/routes/mcp-conversion.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The MCP surface has to be usable by something that cannot fill in a form.
+ *
+ * Measured in the seven days to 2026-08-15: 176 distinct agents opened an MCP
+ * session, 2 real callers executed anything, and there were 0 signups. Over the
+ * same period 653 x402 calls arrived — from agents that had found the
+ * pay-per-call route somewhere other than here.
+ *
+ * The reason is visible in what the surface said. Hitting a paid capability
+ * without a key returned exactly one instruction: "Get a free API key at
+ * https://strale.dev/signup". That is a web form. An autonomous agent cannot
+ * complete it, and x402 — payment-as-auth, no account, built for precisely
+ * this caller — was never mentioned.
+ *
+ * These tests pin the two properties that fix costs nothing to keep: the
+ * machine-actionable route is offered, and the first-contact response does not
+ * assert catalogue facts it has not checked.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { executeCapability, type StraleClientOptions } from "strale-mcp/tools";
+
+const OPTS: StraleClientOptions = {
+  baseUrl: "https://api.example.test",
+  apiKey: "", // the whole point: no credentials
+  maxPriceCents: 100,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function refusalFor(slug: string): Promise<Record<string, unknown>> {
+  const res = await executeCapability(slug, { any: "input" }, OPTS);
+  return JSON.parse(res.content[0].text) as Record<string, unknown>;
+}
+
+describe("an agent refused for lack of credentials is told what it can actually do", () => {
+  it("offers the pay-per-call route, with the endpoint to call", async () => {
+    const body = await refusalFor("swedish-company-data");
+    const pay = body.pay_per_call as Record<string, string> | undefined;
+
+    expect(pay, "a refusal must offer the no-signup route").toBeDefined();
+    expect(pay!.endpoint).toBe("https://api.example.test/x402/swedish-company-data");
+    expect(pay!.catalog).toContain("/x402/catalog");
+    expect(pay!.discovery).toContain("/.well-known/x402.json");
+  });
+
+  it("does not present a web signup as the only way forward", async () => {
+    const body = await refusalFor("swedish-company-data");
+    // Signup is still offered — for a human. It just cannot be the sole path,
+    // which is what produced 176 arrivals and 0 signups.
+    const asText = JSON.stringify(body);
+    expect(asText).toContain("strale.dev/signup");
+    expect(Object.keys(body), "the machine route must be present too").toContain("pay_per_call");
+  });
+
+  it("names the free capabilities rather than gesturing at them", async () => {
+    const body = await refusalFor("swedish-company-data");
+    const free = String(body.free_without_either ?? "");
+    expect(free).toContain("email-validate");
+    expect(free).toContain("bitcoin-address-validate"); // one of the six added later
+  });
+
+  it("still lets a free-tier capability through without any of this", async () => {
+    // The refusal must not have widened. Free tier works with no key and no
+    // payment; only the paid path should reach the message above.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(JSON.stringify({ result: { output: { valid: true } } }), { status: 200 }),
+      ),
+    );
+    const res = await executeCapability("email-validate", { email: "a@b.com" }, OPTS);
+    const body = JSON.parse(res.content[0].text) as Record<string, unknown>;
+    expect(body.pay_per_call, "free tier must not be told to pay").toBeUndefined();
+  });
+});
+
+describe("first contact does not assert facts it has not checked", () => {
+  it("carries no hardcoded catalogue counts or retired concepts", async () => {
+    // The previous response claimed "256 capabilities, 81 solutions" and
+    // "dual-profile quality scores" — the SQS engine, deleted in
+    // DEC-20260503-B. Counts drift within days and retired concepts never
+    // un-retire, so neither belongs in a machine surface as a literal.
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    // vitest runs with cwd = apps/api
+    const src = readFileSync(
+      resolve(process.cwd(), "../../packages/mcp-server/src/tools.ts"),
+      "utf8",
+    );
+    // "strale_execute" also appears earlier in the file, so the end marker
+    // must be searched for AFTER the start — slicing on the first occurrence
+    // yields a negative range and an empty string that passes vacuously.
+    const start = src.indexOf('"strale_getting_started"');
+    expect(start, "getting_started registration must be findable").toBeGreaterThan(0);
+    const end = src.indexOf('"strale_execute"', start);
+    const gettingStarted = src
+      .slice(start, end > start ? end : undefined)
+      // Strip comments: this asserts on what the tool RETURNS, and the
+      // surrounding commentary legitimately names the retired concept in
+      // order to explain why it must not appear in the payload.
+      .split("\n")
+      .filter((l) => !l.trim().startsWith("//") && !l.trim().startsWith("*"))
+      .join("\n");
+    expect(gettingStarted.length, "slice must not be empty").toBeGreaterThan(200);
+    expect(gettingStarted).not.toMatch(/dual-profile|SQS score/i);
+    expect(gettingStarted, "counts must be read live, not written in").not.toMatch(
+      /\b(256|271|81) (capabilities|solutions)/,
+    );
+    expect(gettingStarted, "must read the canonical facts endpoint").toContain(
+      "/v1/platform/facts",
+    );
+  });
+});

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -268,8 +268,24 @@ export async function executeCapability(
             type: "text",
             text: JSON.stringify({
               error: "Authentication required for paid capabilities.",
-              fix: "Get a free API key at https://strale.dev/signup — includes €2 free credits, no card needed. Then reconnect with Authorization: Bearer sk_live_YOUR_KEY",
-              tip: "Several capabilities are free with no API key — call strale_search and look for is_free_tier, e.g. email-validate or dns-lookup.",
+              // Ordering is deliberate. This message is read by an autonomous
+              // agent, and the only path it used to offer was a web signup
+              // form — something an agent cannot complete. In the seven days
+              // to 2026-08-15, 176 distinct agents opened an MCP session and
+              // zero signups resulted, while 653 x402 calls arrived from
+              // agents that had found the pay-per-call route some other way.
+              // The machine-actionable option goes first.
+              pay_per_call: {
+                how: "No signup. POST to the x402 endpoint below, settle the 402 challenge it returns in USDC on Base, and replay the request — the payment is the authentication.",
+                endpoint: `${opts.baseUrl}/x402/${slug}`,
+                catalog: `${opts.baseUrl}/x402/catalog`,
+                discovery: `${opts.baseUrl}/.well-known/x402.json`,
+              },
+              api_key: {
+                how: "If a human can complete a web form, https://strale.dev/signup issues a key with €2 of credit and no card.",
+                then: "Reconnect with Authorization: Bearer sk_live_YOUR_KEY",
+              },
+              free_without_either: `${FREE_TIER_SLUGS.length} capabilities need no key and no payment (10/day per IP): ${FREE_TIER_SLUGS.join(", ")}.`,
             }),
           },
         ],
@@ -362,7 +378,7 @@ export async function executeCapability(
   if (r.wallet_balance_cents != null) meta.wallet_balance_cents = r.wallet_balance_cents;
   if (r.provenance) meta.provenance = r.provenance;
 
-  // Dual-profile quality data (lives in meta block now)
+  // Quality signals, when the API returns them (lives in meta block now)
   if (m.quality) meta.quality = m.quality;
   if (m.execution_guidance) meta.execution_guidance = m.execution_guidance;
 
@@ -372,7 +388,7 @@ export async function executeCapability(
   // Next-steps guidance on every successful execution
   meta.next_steps = [
     `Transaction ID recorded. Call strale_transaction with id "${r.transaction_id ?? ""}" to retrieve the full audit record.`,
-    `Call strale_trust_profile with slug "${slug}" to see its dual-profile quality assessment.`,
+    `Call strale_trust_profile with slug "${slug}" to see how this source is tested and evidenced.`,
     "Call strale_search to find related capabilities.",
   ];
 
@@ -524,26 +540,72 @@ export function registerStraleTools(
     "strale_getting_started",
     {
       description:
-        "Lists the free capabilities available without an API key and explains how to get started. Call this on first connection to see what you can do immediately. Returns 5 free capability slugs (email-validate, dns-lookup, json-repair, url-to-markdown, iban-validate) with descriptions, example inputs, and instructions for accessing the full registry of 271 paid capabilities. No API key required.",
+        "Explains how to start using Strale and what is available without credentials. Call this on first connection. Returns the current free-tier capability list with example inputs, the pay-per-call (x402) route that needs no signup, and how to reach the full registry. No API key required.",
       inputSchema: z.object({}),
     },
     async () => {
+      // Counts and the free-tier list are read live rather than hardcoded.
+      // The previous version of this response claimed "256 capabilities, 81
+      // solutions", listed 5 free capabilities when there were 11, and
+      // advertised "dual-profile quality scores" — the SQS engine, deleted in
+      // May under DEC-20260503-B. All of it was the first thing an agent saw.
+      // Per CLAUDE.md's drift-prevention rule, /v1/platform/facts is the
+      // canonical source; this reads from it and degrades to the shipped
+      // constants if the call fails rather than printing a stale number.
+      let capabilityCount: number | null = null;
+      let solutionCount: number | null = null;
+      let freeSlugs: string[] = FREE_TIER_SLUGS;
+      try {
+        const data = await straleGet<{
+          capability_counts?: { active_visible?: number; free_tier_slugs?: string[] };
+          solution_count_active?: number;
+        }>("/v1/platform/facts", opts);
+        capabilityCount = data?.capability_counts?.active_visible ?? null;
+        solutionCount = data?.solution_count_active ?? null;
+        if (data?.capability_counts?.free_tier_slugs?.length) {
+          freeSlugs = data.capability_counts.free_tier_slugs;
+        }
+      } catch {
+        // Fall through to the shipped constants — a first-contact response
+        // that works with slightly stale counts beats one that errors.
+      }
+
+      const EXAMPLES: Record<string, Record<string, unknown>> = {
+        "email-validate": { email: "test@example.com" },
+        "dns-lookup": { domain: "example.com" },
+        "json-repair": { json: '{"name": "test"' },
+        "url-to-markdown": { url: "https://example.com" },
+        "iban-validate": { iban: "DE89370400440532013000" },
+        "bitcoin-address-validate": { address: "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa" },
+        "eth-address-validate": { address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
+      };
+
       return {
         content: [
           {
             type: "text" as const,
             text: JSON.stringify({
-              welcome: "Strale is the trust layer for AI agents. 256 verified data capabilities and 81 bundled solutions with dual-profile quality scores.",
-              free_capabilities: [
-                { slug: "email-validate", description: "Validate any email address", example_input: { email: "test@example.com" } },
-                { slug: "dns-lookup", description: "DNS records for any domain", example_input: { domain: "example.com" } },
-                { slug: "json-repair", description: "Fix malformed JSON", example_input: { json: '{"name": "test"' } },
-                { slug: "url-to-markdown", description: "Convert any URL to markdown", example_input: { url: "https://example.com" } },
-                { slug: "iban-validate", description: "Validate IBAN numbers", example_input: { iban: "DE89370400440532013000" } },
-              ],
-              try_now: "Call strale_execute with any free capability above — no API key needed (10/day limit).",
-              full_access: "Sign up at https://strale.dev/signup for 256 capabilities and 81 solutions (KYB, Invoice Verify). Free €2 credits, no card needed.",
-              learn_more: "Call strale_methodology for quality scoring details, or strale_search to browse all capabilities.",
+              welcome:
+                "Strale is the data layer for AI agents — independently tested, audit-logged data sources" +
+                (capabilityCount ? `. ${capabilityCount} capabilities` : "") +
+                (solutionCount ? ` and ${solutionCount} bundled solutions` : "") +
+                " available.",
+              free_capabilities: freeSlugs.map((slug) => ({
+                slug,
+                ...(EXAMPLES[slug] ? { example_input: EXAMPLES[slug] } : {}),
+              })),
+              try_now:
+                "Call strale_execute with any free capability above — no API key, no payment (10/day per IP).",
+              // The route an agent can actually take on its own.
+              pay_per_call_no_signup: {
+                how: "POST to /x402/{slug}, settle the 402 challenge it returns in USDC on Base, replay the request. The payment is the authentication — no account, no key.",
+                catalog: `${opts.baseUrl}/x402/catalog`,
+                discovery: `${opts.baseUrl}/.well-known/x402.json`,
+              },
+              api_key_alternative:
+                "If a human can complete a web form: https://strale.dev/signup issues a key with €2 of credit, no card.",
+              learn_more:
+                "Call strale_search to browse capabilities, or strale_methodology for how sources are tested and evidenced.",
             }, null, 2),
           },
         ],


### PR DESCRIPTION
See commit message. Key numbers: 176 agents/7d, 0 signups, 653 x402 calls that found the route elsewhere. 16 tests across both MCP files pass; package builds clean. Will verify CI and the deployed surface before merging.