### PR TITLE
fix(do): input-contract drift synced to prod + value-in-task hints on the 400 path

### DIFF
--- a/apps/api/src/lib/task-value-hints.test.ts
+++ b/apps/api/src/lib/task-value-hints.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { recoverValuesFromTask, recoveredValuesHint } from "./task-value-hints.js";
+
+describe("recoverValuesFromTask", () => {
+  it("recovers the 2026-08-08 incident IBAN from the task text", () => {
+    // Verbatim task from failed_requests row 1c331888 — the caller retried
+    // three times without ever structuring inputs.iban.
+    const r = recoverValuesFromTask(
+      "validate this IBAN DE89370400440532013000",
+      ["iban"],
+    );
+    expect(r).toEqual({ iban: "DE89370400440532013000" });
+  });
+
+  it("normalizes grouped/lowercase IBANs", () => {
+    const r = recoverValuesFromTask(
+      "check de89 3704 0044 0532 0130 00 please",
+      ["iban"],
+    );
+    expect(r).toEqual({ iban: "DE89370400440532013000" });
+  });
+
+  it("refuses ambiguous candidates rather than guessing", () => {
+    const r = recoverValuesFromTask(
+      "compare DE89370400440532013000 and SE4550000000058398257466",
+      ["iban"],
+    );
+    expect(r).toEqual({});
+  });
+
+  it("recovers a url and strips trailing sentence punctuation", () => {
+    const r = recoverValuesFromTask(
+      "what tech stack does https://stripe.com use?",
+      ["url", "domain"],
+    );
+    expect(r.url).toBe("https://stripe.com");
+    // The URL is stripped before domain matching, so no standalone domain remains.
+    expect(r.domain).toBeUndefined();
+  });
+
+  it("recovers a bare domain but never from inside an email address", () => {
+    expect(recoverValuesFromTask("detect stack for stripe.com", ["domain"]))
+      .toEqual({ domain: "stripe.com" });
+    expect(recoverValuesFromTask("validate bob@example.org", ["domain"]))
+      .toEqual({});
+  });
+
+  it("recovers an email", () => {
+    expect(recoverValuesFromTask("is bob.smith+x@example.org deliverable?", ["email"]))
+      .toEqual({ email: "bob.smith+x@example.org" });
+  });
+
+  it("returns nothing for fields without a recognizer", () => {
+    expect(recoverValuesFromTask("look up org 5593957979", ["org_number"]))
+      .toEqual({});
+  });
+
+  it("handles null/empty task", () => {
+    expect(recoverValuesFromTask(null, ["iban"])).toEqual({});
+    expect(recoverValuesFromTask("", ["iban"])).toEqual({});
+  });
+});
+
+describe("recoveredValuesHint", () => {
+  it("renders a retry-ready inputs object", () => {
+    const hint = recoveredValuesHint({ iban: "DE89370400440532013000" });
+    expect(hint).toContain('"inputs": { "iban": "DE89370400440532013000" }');
+  });
+
+  it("is undefined when nothing was recovered", () => {
+    expect(recoveredValuesHint({})).toBeUndefined();
+  });
+});

--- a/apps/api/src/lib/task-value-hints.test.ts
+++ b/apps/api/src/lib/task-value-hints.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { recoverValuesFromTask, recoveredValuesHint } from "./task-value-hints.js";
+import {
+  recoverValuesFromTask,
+  recoveredValuesHint,
+  unsatisfiedGroupFields,
+} from "./task-value-hints.js";
 
 describe("recoverValuesFromTask", () => {
   it("recovers the 2026-08-08 incident IBAN from the task text", () => {
@@ -59,12 +63,56 @@ describe("recoverValuesFromTask", () => {
     expect(recoverValuesFromTask(null, ["iban"])).toEqual({});
     expect(recoverValuesFromTask("", ["iban"])).toEqual({});
   });
+
+  it("never scans past the cap, so adversarial megabyte tasks stay cheap", () => {
+    // Value placed beyond the 2000-char scan window is not recovered…
+    const far = "x".repeat(3000) + " DE89370400440532013000";
+    expect(recoverValuesFromTask(far, ["iban"])).toEqual({});
+    // …and a hostile dotted string doesn't hang the recognizers.
+    const hostile = ("a".repeat(60) + ".").repeat(50_000) + "!";
+    const start = Date.now();
+    recoverValuesFromTask(hostile, ["domain", "email", "url"]);
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+});
+
+describe("unsatisfiedGroupFields", () => {
+  const schema = {
+    anyOf: [{ required: ["url"] }, { required: ["domain"] }],
+    properties: { url: {}, domain: {}, verbose: {} },
+  };
+
+  it("returns only fields from the group branches, not all properties", () => {
+    expect(unsatisfiedGroupFields(schema, {}).sort()).toEqual(["domain", "url"]);
+  });
+
+  it("excludes fields the caller already sent", () => {
+    expect(unsatisfiedGroupFields(schema, { url: "https://x.com" })).toEqual(["domain"]);
+  });
+
+  it("handles schemas without groups", () => {
+    expect(unsatisfiedGroupFields({ properties: { a: {} } }, {})).toEqual([]);
+    expect(unsatisfiedGroupFields(null, {})).toEqual([]);
+  });
 });
 
 describe("recoveredValuesHint", () => {
   it("renders a retry-ready inputs object", () => {
     const hint = recoveredValuesHint({ iban: "DE89370400440532013000" });
-    expect(hint).toContain('"inputs": { "iban": "DE89370400440532013000" }');
+    expect(hint).toContain('"inputs": {"iban":"DE89370400440532013000"}');
+  });
+
+  it("merges the caller's existing inputs so following the hint loses nothing", () => {
+    const hint = recoveredValuesHint(
+      { url: "https://stripe.com" },
+      { verbose: true },
+    );
+    expect(hint).toContain('{"verbose":true,"url":"https://stripe.com"}');
+  });
+
+  it("JSON-encodes recovered values so they cannot break the example", () => {
+    const hint = recoveredValuesHint({ url: 'https://x.com/a"b\\' });
+    expect(hint).toContain(JSON.stringify({ url: 'https://x.com/a"b\\' }));
   });
 
   it("is undefined when nothing was recovered", () => {

--- a/apps/api/src/lib/task-value-hints.ts
+++ b/apps/api/src/lib/task-value-hints.ts
@@ -19,6 +19,8 @@
  * hint rather than a wrong one.
  */
 
+import { branchesOf, requiredOf } from "./x402-input-validation.js";
+
 /** Strip whitespace and uppercase; IBANs are case- and grouping-insensitive. */
 function normalizeIban(raw: string): string {
   return raw.replace(/\s+/g, "").toUpperCase();
@@ -32,9 +34,16 @@ function normalizeIban(raw: string): string {
  */
 const IBAN_RE =
   /\b[A-Za-z]{2}\d{2}(?:[A-Za-z0-9]{11,30}|(?: [A-Za-z0-9]{4}){2,7}(?: [A-Za-z0-9]{1,4})?)\b/g;
-const EMAIL_RE = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}\b/g;
+// Same bounded-quantifier shape as capabilities/domain-contact-extract.ts's
+// EMAIL_RE, which carries the ReDoS regression suite for this pattern class
+// (7.9s catastrophic backtracking on a 32KB body pre-fix). Duplicated rather
+// than imported because that module registers its capability on import — a
+// side effect a pure lib must not drag in. If a third copy appears, hoist
+// one canonical export into lib/.
+const EMAIL_RE = /[a-zA-Z0-9._%+-]{1,64}@(?:[a-zA-Z0-9-]{1,63}\.){1,8}[a-zA-Z]{2,24}/g;
 const URL_RE = /\bhttps?:\/\/[^\s"'<>)\]]+/gi;
-const DOMAIN_RE = /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}\b/gi;
+// Label count and TLD length bounded for the same backtracking reason.
+const DOMAIN_RE = /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.){1,8}[a-z]{2,24}\b/gi;
 
 function distinct(matches: string[]): string | undefined {
   const set = new Set(matches);
@@ -74,6 +83,14 @@ const RECOGNIZERS: Record<string, (task: string) => string | undefined> = {
 };
 
 /**
+ * Recognizers only ever scan this much of the task. A legitimate task that
+ * names a value does so in the first sentence; an adversarial multi-megabyte
+ * task must not buy quadratic regex backtracking on an unauthenticated 400
+ * path (cross-provider review finding, 2026-08-15).
+ */
+const MAX_SCAN_CHARS = 2000;
+
+/**
  * For each named field with a known recognizer, return the single
  * high-confidence value found in the task text. Fields without a recognizer,
  * or with zero/ambiguous candidates, are simply absent from the result.
@@ -84,25 +101,49 @@ export function recoverValuesFromTask(
 ): Record<string, string> {
   const recovered: Record<string, string> = {};
   if (!task) return recovered;
+  const scanText = task.slice(0, MAX_SCAN_CHARS);
   for (const field of fieldNames) {
     const recognize = RECOGNIZERS[field.toLowerCase()];
     if (!recognize) continue;
-    const value = recognize(task);
+    const value = recognize(scanText);
     if (value !== undefined) recovered[field] = value;
   }
   return recovered;
 }
 
 /**
+ * The fields a caller could still supply to satisfy an unsatisfied
+ * anyOf/oneOf group: the union of the branches' required lists, minus what
+ * they already sent. Recognizers must only run over these — offering an
+ * unrelated optional field as "the fix" would contradict the declared
+ * contract (cross-provider review finding, 2026-08-15).
+ */
+export function unsatisfiedGroupFields(
+  schema: Record<string, unknown> | null | undefined,
+  existingInputs: Record<string, unknown>,
+): string[] {
+  const fields = new Set<string>();
+  for (const branch of (schema ? branchesOf(schema) : null) ?? []) {
+    for (const field of requiredOf(branch)) {
+      if (!(field in existingInputs)) fields.add(field);
+    }
+  }
+  return [...fields];
+}
+
+/**
  * Render the recovered values as a retry-ready hint sentence, or undefined
- * when nothing was recovered.
+ * when nothing was recovered. The example merges the caller's existing
+ * inputs so following it verbatim never loses fields they already sent,
+ * and is JSON.stringify-encoded so recovered values can't break the example.
  */
 export function recoveredValuesHint(
   recovered: Record<string, string>,
+  existingInputs: Record<string, unknown> = {},
 ): string | undefined {
   const entries = Object.entries(recovered);
   if (entries.length === 0) return undefined;
-  const inputsJson = `{ ${entries.map(([f, v]) => `"${f}": "${v}"`).join(", ")} }`;
+  const inputsJson = JSON.stringify({ ...existingInputs, ...recovered });
   return ` Your task text appears to already contain ${entries
     .map(([f]) => `'${f}'`)
     .join(", ")} — retry with "inputs": ${inputsJson}.`;

--- a/apps/api/src/lib/task-value-hints.ts
+++ b/apps/api/src/lib/task-value-hints.ts
@@ -1,0 +1,109 @@
+/**
+ * Recover obvious input values from a /v1/do task string, for error hints only.
+ *
+ * Motivating incident (2026-08-08, failed_requests d8568ee3…): an
+ * unauthenticated caller sent task "validate this IBAN DE89370400440532013000"
+ * with no inputs, matched iban-validate correctly, and got the standard
+ * "Missing required input fields: iban" 400 — three retries over 17 minutes,
+ * never converging. The IBAN sat in the task text the whole time. The 400
+ * told the caller *what* was missing but not that they had already supplied it.
+ *
+ * This module recognizes a small set of machine-recognizable value shapes
+ * (IBAN, email, URL, domain) in the task text so the 400 can show the exact
+ * corrected call with the caller's own value.
+ *
+ * Deliberately NOT auto-execution: declared contracts are enforced as
+ * declared, and nobody gets charged on a guess. The recovered value goes into
+ * the error hint, nothing else. A value is only recovered when the task
+ * contains exactly one distinct candidate of that shape — ambiguity means no
+ * hint rather than a wrong one.
+ */
+
+/** Strip whitespace and uppercase; IBANs are case- and grouping-insensitive. */
+function normalizeIban(raw: string): string {
+  return raw.replace(/\s+/g, "").toUpperCase();
+}
+
+/**
+ * ISO 13616 shape: 2 letters, 2 digits, 11–30 alphanumerics (total 15–34).
+ * Two explicit forms — compact, or grouped in fours with single spaces — so
+ * an optional-whitespace quantifier can't greedily swallow trailing words
+ * ("…0130 00 please" must not become "…00PLEASE").
+ */
+const IBAN_RE =
+  /\b[A-Za-z]{2}\d{2}(?:[A-Za-z0-9]{11,30}|(?: [A-Za-z0-9]{4}){2,7}(?: [A-Za-z0-9]{1,4})?)\b/g;
+const EMAIL_RE = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}\b/g;
+const URL_RE = /\bhttps?:\/\/[^\s"'<>)\]]+/gi;
+const DOMAIN_RE = /\b(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}\b/gi;
+
+function distinct(matches: string[]): string | undefined {
+  const set = new Set(matches);
+  return set.size === 1 ? [...set][0] : undefined;
+}
+
+function findIban(task: string): string | undefined {
+  const candidates = (task.match(IBAN_RE) ?? [])
+    .map(normalizeIban)
+    .filter((v) => v.length >= 15 && v.length <= 34);
+  return distinct(candidates);
+}
+
+function findEmail(task: string): string | undefined {
+  return distinct(task.match(EMAIL_RE) ?? []);
+}
+
+function findUrl(task: string): string | undefined {
+  // Trim trailing punctuation a sentence would attach ("…check https://x.com.")
+  const candidates = (task.match(URL_RE) ?? []).map((u) => u.replace(/[.,;:!?]+$/, ""));
+  return distinct(candidates);
+}
+
+function findDomain(task: string): string | undefined {
+  // Emails and URLs contain domain-shaped substrings; remove them first so
+  // "email me at a@b.com" never recovers b.com as a standalone domain.
+  const stripped = task.replace(EMAIL_RE, " ").replace(URL_RE, " ");
+  const candidates = (stripped.match(DOMAIN_RE) ?? []).map((d) => d.toLowerCase());
+  return distinct(candidates);
+}
+
+const RECOGNIZERS: Record<string, (task: string) => string | undefined> = {
+  iban: findIban,
+  email: findEmail,
+  url: findUrl,
+  domain: findDomain,
+};
+
+/**
+ * For each named field with a known recognizer, return the single
+ * high-confidence value found in the task text. Fields without a recognizer,
+ * or with zero/ambiguous candidates, are simply absent from the result.
+ */
+export function recoverValuesFromTask(
+  task: string | undefined | null,
+  fieldNames: string[],
+): Record<string, string> {
+  const recovered: Record<string, string> = {};
+  if (!task) return recovered;
+  for (const field of fieldNames) {
+    const recognize = RECOGNIZERS[field.toLowerCase()];
+    if (!recognize) continue;
+    const value = recognize(task);
+    if (value !== undefined) recovered[field] = value;
+  }
+  return recovered;
+}
+
+/**
+ * Render the recovered values as a retry-ready hint sentence, or undefined
+ * when nothing was recovered.
+ */
+export function recoveredValuesHint(
+  recovered: Record<string, string>,
+): string | undefined {
+  const entries = Object.entries(recovered);
+  if (entries.length === 0) return undefined;
+  const inputsJson = `{ ${entries.map(([f, v]) => `"${f}": "${v}"`).join(", ")} }`;
+  return ` Your task text appears to already contain ${entries
+    .map(([f]) => `'${f}'`)
+    .join(", ")} — retry with "inputs": ${inputsJson}.`;
+}

--- a/apps/api/src/lib/x402-input-validation.ts
+++ b/apps/api/src/lib/x402-input-validation.ts
@@ -47,12 +47,18 @@ function fieldPresent(inputs: Record<string, unknown>, field: string): boolean {
   return !isBlank(inputs[field]);
 }
 
-function requiredOf(schema: unknown): string[] {
+/**
+ * Exported so other schema consumers (task-value-hints.ts's
+ * unsatisfiedGroupFields) parse anyOf/oneOf branches through the same walker
+ * instead of re-implementing it — two independent walkers of the same schema
+ * shape drift silently (reuse review, 2026-08-15).
+ */
+export function requiredOf(schema: unknown): string[] {
   const req = (schema as JsonSchema | undefined)?.required;
   return Array.isArray(req) ? (req.filter((f): f is string => typeof f === "string")) : [];
 }
 
-function branchesOf(schema: JsonSchema): unknown[] | null {
+export function branchesOf(schema: JsonSchema): unknown[] | null {
   if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) return schema.anyOf as unknown[];
   if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) return schema.oneOf as unknown[];
   return null;

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -37,7 +37,7 @@ import { getAiDescription, getDataSourceUrl } from "../lib/audit-helpers.js";
 import { getCapabilityQuality } from "../lib/quality-aggregation.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
 import { validateX402Input } from "../lib/x402-input-validation.js";
-import { recoverValuesFromTask, recoveredValuesHint } from "../lib/task-value-hints.js";
+import { recoverValuesFromTask, recoveredValuesHint, unsatisfiedGroupFields } from "../lib/task-value-hints.js";
 import { logError, logWarn } from "../lib/log.js";
 import { fireAndForget } from "../lib/fire-and-forget.js";
 import { trackBackgroundTask } from "../lib/shutdown.js";
@@ -915,12 +915,9 @@ doRoute.post(
       // ("validate this IBAN DE89…" with empty inputs — 2026-08-08 incident,
       // three retries never converged). Recover recognizable values so the
       // 400 shows the exact corrected call. Hint only, never auto-executed.
-      const recovered = topLevelMatches.length === 0
-        ? recoverValuesFromTask(task, missingFields)
-        : {};
       const hint = topLevelMatches.length > 0
         ? ` It looks like you placed ${topLevelMatches.map((f) => `'${f}'`).join(", ")} at the top level — wrap them inside "inputs": { ${topLevelMatches.map((f) => `"${f}": ...`).join(", ")} }.`
-        : recoveredValuesHint(recovered);
+        : recoveredValuesHint(recoverValuesFromTask(task, missingFields), executionInput);
       const fType = topLevelMatches.length > 0 ? "input_misplaced" : "missing_fields";
       const mIp = getClientIp(c);
       fireAndForget(
@@ -972,12 +969,14 @@ doRoute.post(
     if (!groupCheck.ok) {
       // Same value-in-task recovery as the classic-required path: an
       // either/or capability (url-or-domain etc.) whose caller sent {} but
-      // named the target in the task gets a retry-ready hint.
+      // named the target in the task gets a retry-ready hint. Only fields
+      // that would actually satisfy the unsatisfied group are considered —
+      // never unrelated optional properties.
       const groupRecovered = recoverValuesFromTask(
         task,
-        inputSchema?.properties ? Object.keys(inputSchema.properties) : [],
+        unsatisfiedGroupFields(inputSchema as Record<string, unknown> | null, executionInput),
       );
-      const groupHint = recoveredValuesHint(groupRecovered);
+      const groupHint = recoveredValuesHint(groupRecovered, executionInput);
       const gIp = getClientIp(c);
       fireAndForget(
         () =>

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -37,6 +37,7 @@ import { getAiDescription, getDataSourceUrl } from "../lib/audit-helpers.js";
 import { getCapabilityQuality } from "../lib/quality-aggregation.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
 import { validateX402Input } from "../lib/x402-input-validation.js";
+import { recoverValuesFromTask, recoveredValuesHint } from "../lib/task-value-hints.js";
 import { logError, logWarn } from "../lib/log.js";
 import { fireAndForget } from "../lib/fire-and-forget.js";
 import { trackBackgroundTask } from "../lib/shutdown.js";
@@ -910,9 +911,16 @@ doRoute.post(
     if (missingFields.length > 0) {
       // Detect common mistake: input fields placed at top level instead of inside "inputs"
       const topLevelMatches = missingFields.filter((f) => f in body);
+      // Second common mistake: the value is sitting in the task text itself
+      // ("validate this IBAN DE89…" with empty inputs — 2026-08-08 incident,
+      // three retries never converged). Recover recognizable values so the
+      // 400 shows the exact corrected call. Hint only, never auto-executed.
+      const recovered = topLevelMatches.length === 0
+        ? recoverValuesFromTask(task, missingFields)
+        : {};
       const hint = topLevelMatches.length > 0
         ? ` It looks like you placed ${topLevelMatches.map((f) => `'${f}'`).join(", ")} at the top level — wrap them inside "inputs": { ${topLevelMatches.map((f) => `"${f}": ...`).join(", ")} }.`
-        : undefined;
+        : recoveredValuesHint(recovered);
       const fType = topLevelMatches.length > 0 ? "input_misplaced" : "missing_fields";
       const mIp = getClientIp(c);
       fireAndForget(
@@ -962,6 +970,14 @@ doRoute.post(
   if (declaresGroups) {
     const groupCheck = validateX402Input(executionInput, inputSchema as Record<string, unknown> | null);
     if (!groupCheck.ok) {
+      // Same value-in-task recovery as the classic-required path: an
+      // either/or capability (url-or-domain etc.) whose caller sent {} but
+      // named the target in the task gets a retry-ready hint.
+      const groupRecovered = recoverValuesFromTask(
+        task,
+        inputSchema?.properties ? Object.keys(inputSchema.properties) : [],
+      );
+      const groupHint = recoveredValuesHint(groupRecovered);
       const gIp = getClientIp(c);
       fireAndForget(
         () =>
@@ -982,6 +998,7 @@ doRoute.post(
           {
             expected_fields: inputSchema?.properties ? Object.keys(inputSchema.properties) : [],
             input_schema: inputSchema ?? undefined,
+            ...(groupHint ? { hint: groupHint } : {}),
           },
         ),
         400,

--- a/manifests/tech-stack-detect.yaml
+++ b/manifests/tech-stack-detect.yaml
@@ -1,11 +1,13 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
+# Auto-generated from database on 2026-03-17; description/output example
+# refreshed from the live DB row on 2026-08-15 when the anyOf input contract
+# was synced to prod (the DB had drifted to required:[] with no anyOf, so
+# paying agents sent {} and hit a runtime refusal the schema said couldn't happen).
 
 slug: tech-stack-detect
 name: Tech Stack Detection
 description: >-
-  Detect the technology stack of a website. Identifies frontend framework, CSS framework, CMS, analytics, hosting, CDN,
-  and other technologies.
+  Detect technologies used by a website. Identifies CMS, frameworks, analytics, CDN, payment providers and
+  marketing tools from HTTP headers and HTML patterns.
 category: web-intelligence
 cost_class: free_unlimited
 quota_window: none
@@ -29,21 +31,20 @@ input_schema:
 output_schema:
   type: object
   example:
-    cdn: Google Static (gstatic.com)
+    cdn: null
     cms: null
     url: https://google.com
     hosting: null
     analytics:
       - Google Analytics
-    confidence: high
+    confidence: low
     css_framework: null
     meta_framework: null
     frontend_framework: null
     other_technologies:
-      - Vanilla JavaScript
-      - Google XJS (custom JavaScript framework)
+      - Custom JavaScript
       - Schema.org markup
-      - Service Worker capable
+      - Nonce-based CSP
   properties:
     cms:
       type: string


### PR DESCRIPTION
## Summary
- **Contract drift fixed in prod (already live, DB-only):** `tech-stack-detect`, `image-to-text`, and `us-company-data` declared `anyOf` input contracts in their manifests that never reached the prod DB row — agents saw `required: []`, sent `{}`, and hit a runtime refusal the schema said couldn't happen (real x402 payers hit this Aug 10–11). `us-company-data`'s schema was additionally a double-encoded JSON string serving zero properties. Synced via `sync-manifest-canonical-to-db.ts`, verified on the public API; empty-input calls now 400 cleanly before any charge, with the full contract in the body. This PR carries the manifest side (tech-stack-detect description/output-example refresh so the sync couldn't regress them).
- **Value-in-task hints:** a caller sent task `"validate this IBAN DE89…"` with empty inputs on 2026-08-08, matched `iban-validate`, and got "Missing required input fields: iban" three times without converging — the IBAN sat in the task text the whole time. The 400 (classic-required and anyOf-group paths) now recovers high-confidence values (IBAN, email, URL, domain) from the task and shows the exact corrected call, merged over the caller's existing inputs. Hint only — declared contracts stay enforced as declared, recovered values are never executed, nobody is charged on a guess.

## Verification
- `tsc --noEmit` — clean
- `vitest` task-value-hints (16) + x402-input-validation (18) + do.spend-cap (6) — all pass
- `validate-capability --slug tech-stack-detect` — pass; `smoke-test` — pass; `checkReadiness` — `ready: true`
- Prod behavior verified live: empty-input wallet call to tech-stack-detect returns the anyOf 400 pre-charge; all three capabilities serve the declared contract on `/v1/capabilities/:slug`
- No route-level integration test exists for the missing-fields 400 path (no harness); covered at unit level via the pure lib

## Reviewer findings
Cross-provider review (Codex `gpt-5.6-sol` via model-os dispatch) — 1 HIGH, 2 MEDIUM, 1 LOW, **all fixed in `a1c344a`**: scan cap against regex backtracking on the unauthenticated 400 path; group hints scoped to fields that satisfy the unsatisfied group; hint example merges existing inputs; JSON-encoded example. Cleanup lenses (4 parallel): bounded-quantifier email/domain regexes adopted from the ReDoS-regression-tested pattern in `domain-contact-extract`; `unsatisfiedGroupFields` reuses `branchesOf`/`requiredOf` from `x402-input-validation`.

**Deferred (MEDIUM/LOW, deliberate):**
- One duplicate `URL_RE` pass (≤2000 chars, cold 400 path) left as-is — the dedup adds more plumbing than it removes.
- Email regex is pattern-copied, not imported, from `domain-contact-extract` — importing would drag its `registerCapability` side effect into a pure lib. If a third copy appears, hoist one canonical export into `lib/`.

## Related prod actions this session (not in this diff)
- `eu-regulation-search` quarantined (`visible=false`, `x402_enabled=false`, evidence row in `health_monitor_events`): zero lifetime successes, EUR-Lex scrape broken since Aug 12. Rebuild on the official CELLAR SPARQL endpoint is in progress on a separate branch.

## Test plan
- `POST /v1/do` with `{"task":"validate this IBAN DE89370400440532013000","max_price_cents":10,"inputs":{}}` → 400 whose `details.hint` shows `"inputs": {"iban":"DE89370400440532013000"}`
- Same with `{"task":"what stack does https://stripe.com use","inputs":{}}` against tech-stack-detect → anyOf 400 with the URL recovered in the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)