### PR TITLE
fix(eu-regulation-search): rebuild on the official CELLAR SPARQL endpoint

### DIFF
--- a/apps/api/src/capabilities/eu-regulation-search.test.ts
+++ b/apps/api/src/capabilities/eu-regulation-search.test.ts
@@ -26,6 +26,10 @@ describe("tokenizeQuery", () => {
     expect(new Set(tokens).size).toBe(tokens.length);
     expect(tokens.length).toBeLessThanOrEqual(6);
   });
+
+  it("drops oversized tokens so caller input cannot inflate the GET URL", () => {
+    expect(tokenizeQuery("x".repeat(500) + " protection")).toEqual(["protection"]);
+  });
 });
 
 describe("executor input refusals (no network)", () => {

--- a/apps/api/src/capabilities/eu-regulation-search.test.ts
+++ b/apps/api/src/capabilities/eu-regulation-search.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { tokenizeQuery } from "./eu-regulation-search.js";
+import { getExecutor } from "./index.js";
+
+describe("tokenizeQuery", () => {
+  it("drops stop/instrument words and lowercases", () => {
+    expect(tokenizeQuery("the Artificial Intelligence Act")).toEqual([
+      "artificial",
+      "intelligence",
+    ]);
+  });
+
+  it("produces only injection-safe alphanumeric tokens", () => {
+    const tokens = tokenizeQuery(`data' ) . } DROP protection " bif:contains`);
+    for (const t of tokens) expect(t).toMatch(/^[a-z0-9]{2,}$/);
+    expect(tokens).toContain("data");
+    expect(tokens).toContain("protection");
+  });
+
+  it("returns empty for queries made only of generic terms", () => {
+    expect(tokenizeQuery("EU regulation law")).toEqual([]);
+  });
+
+  it("dedupes and caps token count", () => {
+    const tokens = tokenizeQuery("alpha alpha beta gamma delta epsilon zeta eta theta");
+    expect(new Set(tokens).size).toBe(tokens.length);
+    expect(tokens.length).toBeLessThanOrEqual(6);
+  });
+});
+
+describe("executor input refusals (no network)", () => {
+  const exec = () => getExecutor("eu-regulation-search")!;
+
+  it("refuses empty input", async () => {
+    await expect(exec()({})).rejects.toThrow(/'query' or 'topic' is required/);
+  });
+
+  it("refuses an unknown type", async () => {
+    await expect(exec()({ query: "ai", type: "treaty" })).rejects.toThrow(
+      /must be one of: regulation, directive, decision/,
+    );
+  });
+
+  it("refuses a malformed year", async () => {
+    await expect(exec()({ query: "ai", year: "24" })).rejects.toThrow(/4-digit year/);
+  });
+
+  it("refuses an all-generic query with actionable guidance", async () => {
+    await expect(exec()({ query: "EU regulation law" })).rejects.toThrow(
+      /no searchable words/,
+    );
+  });
+});

--- a/apps/api/src/capabilities/eu-regulation-search.ts
+++ b/apps/api/src/capabilities/eu-regulation-search.ts
@@ -1,110 +1,150 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
-import {
-  fetchRenderedHtml,
-  htmlToText,
-} from "./lib/browserless-extract.js";
-import Anthropic from "@anthropic-ai/sdk";
 
-// EUR-Lex search via Browserless
-const EURLEX_SEARCH = "https://eur-lex.europa.eu/search.html";
+/**
+ * EU regulation search via the Publications Office CELLAR SPARQL endpoint.
+ *
+ * Rebuilt 2026-08-15. The previous implementation rendered the EUR-Lex
+ * search page through Browserless and extracted results with an LLM; it had
+ * zero lifetime successes (results-region anchor drifted, then EUR-Lex
+ * started answering the search URL with HTTP 400) and was quarantined.
+ * CELLAR is the official machine interface to the same corpus — no auth, no
+ * browser render, no LLM, ~300ms observed latency (DEC-20260813-A preference
+ * order: official API > per-call parsing).
+ *
+ * Search semantics: query text is tokenized to lowercase alphanumeric words;
+ * stop/instrument words are dropped; remaining tokens are AND-matched
+ * against English document titles via Virtuoso's full-text index
+ * (bif:contains). Results are restricted to CELEX sector 3 legislation
+ * (regulations R, directives L, decisions D); corrigenda entries
+ * ("…R(02)") are excluded. An empty result set is a VALID answer
+ * ({ result_count: 0 }), never an error — a correct "nothing matches" must
+ * not trip the circuit breaker.
+ */
+
+const SPARQL_ENDPOINT = "https://publications.europa.eu/webapi/rdf/sparql";
+const ENG = "http://publications.europa.eu/resource/authority/language/ENG";
+
+/** Words that carry no discriminating power in a title full-text AND-match. */
+const DROP_WORDS = new Set([
+  "a", "an", "the", "of", "on", "for", "and", "or", "in", "to", "by", "with",
+  "about", "regarding", "concerning", "search", "find", "lookup",
+  "eu", "european", "union", "commission", "council", "parliament",
+  "law", "laws", "act", "acts",
+  "regulation", "regulations", "directive", "directives", "decision", "decisions",
+]);
+
+const TYPE_TO_CELEX_LETTER: Record<string, string> = {
+  regulation: "R",
+  directive: "L",
+  decision: "D",
+};
+
+const CELEX_LETTER_TO_TYPE: Record<string, string> = {
+  R: "Regulation",
+  L: "Directive",
+  D: "Decision",
+};
+
+/**
+ * Lowercase alphanumeric tokens, minus noise words. Tokens are guaranteed to
+ * match /^[a-z0-9]{2,}$/, which is what makes interpolating them into the
+ * bif:contains argument injection-safe.
+ */
+export function tokenizeQuery(query: string): string[] {
+  const tokens = query
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 2 && !DROP_WORDS.has(t));
+  return [...new Set(tokens)].slice(0, 6);
+}
+
+interface SparqlBinding {
+  celex?: { value: string };
+  title?: { value: string };
+  date?: { value: string };
+  inforce?: { value: string };
+}
+
+function buildSparql(tokens: string[], typeLetter: string | null, year: string | null, limit: number): string {
+  const containsArg = tokens.map((t) => `'${t}'`).join(" AND ");
+  const celexPrefix = year ? `3${year}` : "3";
+  return `PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
+SELECT DISTINCT ?celex ?title ?date ?inforce WHERE {
+  ?work cdm:resource_legal_id_celex ?celex .
+  OPTIONAL { ?work cdm:work_date_document ?date . }
+  OPTIONAL { ?work cdm:resource_legal_in-force ?inforce . }
+  ?exp cdm:expression_belongs_to_work ?work .
+  ?exp cdm:expression_uses_language <${ENG}> .
+  ?exp cdm:expression_title ?title .
+  FILTER( bif:contains(?title, "${containsArg}") )
+  FILTER( REGEX(STR(?celex), "^${celexPrefix}[0-9]*[${typeLetter ?? "RLD"}]") )
+  FILTER( !CONTAINS(STR(?celex), "(") )
+} ORDER BY DESC(?date) LIMIT ${limit}`;
+}
 
 registerCapability("eu-regulation-search", async (input: CapabilityInput) => {
-  const query = ((input.query as string) ?? (input.topic as string) ?? (input.task as string) ?? "").trim();
+  const query = ((input.query as string) ?? (input.topic as string) ?? "").trim();
   if (!query) {
     throw new Error("'query' or 'topic' is required. Describe the regulation topic to search.");
   }
 
-  const type = ((input.type as string) ?? "").trim(); // regulation, directive, decision
-  const year = (input.year as string) ?? "";
+  const rawType = ((input.type as string) ?? "").trim().toLowerCase();
+  if (rawType && !(rawType in TYPE_TO_CELEX_LETTER)) {
+    throw new Error(`'type' must be one of: regulation, directive, decision (got '${rawType}').`);
+  }
+  const typeLetter = rawType ? TYPE_TO_CELEX_LETTER[rawType] : null;
 
-  // Build EUR-Lex search URL
-  let searchParams = `?text=${encodeURIComponent(query)}&scope=EURLEX&type=quick`;
-  if (type) searchParams += `&qid=${Date.now()}`;
+  const rawYear = String((input.year as string | number) ?? "").trim();
+  if (rawYear && !/^\d{4}$/.test(rawYear)) {
+    throw new Error(`'year' must be a 4-digit year (got '${rawYear}').`);
+  }
 
-  const url = `${EURLEX_SEARCH}${searchParams}`;
-  // EUR-Lex serves a JS challenge to plain fetchers (P2 triage 2026-08-12) and
-  // the real page is heavy: the render must go to the browser tier and needs
-  // more than the default budgets (observed ~32s). networkidle2 instead of
-  // networkidle0 — EUR-Lex keeps long-polling trackers open that never idle.
-  const html = await fetchRenderedHtml(url, {
-    waitUntil: "networkidle2",
-    pageTimeout: 40_000,
-    fetchTimeout: 55_000,
-    // One attempt: this path is always a paid Browserless render holding one
-    // of two global browser slots for up to ~55s — a retry doubles that
-    // exposure for a page whose failures are rarely transient (review M-3).
-    maxRetries: 1,
-  });
-
-  // Text the RESULTS region, not the whole document: EUR-Lex spends its first
-  // ~15K chars of text on nav and filter widgets, so texting from the top
-  // truncated the actual results away (the model then honestly reported
-  // "no results in the provided excerpt" — P2 triage 2026-08-12). Result rows
-  // are SearchResult-classed blocks; match without the closing quote so
-  // additional classes ("SearchResult row") don't break the anchor.
-  const resultsStart = html.indexOf('class="SearchResult');
-  if (resultsStart < 0) {
-    // Parse failure is an infrastructure error, never a "no results" answer —
-    // asserting EUR-Lex has no matching legislation because OUR anchor
-    // disappeared is a manufactured negative (review M-4). This message is
-    // breaker-visible, unlike a caller-input refusal.
+  const tokens = tokenizeQuery(query);
+  if (tokens.length === 0) {
     throw new Error(
-      "Could not locate the results region on the EUR-Lex page — the page layout may have changed. " +
-        "This is a Strale-side parsing issue, not an answer about EU law.",
+      "The query contains no searchable words after removing generic terms " +
+        "(e.g. 'regulation', 'EU'). Name the subject matter — e.g. 'artificial intelligence' or 'data protection'.",
     );
   }
-  const text = htmlToText(html.slice(Math.max(0, resultsStart - 200)));
-  if (text.length < 200) {
-    throw new Error(`No EU regulations found for "${query}".`);
+
+  const sparql = buildSparql(tokens, typeLetter, rawYear || null, 10);
+  const url = `${SPARQL_ENDPOINT}?${new URLSearchParams({ query: sparql })}`;
+  const response = await fetch(url, {
+    headers: { Accept: "application/sparql-results+json" },
+    signal: AbortSignal.timeout(25000),
+  });
+  if (!response.ok) {
+    throw new Error(`EU Publications Office SPARQL endpoint returned HTTP ${response.status}.`);
   }
 
-  // Use Claude to extract structured results from EUR-Lex search results
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error("ANTHROPIC_API_KEY is required.");
+  const data = (await response.json()) as { results?: { bindings?: SparqlBinding[] } };
+  const bindings = data.results?.bindings ?? [];
 
-  const client = new Anthropic({ apiKey });
-  const r = await client.messages.create({
-    model: "claude-haiku-4-5-20251001",
-    max_tokens: 1500,
-    messages: [
-      {
-        role: "user",
-        content: `Extract EU regulation search results from this EUR-Lex page. Return ONLY valid JSON.
-
-Search query: "${query}"${type ? `\nType filter: ${type}` : ""}${year ? `\nYear filter: ${year}` : ""}
-
-Page text:
-${text.slice(0, 12000)}
-
-Return:
-{
-  "query": "${query}",
-  "result_count": number,
-  "regulations": [
-    {
-      "title": "Full title of the regulation/directive",
-      "celex_number": "CELEX number if found (e.g. 32016R0679)",
-      "type": "Regulation/Directive/Decision/etc.",
-      "date": "Date of the act",
-      "in_force": true/false or null,
-      "summary": "Brief summary (1-2 sentences)"
-    }
-  ]
-}
-
-Return up to 10 results. If you cannot find structured results, return what information is available.`,
-      },
-    ],
-  });
-
-  const responseText = r.content[0].type === "text" ? r.content[0].text.trim() : "";
-  const jsonMatch = responseText.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) throw new Error("Failed to extract regulation search results.");
-
-  const output = JSON.parse(jsonMatch[0]);
+  const regulations = bindings
+    .filter((b) => b.celex?.value && b.title?.value)
+    .map((b) => {
+      const celex = b.celex!.value;
+      const letter = celex.match(/^\d{5}([A-Z])/)?.[1] ?? "";
+      return {
+        title: b.title!.value,
+        celex_number: celex,
+        type: CELEX_LETTER_TO_TYPE[letter] ?? "Other",
+        date: b.date?.value ?? null,
+        in_force: b.inforce ? b.inforce.value === "1" || b.inforce.value === "true" : null,
+        eur_lex_url: `https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:${encodeURIComponent(celex)}`,
+      };
+    });
 
   return {
-    output,
-    provenance: { source: "eur-lex.europa.eu", fetched_at: new Date().toISOString() },
+    output: {
+      query,
+      matched_terms: tokens,
+      result_count: regulations.length,
+      regulations,
+    },
+    provenance: {
+      source: "publications.europa.eu (CELLAR SPARQL)",
+      fetched_at: new Date().toISOString(),
+    },
   };
 });

--- a/apps/api/src/capabilities/eu-regulation-search.ts
+++ b/apps/api/src/capabilities/eu-regulation-search.ts
@@ -54,7 +54,10 @@ export function tokenizeQuery(query: string): string[] {
   const tokens = query
     .toLowerCase()
     .split(/[^a-z0-9]+/)
-    .filter((t) => t.length >= 2 && !DROP_WORDS.has(t));
+    // Length-capped as well as count-capped: an unbounded token would ride
+    // into the SPARQL GET URL and turn caller input into an upstream 414
+    // misread as a service failure (cross-provider review, 2026-08-15).
+    .filter((t) => t.length >= 2 && t.length <= 40 && !DROP_WORDS.has(t));
   return [...new Set(tokens)].slice(0, 6);
 }
 
@@ -118,7 +121,17 @@ registerCapability("eu-regulation-search", async (input: CapabilityInput) => {
   }
 
   const data = (await response.json()) as { results?: { bindings?: SparqlBinding[] } };
-  const bindings = data.results?.bindings ?? [];
+  // A response that parses but lacks the SPARQL results shape is an
+  // endpoint/protocol failure, not a zero-result answer — defaulting it to
+  // [] would manufacture a valid-looking "nothing matches" (cross-provider
+  // review, 2026-08-15). Only a real bindings array may say "no results".
+  if (!Array.isArray(data.results?.bindings)) {
+    throw new Error(
+      "EU Publications Office SPARQL endpoint returned an unexpected response shape — " +
+        "this is a service fault, not an answer about EU law.",
+    );
+  }
+  const bindings = data.results.bindings;
 
   const regulations = bindings
     .filter((b) => b.celex?.value && b.title?.value)

--- a/manifests/eu-regulation-search.yaml
+++ b/manifests/eu-regulation-search.yaml
@@ -1,13 +1,15 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
+# Rebuilt 2026-08-15: EUR-Lex page scrape (Browserless + LLM extraction, zero
+# lifetime successes, quarantined) replaced by the Publications Office CELLAR
+# SPARQL endpoint — the official machine interface to the same corpus
+# (DEC-20260813-A preference order: official API > per-call parsing).
 
 slug: eu-regulation-search
 name: EU Regulation Search
 description: >-
-  Search EU regulations, directives, and decisions on EUR-Lex. Returns matching legislation with titles, CELEX numbers,
-  dates, and summaries.
+  Search EU regulations, directives, and decisions by topic. Official Publications Office data with titles, CELEX
+  numbers, dates, in-force status, and EUR-Lex links.
 category: compliance
-cost_class: paid_prepaid
+cost_class: free_unlimited
 quota_window: none
 price_cents: 30
 is_free_tier: false
@@ -16,37 +18,53 @@ input_schema:
   required:
     - query
   properties:
-    type:
-      type: string
-      description: Regulation type filter (regulation/directive/decision)
     query:
       type: string
-      description: Search topic or keywords
+      description: Search topic or keywords (e.g. "artificial intelligence", "data protection")
+    type:
+      type: string
+      description: Optional filter — regulation, directive, or decision
+    year:
+      type: string
+      description: Optional 4-digit year of adoption (e.g. "2024")
 output_schema:
   type: object
   example:
-    query: ;
-    regulations: []
-    result_count: 0
+    query: general data protection
+    matched_terms:
+      - general
+      - data
+      - protection
+    result_count: 1
+    regulations:
+      - title: Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data, and repealing Directive 95/46/EC (General Data Protection Regulation)
+        celex_number: 32016R0679
+        type: Regulation
+        date: "2016-04-27"
+        in_force: true
+        eur_lex_url: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679
   properties:
     query:
       type: string
-    regulations:
+    matched_terms:
       type: array
     result_count:
       type: integer
-data_source: EUR-Lex (Official Journal of the European Union)
-data_source_type: scrape
-transparency_tag: ai_generated
+    regulations:
+      type: array
+data_source: EU Publications Office CELLAR (SPARQL)
+data_source_type: api
+transparency_tag: algorithmic
 freshness_category: live-fetch
-maintenance_class: scraping-stable-target
+maintenance_class: free-stable-api
 # SA.2b: per-capability PII classification (F-A-003, F-A-009)
 processes_personal_data: false
 geography: global
 test_fixtures:
   known_answer:
     input:
-      query: artificial intelligence act
+      query: general data protection
+      type: regulation
     expected_fields:
       - field: query
         operator: not_null
@@ -72,21 +90,33 @@ test_fixtures:
       - field: result_count
         operator: gt
         reliability: guaranteed
-        value: -1
+        value: 0
   health_check_input:
-    query: test
+    query: data protection
 output_field_reliability:
   query: guaranteed
-  regulations: guaranteed
+  matched_terms: guaranteed
   result_count: guaranteed
+  regulations: guaranteed
 limitations:
-  - title: Searches published EU regulations only — draft proposals and pending amendments are not included
-    text: Searches published EU regulations — draft proposals and pending amendments may not be included
-    category: freshness
-    severity: info
-    workaround: Check EUR-Lex directly for the latest legislative procedure status on regulations returned in results
-  - title: AI relevance ranking means returned regulations should be verified against official EUR-Lex text
-    text: AI-assisted relevance ranking — returned regulations should be verified against the official EUR-Lex text
-    category: accuracy
+  - title: Title-based matching — legislation whose title doesn't name the topic may be missed
+    text: >-
+      Queries are matched against official English titles (all words must appear). Legislation known by an
+      abbreviation not present in its title (e.g. "AI" for the Artificial Intelligence Act) or covering a topic
+      not named in the title will not be found. Query with the spelled-out subject matter.
+    category: coverage
     severity: warning
-    workaround: Use the regulation reference numbers from results to retrieve the canonical text from eur-lex.europa.eu
+    workaround: Use full subject words ("artificial intelligence", not "AI"); add the year filter to narrow results
+  - title: Covers adopted sector-3 legislation only — proposals, corrigenda, and consolidated texts are excluded
+    text: >-
+      Results are restricted to adopted regulations, directives, and decisions (CELEX sector 3). Draft proposals
+      (COM documents), corrigenda, communications, and consolidated versions are excluded by design.
+    category: coverage
+    severity: info
+    workaround: Check EUR-Lex directly for legislative procedure status or consolidated texts of returned acts
+  - title: An empty result set is a valid answer, not an error
+    text: >-
+      A query matching no legislation returns result_count 0 with an empty regulations array. This is a correct
+      "nothing matches" answer — it does not indicate a service fault.
+    category: accuracy
+    severity: info


### PR DESCRIPTION
## Summary
- Replaces the Browserless-rendered EUR-Lex page scrape (+ Haiku extraction) with direct queries to the **official EU Publications Office CELLAR SPARQL endpoint** — no auth, no browser render, no LLM, 59–380ms observed. The scrape had **zero lifetime successes**; the capability was quarantined earlier today with its breaker stuck `half_open` since Aug 12. DEC-20260813-A preference order applied: official API > per-call parsing.
- Empty result set is now a **valid output** (`{result_count: 0}`), never a thrown error — a correct "nothing matches" must not trip the circuit breaker.
- Query tokens (`/^[a-z0-9]{2,40}$/` enforced pre-interpolation) AND-match English titles via the Virtuoso full-text index; results restricted to CELEX sector-3 legislation, corrigenda excluded; `type`/`year` filters map to CELEX structure; new optional `year` input.
- Manifest: `data_source_type` scrape→api, `transparency_tag` ai_generated→algorithmic, `cost_class` paid_prepaid→free_unlimited (per-call vendor cost is genuinely zero now — this also re-arms scheduled testing). **`price_cents` untouched** (pricing is human-gated per DEC-20260812-A).

## Verification
- `tsc --noEmit` clean; 9/9 unit tests (tokenizer incl. injection-safety and length cap, all input refusals)
- Live battery against the endpoint: AI Act query, GDPR (exact single hit with type filter → `32016R0679`), year filter (`32024R1689` found), nonsense → `result_count: 0`, topic alias, four structured refusals
- `onboard.ts --backfill --dry-run` reviewed — drift set is exactly the intended field updates
- Cross-provider review (Codex `gpt-5.6-sol` via model-os dispatch): 2 MEDIUM findings, **both fixed** (malformed-response-as-zero-results; unbounded token length → upstream 414 misclassification)

## Deploy-gated follow-up (DEC-20260504-C — do after merge + deploy)
Prod runs the old scrape until this deploys, so the capability **stays quarantined** (`visible=false`, `x402_enabled=false`) in this PR. After `/health` shows this commit:
1. `npx tsx scripts/onboard.ts --manifest ../../manifests/eu-regulation-search.yaml --backfill --discover` (updates fixtures/tests against the live executor)
2. `npx tsx scripts/sync-manifest-canonical-to-db.ts eu-regulation-search` (data_source/transparency/cost_class fields)
3. `npx tsx scripts/smoke-test.ts --slug eu-regulation-search` — must be green
4. Un-quarantine: `visible=true, x402_enabled=true` + `health_monitor_events` promotion row (mirror of today's quarantine row). Breaker closes itself on first success.

## Limitations documented in the manifest
Title-only AND matching (abbreviations like "AI" won't hit unless in the title); adopted sector-3 legislation only (no proposals/corrigenda/consolidated texts); empty result = valid answer.

## Test plan
After deploy: `POST /v1/do` with `{"capability_slug":"eu-regulation-search","max_price_cents":50,"inputs":{"query":"general data protection","type":"regulation"}}` → `result_count: 1`, CELEX `32016R0679`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)