### PR TITLE
feat(drift-sweep): input_schema joins the weekly manifest-drift sweep

### DIFF
--- a/apps/api/scripts/sweep-manifest-drift.ts
+++ b/apps/api/scripts/sweep-manifest-drift.ts
@@ -40,6 +40,7 @@ interface Manifest {
   output_field_reliability?: unknown;
   processes_personal_data?: unknown;
   personal_data_categories?: unknown[];
+  input_schema?: unknown;
 }
 
 interface Drift {
@@ -73,7 +74,7 @@ for (const file of manifestFiles) {
   const rows = await sql`
     SELECT slug, data_source, maintenance_class, transparency_tag, freshness_category,
            output_field_reliability, processes_personal_data, personal_data_categories,
-           gdpr_art_22_classification
+           gdpr_art_22_classification, input_schema
     FROM capabilities
     WHERE slug = ${slug}
   `;
@@ -112,6 +113,18 @@ for (const file of manifestFiles) {
   compare("processes_personal_data", dbRow.processes_personal_data, manifest.processes_personal_data);
   compare("personal_data_categories", dbRow.personal_data_categories, manifest.personal_data_categories);
   compare("gdpr_art_22_classification", dbRow.gdpr_art_22_classification, manifest.gdpr_art_22_classification);
+  // input_schema is the customer-facing contract: it's what MCP tool
+  // definitions, /v1/capabilities, and the x402 catalog serve. Drift here is
+  // how three capabilities spent months advertising "nothing required" while
+  // their executors demanded input (2026-08-15 incident — real x402 payers
+  // sent {} and hit refusals the schema said couldn't happen). A DB value
+  // stored as a JSON *string* (double-encoding) serves zero properties and
+  // is flagged as drift regardless of content.
+  compare(
+    "input_schema",
+    typeof dbRow.input_schema === "string" ? "<DOUBLE-ENCODED JSON STRING>" : dbRow.input_schema,
+    manifest.input_schema,
+  );
 
   if (fields.length === 0) {
     cleanCount++;


### PR DESCRIPTION
## Summary
- Adds `input_schema` to the weekly `sweep-manifest-drift.ts` comparison — it's the customer-facing contract (MCP tools, `/v1/capabilities`, x402 catalog all serve it from the DB), and it was the one canonical field the sweep didn't watch. That gap is how three capabilities served "nothing required" for months while their executors demanded input.
- Double-encoded DB schemas (JSON stored as a string → serves zero properties) are flagged explicitly. Two more found via this check today and already fixed in prod: `invoice-validate`, `ssl-certificate-chain` (both now also declare `required` properly).

## Verification
- `tsc --noEmit` clean; sweep run against prod: catches the 10 remaining pre-existing drift slugs (registry caps awaiting per-slug reconciliation: austrian/dutch/french/italian/portuguese/swiss-company-data, email-pattern-discover, officer-search, product-reviews-extract, annual-report-extract), no false positives on the 300+ clean ones.

## Test plan
`cd apps/api && npx tsx scripts/sweep-manifest-drift.ts` — read-only; the weekly cron picks it up unchanged (same script path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)