### PR TITLE
feat(x402): lead the discovery file with what agents actually buy

### DIFF
--- a/apps/api/src/lib/seller-rank.test.ts
+++ b/apps/api/src/lib/seller-rank.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Ranking discovery surfaces by what agents actually buy.
+ *
+ * Context: as of 2026-08-15 a single anonymous wallet accounts for 98.7% of
+ * revenue (€249 over 90 days) while 33 human signups produced €3.33. Finding a
+ * second buyer on the paying rail is the whole growth problem, and every shelf
+ * we publish was stocked in arbitrary order.
+ */
+import { describe, it, expect } from "vitest";
+import { rankBySales } from "./seller-rank.js";
+
+interface Item { slug: string; free?: boolean }
+const slugOf = (i: Item) => i.slug;
+const isFree = (i: Item) => i.free === true;
+
+describe("ranking a catalogue by proven sales", () => {
+  const catalogue: Item[] = [
+    { slug: "exchange-rate" },              // what the shelf used to lead with
+    { slug: "token-security-check" },
+    { slug: "google-search" },              // €24.30/30d — a real seller
+    { slug: "email-validate", free: true }, // 380 calls/30d
+    { slug: "zebra-tool" },
+  ];
+  const revenue = new Map([["google-search", 2430], ["email-validate", 1140]]);
+
+  it("puts the biggest earner first, not whatever the database returned first", () => {
+    const ranked = rankBySales(catalogue, revenue, slugOf, isFree);
+    expect(ranked[0].slug).toBe("google-search");
+    expect(ranked[1].slug).toBe("email-validate");
+  });
+
+  it("ranks never-sold items below every seller", () => {
+    const ranked = rankBySales(catalogue, revenue, slugOf, isFree).map(slugOf);
+    expect(ranked.indexOf("exchange-rate")).toBeGreaterThan(ranked.indexOf("google-search"));
+    expect(ranked.indexOf("token-security-check")).toBeGreaterThan(ranked.indexOf("email-validate"));
+  });
+
+  it("offers free items before paid ones among equally-unsold items", () => {
+    // A free capability is an agent's cheapest way to try us at all.
+    const items: Item[] = [{ slug: "b-paid" }, { slug: "a-free", free: true }];
+    expect(rankBySales(items, new Map(), slugOf, isFree)[0].slug).toBe("a-free");
+  });
+
+  it("is deterministic when nothing has sold — alphabetical, not random", () => {
+    const items: Item[] = [{ slug: "c" }, { slug: "a" }, { slug: "b" }];
+    expect(rankBySales(items, new Map(), slugOf, isFree).map(slugOf)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const items: Item[] = [{ slug: "z" }, { slug: "a" }];
+    const before = items.map(slugOf);
+    rankBySales(items, new Map(), slugOf, isFree);
+    expect(items.map(slugOf)).toEqual(before);
+  });
+
+  it("falls back to alphabetical when the revenue map is empty", () => {
+    // sellerRevenueBySlug returns an empty map on any query error, so this is
+    // the production degraded path: a discovery surface must never 500 or
+    // return nothing because a reporting query failed.
+    const ranked = rankBySales(catalogue, new Map(), slugOf, isFree);
+    expect(ranked).toHaveLength(catalogue.length);
+    expect(ranked[0].slug).toBe("email-validate"); // free first, then alphabetical
+  });
+});

--- a/apps/api/src/lib/seller-rank.ts
+++ b/apps/api/src/lib/seller-rank.ts
@@ -1,0 +1,91 @@
+/**
+ * Ranking machine-readable catalogues by what agents actually buy.
+ *
+ * Every discovery surface Strale publishes is a shelf, and until 2026-08-15
+ * every one of them was stocked in arbitrary order. The agent card listed 406
+ * skills starting with whatever the database returned first; the x402 discovery
+ * file lists 334 endpoints the same way. An agent reading either one sees the
+ * top of the list, not the middle of it.
+ *
+ * The fix is the same everywhere: order by external revenue over a rolling
+ * window, so the shelf leads with what other agents have already paid for.
+ * Shared here rather than copied so a second surface cannot drift from the
+ * first — the agent card's copy of this logic is the reason this module exists.
+ *
+ * Two properties this must never lose:
+ *
+ *  - **The canonical internal filter.** ~98% of platform traffic is our own
+ *    test harness. Ranking without the filter would sort the shelf by what WE
+ *    test, which is the wrong-population error catalogued in
+ *    docs/company/MEASUREMENT.md — four times in one day.
+ *  - **Failing open.** A discovery surface that 500s because a ranking query
+ *    failed is worse than one in arbitrary order. Every caller gets an empty
+ *    map on error and falls back to alphabetical.
+ */
+import { sql } from "drizzle-orm";
+import { getDb } from "../db/index.js";
+import { INTERNAL_EMAIL_LIKE_PATTERNS, EXTRA_EXCLUDED_EMAILS } from "./internal-accounts.js";
+import { logWarn } from "./log.js";
+
+const CACHE_TTL_MS = 15 * 60 * 1000;
+let cache: Map<string, number> | null = null;
+let cachedAt = 0;
+
+/**
+ * Cents of external revenue per capability/solution slug over the window.
+ * Cached — discovery surfaces are hot and this is a reporting-grade number,
+ * not a billing one.
+ */
+export async function sellerRevenueBySlug(windowDays = 28): Promise<Map<string, number>> {
+  const now = Date.now();
+  if (cache && now - cachedAt < CACHE_TTL_MS) return cache;
+  try {
+    const likeAny = sql.join(
+      INTERNAL_EMAIL_LIKE_PATTERNS.map((p) => sql`email LIKE ${p}`), sql` OR `);
+    const eqAny = sql.join(
+      EXTRA_EXCLUDED_EMAILS.map((e) => sql`email = ${e}`), sql` OR `);
+    const rows = (await getDb().execute(sql`
+      SELECT c.slug, COALESCE(SUM(t.price_cents), 0)::int AS cents
+      FROM transactions t JOIN capabilities c ON c.id = t.capability_id
+      WHERE t.status = 'completed' AND t.price_cents > 0
+        AND t.created_at > now() - (${String(windowDays)} || ' days')::interval
+        AND (t.user_id IS NULL OR t.user_id NOT IN (
+          SELECT id FROM users WHERE (${likeAny}) OR (${eqAny})))
+      GROUP BY 1`)) as unknown as Array<{ slug: string; cents: number }>;
+    cache = new Map(rows.map((r) => [r.slug, Number(r.cents)]));
+    cachedAt = now;
+    return cache;
+  } catch (err) {
+    // Fail open: arbitrary order beats a broken discovery surface.
+    logWarn("seller-rank-failed", "ranking query failed; discovery falls back to alphabetical", { err: String(err) });
+    return new Map();
+  }
+}
+
+/**
+ * Sort a catalogue so proven sellers lead, then free items (an agent's
+ * cheapest first step), then everything else alphabetically for stability.
+ * `slugOf` lets callers pass their own row shape.
+ */
+export function rankBySales<T>(
+  items: T[],
+  revenue: Map<string, number>,
+  slugOf: (item: T) => string,
+  isFree: (item: T) => boolean = () => false,
+): T[] {
+  return [...items].sort((a, b) => {
+    const ra = revenue.get(slugOf(a)) ?? 0;
+    const rb = revenue.get(slugOf(b)) ?? 0;
+    if (ra !== rb) return rb - ra;
+    const fa = isFree(a) ? 0 : 1;
+    const fb = isFree(b) ? 0 : 1;
+    if (fa !== fb) return fa - fb;
+    return slugOf(a).localeCompare(slugOf(b));
+  });
+}
+
+/** Test seam — discovery surfaces are cached for 15 minutes in production. */
+export function __resetSellerRankCache(): void {
+  cache = null;
+  cachedAt = 0;
+}

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -37,6 +37,7 @@ import {
   type X402VerifiedPayment,
 } from "../lib/x402-gateway.js";
 import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
+import { sellerRevenueBySlug, rankBySales } from "../lib/seller-rank.js";
 import { encodePaymentRequiredHeader } from "@x402/core/http";
 import { extractClientMeta, recordDiscoveryHit, hashX402Payer } from "../lib/attribution.js";
 import { rateLimitByIp } from "../lib/rate-limit.js";
@@ -1462,8 +1463,17 @@ export async function getX402Manifest(): Promise<{
   // /.well-known/x402.json. The canonical numeric value is always
   // available server-side as `priceCents` (EUR) and the live USD figure
   // is `eurCentsToUsd(priceCents)` per DEC-20260502-A.
+  // Ordered by what agents actually pay for, not by database order. This file
+  // is fetched ~40 times a month by distinct agents; before 2026-08-15 they
+  // landed on exchange-rate and token-security-check while our proven sellers
+  // (email-validate, google-search) sat somewhere in a list of 334.
+  const revenue = await sellerRevenueBySlug();
+  const caps = rankBySales(
+    [..._capCache.values()], revenue, (c) => c.slug, (c) => c.x402PriceUsd === 0);
+  const sols = rankBySales([..._solCache.values()], revenue, (s) => s.slug);
+
   const endpoints = [
-    ...[..._capCache.values()].map((cap) => ({
+    ...caps.map((cap) => ({
       path: `/x402/v2/${cap.slug}`,
       method: cap.x402Method,
       price: cap.x402PriceUsd.toFixed(2),
@@ -1471,7 +1481,7 @@ export async function getX402Manifest(): Promise<{
       network: NETWORK,
       description: cap.description,
     })),
-    ...[..._solCache.values()].map((sol) => ({
+    ...sols.map((sol) => ({
       path: `/x402/v2/solutions/${sol.slug}`,
       method: "POST",
       price: sol.x402PriceUsd.toFixed(2),


### PR DESCRIPTION
Investigating how to find buyer #2. Our x402 discovery file — fetched by ~40 distinct agents/month — listed 334 endpoints in arbitrary order, burying the services our one paying customer buys 1,300 times a month. Now revenue-ranked via a shared lib the agent card will also adopt. 6 tests incl. the fail-open path.