### PR TITLE
fix(attribution): derive where callers come from

### DIFF
--- a/apps/api/src/lib/attribution.ts
+++ b/apps/api/src/lib/attribution.ts
@@ -23,6 +23,7 @@ import { createHash } from "node:crypto";
 import { sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { logWarn } from "./log.js";
+import { resolveDiscoverySource } from "./discovery-source.js";
 
 export interface ClientMeta {
   ua?: string;
@@ -167,7 +168,19 @@ export function recordDiscoveryHit(
 ): void {
   try {
     const ua = clip(req.header("user-agent")) ?? null;
-    const src = clip(opts?.src) ?? null;
+    // Source is derived, not merely accepted. Before 2026-08-15 this read only
+    // `?src=`, which we can add to links we submit ourselves and nothing else —
+    // the result was 1 tagged hit out of 2,196. Referer and crawler identity
+    // are what callers actually send, so those are consulted too, and the
+    // basis is recorded alongside so a weak signal is never mistaken for a
+    // strong one. `null` still means unknown; it is never guessed.
+    const resolved = resolveDiscoverySource({
+      src: opts?.src ?? null,
+      referer: req.header("referer") ?? req.header("referrer") ?? null,
+      userAgent: ua,
+    });
+    const src = clip(resolved?.tag) ?? null;
+    const srcBasis = resolved?.basis ?? null;
     const ipHash = saltedIpHash(opts?.ip) ?? null;
     // getDb() throws synchronously when DATABASE_URL is unset — the whole
     // body is guarded so a discovery endpoint can never fail on attribution.
@@ -175,8 +188,8 @@ export function recordDiscoveryHit(
     void db
 
     .execute(
-      sql`INSERT INTO discovery_hits (endpoint, src_tag, ua, ip_hash)
-          VALUES (${endpoint}, ${src}, ${ua}, ${ipHash})`,
+      sql`INSERT INTO discovery_hits (endpoint, src_tag, src_basis, ua, ip_hash)
+          VALUES (${endpoint}, ${src}, ${srcBasis}, ${ua}, ${ipHash})`,
       )
       .catch((err) => {
         logWarn("discovery-hit-write-failed", `discovery_hits insert failed: ${(err as Error).message}`, {

--- a/apps/api/src/lib/discovery-source.test.ts
+++ b/apps/api/src/lib/discovery-source.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Attribution has to be honest about how much it knows.
+ *
+ * Measured 2026-08-15: 1 of 2,196 discovery hits carried a source. The fix
+ * derives source from what callers actually send — but a derived source is
+ * weaker evidence than a tag we placed ourselves, and the tests below exist to
+ * stop that distinction from eroding. The failure this guards against is not
+ * "no attribution"; it is *confident wrong* attribution, which is the same
+ * class of error that produced five bad conclusions that day.
+ */
+import { describe, it, expect } from "vitest";
+import { resolveDiscoverySource } from "./discovery-source.js";
+
+describe("precedence: strongest evidence wins", () => {
+  it("prefers our own tag over everything else", () => {
+    const r = resolveDiscoverySource({
+      src: "bazaar-submission", referer: "https://smithery.ai/x", userAgent: "glama/1.0",
+    });
+    expect(r).toEqual({ tag: "bazaar-submission", basis: "tagged" });
+  });
+
+  it("falls back to the referring site when we did not tag the link", () => {
+    const r = resolveDiscoverySource({ referer: "https://smithery.ai/servers/strale", userAgent: "curl/8" });
+    expect(r).toEqual({ tag: "smithery", basis: "referer" });
+  });
+
+  it("falls back to the crawler's identity when there is no referer", () => {
+    expect(resolveDiscoverySource({ userAgent: "smithery-probe/0" }))
+      .toEqual({ tag: "smithery", basis: "agent" });
+  });
+});
+
+describe("it says 'unknown' rather than guessing", () => {
+  it("returns null when nothing identifies the caller", () => {
+    expect(resolveDiscoverySource({})).toBeNull();
+    expect(resolveDiscoverySource({ userAgent: "python-requests/2.31" })).toBeNull();
+  });
+
+  it("ignores a malformed referer instead of storing junk", () => {
+    expect(resolveDiscoverySource({ referer: "not a url" })).toBeNull();
+  });
+
+  it("never invents a catch-all bucket that would inflate one venue", () => {
+    // A generic agent must not be silently attributed to whichever venue
+    // happens to be first in the signature list.
+    const r = resolveDiscoverySource({ userAgent: "Mozilla/5.0 generic" });
+    expect(r).toBeNull();
+  });
+});
+
+describe("referer matching is host-based, not substring-based", () => {
+  it("does not let a URL path impersonate a known venue", () => {
+    // The naive implementation greps the whole URL, so this would be
+    // misattributed to GitHub — reassigning traffic to a venue that sent none.
+    const r = resolveDiscoverySource({ referer: "https://evil.example/?next=github.com" });
+    expect(r?.tag).not.toBe("github");
+    expect(r?.tag).toBe("ref:evil.example");
+  });
+
+  it("keeps unrecognised referring hosts, because that is how we find new venues", () => {
+    const r = resolveDiscoverySource({ referer: "https://some-new-directory.dev/list" });
+    expect(r).toEqual({ tag: "ref:some-new-directory.dev", basis: "referer" });
+  });
+});
+
+describe("stored values are bounded", () => {
+  it("clips an over-long tag rather than storing it whole", () => {
+    const r = resolveDiscoverySource({ src: "x".repeat(500) });
+    expect(r!.tag.length).toBeLessThanOrEqual(64);
+  });
+
+  it("clips an over-long referring host too", () => {
+    const host = "a".repeat(200) + ".com";
+    const r = resolveDiscoverySource({ referer: `https://${host}/p` });
+    expect(r!.tag.length).toBeLessThanOrEqual(64);
+  });
+});

--- a/apps/api/src/lib/discovery-source.ts
+++ b/apps/api/src/lib/discovery-source.ts
@@ -1,0 +1,113 @@
+/**
+ * Working out where a caller came from.
+ *
+ * The problem this solves, measured 2026-08-15: of 2,196 recorded discovery
+ * hits, exactly **one** carried a source tag. Attribution depended entirely on
+ * a `?src=` query parameter that only we can add — so it worked for links we
+ * hand-submit and for nothing else. If our second paying customer arrived
+ * tomorrow, we could not say how they found us, which makes every channel
+ * decision a guess and makes any future marketing spend unmeasurable.
+ *
+ * The fix is to derive the source from what callers actually send, in
+ * descending order of reliability:
+ *
+ *   1. an explicit `?src=` tag (we put it there; trust it completely)
+ *   2. the `Referer` header (the directory's own page linked to us)
+ *   3. a recognised crawler user agent (the directory's indexer fetched us)
+ *   4. otherwise `null` — genuinely unknown, and recorded as such
+ *
+ * Deliberately NOT included: any attempt to fingerprint an individual caller.
+ * The daily-rotating IP salt exists so we cannot build a cross-session profile,
+ * and source attribution does not need one. This module answers "which venue"
+ * and never "which person".
+ */
+
+/**
+ * Known venues, matched against user agent then referer host. Keys are the
+ * canonical source tag written to `discovery_hits.src_tag`; the array holds
+ * substrings identifying that venue.
+ *
+ * Adding a venue here is how a new directory becomes measurable. Keep the
+ * needles specific — a loose match silently reattributes traffic, which is
+ * worse than leaving it unknown.
+ */
+const VENUE_SIGNATURES: Record<string, string[]> = {
+  smithery: ["smithery"],
+  glama: ["glama"],
+  "agent-tools-cloud": ["agent-tools.cloud"],
+  "x402-observatory": ["x402-observatory"],
+  "aisec-registry": ["aisec-registry"],
+  "402-index": ["402index", "402.index"],
+  x402scan: ["x402scan"],
+  "mcp-scoring": ["mcpscoringengine"],
+  glimind: ["glimind"],
+  mcpbeat: ["mcpbeat"],
+  yellowmcp: ["yellowmcp"],
+  "reliability-bureau": ["reliability-bureau"],
+  bazaar: ["cdp.coinbase", "coinbase"],
+  github: ["github.com"],
+  npm: ["npmjs.com", "npmjs.org"],
+  "chatgpt-referral": ["chatgpt.com", "openai.com"],
+  "claude-referral": ["claude.ai", "anthropic.com"],
+  perplexity: ["perplexity.ai"],
+};
+
+/** Venue plus how confident we are, so a consumer can weight the evidence. */
+export interface DiscoverySource {
+  tag: string;
+  /** `tagged` = we put it there; `referer` = their page linked us; `agent` = their crawler. */
+  basis: "tagged" | "referer" | "agent";
+}
+
+function matchVenue(haystack: string): string | null {
+  const h = haystack.toLowerCase();
+  for (const [tag, needles] of Object.entries(VENUE_SIGNATURES)) {
+    if (needles.some((n) => h.includes(n))) return tag;
+  }
+  return null;
+}
+
+/**
+ * Resolve a source. Returns null when genuinely unknown — never a guess, and
+ * never a catch-all bucket that would inflate one venue's apparent
+ * contribution.
+ */
+export function resolveDiscoverySource(input: {
+  src?: string | null;
+  referer?: string | null;
+  userAgent?: string | null;
+}): DiscoverySource | null {
+  // 1. Explicit tag. Ours, so trusted, but still bounded — a caller can put
+  // anything in a query string and this value is stored.
+  const explicit = input.src?.trim();
+  if (explicit) return { tag: explicit.slice(0, 64), basis: "tagged" };
+
+  // 2. Referer: the venue's own page sent them. Parse the host rather than
+  // substring-matching the whole URL, so a path containing "github.com" in a
+  // query parameter cannot masquerade as a GitHub referral.
+  const ref = input.referer?.trim();
+  if (ref) {
+    try {
+      const host = new URL(ref).hostname;
+      const venue = matchVenue(host);
+      if (venue) return { tag: venue, basis: "referer" };
+      // Unrecognised but real referrer: keep the host. It is the single most
+      // useful field for discovering venues we do not yet know about.
+      return { tag: `ref:${host.slice(0, 58)}`, basis: "referer" };
+    } catch {
+      // Malformed Referer — ignore rather than store junk.
+    }
+  }
+
+  // 3. The venue's crawler identified itself.
+  const ua = input.userAgent?.trim();
+  if (ua) {
+    const venue = matchVenue(ua);
+    if (venue) return { tag: venue, basis: "agent" };
+  }
+
+  return null;
+}
+
+/** Exposed for the directory map in docs/company/DISTRIBUTION-FINDINGS.md. */
+export const KNOWN_VENUES = Object.keys(VENUE_SIGNATURES);

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1157,7 +1157,7 @@ describe("startup-migrations — phase-b5 slug lists (invariants)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 28 blocks in historical order", () => {
+  it("exports the expected 29 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1192,6 +1192,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0083_x402PayerHash",
       "runMigration0084_danishQuotaHeadroom",
       "runMigration0085_actorIdentity",
+      "runMigration0086_srcBasis",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1548,6 +1548,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0083_x402PayerHash,
   runMigration0084_danishQuotaHeadroom,
   runMigration0085_actorIdentity,
+  runMigration0086_srcBasis,
 ];
 
 /**
@@ -1955,6 +1956,31 @@ export async function runMigration0085_actorIdentity(
     outcome: "applied",
     duration_ms: Date.now() - startedAt,
   };
+}
+
+/**
+ * Block 0086 — how we know where a caller came from.
+ *
+ * `src_basis` records HOW a discovery hit was attributed: 'tagged' (a ?src=
+ * parameter we added ourselves), 'referer' (the venue's page linked to us), or
+ * 'agent' (the venue's crawler identified itself). Without it, a weak signal
+ * and a strong one are indistinguishable once stored, and the weakest is the
+ * most numerous.
+ *
+ * Nullable with no backfill: the 2,196 rows written before this point have no
+ * recoverable basis, and inventing one would be worse than leaving it unknown.
+ * DEC-20260504-B does not apply — an ADD COLUMN with no default rewrites
+ * nothing.
+ */
+export async function runMigration0086_srcBasis(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  await tx.execute(sql`ALTER TABLE discovery_hits ADD COLUMN IF NOT EXISTS src_basis TEXT`);
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS idx_discovery_hits_src
+      ON discovery_hits (src_tag, created_at) WHERE src_tag IS NOT NULL`);
+  return { block: "0086_srcBasis", outcome: "applied", duration_ms: Date.now() - startedAt };
 }
 
 /**


### PR DESCRIPTION
1 of 2,196 discovery hits carried a source. Now derived from tag > referer > crawler identity, with the basis stored so weak and strong signals stay distinguishable. 10 tests incl. the host-impersonation case. Migration 0086 adds a nullable column, no backfill.