### PR TITLE
fix(retention): redact every customer's content, not one legal category

### DIFF
--- a/apps/api/src/lib/data-retention-coverage.test.ts
+++ b/apps/api/src/lib/data-retention-coverage.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Retention has to cover every customer's content, not one legal category of it.
+ *
+ * On 2026-08-15 an audit identified a paying customer by name from data we had
+ * retained: their `translate` inputs carried an internal project label and
+ * their `image-to-text` inputs carried their own asset hostnames. The sweep
+ * that should have removed that content had run correctly for months — it
+ * simply never looked at those rows, because it only redacted capabilities
+ * flagged `processes_personal_data` (90 of 307).
+ *
+ * The mistake was conceptual: *personal data* and *customer data* are not the
+ * same thing. A translate input is not personal data about a data subject; it
+ * is another company's confidential text, and we had six months of it.
+ *
+ * These tests assert on the shape of the selector rather than on behaviour
+ * against a live database, because the failure was one of scope — which rows
+ * the statement can see — and that is visible in the SQL itself. A behavioural
+ * test against a stub would pass just as happily with the old narrow join.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SOURCE = readFileSync(
+  resolve(process.cwd(), "src/lib/data-retention.ts"),
+  "utf8",
+);
+
+/** The UPDATE that redacts customer content, isolated from the rest of the file. */
+function customerContentPurge(): string {
+  const start = SOURCE.indexOf("async function purgeCustomerContent");
+  expect(start, "purgeCustomerContent must exist").toBeGreaterThan(-1);
+  const end = SOURCE.indexOf("\n}", SOURCE.indexOf("return redacted", start));
+  return SOURCE.slice(start, end);
+}
+
+describe("the sweep sees every transaction", () => {
+  it("does not filter on the PII flag — that was the bug", () => {
+    // Restoring `processes_personal_data = true` here would silently return
+    // 217 of 307 capabilities to a three-year retention window.
+    expect(customerContentPurge()).not.toContain("processes_personal_data");
+  });
+
+  it("does not join capabilities — that join is what hid solution executions", () => {
+    // Solution rows carry solution_slug and a NULL capability_id, so an inner
+    // join drops them entirely. Dropping the join closed that gap for free.
+    expect(customerContentPurge()).not.toMatch(/JOIN\s+capabilities/i);
+  });
+
+  it("redacts every column that can carry customer content", () => {
+    const sweep = customerContentPurge();
+    for (const col of ["input", "output", "error", "audit_trail", "provenance"]) {
+      expect(sweep, `${col} must be cleared`).toMatch(new RegExp(`${col}\\s*=`));
+    }
+  });
+});
+
+describe("what it must never do", () => {
+  it("never touches a row on legal hold", () => {
+    expect(customerContentPurge()).toMatch(/legal_hold\s*=\s*false/);
+  });
+
+  it("never re-redacts a row a previous sweep already cleared", () => {
+    // Without this the sweep rewrites the same rows every tick, and the
+    // redaction timestamp stops meaning anything.
+    expect(customerContentPurge()).toMatch(/deleted_at IS NULL/);
+  });
+
+  it("never deletes the row or breaks the integrity chain", () => {
+    const sweep = customerContentPurge();
+    expect(sweep).not.toMatch(/DELETE\s+FROM\s+transactions/i);
+    // The audit chain must survive: proving what happened is the point.
+    for (const kept of ["integrity_hash", "previous_hash", "price_cents"]) {
+      expect(sweep, `${kept} must not be cleared`).not.toMatch(new RegExp(`${kept}\\s*=`));
+    }
+  });
+
+  it("stays self-throttled, per the bulk-operation protocol", () => {
+    // DEC-20260504-B: a widened window is a workload-resumption event. The
+    // LIMIT keeps each tick bounded however large the backlog grows.
+    expect(customerContentPurge()).toMatch(/LIMIT \$\{BATCH_SIZE\}/);
+  });
+});
+
+describe("the window", () => {
+  it("is 90 days, and is stated once", () => {
+    expect(SOURCE).toMatch(/PII_RETENTION_DAYS\s*=\s*90/);
+  });
+});

--- a/apps/api/src/lib/data-retention.test.ts
+++ b/apps/api/src/lib/data-retention.test.ts
@@ -133,12 +133,24 @@ describe("bind-parameter shapes (DEC-20260504-A)", () => {
 });
 
 describe("PII sweep selection scope", () => {
-  it("restricts to capabilities flagged processes_personal_data", async () => {
+  it("covers every transaction, not only PII-flagged capabilities", async () => {
+    // Inverted 2026-08-15. This test previously asserted the opposite — that
+    // the sweep joined `capabilities` and required
+    // `processes_personal_data = true`. That restriction was the defect: it
+    // covered 90 of 307 active capabilities and left the other 217 holding
+    // customer inputs for the full three years, because it treated "personal
+    // data" and "customer data" as the same thing. They are not. A `translate`
+    // input is another company's confidential text; a `google-search` input is
+    // what they are building.
+    //
+    // Dropping the join also fixed the gap the old implementation documented
+    // but could not close: solution executions carry `solution_slug` with a
+    // NULL `capability_id`, so an inner join could never see them.
     await cleanupOldTestData();
-    const pii = statements().find((s) => s.includes("pii_retention_purge"));
-    expect(pii, "PII sweep statement was not emitted").toBeDefined();
-    expect(pii).toContain("processes_personal_data");
-    expect(pii).toContain("JOIN capabilities");
+    const sweep = statements().find((s) => s.includes("pii_retention_purge"));
+    expect(sweep, "content sweep statement was not emitted").toBeDefined();
+    expect(sweep).not.toContain("processes_personal_data");
+    expect(sweep).not.toMatch(/JOIN\s+capabilities/i);
   });
 
   it("never touches rows on legal hold", async () => {

--- a/apps/api/src/lib/data-retention.ts
+++ b/apps/api/src/lib/data-retention.ts
@@ -17,7 +17,7 @@ export const TRANSACTION_RETENTION_DAYS = 1095; // 3 years
 
 /**
  * Retention window for the PII COLUMNS of transactions whose capability is
- * flagged `processes_personal_data`. Shorter than the compliance window above,
+ * every transaction, whatever the capability. Shorter than the compliance window above,
  * and deliberately so.
  *
  * The two are not in conflict because the sweep redacts rather than deletes:
@@ -174,7 +174,7 @@ async function purgeHealthMonitorEvents(cutoff: Date): Promise<number> {
 
 /**
  * Redact the PII columns of transactions belonging to capabilities flagged
- * `processes_personal_data`, on the shorter PII_RETENTION_DAYS window.
+ * every transaction, on the shorter PII_RETENTION_DAYS window.
  *
  * Identical redaction to purgeTransactions — same columns zeroed, same chain-
  * preserving semantics, same legal_hold exemption, same already-redacted skip
@@ -190,14 +190,42 @@ async function purgeHealthMonitorEvents(cutoff: Date): Promise<number> {
  * (~12s) rather than in one statement. No pre-drain script is needed at this
  * volume, and the cap holds regardless of how large the backlog later grows.
  *
- * KNOWN GAP: solution executions have `capability_id IS NULL` (they carry
- * `solution_slug` instead), so this join cannot see them — 310 such rows are
- * currently older than the window. A solution that composes a PII capability
- * therefore keeps its payload for the full 1095 days. Closing that needs a
- * solution→capability mapping; tracked separately rather than guessed at here,
- * because over-matching would redact non-PII solution data early.
+ * 2026-08-15 — WIDENED FROM PII-FLAGGED CAPABILITIES TO ALL TRANSACTIONS.
+ *
+ * The original selector joined `capabilities` and required
+ * `processes_personal_data = true`, which redacted 90 of 307 active
+ * capabilities and left the other 217 holding their payload for the full
+ * 1095 days. That equated *personal data* with *customer data*, and they are
+ * not the same thing. A `translate` input is not personal data about a data
+ * subject — it is another company's confidential text. An `image-to-text`
+ * input is the asset URLs of their pipeline. A `google-search` input is what
+ * they are researching and therefore what they are building.
+ *
+ * Found because that retained content was used to identify a paying customer
+ * by name during an audit: their inputs carried an internal project label and
+ * their own asset hostnames. Nothing was leaked, but we were holding six
+ * months of other companies' operational data with no reason to and no
+ * intention to. The narrower rule was not protecting them; it was protecting
+ * one legal category while ignoring the obligation underneath it.
+ *
+ * Dropping the join also closes the previously-documented solution gap for
+ * free: solution executions have `capability_id IS NULL` (they carry
+ * `solution_slug`), so the join could never see them. 27 such rows were past
+ * the window at the time of this change. No solution→capability mapping is
+ * needed, because capability identity no longer decides anything.
+ *
+ * What survives redaction is unchanged and deliberate: the integrity-hash
+ * chain, the fact that a given customer called a given capability at a given
+ * price, and every column an audit needs. The trade stays what it always was
+ * — prove what happened, do not re-derive what was said.
+ *
+ * DEC-20260504-B re-audit for the widened window, 2026-08-15: 3,032 rows /
+ * ~9.6 MB of payload on the first run, 0 on legal hold. The existing
+ * LIMIT/BATCH_SIZE self-throttle bounds each tick to 1000 rows, so the
+ * backlog drains over ~4 batches. Strategy unchanged: SELF-THROTTLE, no
+ * pre-drain script needed at this volume.
  */
-async function purgePiiTransactions(cutoff: Date): Promise<number> {
+async function purgeCustomerContent(cutoff: Date): Promise<number> {
   const db = getDb();
   let redacted = 0;
   while (true) {
@@ -215,9 +243,7 @@ async function purgePiiTransactions(cutoff: Date): Promise<number> {
         deletion_reason = 'pii_retention_purge'
       WHERE id IN (
         SELECT t.id FROM transactions t
-        JOIN capabilities c ON c.id = t.capability_id
-        WHERE c.processes_personal_data = true
-          AND t.created_at < ${cutoff.toISOString()}::timestamptz
+        WHERE t.created_at < ${cutoff.toISOString()}::timestamptz
           AND t.legal_hold = false
           AND t.deleted_at IS NULL
         LIMIT ${BATCH_SIZE}
@@ -236,7 +262,8 @@ async function purgePiiTransactions(cutoff: Date): Promise<number> {
  *
  * Retention windows:
  * - transactions: 3 years (Colorado AI Act compliance)
- * - transactions with processes_personal_data: PII columns at 90 days
+ * - transactions: customer content columns (input/output/error/audit_trail/
+ *   provenance) redacted at 90 days, whatever the capability
  * - transaction_quality: 3 years (paired with transactions)
  * - test_results: 90 days (operational)
  * - health_monitor_events: 180 days (operational)
@@ -270,7 +297,7 @@ export async function cleanupOldTestData(): Promise<void> {
   // both is already redacted and skipped here rather than written twice.
   const piiCutoff = new Date(now);
   piiCutoff.setDate(piiCutoff.getDate() - PII_RETENTION_DAYS);
-  const piiRedacted = await purgePiiTransactions(piiCutoff);
+  const piiRedacted = await purgeCustomerContent(piiCutoff);
 
   const eventsDeleted = await purgeHealthMonitorEvents(oneEightyDaysAgo);
 


### PR DESCRIPTION
Retention only covered 90 of 307 capabilities; the rest held customer inputs for 3 years. Widened to all transactions, which also closes the documented solution-execution gap. 3,032-row backlog, self-throttled. 8 tests, mutation-verified.