### PR TITLE
feat(jobs): notice when the money stops

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -191,6 +191,12 @@ async function main() {
   const { startX402SettlementWatch } = await import("./jobs/x402-settlement-watch.js");
   startX402SettlementWatch();
 
+  // Revenue concentration is ~99% in one wallet. The settlement watch above
+  // catches the payment rail breaking; this catches the money stopping for any
+  // other reason — including the customer simply leaving.
+  const { startRevenueHeartbeat } = await import("./jobs/revenue-heartbeat.js");
+  startRevenueHeartbeat();
+
   const port = parseInt(process.env.PORT || "3000", 10);
 
   const server = serve({ fetch: app.fetch, port }, (info) => {

--- a/apps/api/src/jobs/revenue-heartbeat.test.ts
+++ b/apps/api/src/jobs/revenue-heartbeat.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The heartbeat has to fire on the case that already cost us money, and stay
+ * quiet on the case that already looked like it.
+ *
+ * Both are real, measured over 60 days of the paying wallet's behaviour:
+ *  - it once went 177 hours between calls and resumed normally — a fixed
+ *    "silent for 24h" rule would have cried wolf until it was ignored;
+ *  - a 21-hour settlement outage stopped it completely and nobody noticed.
+ *
+ * So the rule is relative to each customer's own rhythm. These tests pin that,
+ * and pin the two ways it could quietly stop working: alerting on customers who
+ * never had a rhythm, and letting one customer's cooldown mask another's.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execute = vi.fn();
+vi.mock("../db/index.js", () => ({ getDb: () => ({ execute }) }));
+vi.mock("../lib/log.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logWarn: vi.fn(), logError: vi.fn(),
+}));
+
+const { findSilentPayers } = await import("./revenue-heartbeat.js");
+
+/** One row as the SQL returns it — strings, as postgres hands them over. */
+function row(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    actor: "x402:abc123",
+    active_days: 12,          // established: paid on 12 of the last 14 days
+    revenue_cents: 4800,
+    hours_silent: 2,
+    expected_gap_hours: 28,   // 14 days / 12 active days ≈ 28h
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  execute.mockReset();
+});
+
+describe("it fires when an established customer breaks their own rhythm", () => {
+  it("alerts on a daily caller silent for three times their normal gap", async () => {
+    execute.mockResolvedValue([row({ hours_silent: 90 })]); // 90h vs 28h × 3 = 84h
+    const found = await findSilentPayers();
+    expect(found).toHaveLength(1);
+    expect(found[0].hoursSilent).toBe(90);
+    expect(found[0].revenueCents).toBe(4800);
+  });
+
+  it("stays quiet inside the rhythm — the 177-hour gap case", async () => {
+    // A customer active on only 2 of 14 days has an expected gap of 168h, so
+    // a 177h silence is barely outside their normal pattern and must not page.
+    execute.mockResolvedValue([
+      row({ active_days: 2, expected_gap_hours: 168, hours_silent: 177 }),
+    ]);
+    expect(await findSilentPayers()).toHaveLength(0);
+  });
+
+  it("never alerts on a customer with no established rhythm", async () => {
+    // The HAVING clause excludes these in SQL; this asserts the JS filter does
+    // not resurrect them if the query is ever loosened.
+    execute.mockResolvedValue([
+      row({ active_days: 1, expected_gap_hours: 336, hours_silent: 300 }),
+    ]);
+    expect(await findSilentPayers()).toHaveLength(0);
+  });
+});
+
+describe("the floor and the multiple both apply", () => {
+  it("never pages before 24 hours, however tight the rhythm", async () => {
+    // A customer calling every 30 minutes has an expected gap under an hour;
+    // without the floor, a two-hour lull would page at 3am for nothing.
+    execute.mockResolvedValue([
+      row({ expected_gap_hours: 0.5, hours_silent: 6 }),
+    ]);
+    expect(await findSilentPayers()).toHaveLength(0);
+  });
+
+  it("does page that same customer once a full day has passed", async () => {
+    execute.mockResolvedValue([row({ expected_gap_hours: 0.5, hours_silent: 25 })]);
+    expect(await findSilentPayers()).toHaveLength(1);
+  });
+});
+
+describe("multiple customers are tracked independently", () => {
+  it("returns every silent payer, not just the first", async () => {
+    // With 99% concentration today this is theoretical — but the whole point
+    // of the work is that it stops being theoretical, and a loop that returns
+    // early would then hide the second customer leaving.
+    execute.mockResolvedValue([
+      row({ actor: "x402:aaa", hours_silent: 100 }),
+      row({ actor: "user:bbb", hours_silent: 200 }),
+      row({ actor: "x402:ccc", hours_silent: 3 }),   // healthy
+    ]);
+    const found = await findSilentPayers();
+    expect(found.map((f) => f.actor)).toEqual(["x402:aaa", "user:bbb"]);
+  });
+});
+
+describe("it degrades safely", () => {
+  it("returns nothing rather than throwing when there is no data", async () => {
+    execute.mockResolvedValue([]);
+    expect(await findSilentPayers()).toEqual([]);
+  });
+});

--- a/apps/api/src/jobs/revenue-heartbeat.ts
+++ b/apps/api/src/jobs/revenue-heartbeat.ts
@@ -1,0 +1,146 @@
+/**
+ * Revenue heartbeat — notice when the money stops.
+ *
+ * As of 2026-08-15 one anonymous wallet is ~99% of weekly external revenue.
+ * If it stops — because they churned, because we broke, or because settlement
+ * failed — the business is at roughly €0.60/week and nobody would find out
+ * from a dashboard nobody is watching at 3am. That already happened once: the
+ * 21-hour CDP settlement outage stopped this customer completely and was
+ * noticed after the fact.
+ *
+ * This job does not try to predict churn. It answers a simpler question that
+ * covers both causes at once: **is money still arriving?** A stop is worth
+ * knowing about whether the reason is theirs or ours.
+ *
+ * Why not "alert when revenue is zero": measured over 60 days, the paying
+ * wallet's average gap between calls is 31 minutes, but its longest legitimate
+ * gap was 177 hours — more than seven days — after which it resumed normally.
+ * A fixed "silent for 24h" rule would have cried wolf; a "silent for 8 days"
+ * rule would be useless. So the trigger is *relative*: alert when a customer
+ * who was recently busy goes quiet for longer than their own established
+ * rhythm. Quiet customers never trigger it, because they have no rhythm to
+ * break.
+ */
+import { sql } from "drizzle-orm";
+import { getDb } from "../db/index.js";
+import { alertOnce } from "../lib/alert-once.js";
+import { log, logWarn } from "../lib/log.js";
+import { externalCustomers } from "../lib/metrics/populations.js";
+
+const CHECK_INTERVAL_MS = 60 * 60 * 1000; // hourly — the gap we care about is hours
+const ALERT_COOLDOWN_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * A customer counts as "established" once they have paid on at least this many
+ * distinct days in the trailing window. One busy afternoon is not a rhythm, and
+ * alerting on it would page us about every passing experimenter.
+ */
+const MIN_ACTIVE_DAYS = 5;
+const TRAILING_DAYS = 14;
+
+/**
+ * How many times their own typical daily gap must elapse before we care.
+ * Set from the observed 177-hour legitimate gap: an established daily caller
+ * silent for ~3× their normal cadence is unusual enough to look at, without
+ * firing on the ordinary weekend lull.
+ */
+const SILENCE_MULTIPLE = 3;
+const MIN_SILENCE_HOURS = 24;
+
+export interface HeartbeatFinding {
+  actor: string;
+  activeDays: number;
+  hoursSilent: number;
+  expectedGapHours: number;
+  revenueCents: number;
+}
+
+/**
+ * Established payers who have now been quiet for longer than their own rhythm.
+ * Exported for tests and for the check-in to reuse — no business number is
+ * computed twice in this codebase.
+ */
+export async function findSilentPayers(): Promise<HeartbeatFinding[]> {
+  const rows = (await getDb().execute(sql`
+    WITH paid AS (
+      SELECT
+        COALESCE(t.user_id::text, 'x402:' || t.x402_payer_hash) AS actor,
+        t.created_at,
+        t.price_cents
+      FROM transactions t
+      WHERE t.status = 'completed' AND t.price_cents > 0
+        AND t.created_at > now() - (${String(TRAILING_DAYS)} || ' days')::interval
+        AND COALESCE(t.user_id::text, t.x402_payer_hash) IS NOT NULL
+        AND ${externalCustomers("t")}
+    )
+    SELECT actor,
+           COUNT(DISTINCT date_trunc('day', created_at))::int AS active_days,
+           SUM(price_cents)::int                              AS revenue_cents,
+           ROUND(EXTRACT(EPOCH FROM (now() - MAX(created_at))) / 3600.0, 1) AS hours_silent,
+           -- Their own rhythm: the trailing window divided by the days they
+           -- actually used us. A five-day-a-week caller expects ~a day.
+           ROUND((${String(TRAILING_DAYS)} * 24.0)
+                 / GREATEST(COUNT(DISTINCT date_trunc('day', created_at)), 1), 1) AS expected_gap_hours
+    FROM paid
+    GROUP BY actor
+    HAVING COUNT(DISTINCT date_trunc('day', created_at)) >= ${MIN_ACTIVE_DAYS}
+  `)) as unknown as Array<{
+    actor: string; active_days: number; revenue_cents: number;
+    hours_silent: number; expected_gap_hours: number;
+  }>;
+
+  return rows
+    .filter((r) => {
+      const threshold = Math.max(
+        MIN_SILENCE_HOURS,
+        Number(r.expected_gap_hours) * SILENCE_MULTIPLE,
+      );
+      return Number(r.hours_silent) >= threshold;
+    })
+    .map((r) => ({
+      actor: r.actor,
+      activeDays: Number(r.active_days),
+      hoursSilent: Number(r.hours_silent),
+      expectedGapHours: Number(r.expected_gap_hours),
+      revenueCents: Number(r.revenue_cents),
+    }));
+}
+
+async function tick(): Promise<void> {
+  try {
+    const silent = await findSilentPayers();
+    if (silent.length === 0) {
+      log.info({ label: "revenue-heartbeat-ok" }, "revenue-heartbeat-ok");
+      return;
+    }
+    for (const f of silent) {
+      // The alert key is the actor, so each customer alerts independently and
+      // a cooldown on one never masks another going quiet.
+      await alertOnce(`revenue-heartbeat:${f.actor}`, ALERT_COOLDOWN_MS, {
+        severity: "critical",
+        subject: `A paying customer has gone quiet (${f.hoursSilent}h)`,
+        body:
+          `A customer who paid on ${f.activeDays} of the last ${TRAILING_DAYS} days ` +
+          `has made no paid call for ${f.hoursSilent} hours. Their normal gap is about ` +
+          `${f.expectedGapHours} hours. They are worth €${(f.revenueCents / 100).toFixed(2)} ` +
+          `over that period.\n\n` +
+          `This fires for either cause and does not distinguish them: they may have ` +
+          `stopped, or we may be broken. Check x402 settlement health and the ` +
+          `circuit breakers first — a 21-hour settlement outage on 2026-08-14 stopped ` +
+          `this exact revenue and went unnoticed at the time.\n\n` +
+          `Do not contact the customer on the strength of this alert; see the ` +
+          `customer-data boundary in docs/company/CHARTER.md.`,
+      });
+    }
+  } catch (err) {
+    // A monitoring job must never take the process down, but a silent monitor
+    // is worse than none — so the swallow is always logged (DEC-20260504-A).
+    logWarn("revenue-heartbeat-failed", "heartbeat check failed", { err: String(err) });
+  }
+}
+
+export function startRevenueHeartbeat(): void {
+  log.info({ label: "revenue-heartbeat-start" }, "revenue-heartbeat-start");
+  void tick();
+  setInterval(() => void tick(), CHECK_INTERVAL_MS).unref();
+}


### PR DESCRIPTION
99% revenue concentration + a prior 21h outage that stopped it unnoticed. Relative-to-rhythm silence alert (3x own gap, 24h floor, 5+ active days to qualify), per-customer cooldown. 7 tests including the 177-hour legitimate-gap case that rules out a fixed window.