### PR TITLE
fix(catalog): land the promotion job's review fixes — #269 merged the draft

### DIFF
--- a/apps/api/scripts/preview-promotions.ts
+++ b/apps/api/scripts/preview-promotions.ts
@@ -1,15 +1,11 @@
 /**
  * Read-only preview of what the capability-promotion tick would decide.
  *
- * Runs the job's exact evidence query and the exact pure core, and writes
- * nothing — no flag flips, no health_monitor_events. Use it to see the next
- * tick's decisions before they happen, or to check a promotion after the fact
- * against the evidence that produced it.
- *
- * The query is duplicated from jobs/capability-promotion.ts on purpose: this
- * script must be provably incapable of writing, which a shared code path that
- * also does the applying could not promise. The decision logic — the part
- * where being wrong matters — is imported, not copied.
+ * Runs the job's exact evidence query (imported, not copied — a preview that
+ * can drift from the job is worse than none) and the job's exact pure core,
+ * and writes nothing: no flag flips, no health_monitor_events. Use it to see
+ * the next tick's decisions before they happen, or to check a promotion after
+ * the fact against the evidence that produced it.
  *
  * Run: cd apps/api && npx tsx scripts/preview-promotions.ts
  */
@@ -21,7 +17,12 @@ import {
   evaluatePromotion,
   DEFAULT_PROMOTION_CONFIG,
 } from "../src/lib/capability-promotion.js";
-import { toPromotionStats, type PromotionEvidenceRow } from "../src/jobs/capability-promotion.js";
+import {
+  toPromotionStats,
+  PROMOTION_EVIDENCE_SQL,
+  isEnforceMode,
+  type PromotionEvidenceRow,
+} from "../src/jobs/capability-promotion.js";
 
 const connStr = process.env.DATABASE_URL;
 if (!connStr) {
@@ -30,37 +31,12 @@ if (!connStr) {
 }
 const sql = postgres(connStr, { max: 1 });
 
-const rows = await sql<PromotionEvidenceRow[]>`
-  SELECT c.slug,
-         c.lifecycle_state,
-         c.visible,
-         c.x402_enabled,
-         COALESCE(c.is_free_tier, false)         AS is_free_tier,
-         c.maintenance_class,
-         COALESCE(c.marketplace_eligible, false) AS marketplace_eligible,
-         c.deactivation_reason,
-         (c.x402_method IS NOT NULL)             AS has_x402_method,
-         h.state                                 AS breaker_state,
-         COUNT(tr.id)::int                                          AS total_tests,
-         COUNT(tr.id) FILTER (WHERE tr.passed)::int                 AS passed_tests,
-         COUNT(DISTINCT date_trunc('day', tr.executed_at))::int     AS distinct_test_days,
-         COUNT(tr.id) FILTER (WHERE ts.test_type = 'known_answer')::int               AS ka_total,
-         COUNT(tr.id) FILTER (WHERE ts.test_type = 'known_answer' AND tr.passed)::int AS ka_passed
-  FROM capabilities c
-  LEFT JOIN capability_health h ON h.capability_slug = c.slug
-  LEFT JOIN test_results tr
-         ON tr.capability_slug = c.slug
-        AND tr.executed_at > NOW() - INTERVAL '7 days'
-  LEFT JOIN test_suites ts ON ts.id = tr.test_suite_id
-  WHERE c.is_active = true
-    AND c.visible = false
-  GROUP BY c.slug, c.lifecycle_state, c.visible, c.x402_enabled, c.is_free_tier,
-           c.maintenance_class, c.marketplace_eligible, c.deactivation_reason,
-           c.x402_method, h.state`;
-
-const decisions = evaluatePromotion(toPromotionStats(rows), DEFAULT_PROMOTION_CONFIG);
+const rows = await sql.unsafe<PromotionEvidenceRow[]>(PROMOTION_EVIDENCE_SQL);
+const stats = toPromotionStats(rows);
+const decisions = evaluatePromotion(stats, DEFAULT_PROMOTION_CONFIG);
 
 console.log(`Delisted-but-active capabilities evaluated: ${rows.length}`);
+console.log(`Job would run in: ${isEnforceMode() ? "ENFORCE" : "dry-run"} mode`);
 console.log(`Config: ${JSON.stringify(DEFAULT_PROMOTION_CONFIG)}\n`);
 
 for (const action of ["promote", "flag", "none"] as const) {
@@ -70,35 +46,37 @@ for (const action of ["promote", "flag", "none"] as const) {
   for (const d of group) console.log(`  ${d.slug}\n    ${d.reason}`);
   console.log();
 }
-if (decisions.length === 0) console.log("No decisions: nothing clears the bar this window.");
+if (decisions.length === 0) console.log("No decisions: nothing clears the bar this window.\n");
 
-// The core's hard filters produce no decision at all, by design — a
-// capability that fails one of them is not a near-miss worth an event every
-// day. But "absent from the output" is the shape a bug hides in, so the
-// preview always shows the full evidence table and names the first unmet
-// gate for anything the core never reached a decision on.
-const decided = new Set(decisions.map((d) => d.slug));
+// The core's hard filters produce no decision at all, by design — a capability
+// that fails one of them is not a near-miss worth an event every day. But
+// "absent from the output" is the shape a bug hides in, so the preview always
+// shows the full evidence table and names the first unmet gate for anything
+// the core never reached a decision on.
+const byslug = new Map(decisions.map((d) => [d.slug, d]));
 const cfg = DEFAULT_PROMOTION_CONFIG;
 console.log("--- EVIDENCE (all evaluated) ---");
-console.log("slug".padEnd(32), "state".padEnd(11), "pass".padEnd(9), "days", "ka".padStart(8), "  blocked by");
-for (const r of [...rows].sort((a, b) => a.slug.localeCompare(b.slug))) {
-  const rate = r.total_tests > 0 ? r.passed_tests / r.total_tests : 0;
+console.log("slug".padEnd(32), "state".padEnd(11), "pass".padEnd(14), "days", "ka".padStart(8), "24h".padStart(7), "  outcome");
+for (const s of [...stats].sort((a, b) => a.slug.localeCompare(b.slug))) {
+  const rate = s.totalTests > 0 ? s.passedTests / s.totalTests : 0;
+  const d = byslug.get(s.slug);
   const blocked =
-    !cfg.promotableLifecycles.includes(r.lifecycle_state) ? `lifecycle_state=${r.lifecycle_state}`
-    : r.deactivation_reason !== null ? `deactivation_reason set`
-    : !r.marketplace_eligible ? "marketplace_eligible=false"
-    : !(r.breaker_state === null || r.breaker_state === "closed") ? `breaker=${r.breaker_state}`
-    : r.total_tests < cfg.minTests ? `only ${r.total_tests} results (need ${cfg.minTests})`
-    : r.distinct_test_days < cfg.minDistinctTestDays ? `only ${r.distinct_test_days} test days (need ${cfg.minDistinctTestDays})`
+    !cfg.promotableLifecycles.includes(s.lifecycleState) ? `lifecycle_state=${s.lifecycleState}`
+    : s.deactivationReason !== null ? "deactivation_reason set"
+    : !s.marketplaceEligible ? "marketplace_eligible=false"
+    : !(s.breakerState === null || s.breakerState === "closed") ? `breaker=${s.breakerState}`
+    : s.totalTests < cfg.minTests ? `only ${s.totalTests} results (need ${cfg.minTests})`
+    : s.distinctTestDays < cfg.minDistinctTestDays ? `only ${s.distinctTestDays} test days (need ${cfg.minDistinctTestDays})`
     : rate < cfg.minPassRate ? `pass rate below ${cfg.minPassRate}`
-    : decided.has(r.slug) ? "" : "(see decision above)";
+    : "(no decision — unexpected, investigate)";
   console.log(
-    r.slug.padEnd(32),
-    r.lifecycle_state.padEnd(11),
-    `${(rate * 100).toFixed(0)}% (${r.passed_tests}/${r.total_tests})`.padEnd(9),
-    String(r.distinct_test_days).padEnd(4),
-    `${r.ka_passed}/${r.ka_total}`.padStart(8),
-    "  " + (decided.has(r.slug) ? `→ ${decisions.find((d) => d.slug === r.slug)!.action}` : blocked),
+    s.slug.padEnd(32),
+    s.lifecycleState.padEnd(11),
+    `${(rate * 100).toFixed(0)}% (${s.passedTests}/${s.totalTests})`.padEnd(14),
+    String(s.distinctTestDays).padEnd(4),
+    `${s.knownAnswerPassed}/${s.knownAnswerTotal}`.padStart(8),
+    `${s.recentPassed}/${s.recentTotal}`.padStart(7),
+    "  " + (d ? `→ ${d.action}` : blocked),
   );
 }
 

--- a/apps/api/src/jobs/capability-promotion.ts
+++ b/apps/api/src/jobs/capability-promotion.ts
@@ -2,41 +2,50 @@
  * Capability-promotion job — publishes capabilities that have earned it.
  *
  * Thin DB glue around the pure core in lib/capability-promotion.ts, which
- * carries the rationale. Mirrors jobs/quality-floor.ts deliberately: same
- * advisory-lock shape, same transactional "flag flip and its audit event
- * commit together" rule (floor review M-2 — a catalog change without its
- * evidence must be impossible), same heartbeat so a zero-decision tick is
- * still provable per DEC-20260504-C.
+ * carries the rationale and the cross-provider review findings. Mirrors
+ * jobs/quality-floor.ts deliberately: same advisory-lock shape, same
+ * transactional "flag flip and its audit event commit together" rule (floor
+ * review M-2 — a catalog change without its evidence must be impossible), same
+ * heartbeat so a zero-decision tick is still provable per DEC-20260504-C.
  *
  * Per tick:
- *   1. Aggregate the trailing 7 days of scheduled + piggyback test results per
- *      delisted-but-active capability, with the known_answer subset broken out
- *      and the circuit-breaker state joined in.
+ *   1. Aggregate the trailing 7 days of test results per delisted-but-active
+ *      capability, with the known_answer subset, the piggyback subset, the
+ *      trailing-24h subset and the last listing-state event broken out, plus
+ *      the circuit-breaker state.
  *   2. evaluatePromotion() → at most maxPromotionsPerRun promotions/tick.
- *   3. Apply: lifecycle_state='active', visible=true, and x402_enabled=true
- *      where the capability has a method and is not free-tier — inside a
- *      transaction with its `capability_promotion` event.
+ *   3. Apply: lifecycle_state='active', visible=true, x402_enabled set to the
+ *      decision's value — inside a transaction with its event.
  *   4. Always emit per-decision events plus a tick_complete heartbeat.
  *
- * ENFORCEMENT: enforcing by default, braked by CAPABILITY_PROMOTION_DRY_RUN.
- * This is the opposite default to the quality floor and the asymmetry is
- * intentional — see the pure core's "Direction of risk" section. Briefly:
- * delisting is not self-reversing, promotion is, and the floor's own daily
- * tick catches anything promoted in error. Three months of green capabilities
- * sitting dark is the cost of the cautious default, and it has already been
- * paid once.
+ * ENFORCEMENT GATE: dry-run by default, armed by CAPABILITY_PROMOTION_ENFORCE
+ * =true. The first draft enforced by default on the argument that promotion is
+ * self-correcting because the floor re-quarantines mistakes. Cross-provider
+ * review pointed out that the floor needs ≥10 external calls over 30 days
+ * before it can act at all, so a wrongly promoted low-traffic capability may
+ * never trip it — which is precisely the population most at risk of being
+ * promoted in error. The self-correcting claim does not hold where it is
+ * needed, so this is a normal autonomous public-surface write path and it gets
+ * the normal brake: dry-run until a human has read a tick's worth of
+ * `dry_run_would_promote` events.
  *
- * Bulk-operation note (DEC-20260504-B): the first tick after deploy is a
- * workload-resumption event — a backlog that accumulated since May 2026, not a
- * steady-state run. maxPromotionsPerRun is the self-throttle that makes it one:
- * the backlog drains at 3/day, each batch visible in health_monitor_events
- * before the next runs. Measured backlog at authoring time: 8 capabilities
- * clearing the pass-rate bar, of which the strongest 3 go first.
+ * RACE HANDLING (review finding 5): the evidence query and the write are not
+ * atomic — a floor quarantine, an operator unpublish, or a breaker trip can
+ * land in between. The UPDATE therefore re-asserts every eligibility
+ * precondition in its WHERE clause and the transaction is rolled back unless
+ * exactly one row changed. A promotion recorded against a stale snapshot would
+ * silently overwrite a newer safety decision.
+ *
+ * Bulk-operation note (DEC-20260504-B): the first enforcing tick is a
+ * workload-resumption event — a backlog accumulated since May 2026, not a
+ * steady-state run. maxPromotionsPerRun is the self-throttle that makes it
+ * one: the backlog drains at 3/day, each batch visible in
+ * health_monitor_events before the next runs.
  */
 import postgres from "postgres";
 import { getDb } from "../db/index.js";
 import { capabilities, healthMonitorEvents } from "../db/schema.js";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, sql as dsql } from "drizzle-orm";
 import {
   evaluatePromotion,
   DEFAULT_PROMOTION_CONFIG,
@@ -60,11 +69,17 @@ export interface PromotionEvidenceRow {
   deactivation_reason: string | null;
   has_x402_method: boolean;
   breaker_state: string | null;
+  last_listing_event: string | null;
   total_tests: number;
   passed_tests: number;
   distinct_test_days: number;
   ka_total: number;
   ka_passed: number;
+  latest_ka_passed: boolean | null;
+  recent_total: number;
+  recent_passed: number;
+  piggyback_total: number;
+  piggyback_passed: number;
 }
 
 /**
@@ -72,36 +87,119 @@ export interface PromotionEvidenceRow {
  * column-to-field correspondence is the part that silently rots when the
  * query is edited, and a swapped `ka_passed`/`passed_tests` would read as a
  * capability that is green on correctness when it is not.
+ *
+ * `last_listing_event` collapses to the two things the core needs: was this a
+ * takedown, and what was it. A capability that has never been listed has no
+ * such event and is a dark launch, not a reinstatement.
  */
 export function toPromotionStats(rows: PromotionEvidenceRow[]): PromotionStats[] {
-  return rows.map((r) => ({
-    slug: r.slug,
-    lifecycleState: r.lifecycle_state,
-    visible: r.visible,
-    x402Enabled: r.x402_enabled,
-    isFreeTier: r.is_free_tier,
-    maintenanceClass: r.maintenance_class,
-    marketplaceEligible: r.marketplace_eligible,
-    deactivationReason: r.deactivation_reason,
-    hasX402Method: r.has_x402_method,
-    breakerState: r.breaker_state,
-    totalTests: r.total_tests,
-    passedTests: r.passed_tests,
-    distinctTestDays: r.distinct_test_days,
-    knownAnswerTotal: r.ka_total,
-    knownAnswerPassed: r.ka_passed,
-  }));
+  return rows.map((r) => {
+    const wasDelisted = r.last_listing_event !== null && !r.last_listing_event.startsWith("promoted");
+    return {
+      slug: r.slug,
+      lifecycleState: r.lifecycle_state,
+      visible: r.visible,
+      x402Enabled: r.x402_enabled,
+      isFreeTier: r.is_free_tier,
+      maintenanceClass: r.maintenance_class,
+      marketplaceEligible: r.marketplace_eligible,
+      deactivationReason: r.deactivation_reason,
+      hasX402Method: r.has_x402_method,
+      breakerState: r.breaker_state,
+      wasDelisted,
+      delistingReason: wasDelisted ? r.last_listing_event : null,
+      totalTests: r.total_tests,
+      passedTests: r.passed_tests,
+      distinctTestDays: r.distinct_test_days,
+      knownAnswerTotal: r.ka_total,
+      knownAnswerPassed: r.ka_passed,
+      latestKnownAnswerPassed: r.latest_ka_passed,
+      recentTotal: r.recent_total,
+      recentPassed: r.recent_passed,
+      piggybackTotal: r.piggyback_total,
+      piggybackPassed: r.piggyback_passed,
+    };
+  });
 }
 
-export function isDryRun(): boolean {
-  return process.env.CAPABILITY_PROMOTION_DRY_RUN === "true";
+export function isEnforceMode(): boolean {
+  return process.env.CAPABILITY_PROMOTION_ENFORCE === "true";
 }
+
+/**
+ * The evidence query, shared with scripts/preview-promotions.ts so the preview
+ * cannot drift from what the job will actually decide.
+ *
+ * Two joins are worth naming. `capability_health` is safe to join directly:
+ * `capability_health_capability_slug_unique` guarantees one row per slug, so
+ * it cannot fan the aggregate out or split a capability across grouped rows
+ * (verified against prod 2026-08-16 — max 1 row/slug over 298 rows).
+ * `test_suites` joins on the result's own suite id, one-to-one by primary key.
+ */
+export const PROMOTION_EVIDENCE_SQL = `
+  SELECT c.slug,
+         c.lifecycle_state,
+         c.visible,
+         c.x402_enabled,
+         COALESCE(c.is_free_tier, false)         AS is_free_tier,
+         c.maintenance_class,
+         COALESCE(c.marketplace_eligible, false) AS marketplace_eligible,
+         c.deactivation_reason,
+         (c.x402_method IS NOT NULL)             AS has_x402_method,
+         h.state                                 AS breaker_state,
+         le.action_taken                         AS last_listing_event,
+         COUNT(tr.id)::int                                          AS total_tests,
+         COUNT(tr.id) FILTER (WHERE tr.passed)::int                 AS passed_tests,
+         COUNT(DISTINCT date_trunc('day', tr.executed_at))::int     AS distinct_test_days,
+         COUNT(tr.id) FILTER (WHERE ts.test_type = 'known_answer')::int               AS ka_total,
+         COUNT(tr.id) FILTER (WHERE ts.test_type = 'known_answer' AND tr.passed)::int AS ka_passed,
+         lk.passed                                                                    AS latest_ka_passed,
+         COUNT(tr.id) FILTER (WHERE tr.executed_at > NOW() - INTERVAL '24 hours')::int                AS recent_total,
+         COUNT(tr.id) FILTER (WHERE tr.executed_at > NOW() - INTERVAL '24 hours' AND tr.passed)::int  AS recent_passed,
+         COUNT(tr.id) FILTER (WHERE ts.test_type = 'piggyback')::int                  AS piggyback_total,
+         COUNT(tr.id) FILTER (WHERE ts.test_type = 'piggyback' AND tr.passed)::int    AS piggyback_passed
+  FROM capabilities c
+  LEFT JOIN capability_health h ON h.capability_slug = c.slug
+  LEFT JOIN test_results tr
+         ON tr.capability_slug = c.slug
+        AND tr.executed_at > NOW() - INTERVAL '7 days'
+  LEFT JOIN test_suites ts ON ts.id = tr.test_suite_id
+  -- The most recent event that changed whether this capability was listed.
+  -- Distinguishes "never listed" (dark launch) from "taken down".
+  LEFT JOIN LATERAL (
+    SELECT e.action_taken
+    FROM health_monitor_events e
+    WHERE e.capability_slug = c.slug
+      AND (   (e.event_type = 'quality_floor'        AND e.action_taken = 'quarantined')
+           OR (e.event_type = 'capability_promotion' AND e.action_taken LIKE 'promoted%')
+           OR (e.event_type = 'lifecycle_transition' AND (e.action_taken LIKE 'Unpublished%'
+                                                       OR e.action_taken LIKE 'Suspended%'
+                                                       OR e.action_taken LIKE 'Published%')))
+    ORDER BY e.created_at DESC
+    LIMIT 1
+  ) le ON true
+  -- Did the single most recent known_answer result pass? An average survives a
+  -- fresh break; this does not.
+  LEFT JOIN LATERAL (
+    SELECT tr2.passed
+    FROM test_results tr2
+    JOIN test_suites ts2 ON ts2.id = tr2.test_suite_id
+    WHERE tr2.capability_slug = c.slug AND ts2.test_type = 'known_answer'
+    ORDER BY tr2.executed_at DESC
+    LIMIT 1
+  ) lk ON true
+  WHERE c.is_active = true
+    AND c.visible = false
+  GROUP BY c.slug, c.lifecycle_state, c.visible, c.x402_enabled, c.is_free_tier,
+           c.maintenance_class, c.marketplace_eligible, c.deactivation_reason,
+           c.x402_method, h.state, le.action_taken, lk.passed`;
 
 export async function runCapabilityPromotionOnce(): Promise<{
   outcome: string;
   mode?: "enforce" | "dry_run";
   promoted?: string[];
   flagged?: string[];
+  raced?: string[];
 }> {
   const connStr = process.env.DATABASE_URL;
   if (!connStr) return { outcome: "skipped-no-db" };
@@ -114,42 +212,17 @@ export async function runCapabilityPromotionOnce(): Promise<{
       SELECT pg_try_advisory_lock(${ADVISORY_LOCK_ID}) AS acquired`;
     if (!acquired) return { outcome: "skipped-lock-busy" };
 
-    const mode = isDryRun() ? "dry_run" : "enforce";
+    const mode = isEnforceMode() ? "enforce" : "dry_run";
     try {
       // LEFT JOIN on test_results: a capability with zero results must still
       // appear, as a zero-evidence row the core rejects — an INNER JOIN would
       // make "never tested" indistinguishable from "not a candidate".
-      const rows = await sql<PromotionEvidenceRow[]>`
-        SELECT c.slug,
-               c.lifecycle_state,
-               c.visible,
-               c.x402_enabled,
-               COALESCE(c.is_free_tier, false)        AS is_free_tier,
-               c.maintenance_class,
-               COALESCE(c.marketplace_eligible, false) AS marketplace_eligible,
-               c.deactivation_reason,
-               (c.x402_method IS NOT NULL)             AS has_x402_method,
-               h.state                                 AS breaker_state,
-               COUNT(tr.id)::int                                            AS total_tests,
-               COUNT(tr.id) FILTER (WHERE tr.passed)::int                   AS passed_tests,
-               COUNT(DISTINCT date_trunc('day', tr.executed_at))::int       AS distinct_test_days,
-               COUNT(tr.id) FILTER (WHERE ts.test_type = 'known_answer')::int                 AS ka_total,
-               COUNT(tr.id) FILTER (WHERE ts.test_type = 'known_answer' AND tr.passed)::int   AS ka_passed
-        FROM capabilities c
-        LEFT JOIN capability_health h ON h.capability_slug = c.slug
-        LEFT JOIN test_results tr
-               ON tr.capability_slug = c.slug
-              AND tr.executed_at > NOW() - INTERVAL '7 days'
-        LEFT JOIN test_suites ts ON ts.id = tr.test_suite_id
-        WHERE c.is_active = true
-          AND c.visible = false
-        GROUP BY c.slug, c.lifecycle_state, c.visible, c.x402_enabled, c.is_free_tier,
-                 c.maintenance_class, c.marketplace_eligible, c.deactivation_reason,
-                 c.x402_method, h.state`;
+      const rows = await sql.unsafe<PromotionEvidenceRow[]>(PROMOTION_EVIDENCE_SQL);
 
       const decisions = evaluatePromotion(toPromotionStats(rows), DEFAULT_PROMOTION_CONFIG);
       const promoted: string[] = [];
       const flagged: string[] = [];
+      const raced: string[] = [];
       const db = getDb();
 
       for (const d of decisions) {
@@ -163,7 +236,44 @@ export async function runCapabilityPromotionOnce(): Promise<{
         };
 
         if (d.action === "promote" && mode === "enforce") {
+          // Conditional write (review finding 5). Every precondition the
+          // decision rested on is re-asserted here, so a quarantine or
+          // unpublish that landed after the evidence query wins the race
+          // rather than being silently overwritten. Anything other than
+          // exactly one affected row rolls the event back with it.
+          let applied = false;
           await db.transaction(async (tx) => {
+            const res = await tx
+              .update(capabilities)
+              .set({
+                lifecycleState: "active",
+                visible: true,
+                // Always written, never conditionally omitted: `false` has to
+                // clear a stale `true` on a capability that cannot serve the
+                // paid rail, or promotion leaves an unusable route open.
+                x402Enabled: d.enableX402,
+                updatedAt: new Date(),
+              })
+              .where(
+                and(
+                  eq(capabilities.slug, d.slug),
+                  eq(capabilities.isActive, true),
+                  eq(capabilities.visible, false),
+                  isNull(capabilities.deactivationReason),
+                  dsql`NOT EXISTS (
+                    SELECT 1 FROM capability_health h
+                    WHERE h.capability_slug = ${d.slug} AND h.state <> 'closed'
+                  )`,
+                ),
+              );
+            const affected = (res as unknown as { count?: number; rowCount?: number }).count
+              ?? (res as unknown as { rowCount?: number }).rowCount
+              ?? 0;
+            if (affected !== 1) {
+              // Roll the event back with the write: recording a promotion that
+              // did not happen is worse than recording nothing.
+              throw new PromotionRaced(d.slug, affected);
+            }
             await tx.insert(healthMonitorEvents).values({
               eventType: "capability_promotion",
               capabilitySlug: d.slug,
@@ -171,17 +281,22 @@ export async function runCapabilityPromotionOnce(): Promise<{
               actionTaken: d.enableX402 ? "promoted_with_x402" : "promoted",
               details,
             });
-            await tx
-              .update(capabilities)
-              .set({
-                lifecycleState: "active",
-                visible: true,
-                ...(d.enableX402 ? { x402Enabled: true } : {}),
-                updatedAt: new Date(),
-              })
-              .where(eq(capabilities.slug, d.slug));
+            applied = true;
+          }).catch(async (err) => {
+            if (!(err instanceof PromotionRaced)) throw err;
+            logWarn("capability-promotion-raced", "eligibility changed between evidence and write", {
+              slug: d.slug, affected_rows: err.affected,
+            });
+            await db.insert(healthMonitorEvents).values({
+              eventType: "capability_promotion",
+              capabilitySlug: d.slug,
+              tier: 1,
+              actionTaken: "raced_not_applied",
+              details: { ...details, affected_rows: err.affected },
+            });
+            raced.push(d.slug);
           });
-          promoted.push(d.slug);
+          if (applied) promoted.push(d.slug);
           continue;
         }
 
@@ -203,17 +318,13 @@ export async function runCapabilityPromotionOnce(): Promise<{
         capabilitySlug: null,
         tier: 1,
         actionTaken: "tick_complete",
-        details: { mode, evaluated: rows.length, decisions: decisions.length, promoted, flagged },
+        details: { mode, evaluated: rows.length, decisions: decisions.length, promoted, flagged, raced },
       });
 
       logWarn("capability-promotion-tick", "promotion evaluation complete", {
-        mode,
-        evaluated: rows.length,
-        decisions: decisions.length,
-        promoted,
-        flagged,
+        mode, evaluated: rows.length, decisions: decisions.length, promoted, flagged, raced,
       });
-      return { outcome: "ok", mode, promoted, flagged };
+      return { outcome: "ok", mode, promoted, flagged, raced };
     } finally {
       await sql`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`.catch((err) =>
         logError("capability-promotion-unlock-failed", err),
@@ -227,13 +338,21 @@ export async function runCapabilityPromotionOnce(): Promise<{
   }
 }
 
+/** Thrown to roll back a promotion whose preconditions changed mid-flight. */
+class PromotionRaced extends Error {
+  constructor(readonly slug: string, readonly affected: number) {
+    super(`promotion of '${slug}' affected ${affected} rows, expected 1`);
+    this.name = "PromotionRaced";
+  }
+}
+
 export function startCapabilityPromotion(): void {
   setTimeout(() => {
     void runCapabilityPromotionOnce();
     setInterval(() => void runCapabilityPromotionOnce(), INTERVAL_MS);
   }, STARTUP_DELAY_MS);
   logWarn("capability-promotion-scheduled", "daily capability-promotion tick scheduled", {
-    mode: isDryRun() ? "dry_run" : "enforce",
+    mode: isEnforceMode() ? "enforce" : "dry_run",
     startup_delay_ms: STARTUP_DELAY_MS,
     interval_ms: INTERVAL_MS,
     config: DEFAULT_PROMOTION_CONFIG,

--- a/apps/api/src/lib/capability-promotion.test.ts
+++ b/apps/api/src/lib/capability-promotion.test.ts
@@ -1,15 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, afterEach } from "vitest";
 import {
   evaluatePromotion,
   DEFAULT_PROMOTION_CONFIG,
   type PromotionStats,
 } from "./capability-promotion.js";
-import { toPromotionStats, type PromotionEvidenceRow } from "../jobs/capability-promotion.js";
+import {
+  toPromotionStats,
+  isEnforceMode,
+  PROMOTION_EVIDENCE_SQL,
+  type PromotionEvidenceRow,
+} from "../jobs/capability-promotion.js";
 
-// Promotion semantics pinned both directions (DEC-20260504-A). Every test here
-// is written to fail against the pre-fix state, which was "no promotion code
-// exists at all" — so the discriminating property is that each one asserts a
-// specific gate, not merely that a decision list is returned.
+// Promotion semantics pinned both directions (DEC-20260504-A). Each test
+// asserts one specific gate, so breaking that gate breaks that test — verified
+// by mutation, see the PR body.
 
 function cap(partial: Partial<PromotionStats>): PromotionStats {
   return {
@@ -23,16 +27,34 @@ function cap(partial: Partial<PromotionStats>): PromotionStats {
     deactivationReason: null,
     hasX402Method: true,
     breakerState: "closed",
+    wasDelisted: false,
+    delistingReason: null,
     totalTests: 100,
     passedTests: 100,
     distinctTestDays: 7,
     knownAnswerTotal: 20,
     knownAnswerPassed: 20,
+    latestKnownAnswerPassed: true,
+    recentTotal: 14,
+    recentPassed: 14,
+    piggybackTotal: 0,
+    piggybackPassed: 0,
     ...partial,
   };
 }
 
 const only = (rows: PromotionStats[]) => evaluatePromotion(rows)[0];
+
+function row(partial: Partial<PromotionEvidenceRow>): PromotionEvidenceRow {
+  return {
+    slug: "s", lifecycle_state: "validating", visible: false, x402_enabled: false,
+    is_free_tier: false, maintenance_class: "free-stable-api", marketplace_eligible: true,
+    deactivation_reason: null, has_x402_method: true, breaker_state: "closed",
+    last_listing_event: null, total_tests: 100, passed_tests: 100, distinct_test_days: 7,
+    ka_total: 20, ka_passed: 20, latest_ka_passed: true, recent_total: 14, recent_passed: 14,
+    piggyback_total: 0, piggyback_passed: 0, ...partial,
+  };
+}
 
 describe("evaluatePromotion — the happy path", () => {
   it("promotes a delisted capability with a green week and opens x402", () => {
@@ -62,32 +84,84 @@ describe("evaluatePromotion — evidence gates", () => {
   });
 
   it("holds when a whole week of results landed on too few calendar days", () => {
-    // 100 green results in a single day is a burst, not a week.
     expect(evaluatePromotion([cap({ distinctTestDays: 1 })])).toEqual([]);
   });
 
   it("refuses when liveness is green but correctness is failing", () => {
-    // The case an aggregate pass rate hides: schema/negative/dependency suites
-    // carry the average while every known_answer assertion fails.
     const d = only([cap({ totalTests: 100, passedTests: 96, knownAnswerTotal: 20, knownAnswerPassed: 4 })]);
     expect(d.action).toBe("none");
     expect(d.reason).toContain("failing correctness");
   });
 
   it("refuses when there is no known_answer evidence at all", () => {
-    const d = only([cap({ knownAnswerTotal: 0, knownAnswerPassed: 0 })]);
+    const d = only([cap({ knownAnswerTotal: 0, knownAnswerPassed: 0, latestKnownAnswerPassed: null })]);
     expect(d.action).toBe("none");
     expect(d.reason).toContain("correctness unproven");
   });
 });
 
-describe("evaluatePromotion — human intent is never overridden", () => {
+describe("evaluatePromotion — the week's average must not outvote today", () => {
+  it("refuses when the most recent known_answer result failed", () => {
+    // 95 passes then a fresh failure still averages 95%. Promotion is a claim
+    // about now.
+    const d = only([cap({ latestKnownAnswerPassed: false })]);
+    expect(d.action).toBe("none");
+    expect(d.reason).toContain("broken now");
+  });
+
+  it("refuses when the trailing 24h is degrading, however green the week", () => {
+    const d = only([cap({ recentTotal: 10, recentPassed: 5 })]);
+    expect(d.action).toBe("none");
+    expect(d.reason).toContain("currently degrading");
+  });
+
+  it("refuses when the last 24h carries too little evidence to judge", () => {
+    const d = only([cap({ recentTotal: 1, recentPassed: 1 })]);
+    expect(d.action).toBe("none");
+    expect(d.reason).toContain("last 24h");
+  });
+});
+
+describe("evaluatePromotion — real customers outrank our own harness", () => {
+  it("refuses when piggyback (real paid calls) is failing under a green harness", () => {
+    // ~98% of platform traffic is the harness. Averaging 2 real failures into
+    // 100 harness passes erases the only evidence that matters.
+    const d = only([cap({ totalTests: 102, passedTests: 100, piggybackTotal: 2, piggybackPassed: 0 })]);
+    expect(d.action).toBe("none");
+    expect(d.reason).toContain("the customers are the ones who count");
+  });
+
+  it("promotes when piggyback evidence exists and is green", () => {
+    expect(only([cap({ piggybackTotal: 4, piggybackPassed: 4 })]).action).toBe("promote");
+  });
+});
+
+describe("evaluatePromotion — human and floor decisions are never overturned", () => {
   it("never promotes a capability that carries a deactivation reason", () => {
     expect(evaluatePromotion([cap({ deactivationReason: "CourtListener token expired" })])).toEqual([]);
   });
 
   it("never promotes a marketplace-ineligible capability", () => {
     expect(evaluatePromotion([cap({ marketplaceEligible: false })])).toEqual([]);
+  });
+
+  it("flags rather than promotes something the quality floor took down", () => {
+    // The floor delists on real paid traffic and leaves lifecycle_state
+    // 'active' with no deactivation_reason — indistinguishable from a dark
+    // launch except for this signal. Without it the two jobs would fight
+    // nightly, and the harness would win an argument it cannot see.
+    const d = only([cap({ wasDelisted: true, delistingReason: "quarantined" })]);
+    expect(d.action).toBe("flag");
+    expect(d.reason).toContain("taken down, not merely never listed");
+  });
+
+  it("flags rather than promotes something an operator unpublished", () => {
+    expect(only([cap({ wasDelisted: true, delistingReason: "Unpublished: removed from catalog" })]).action).toBe("flag");
+  });
+
+  it("still promotes a capability whose last listing event was a promotion", () => {
+    // "promoted" is not a takedown — this is the re-run case, not a reinstatement.
+    expect(only([cap({ wasDelisted: false, delistingReason: null })]).action).toBe("promote");
   });
 
   it("flags rather than promotes a fragile maintenance class", () => {
@@ -108,7 +182,10 @@ describe("evaluatePromotion — safety interlocks", () => {
     }
   });
 
-  it("treats a missing breaker row as healthy", () => {
+  it("treats a missing breaker row as permitted", () => {
+    // 14 active capabilities have no capability_health row; rows are created
+    // lazily on first incident, so requiring one would exclude everything that
+    // has never failed. The pass-rate and recency gates carry the weight.
     expect(only([cap({ breakerState: null })]).action).toBe("promote");
   });
 
@@ -125,11 +202,39 @@ describe("evaluatePromotion — safety interlocks", () => {
     expect(decisions.find((d) => d.slug === "middle")?.reason).toContain("budget");
   });
 
-  it("publishes to the catalog but not to x402 when the rail is inapplicable", () => {
+  it("publishes to the catalog but closes x402 when the rail is inapplicable", () => {
+    // enableX402 false is written, not omitted — it has to clear a stale true.
     expect(only([cap({ isFreeTier: true })]).enableX402).toBe(false);
     expect(only([cap({ hasX402Method: false })]).enableX402).toBe(false);
-    // …and still publishes, because catalog visibility is the point.
     expect(only([cap({ hasX402Method: false })]).action).toBe("promote");
+  });
+});
+
+describe("the job's enforcement gate", () => {
+  const original = process.env.CAPABILITY_PROMOTION_ENFORCE;
+  afterEach(() => {
+    if (original === undefined) delete process.env.CAPABILITY_PROMOTION_ENFORCE;
+    else process.env.CAPABILITY_PROMOTION_ENFORCE = original;
+  });
+
+  it("is dry-run unless explicitly armed", () => {
+    delete process.env.CAPABILITY_PROMOTION_ENFORCE;
+    expect(isEnforceMode()).toBe(false);
+    process.env.CAPABILITY_PROMOTION_ENFORCE = "1";
+    expect(isEnforceMode()).toBe(false); // only the exact string arms it
+    process.env.CAPABILITY_PROMOTION_ENFORCE = "true";
+    expect(isEnforceMode()).toBe(true);
+  });
+});
+
+describe("the evidence query", () => {
+  it("only ever considers active, delisted capabilities", () => {
+    expect(PROMOTION_EVIDENCE_SQL).toContain("c.is_active = true");
+    expect(PROMOTION_EVIDENCE_SQL).toContain("c.visible = false");
+  });
+
+  it("scopes the aggregate to the promotion window rather than all history", () => {
+    expect(PROMOTION_EVIDENCE_SQL).toContain("tr.executed_at > NOW() - INTERVAL '7 days'");
   });
 });
 
@@ -137,24 +242,7 @@ describe("toPromotionStats", () => {
   it("maps every SQL column to the field the core reads", () => {
     // Guards the swap that would matter most: ka_passed read as passed_tests
     // would report correctness as green on the strength of liveness tests.
-    const row: PromotionEvidenceRow = {
-      slug: "s",
-      lifecycle_state: "validating",
-      visible: false,
-      x402_enabled: false,
-      is_free_tier: true,
-      maintenance_class: "free-stable-api",
-      marketplace_eligible: true,
-      deactivation_reason: null,
-      has_x402_method: true,
-      breaker_state: "closed",
-      total_tests: 90,
-      passed_tests: 89,
-      distinct_test_days: 6,
-      ka_total: 10,
-      ka_passed: 3,
-    };
-    expect(toPromotionStats([row])[0]).toEqual({
+    expect(toPromotionStats([row({ is_free_tier: true, total_tests: 90, passed_tests: 89, distinct_test_days: 6, ka_total: 10, ka_passed: 3, recent_total: 9, recent_passed: 8, piggyback_total: 2, piggyback_passed: 1 })])[0]).toEqual({
       slug: "s",
       lifecycleState: "validating",
       visible: false,
@@ -165,21 +253,29 @@ describe("toPromotionStats", () => {
       deactivationReason: null,
       hasX402Method: true,
       breakerState: "closed",
+      wasDelisted: false,
+      delistingReason: null,
       totalTests: 90,
       passedTests: 89,
       distinctTestDays: 6,
       knownAnswerTotal: 10,
       knownAnswerPassed: 3,
+      latestKnownAnswerPassed: true,
+      recentTotal: 9,
+      recentPassed: 8,
+      piggybackTotal: 2,
+      piggybackPassed: 1,
     });
   });
 
+  it("reads a takedown from the last listing event, and a promotion as not one", () => {
+    expect(toPromotionStats([row({ last_listing_event: "quarantined" })])[0].wasDelisted).toBe(true);
+    expect(toPromotionStats([row({ last_listing_event: "Unpublished: removed from catalog" })])[0].wasDelisted).toBe(true);
+    expect(toPromotionStats([row({ last_listing_event: "promoted_with_x402" })])[0].wasDelisted).toBe(false);
+    expect(toPromotionStats([row({ last_listing_event: null })])[0].wasDelisted).toBe(false);
+  });
+
   it("carries a correctness failure through the mapping into a refusal", () => {
-    const row: PromotionEvidenceRow = {
-      slug: "s", lifecycle_state: "validating", visible: false, x402_enabled: false,
-      is_free_tier: false, maintenance_class: "free-stable-api", marketplace_eligible: true,
-      deactivation_reason: null, has_x402_method: true, breaker_state: "closed",
-      total_tests: 100, passed_tests: 97, distinct_test_days: 7, ka_total: 10, ka_passed: 1,
-    };
-    expect(only(toPromotionStats([row])).action).toBe("none");
+    expect(only(toPromotionStats([row({ passed_tests: 97, ka_total: 10, ka_passed: 1 })])).action).toBe("none");
   });
 });

--- a/apps/api/src/lib/capability-promotion.ts
+++ b/apps/api/src/lib/capability-promotion.ts
@@ -2,23 +2,31 @@
  * Capability promotion — the missing counterpart to the quality floor.
  *
  * `lib/quality-floor.ts` takes capabilities OFF the catalog. Nothing put them
- * back on. Its header says so in as many words: "Promotion is NOT automatic in
+ * back. Its header says so in as many words: "Promotion is NOT automatic in
  * v1 — the platform-doctor flow ... restores the flags." The doctor flow is a
  * human, and the SQS engine that used to run `validating → active` was deleted
  * on 2026-05-05 (DEC-20260503-B). So since May there has been no code path,
  * automatic or scheduled, that makes a capability visible.
  *
- * Measured consequence, prod, 2026-08-16: eight capabilities with a 91–100%
- * pass rate over the trailing week were `is_active = true, visible = false,
- * x402_enabled = false` — absent from /v1/capabilities (290 listed, none of
- * them) and unbuyable on x402, which is the rail essentially all revenue
- * arrives on. Two of them (`url-to-text`, `screenshot-url`) are utility
- * primitives, the exact class GOALS.md records x402 buyers actually paying
- * for. The factory kept dark-launching under DEC-20260812-A; the "until first
- * green week" half of that sentence was never implemented.
+ * Measured, prod 2026-08-16: 17 capabilities are `is_active = true,
+ * visible = false` — absent from /v1/capabilities (290 listed) and unbuyable
+ * on x402, the rail essentially all revenue arrives on. Five of them are
+ * genuine dark launches from 2026-08-13/14 with a 91–100% harness record and
+ * no way to ever become visible. They are the population this job exists for.
  *
- * This module is the pure decision core. Given per-capability evidence from
- * the test harness, it decides who gets published.
+ * The other twelve are not, and finding that out is why the takedown
+ * interlock below exists. `brazilian-company-data`, `url-to-text` and
+ * `screenshot-url` all show a 100% harness pass rate over the full week — and
+ * all three were quarantined by the quality floor in ENFORCE mode on
+ * 2026-08-12/13 for 39–59% completion on real paid customer calls. A
+ * promotion job reading only the harness would have re-listed all three the
+ * night after the floor delisted them, forever, on evidence from an
+ * instrument that never sees a customer. That gap between "100% in our tests"
+ * and "39% for people paying" is the most important thing this module's
+ * authoring turned up, and it is a measurement problem, not a promotion one.
+ *
+ * This module is the pure decision core. Given per-capability evidence, it
+ * decides who gets published.
  *
  * ## Why the test harness is the instrument here
  *
@@ -26,40 +34,69 @@
  * unavailable by construction on this side: a delisted capability receives no
  * catalog traffic, so its real-traffic record is empty and stays empty. The
  * only evidence a dark capability can generate is the scheduled harness, which
- * is also precisely what DEC-20260812-A means by "first green week". Piggyback
- * suites (fed by real customer calls) are counted too and are strictly better
- * evidence when present.
+ * is also what DEC-20260812-A means by "first green week". Piggyback suites
+ * are fed by real customer calls and are strictly better evidence — so they
+ * get their own gate rather than being averaged in (see below).
  *
  * ## Why the bar is higher than the floor's
  *
  * The floor quarantines below 70%. Promotion does NOT use 70% — a capability
  * that only just clears the delisting bar has no business being advertised.
  * The bar is ≥95% over ≥`minTests` results spanning ≥`minDistinctTestDays`
- * calendar days, AND the `known_answer` suite must itself be green. That last
- * clause is the one that matters: schema, negative and dependency-health tests
- * can all pass while the capability returns confidently wrong answers, and an
+ * days, AND the `known_answer` suite must itself be green. That last clause is
+ * the one that matters: schema, negative and dependency-health tests can all
+ * pass while the capability returns confidently wrong answers, and an
  * aggregate pass rate hides that behind volume.
  *
- * ## Direction of risk (why this side enforces and the floor does not)
+ * ## What cross-provider review changed (2026-08-16, sol@high)
  *
- * The floor is dry-run by default because delisting is not self-reversing:
- * once delisted, a capability stops receiving the traffic that could prove it
- * healthy. Promotion has the opposite shape. It is reversible in one flag, and
- * it is *self-correcting* — anything promoted in error walks straight into the
- * floor's daily tick. The failure mode of being too cautious here is the one
- * already observed: green capabilities sitting dark for three months. So this
- * job enforces by default and takes `CAPABILITY_PROMOTION_DRY_RUN=true` as the
- * brake, rather than the other way round.
+ * The first draft of this module was reviewed by the other provider before
+ * merge. Five of its findings are answered by code here, and they are the
+ * reason several gates exist that a reading of DEC-20260812-A alone would not
+ * suggest:
+ *
+ * 1. **A floor quarantine must not be undone by harness evidence.** The floor
+ *    delists on real paid traffic and leaves `lifecycle_state='active'`,
+ *    `deactivation_reason` NULL — which is exactly the shape of a promotable
+ *    dark launch. Without an interlock this job would re-list a capability
+ *    every day that the floor delists every night, on evidence from a harness
+ *    that never sees the failing customer calls. `wasDelisted` distinguishes
+ *    "never listed" (a dark launch, promotable) from "taken down" (a floor
+ *    quarantine, a human unpublish, or a suspension — flagged, never
+ *    auto-promoted). The floor has really quarantined 6 times, so this is not
+ *    hypothetical.
+ * 2. **Harness volume must not outvote real customers.** ~98% of platform
+ *    traffic is our own harness. A capability with 100 green harness results
+ *    and 2 failing piggyback results — piggyback being real customer calls —
+ *    averages to 98% and would promote on a 0% real-world record. Piggyback
+ *    evidence is therefore gated separately, and never averaged in.
+ * 3. **A seven-day aggregate can promote something broken right now.** 95
+ *    passes followed by 5 fresh failures still averages to 95%. So the most
+ *    recent `known_answer` result must be a pass, and the trailing 24h must
+ *    clear the bar on its own.
+ * 4. **Enforcement default.** The reviewer's argument was that "the floor will
+ *    catch a bad promotion" is weaker than it sounds: the floor needs ≥10
+ *    external calls in 30 days before it can act, and a wrongly promoted
+ *    low-traffic capability may never reach that. That is correct and it
+ *    defeats the self-correcting claim for exactly the capabilities most
+ *    likely to be promoted in error. The job is dry-run by default.
+ * 5. **A NULL breaker row is not affirmative health.** True, but 14 of the
+ *    active capabilities have no `capability_health` row at all and 10 of the
+ *    17 current candidates are among them — rows are created lazily on first
+ *    incident, so requiring one would permanently exclude every capability
+ *    that has never failed. NULL stays permitted; the pass-rate, recency and
+ *    known_answer gates carry the weight. A non-closed breaker is still an
+ *    absolute no.
  *
  * ## Deliberate boundaries (v1)
  *
  * - Only `visible = false` capabilities are candidates. 35 capabilities are
  *   visible with `x402_enabled = false`; some of those are deliberate and
  *   deciding which needs a separate pass. They are not touched here.
- * - `deactivation_reason IS NOT NULL` is treated as a human "no", forever.
- *   A capability someone switched off on purpose is not re-litigated by a job.
- * - Fragile maintenance classes are never auto-promoted — they are flagged
- *   for a human, because a scraping target that passed all week is exactly the
+ * - `deactivation_reason IS NOT NULL` is a human "no", forever. A capability
+ *   someone switched off on purpose is not re-litigated by a job.
+ * - Fragile maintenance classes are never auto-promoted — they are flagged for
+ *   a human, because a scraping target that passed all week is exactly the
  *   thing that breaks the week after.
  */
 
@@ -76,6 +113,14 @@ export interface PromotionStats {
   hasX402Method: boolean;
   /** capability_health.state; null when the capability has no breaker row yet. */
   breakerState: string | null;
+  /**
+   * True when the most recent listing-state event was a takedown (floor
+   * quarantine, human unpublish, suspension) rather than a promotion. False
+   * for a capability that has simply never been listed.
+   */
+  wasDelisted: boolean;
+  /** What that takedown was, for the flag message. */
+  delistingReason: string | null;
   totalTests: number;
   passedTests: number;
   /** Distinct calendar days carrying at least one result — the "week" in "green week". */
@@ -83,6 +128,14 @@ export interface PromotionStats {
   /** known_answer results only: correctness, as distinct from liveness. */
   knownAnswerTotal: number;
   knownAnswerPassed: number;
+  /** Did the single most recent known_answer result pass? Null when there is none. */
+  latestKnownAnswerPassed: boolean | null;
+  /** Trailing 24h, all suites — the "is it working right now" gate. */
+  recentTotal: number;
+  recentPassed: number;
+  /** Piggyback suites only: real customer traffic, gated separately from harness volume. */
+  piggybackTotal: number;
+  piggybackPassed: number;
 }
 
 export interface PromotionConfig {
@@ -91,6 +144,8 @@ export interface PromotionConfig {
   minPassRate: number;
   minKnownAnswerTests: number;
   minKnownAnswerPassRate: number;
+  /** Minimum results in the trailing 24h before recency can be judged at all. */
+  minRecentTests: number;
   maxPromotionsPerRun: number;
   /** Lifecycle states a capability may be promoted out of. */
   promotableLifecycles: string[];
@@ -104,6 +159,7 @@ export const DEFAULT_PROMOTION_CONFIG: PromotionConfig = {
   minPassRate: 0.95,
   minKnownAnswerTests: 5,
   minKnownAnswerPassRate: 0.95,
+  minRecentTests: 3,
   // Self-throttle, same reasoning as the floor (DEC-20260504-B): a long-silent
   // bulk operation's first successful run is a workload-resumption event. Three
   // per tick means the backlog drains over days, each batch observable.
@@ -115,7 +171,11 @@ export const DEFAULT_PROMOTION_CONFIG: PromotionConfig = {
 export interface PromotionDecision {
   slug: string;
   action: "promote" | "flag" | "none";
-  /** Whether the promotion should also open the x402 rail. */
+  /**
+   * Whether the paid rail should be open after this promotion. Written
+   * unconditionally by the job — `false` clears a stale `true` rather than
+   * leaving an unusable paid route on a capability that cannot serve one.
+   */
   enableX402: boolean;
   passRate: number;
   totalTests: number;
@@ -154,55 +214,76 @@ export function evaluatePromotion(
   for (const r of candidates) {
     if (r.passRate < config.minPassRate) continue;
 
+    const hold = (reason: string) =>
+      decisions.push({
+        slug: r.slug, action: "none", enableX402: false,
+        passRate: r.passRate, totalTests: r.totalTests, reason,
+      });
+
     // Correctness gate. An aggregate pass rate is dominated by schema,
     // negative and dependency-health suites; a capability can be 97% green
     // overall while every known_answer assertion fails. Promotion advertises
     // correctness, so correctness is what has to be proven.
     if (r.knownAnswerTotal < config.minKnownAnswerTests) {
-      decisions.push({
-        slug: r.slug,
-        action: "none",
-        enableX402: false,
-        passRate: r.passRate,
-        totalTests: r.totalTests,
-        reason: `${pct(r.passRate)} over ${r.totalTests} results, but only ${r.knownAnswerTotal} known_answer result(s) (need ${config.minKnownAnswerTests}) — correctness unproven`,
-      });
+      hold(`${pct(r.passRate)} over ${r.totalTests} results, but only ${r.knownAnswerTotal} known_answer result(s) (need ${config.minKnownAnswerTests}) — correctness unproven`);
       continue;
     }
     const kaRate = r.knownAnswerPassed / r.knownAnswerTotal;
     if (kaRate < config.minKnownAnswerPassRate) {
+      hold(`${pct(r.passRate)} overall but known_answer is ${pct(kaRate)} (${r.knownAnswerPassed}/${r.knownAnswerTotal}) — passing liveness, failing correctness`);
+      continue;
+    }
+
+    // Recency (review finding 3). A week's aggregate survives a fresh break:
+    // 95 passes then 5 failures is still 95%. Promotion is a statement about
+    // now, so now is what gets checked.
+    if (r.latestKnownAnswerPassed === false) {
+      hold(`${pct(r.passRate)} over the week but the most recent known_answer result failed — broken now, whatever the average says`);
+      continue;
+    }
+    if (r.recentTotal < config.minRecentTests) {
+      hold(`${pct(r.passRate)} over the week but only ${r.recentTotal} result(s) in the last 24h (need ${config.minRecentTests}) — cannot tell whether it still works`);
+      continue;
+    }
+    const recentRate = r.recentPassed / r.recentTotal;
+    if (recentRate < config.minPassRate) {
+      hold(`${pct(r.passRate)} over the week but ${pct(recentRate)} (${r.recentPassed}/${r.recentTotal}) in the last 24h — currently degrading`);
+      continue;
+    }
+
+    // Real customers outrank our own harness (review finding 2). Piggyback
+    // rows come from actual paid calls; there are few of them, so averaging
+    // them into a thousand harness results erases them entirely.
+    if (r.piggybackTotal > 0) {
+      const pbRate = r.piggybackPassed / r.piggybackTotal;
+      if (pbRate < config.minPassRate) {
+        hold(`harness is ${pct(r.passRate)} but real customer calls are ${pct(pbRate)} (${r.piggybackPassed}/${r.piggybackTotal} piggyback) — the customers are the ones who count`);
+        continue;
+      }
+    }
+
+    // A takedown is a decision, and this job does not overturn decisions
+    // (review finding 1). Never having been listed is not a takedown.
+    if (r.wasDelisted) {
       decisions.push({
-        slug: r.slug,
-        action: "none",
-        enableX402: false,
-        passRate: r.passRate,
-        totalTests: r.totalTests,
-        reason: `${pct(r.passRate)} overall but known_answer is ${pct(kaRate)} (${r.knownAnswerPassed}/${r.knownAnswerTotal}) — passing liveness, failing correctness`,
+        slug: r.slug, action: "flag", enableX402: false,
+        passRate: r.passRate, totalTests: r.totalTests,
+        reason: `clears the bar (${pct(r.passRate)} over ${r.totalTests}) but was taken down, not merely never listed — "${r.delistingReason}". Re-listing after a takedown needs the evidence that the takedown was wrong, which the harness cannot supply; human call`,
       });
       continue;
     }
 
     if (r.maintenanceClass !== null && config.manualReviewClasses.includes(r.maintenanceClass)) {
       decisions.push({
-        slug: r.slug,
-        action: "flag",
-        enableX402: false,
-        passRate: r.passRate,
-        totalTests: r.totalTests,
+        slug: r.slug, action: "flag", enableX402: false,
+        passRate: r.passRate, totalTests: r.totalTests,
         reason: `clears the bar (${pct(r.passRate)} over ${r.totalTests}, known_answer ${pct(kaRate)}) but maintenance_class '${r.maintenanceClass}' is never auto-promoted — a fragile target passing all week is the one that breaks next week; human call`,
       });
       continue;
     }
 
     if (budget <= 0) {
-      decisions.push({
-        slug: r.slug,
-        action: "none",
-        enableX402: false,
-        passRate: r.passRate,
-        totalTests: r.totalTests,
-        reason: `clears the bar but the per-run promotion budget (${config.maxPromotionsPerRun}) is spent — next tick`,
-      });
+      hold(`clears the bar but the per-run promotion budget (${config.maxPromotionsPerRun}) is spent — next tick`);
       continue;
     }
 
@@ -218,7 +299,7 @@ export function evaluatePromotion(
       enableX402,
       passRate: r.passRate,
       totalTests: r.totalTests,
-      reason: `${pct(r.passRate)} over ${r.totalTests} results across ${r.distinctTestDays} days, known_answer ${pct(kaRate)} (${r.knownAnswerPassed}/${r.knownAnswerTotal}), breaker ${r.breakerState ?? "none"} — green week met${enableX402 ? "; x402 opened" : r.isFreeTier ? "; free tier, x402 not applicable" : "; no x402 method, catalog only"}`,
+      reason: `${pct(r.passRate)} over ${r.totalTests} results across ${r.distinctTestDays} days, known_answer ${pct(kaRate)} (${r.knownAnswerPassed}/${r.knownAnswerTotal}), last 24h ${pct(recentRate)}, breaker ${r.breakerState ?? "no row"} — green week met${enableX402 ? "; x402 opened" : r.isFreeTier ? "; free tier, x402 stays closed" : "; no x402 method, catalog only"}`,
     });
   }
 


### PR DESCRIPTION
**Urgent-ish.** [#269](https://github.com/strale-io/strale/pull/269) auto-merged at its **first commit** while the cross-provider review was still running. Main is therefore carrying the pre-review draft, which:

- **enforces by default**, and
- **has no interlock against the quality floor**.

Its first tick re-lists `brazilian-company-data` and `url-to-text` and opens x402 on both. The floor quarantined those two in **enforce** mode on 2026-08-12 for **59%** and **39%** completion on real paid customer calls. Their only green evidence is the internal harness (455/455 and 425/425 for the week), which never sees a customer. Left as-is, the two jobs fight nightly and the harness wins.

**Prod state at the time of writing** (read-only): zero `capability_promotion` events, and all three at-risk slugs still `visible=false`. The 20-minute startup timer has not fired on the current deploy (`b27c6ef`). This lands inside that window.

## Contents

Commit `814425d` from the #269 branch, replayed onto current main. Nothing new — this is the review outcome that should have been in the squash. The full finding-by-finding disposition is in the [#269 body](https://github.com/strale-io/strale/pull/269); in brief:

| review finding | fix |
|---|---|
| CRITICAL — promotion undoes a floor quarantine | `wasDelisted` separates never-listed from taken-down; takedowns are flagged, never auto-promoted |
| HIGH — harness volume outvotes real customers | piggyback gates separately instead of averaging into ~98%-internal traffic |
| HIGH — enforce-by-default is not self-correcting | dry-run by default; `CAPABILITY_PROMOTION_ENFORCE=true` arms it |
| HIGH — a 7d average promotes something broken now | latest `known_answer` must pass; trailing 24h must clear the bar |
| HIGH — no atomic re-check at write | conditional UPDATE, rolls back unless exactly one row changed |
| HIGH — `enableX402:false` left a stale `true` | `x402Enabled` always written |

## Verification

- `tsc --noEmit` clean; promotion suite 29/29. Identical file contents to `814425d`, which passed the full suite (128 files / 1581 tests) and every CI gate.
- Preview against prod with these gates: **three FLAGs, zero promotions** — versus two wrong promotions without them.
- Mutation-verified: removing the takedown interlock, averaging piggyback in, ignoring the latest `known_answer`, dropping the 24h gate, enforcing by default, or collapsing `wasDelisted` in the mapper each fail the suite.

## Post-deploy check

`SELECT action_taken, capability_slug FROM health_monitor_events WHERE event_type='capability_promotion' ORDER BY created_at DESC` — expect three `flagged_for_human` rows, a `tick_complete` in `dry_run` mode, and **no change to any catalog flag**.

## Process note

Worth fixing separately: a PR merging at its first commit while review is in flight is a repeatable failure mode, not bad luck. Raised in today's handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)