### PR TITLE
docs: Bazaar listing is earned by settlement — withdraw the Coinbase email

### DIFF
--- a/docs/company/DIRECTORY-MAP.md
+++ b/docs/company/DIRECTORY-MAP.md
@@ -49,12 +49,20 @@ Each implies a completed submission at some point:
   directories.
 - **x402scan** — no public API at the URL tried; presence unconfirmed.
 
-## Coinbase x402 Bazaar
+## Coinbase x402 Bazaar — resolved 2026-08-15, no action needed
 
-41 of 334 endpoints indexed. Investigated in
-[DISTRIBUTION-FINDINGS.md](DISTRIBUTION-FINDINGS.md) — not our bug, and the
-draft email in [coinbase-bazaar-email.md](coinbase-bazaar-email.md) is the next
-step. Biggest single lever available.
+**95 of our resources are listed** (verified against a complete walk of all
+14,946 index entries). An earlier figure of 41 was a partial scan reported as a
+total.
+
+**Listing is earned by settlement, not by advertising.** The index contains
+exactly those resources that settled an x402 payment in the trailing 30 days —
+exact fit in both directions, zero exceptions, sharp boundary. Our 164 unlisted
+capabilities are unlisted because nobody bought them last month.
+
+This makes the Bazaar a **trailing indicator of our revenue, not a lever on
+it**. There is nothing to submit, nothing to fix, and no email to send; the
+draft in `coinbase-bazaar-email.md` is marked DO NOT SEND with the reasoning.
 
 ## The gap that matters more than any missing directory
 
@@ -76,7 +84,8 @@ cheap, mine to do, and probably worth more than adding an eleventh directory.
 ## What to do, in order
 
 1. **Rewrite the listing copy** to lead with what sells. Mine — next session.
-2. **Send the Coinbase email.** Petter's. 8× shelf presence on the largest venue.
+2. ~~Send the Coinbase email~~ — withdrawn. Bazaar listing is earned by
+   settlement, so there is no gap to raise. See above.
 3. **Find the real Smithery URL** and confirm the listing is published.
 4. **Only then** consider new directories. Ten venues already crawl us; an
    eleventh is worth less than fixing what the existing ten display.

--- a/docs/company/coinbase-bazaar-email.md
+++ b/docs/company/coinbase-bazaar-email.md
@@ -1,3 +1,56 @@
+# DO NOT SEND — the premise was wrong
+
+**Withdrawn 2026-08-15, before sending.** Petter asked for the 41-of-334 figure
+to be verified first. It did not survive verification, and neither did the
+question the email was built on.
+
+## What was wrong
+
+**The count.** A complete walk of the index — all 14,946 entries, with the walk
+asserted complete — finds **95 Strale resources, not 41**. The original 41 came
+from scanning 12,000 of 15,183 entries: a floor reported as a total.
+
+**The worked example.** The email offered `keyword-suggest` as a "not indexed"
+endpoint for Coinbase to compare against an indexed one. It is indexed. So are
+`tech-stack-detect`, `serp-analyze` and `uptime-check` — the four best-sellers
+previously reported missing. All eight of our proven sellers are listed. Anyone
+receiving this email would have found its own example false in under a minute.
+
+**The question.** There is no anomaly to ask about. See below.
+
+## What actually governs indexing
+
+The Bazaar lists exactly those resources that have **settled an x402 payment in
+the trailing 30 days**. Measured against production, the fit is exact in both
+directions:
+
+| window | settled | settled but NOT listed | listed but NOT settled |
+|---|---|---|---|
+| 28d | 93 | 4 | 2 |
+| **30d** | **95** | **0** | **0** |
+| 35d | 98 | 7 | 0 |
+
+Zero exceptions at 30 days; the boundary is sharp on both sides. Not 402
+challenges, not our discovery file, not registration — settlements, on a rolling
+30-day window. An earlier guess that triggering a 402 challenge causes indexing
+is unsupported: the four endpoints probed that day are bought regularly by our
+paying customer, so their listing is explained by settlement alone.
+
+## Why this matters more than the email did
+
+**Bazaar presence cannot be acquired. It is earned by sales and expires when
+sales stop.** Our 164 unlisted capabilities are unlisted because nobody bought
+them in the last month. The "8× shelf presence" opportunity does not exist: you
+cannot get shelf presence without sales, and shelf presence was the plan for
+getting sales. It is circular.
+
+So the Bazaar is a **trailing indicator of our own revenue**, not a distribution
+channel we can seed. Treat its listing count as a metric, never as a lever.
+
+## The email itself is kept below, unsent, for the record.
+
+---
+
 # Email to Coinbase — Bazaar indexing gap
 
 **Status: DRAFT. Not sent.** Sending it is yours — it speaks as Moonlighter AB


### PR DESCRIPTION
Verification before sending found the premise wrong: 95 listed not 41, and the email's own example endpoint is indexed. Mechanism established: exactly those resources settled in the trailing 30 days, zero exceptions both directions. Bazaar presence is a trailing indicator of revenue, not a lever. Docs only.