### PR TITLE
fix(quality): stop counting correct refusals as capability defects

### DIFF
--- a/apps/api/src/lib/transaction-failure-taxonomy.test.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyTransactionFailure,
+  CALLER_ATTRIBUTABLE,
+  type TransactionFailureClass,
+} from "./transaction-failure-taxonomy.js";
+
+/**
+ * Every string in this file was taken verbatim from `transactions.error` in
+ * production — a census of all 188 distinct external failure strings over 90
+ * days, run 2026-08-16. Nothing here is invented, because the bug being fixed
+ * was precisely that the previous patterns encoded what the messages were
+ * imagined to say rather than what they say.
+ *
+ * The two directions are pinned separately and both matter (DEC-20260504-A):
+ * excusing a real defect blinds the quality floor, and counting a correct
+ * refusal delists a working capability. The second is what actually happened —
+ * `us-company-data` was quarantined at "64% completion on 11 calls" while 7
+ * succeeded, 1 was a genuine SEC 500, and the rest were caller input.
+ */
+
+const excused = (e: string) => CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(e));
+const classOf = (e: string): TransactionFailureClass => classifyTransactionFailure(e);
+
+describe("refusals are the capability working, not failing", () => {
+  it.each([
+    ['No Estonian company found matching "10667868".', "estonian-company-data"],
+    ['No German company found matching "example_company_name".', "german-company-data"],
+    ['No French company found matching "Pooost".', "french-company-data"],
+    ['No US company found matching "Braize" in SEC EDGAR.', "us-company-data"],
+    ['All data providers failed for swiss-company-data: zefix-public-rest: No Swiss company found for "CHE-105.805.977"', "swiss-company-data"],
+  ])("a name that matches nothing is not a defect: %s", (msg) => {
+    expect(classOf(msg)).toBe("caller_input");
+  });
+
+  it.each([
+    ["Country 'ZM' is not supported. Supported: AT, AU, CA, CH, DE, DK, ES, FI, FR, GB, IE, IT, NL, NO, PL, PT, SE, US.", "employment-cost-estimate"],
+    ["Tax data not available for 'ZM'. Supported: SE, NO, DK, FI, DE, GB, US, FR, NL, ES, IT, PT, AT, BE, IE, CH, PL, CZ", "country-tax-rates"],
+    ['Price comparison currently covers Nordic countries only (SE/NO/DK/FI) via PriceRunner. "us" is not supported — no licensed price source exists for it yet.', "price-compare"],
+    ["Name search is not available via free APIs. To look up a charity by name, visit the register and provide the 'charity_number' for direct lookup.", "charity-lookup-uk"],
+    ["Unknown model 'claude-sonnet-4-5'. Supported: gpt-4o, gpt-4o-mini, gpt-4-turbo", "llm-cost-calculate"],
+    ["Cannot convert from 'usd' to 'eur'. Supported categories: length, weight, volume, temperature", "unit-convert"],
+  ])("asking for something outside declared coverage is a refusal: %s", (msg) => {
+    expect(classOf(msg)).toBe("caller_input");
+  });
+
+  it("our SSRF guard refusing a caller-supplied address is the opposite of a defect", () => {
+    expect(classOf("This URL targets a restricted address.")).toBe("caller_input");
+  });
+});
+
+describe("malformed input is the caller's", () => {
+  it.each([
+    "Invalid URL format.",
+    "Invalid IP address format.",
+    "Invalid JWT format. Expected 3 parts separated by dots.",
+    'Invalid ABN format: "example_abn". ABN must be exactly 11 digits.',
+    'Invalid label "example_name": underscore allowed only at start',
+    "'from' and 'to' must be valid 3-letter ISO 4217 currency codes.",
+    "'purpose' must be 'work', 'study', or 'visit'.",
+    "CSV must have at least a header row and one data row.",
+    "Could not parse spec as JSON or YAML. Please provide valid OpenAPI spec.",
+    "Provide 'url' (e.g. https://example.com) or 'domain' (e.g. example.com) to detect the technology stack.",
+  ])("%s", (msg) => {
+    expect(classOf(msg)).toBe("caller_input");
+  });
+});
+
+describe("the caller's own target resource", () => {
+  it.each([
+    "Could not fetch example.com (HTTP 403). Check the URL is correct and publicly accessible.",
+    "Could not fetch example.com (HTTP 404). Check the URL is correct and publicly accessible.",
+    "HTTP 404 fetching sitemap from https://example.com/sitemap.xml",
+    "Failed to fetch invoice from URL: HTTP 404",
+    "HTTP 403 from https://example.com",
+    "HTTP 404 from https://example.com",
+    "Could not access repo vercel-labs/eve. It may be private.",
+    "Could not access website at example.com Verify the domain is correct.",
+  ])("403/404 on a caller-supplied resource is theirs: %s", (msg) => {
+    expect(classOf(msg)).toBe("caller_input");
+  });
+
+  it("but a 400 is not — that is frequently a request we malformed", () => {
+    // base64-encode-url and image-resize both produce this shape. A 400 can
+    // mean the caller's URL is odd, or that we built the request wrong; the
+    // conservative reading keeps it counted.
+    expect(excused("HTTP 400 from https://example.com")).toBe(false);
+    expect(excused("Failed to fetch image: HTTP 400")).toBe(false);
+  });
+
+  it("and a 40x on one of OUR OWN outbound calls is never the caller's", () => {
+    // The hazard that a generic "(could not|failed to) fetch … HTTP 40x" rule
+    // creates, and the shape a systematically broken capability takes: every
+    // call fails identically on a vendor path we got wrong, and every failure
+    // is excused, so the floor sees a capability with no eligible calls
+    // instead of a capability that is down.
+    expect(excused("Could not fetch internal config (HTTP 404)")).toBe(false);
+    expect(excused("Failed to fetch model list: HTTP 403")).toBe(false);
+    expect(excused("Failed to fetch PDF: HTTP 404")).toBe(false);
+  });
+
+  it("and a 5xx is never the caller's, however it is phrased (review H-2)", () => {
+    expect(classOf("Could not fetch example.com (HTTP 503).")).toBe("upstream");
+    expect(classOf("URL returned HTTP 503")).toBe("upstream");
+    expect(classOf("SEC EDGAR search returned HTTP 500")).toBe("upstream");
+  });
+
+  it("upstream is checked before the caller patterns, and a 429 proves it", () => {
+    // These strings match BOTH lists — 429 is a 4xx, so the long-standing
+    // "url returned http 4" caller pattern hits it, while `rate.?limit` and
+    // `\b429\b` hit it upstream. Ordering is the only thing deciding, and it
+    // has to decide upstream: a throttled scraping vendor is our problem to
+    // manage, not evidence the caller sent something wrong. Without this the
+    // check order can be swapped and every test still passes.
+    expect(classOf("URL returned HTTP 429. The web scraping service is temporarily rate-limited. Please try again in a few minutes.")).toBe("upstream");
+    expect(classOf("This site is rate-limiting requests (HTTP 429). The target site has throttled access.")).toBe("upstream");
+    expect(excused("URL returned HTTP 429. The web scraping service is temporarily rate-limited.")).toBe(false);
+  });
+});
+
+describe("our defects stay ours — the direction that blinds the floor", () => {
+  it.each([
+    "Expected ',' or ']' after array element in JSON at position 4672",
+    "Unterminated string in JSON at position 7415",
+    "Unexpected non-whitespace character after JSON at position 140",
+    'Claude response parse failed (response may have been truncated). Raw: { "compressed_prompt": "Write a guide"',
+    'Failed to parse enrichment result. Raw: ```json { "company_name": null }',
+    'External web service screenshot returned HTTP 400: [{"message":"\\"waitForSelector\\" is not allowed"}]',
+    "Too many redirects (>0) — refusing to follow further. Starting URL: https://httpbin.org/redirect/1.",
+    "Page at example.com returned too little content.",
+    // Internal invariant failures that a bare "must be " pattern excused.
+    // These are invented rather than observed, on purpose: the bug this file
+    // fixes came from writing patterns against the strings that happened to
+    // exist, so the guard has to be written against the strings that could.
+    "Response validation failed: output must be an object",
+    "Internal assertion failed: result must be non-null",
+    "Config value must be set before use",
+  ])("%s", (msg) => {
+    expect(excused(msg)).toBe(false);
+  });
+
+  it("an LLM payload containing caller-ish prose is still our parse failure", () => {
+    // The discriminating case for INTERNAL_RE's position in the chain. The
+    // model's own output is quoted verbatim, so it can contain any phrase at
+    // all; classifying on the payload rather than on our diagnosis would let
+    // a truncation bug excuse itself.
+    const msg =
+      'Claude response parse failed (response may have been truncated). ' +
+      'Raw: { "note": "No company found matching that name, and the URL format is invalid" }';
+    expect(classOf(msg)).toBe("internal");
+    expect(excused(msg)).toBe(false);
+  });
+});
+
+describe("classes that were already right stay right", () => {
+  it("upstream quota and rate limiting", () => {
+    expect(classOf("ReceitaWS returned HTTP 429")).toBe("upstream");
+    expect(classOf("The Danish business registry API quota has been temporarily exceeded. Please try again in a few hours.")).toBe("upstream");
+    expect(classOf("External service temporarily unavailable")).toBe("upstream");
+  });
+
+  it("timeouts", () => {
+    expect(classOf("The operation was aborted due to timeout")).toBe("timeout");
+    expect(classOf("TLS connection to example.com:443 timed out.")).toBe("timeout");
+  });
+
+  it("our own missing credentials are config, never the caller's fault", () => {
+    expect(classOf("CourtListener rejected the token (HTTP 403). Verify COURTLISTENER_API_TOKEN.")).toBe("config");
+    expect(excused("CourtListener rejected the token (HTTP 403). Verify COURTLISTENER_API_TOKEN.")).toBe(false);
+  });
+
+  it("route-level missing-field errors", () => {
+    expect(classOf("'cik' or 'company_name' is required. Provide a CIK number or US company name.")).toBe("caller_input");
+  });
+
+  it("an empty or absent error is our problem until proven otherwise", () => {
+    expect(classOf("")).toBe("internal");
+    expect(classifyTransactionFailure(null)).toBe("internal");
+    expect(classifyTransactionFailure(undefined)).toBe("internal");
+  });
+});
+
+describe("the incident this fixes", () => {
+  it("recomputes us-company-data's quarantine window as fully caller-attributable", () => {
+    // The floor quarantined it on 2026-08-12 at "completion 64% on 11 eligible
+    // calls/30d". Those 11 were 7 successes, 1 genuine upstream 500, and these
+    // caller-input failures. Under the corrected taxonomy the eligible
+    // denominator is 8, not 11, and completion is 88% — above the 70% floor.
+    const callerFailures = [
+      "'cik' or 'company_name' is required. Provide a CIK number or US company name.",
+      'No confident SEC EDGAR match for "Apple". The closest filing belongs to a different entity ("Apple Hospitality REIT, Inc.")',
+      'No US company found matching "Braize" in SEC EDGAR.',
+      'No US company found matching "I cannot extract a US company name from "FIX" as it is not a request containing company information." in SEC EDGAR.',
+    ];
+    for (const f of callerFailures) expect(excused(f)).toBe(true);
+    // …and the one real failure still counts, so the floor keeps its teeth.
+    expect(excused("SEC EDGAR search returned HTTP 500")).toBe(false);
+  });
+});

--- a/apps/api/src/lib/transaction-failure-taxonomy.test.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.test.ts
@@ -37,7 +37,6 @@ describe("refusals are the capability working, not failing", () => {
     ["Country 'ZM' is not supported. Supported: AT, AU, CA, CH, DE, DK, ES, FI, FR, GB, IE, IT, NL, NO, PL, PT, SE, US.", "employment-cost-estimate"],
     ["Tax data not available for 'ZM'. Supported: SE, NO, DK, FI, DE, GB, US, FR, NL, ES, IT, PT, AT, BE, IE, CH, PL, CZ", "country-tax-rates"],
     ['Price comparison currently covers Nordic countries only (SE/NO/DK/FI) via PriceRunner. "us" is not supported — no licensed price source exists for it yet.', "price-compare"],
-    ["Name search is not available via free APIs. To look up a charity by name, visit the register and provide the 'charity_number' for direct lookup.", "charity-lookup-uk"],
     ["Unknown model 'claude-sonnet-4-5'. Supported: gpt-4o, gpt-4o-mini, gpt-4-turbo", "llm-cost-calculate"],
     ["Cannot convert from 'usd' to 'eur'. Supported categories: length, weight, volume, temperature", "unit-convert"],
   ])("asking for something outside declared coverage is a refusal: %s", (msg) => {
@@ -58,11 +57,27 @@ describe("malformed input is the caller's", () => {
     'Invalid label "example_name": underscore allowed only at start',
     "'from' and 'to' must be valid 3-letter ISO 4217 currency codes.",
     "'purpose' must be 'work', 'study', or 'visit'.",
-    "CSV must have at least a header row and one data row.",
     "Could not parse spec as JSON or YAML. Please provide valid OpenAPI spec.",
     "Provide 'url' (e.g. https://example.com) or 'domain' (e.g. example.com) to detect the technology stack.",
   ])("%s", (msg) => {
     expect(classOf(msg)).toBe("caller_input");
+  });
+
+  it.each([
+    // Real refusals that are DELIBERATELY not excused, because no shape
+    // separates them from an internal failure saying the same thing.
+    // "CSV must have at least a header row" vs "Result must have at least one
+    // row"; "Name search is not available via free APIs" vs "Service is
+    // temporarily not available via API". On a path where under-counting
+    // blinds the armed quality floor, the tie goes to counting.
+    //
+    // Both are cheap to fix at the throw site instead: lead with the quoted
+    // field, as the rest of the house style does. Listed here so the cost is
+    // visible rather than discovered later as a mystery.
+    "CSV must have at least a header row and one data row.",
+    "Name search is not available via free APIs. To look up a charity by name, visit the register and provide the 'charity_number' for direct lookup.",
+  ])("deliberately still counted, reword at the throw site to change this: %s", (msg) => {
+    expect(excused(msg)).toBe(false);
   });
 });
 
@@ -136,6 +151,24 @@ describe("our defects stay ours — the direction that blinds the floor", () => 
     "Internal assertion failed: result must be non-null",
     "Config value must be set before use",
   ])("%s", (msg) => {
+    expect(excused(msg)).toBe(false);
+  });
+
+  it.each([
+    // Every string here came from the cross-provider review (sol@high,
+    // 2026-08-16), which found three over-broad patterns the census-derived
+    // tests could not see — because the tests and the patterns were written
+    // from the same source. These are the shapes a SYSTEMATICALLY broken
+    // capability takes: every call fails identically, and if the failure is
+    // excused, the floor stops seeing the capability at all.
+    'The "chunk" argument must be of type string or an instance of Buffer. Received undefined',
+    "Invalid response format",
+    "Failed to fetch company registry API: HTTP 403",
+    "HTTP 403 from Companies House API",
+    "Service is temporarily not available via API",
+    "Digest method is not supported",
+    "Result must have at least one row",
+  ])("review-found hazard stays ours: %s", (msg) => {
     expect(excused(msg)).toBe(false);
   });
 

--- a/apps/api/src/lib/transaction-failure-taxonomy.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.ts
@@ -111,9 +111,14 @@ const CALLER_INPUT_RE = new RegExp(
     // below is anchored to a string this census actually observed.
 
     // Malformed input. "Invalid URL format.", "Invalid IP address format.",
-    // "Invalid JWT format.", "Invalid ABN format:", "Invalid label ...".
-    "invalid [a-z]{2,20}(?: [a-z]{2,20})? format",
-    "invalid (?:label|value|parameter)",
+    // "Invalid JWT format.", "Invalid ABN format:", "Invalid label …".
+    //
+    // The subject is ENUMERATED rather than matched as `invalid \w+ format`,
+    // and the match is anchored to the start of the message. The general form
+    // also claims "Invalid response format" — a vendor payload we could not
+    // read, which is ours. We know which inputs we validate; guessing from
+    // shape buys nothing and costs the floor its sight.
+    "^invalid (?:url|uri|ip address|ip|jwt|abn|vat|iban|email|domain|date|label|value|parameter|identifier|json)\\b",
     // "'from' and 'to' must be valid 3-letter ISO 4217 currency codes.",
     // "'purpose' must be 'work', 'study', or 'visit'."
     //
@@ -126,8 +131,12 @@ const CALLER_INPUT_RE = new RegExp(
     // internal-error shapes rather than only against the strings they were
     // written from; the tests did not catch it.
     "^'[^']{1,40}'.{0,40}must be ",
-    // "CSV must have at least a header row and one data row."
-    "must have at least",
+    // NOT matched: "CSV must have at least a header row and one data row."
+    // (schema-infer, 5 calls). There is no shape separating it from "Result
+    // must have at least one row", which would be ours, so it stays counted.
+    // If that refusal should be excused, the message needs to lead with its
+    // quoted field the way the rest of the house style does — a cheaper fix
+    // there than a looser rule here.
     // "Provide 'url' (e.g. …) or 'domain' (e.g. …) to detect the technology
     // stack." — a required-field message that never says "is required".
     "^provide ['\"]",
@@ -141,10 +150,19 @@ const CALLER_INPUT_RE = new RegExp(
     "found (?:matching|for) ",
     // Scope refusals: the caller asked for something outside declared
     // coverage. "Country 'ZM' is not supported.", "Tax data not available for
-    // 'ZM'.", "Name search is not available via free APIs.", "… is not
-    // supported — no licensed price source exists for it yet."
-    "is not supported",
-    "not available (?:for|via)",
+    // 'ZM'.", '"us" is not supported — no licensed price source exists for it
+    // yet.'
+    //
+    // A QUOTED SUBJECT is required, because that subject is the caller's
+    // value. Bare `is not supported` also claims "Digest method is not
+    // supported" and bare `not available (?:for|via)` also claims "Service is
+    // temporarily not available via API" — an implementation regression and an
+    // outage respectively, both of which must keep counting. Cost of the
+    // stricter rule: charity-lookup-uk's "Name search is not available via
+    // free APIs." (1 call) is no longer excused. Accepted — on this path,
+    // over-counting is recoverable and under-counting is blindness.
+    "['\"][^'\"]{1,40}['\"] is not supported",
+    "not available (?:for|via) ['\"]",
     // "Unknown model 'claude-sonnet-4-5'. Supported: …",
     // "Cannot convert from 'usd' to 'eur'."
     "unknown (?:model|chain|country|currency|format|type)",
@@ -167,8 +185,13 @@ const CALLER_INPUT_RE = new RegExp(
     // publicly accessible." — the second sentence is the house phrasing for
     // "this was your address", and is unambiguous on its own.
     "check the url is correct",
-    // "HTTP 404 fetching sitemap from …", "HTTP 403 from …", "HTTP 404 from …"
-    "http 40[34] (?:fetching|from) ",
+    // "HTTP 404 fetching sitemap from …" — names the thing fetched.
+    "http 40[34] fetching ",
+    // "HTTP 403 from …", "HTTP 404 from …". The subject must look like a host
+    // or a redacted service marker: "HTTP 403 from Companies House API" is a
+    // vendor WE chose, and a credential expiring there would otherwise excuse
+    // every call the capability makes.
+    "http 40[34] from (?:https?://|\\[service\\]|[a-z0-9-]+\\.[a-z]{2,})",
     // "Failed to fetch invoice from URL: HTTP 404"
     "fetch \\w+ from url",
     // "Could not access repo X. It may be private."

--- a/apps/api/src/lib/transaction-failure-taxonomy.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.ts
@@ -46,6 +46,24 @@ export const CALLER_ATTRIBUTABLE: ReadonlySet<TransactionFailureClass> = new Set
 const CONFIG_ENV_RE = /\b[A-Z][A-Z0-9]+(?:_[A-Z0-9]+)*_(?:KEY|TOKEN|SECRET|GUID|URL|PASSWORD)\b/;
 const CONFIG_PHRASE_RE = /not configured|rejected the (?:api )?(?:key|token)|missing credential/i;
 
+/**
+ * Our own failures, claimed BEFORE the caller patterns, because they quote raw
+ * third-party text that can contain literally any phrase. An LLM-truncation
+ * error carrying a `Raw:` payload that happens to contain "not found" would
+ * otherwise be excused as the caller's fault — the classifier would be reading
+ * the model's prose, not our diagnosis. Matching our own signature first makes
+ * that impossible.
+ *
+ * Deliberately NOT extended to cover screenshot-url's
+ * `"waitForSelector" is not allowed` (Browserless rejecting a parameter we
+ * send, and currently landing in `timeout` because the rejection JSON embeds a
+ * `context` block containing that word). Both classes count against the
+ * capability, so the misfiling costs the floor nothing and only mislabels a
+ * report — and encoding one specific bug's string into a money-path classifier
+ * to fix a label is a worse trade than fixing the bug. Tracked separately.
+ */
+const INTERNAL_RE = /\bin JSON at position\b|\bunterminated string\b|response parse failed|failed to parse\b/i;
+
 const TIMEOUT_RE = /timed? ?out|timeout|deadline|aborted due to timeout|operation was aborted/i;
 
 // Upstream/vendor failure. Checked BEFORE the caller-input patterns so
@@ -75,6 +93,93 @@ const CALLER_INPUT_RE = new RegExp(
     "this url points to a pdf",
     "this url points to an image",
     "could not repair json",
+
+    // ── Added 2026-08-16 after a census of every distinct external failure
+    // string in 90 days (188 strings, 491 calls). The list above encoded the
+    // *intent* — the type says caller_input covers "bad/missing input, wrong
+    // identifier, unresolvable name" — but only implemented the phrasings that
+    // happened to be written when it was authored. 106 distinct strings were
+    // landing in `internal` ("OUR bug until proven otherwise"), and because
+    // QUALITY_FLOOR_ENFORCE is armed, that delisted capabilities for refusing
+    // correctly. `us-company-data` was quarantined at "64% completion on 11
+    // calls": 7 successes, 1 genuine SEC 500, and the rest caller input.
+    //
+    // The line drawn here, and it is the one to keep applying: a failure is
+    // the caller's when the capability DID its job and the answer is "your
+    // input is malformed" or "your input matches nothing". It is ours whenever
+    // we could not complete the operation, whatever the cause. Every pattern
+    // below is anchored to a string this census actually observed.
+
+    // Malformed input. "Invalid URL format.", "Invalid IP address format.",
+    // "Invalid JWT format.", "Invalid ABN format:", "Invalid label ...".
+    "invalid [a-z]{2,20}(?: [a-z]{2,20})? format",
+    "invalid (?:label|value|parameter)",
+    // "'from' and 'to' must be valid 3-letter ISO 4217 currency codes.",
+    // "'purpose' must be 'work', 'study', or 'visit'."
+    //
+    // Anchored to a message that OPENS with a quoted field name, which is the
+    // house style for caller-facing validation. A bare "must be " was tried
+    // first and is far too broad — it excused "Response validation failed:
+    // output must be an object", "Internal assertion failed: result must be
+    // non-null" and "Config value must be set before use", every one of which
+    // is our own defect. Found by probing the patterns against invented
+    // internal-error shapes rather than only against the strings they were
+    // written from; the tests did not catch it.
+    "^'[^']{1,40}'.{0,40}must be ",
+    // "CSV must have at least a header row and one data row."
+    "must have at least",
+    // "Provide 'url' (e.g. …) or 'domain' (e.g. …) to detect the technology
+    // stack." — a required-field message that never says "is required".
+    "^provide ['\"]",
+    // "Could not parse spec as JSON or YAML. Please provide valid OpenAPI spec."
+    "as json or yaml",
+
+    // Refusals: we looked, and the caller's identifier matches nothing. These
+    // are the capability working, not failing — the same rule the circuit
+    // breaker already applies. "No Estonian company found matching …",
+    // "No Swiss company found for …", "No US company found matching …".
+    "found (?:matching|for) ",
+    // Scope refusals: the caller asked for something outside declared
+    // coverage. "Country 'ZM' is not supported.", "Tax data not available for
+    // 'ZM'.", "Name search is not available via free APIs.", "… is not
+    // supported — no licensed price source exists for it yet."
+    "is not supported",
+    "not available (?:for|via)",
+    // "Unknown model 'claude-sonnet-4-5'. Supported: …",
+    // "Cannot convert from 'usd' to 'eur'."
+    "unknown (?:model|chain|country|currency|format|type)",
+    "cannot convert from",
+
+    // The caller's own resource is missing or blocked. 403 and 404 ONLY, and
+    // only in a phrasing that names a fetch — a bare vendor 400 is frequently
+    // a request WE malformed, and a 5xx is upstream (review H-2). Consistent
+    // with "url returned http 4" and "blocks automated access" above, which
+    // already treat the caller's target site as the caller's problem.
+    // "Could not fetch X (HTTP 403)", "HTTP 404 fetching sitemap from X",
+    // "Failed to fetch PDF: HTTP 404", "HTTP 403 from X".
+    // The tell has to be that the fetched thing is the CALLER's, not merely
+    // that a fetch 40x'd. A generic "(could not|failed to) fetch … HTTP 40[34]"
+    // was tried first and excused "Could not fetch internal config (HTTP 404)"
+    // and "Failed to fetch model list: HTTP 403" — our own outbound calls,
+    // which is exactly how a systematically broken capability would look.
+    //
+    // "Could not fetch example.com (HTTP 403). Check the URL is correct and
+    // publicly accessible." — the second sentence is the house phrasing for
+    // "this was your address", and is unambiguous on its own.
+    "check the url is correct",
+    // "HTTP 404 fetching sitemap from …", "HTTP 403 from …", "HTTP 404 from …"
+    "http 40[34] (?:fetching|from) ",
+    // "Failed to fetch invoice from URL: HTTP 404"
+    "fetch \\w+ from url",
+    // "Could not access repo X. It may be private."
+    "may be private",
+    // "Could not access website at X Verify the domain is correct."
+    "verify the domain is correct",
+    // Our SSRF guard refusing a caller-supplied address. The guard working is
+    // the opposite of a defect, and counting it as one is the clearest case of
+    // the rule this whole block exists to enforce.
+    "targets a restricted address",
+
     // Registry name-search refusals. Sourced from capability-refusal.ts so
     // this list, the circuit breaker's and the throw sites cannot drift apart
     // — they are three consumers of one definition.
@@ -96,6 +201,10 @@ export function classifyTransactionFailure(error: string | null | undefined): Tr
   if (!msg) return "internal";
   if (msg.includes(TOS_REFUSAL_MARKER)) return "tos_policy";
   if (CONFIG_ENV_RE.test(msg) || CONFIG_PHRASE_RE.test(msg)) return "config";
+  // Before timeout/upstream/caller: these messages quote raw third-party text
+  // that can contain any phrase, so they must be claimed by their own
+  // signature rather than matched on their payload.
+  if (INTERNAL_RE.test(msg)) return "internal";
   if (TIMEOUT_RE.test(msg)) return "timeout";
   if (UPSTREAM_RE.test(msg)) return "upstream";
   if (CALLER_INPUT_RE.test(msg)) return "caller_input";


### PR DESCRIPTION
Opened as a draft until cross-provider review returned — [#269](https://github.com/strale-io/strale/pull/269) auto-merged at its first commit while review was in flight this morning, and this is a money path. Review is in and applied; see the disposition table below.

## The bug

The quality floor delists a capability below 70% completion on ≥10 real paid calls over 30 days, and **it is armed in production**. Failures the caller caused are meant to be excluded from that rate — the type already says `caller_input` covers *"bad/missing input, wrong identifier, unresolvable name"* — but the patterns only implemented the phrasings that happened to exist when they were written.

A census of every distinct external failure string over 90 days (**188 strings, 491 failed calls**) found **106 calls landing in `internal`**, which the module itself documents as *"OUR bug until proven otherwise"*:

```
Invalid URL format.
This URL targets a restricted address.              <- our own SSRF guard, working
No Estonian company found matching "10667868".
Country 'ZM' is not supported. Supported: AT, AU, CA, ...
Could not fetch X (HTTP 403). Check the URL is correct and publicly accessible.
Provide 'url' (e.g. …) or 'domain' (e.g. …) to detect the technology stack.
Cannot convert from 'usd' to 'eur'. Supported categories: length, weight, ...
Could not access repo vercel-labs/eve. It may be private.
```

`us-company-data` was quarantined on 2026-08-12 at *"completion 64% on 11 eligible calls/30d"*. Those 11 were **7 successes, 1 genuine SEC 500, and 3 caller-input failures**. It was delisted for refusing correctly.

## The line drawn

> A failure is **the caller's** when the capability did its job and the answer is "your input is malformed" or "your input matches nothing". It is **ours** whenever we could not complete the operation, whatever the cause.

Every added pattern is anchored to a string the census actually observed, and the comments name it.

## Two guards that the census alone would not have produced

**`INTERNAL_RE` claims our parse failures before the caller patterns run.** Those messages quote raw LLM output verbatim, so a truncation bug whose `Raw:` payload happens to contain "not found" would otherwise excuse itself — the classifier would be reading the model's prose instead of our own diagnosis.

**The fetch and validation patterns require a tell that the subject is the caller's.** Two over-broad drafts were caught and tightened before review:

| draft pattern | what it wrongly excused |
|---|---|
| `(could not\|failed to) fetch … HTTP 40[34]` | `Could not fetch internal config (HTTP 404)`, `Failed to fetch model list: HTTP 403` — our own outbound calls |
| `must be ` | `Response validation failed: output must be an object`, `Internal assertion failed: result must be non-null`, `Config value must be set before use` |

Both are exactly the shape a **systematically broken** capability takes: every call fails identically, every failure is excused, and the floor stops seeing it. Neither was caught by the tests, because the tests were written from the same census as the patterns. They were found by probing the patterns against *invented* internal-error shapes. Those guard cases are now in the suite.


## Cross-provider review (sol@high via model-os, Claude-authored → OpenAI reviewer)

Three HIGH findings, all in the direction that **blinds** the floor — a pattern broad enough to excuse a systematic failure means a capability failing every call records no eligible failures and cannot be delisted at all. Two had been half-caught by my own hazard probe before the review landed; the review found the remainder and supplied concrete strings.

| finding | the string it excused | disposition |
|---|---|---|
| HIGH — `invalid \w+ format` too broad | `Invalid response format` (a vendor payload we could not read) | Applied. Subject enumerated and anchored to message start. |
| HIGH — `is not supported` / `not available for\|via` too broad | `Digest method is not supported`, `Service is temporarily not available via API` | Applied. Both now require a quoted subject — that subject is the caller's value. |
| HIGH — `fetch … HTTP 40[34]` too broad | `Failed to fetch company registry API: HTTP 403`, `HTTP 403 from Companies House API` | Applied. Requires a caller-facing tell, and the `from` form requires a host, URL, or the redacted `[service]` marker. |
| MEDIUM — timeout check order | `'timeout' must be between 1 and 30 seconds` classifies as `timeout` | **Not addressed here.** Real, but pre-existing, in the over-counting direction, and with no observed instance. Tightening `TIMEOUT_RE` reclassifies existing production strings and belongs in its own change rather than riding along in a money path. |

Every string the review supplied is now a test.

**Two real refusals are deliberately no longer excused**, because no shape separates them from an internal failure phrased identically: `schema-infer`'s "CSV must have at least a header row" (vs "Result must have at least one row") and `charity-lookup-uk`'s "Name search is not available via free APIs" (vs "Service is temporarily not available via API"). 6 calls in 90 days. Both are cheaper to fix at the throw site by leading with the quoted field, and both are asserted as counted so the cost is visible rather than discovered later as a mystery.

## Measured effect on real traffic

Over the floor's own 30-day window, external paid traffic only: **19 distinct strings change class, 55 calls, all `internal` → `caller_input`, zero out.** The change is strictly one-directional, which is the property worth checking on a classifier that gates delisting. (Over 90 days it is 38 strings / 101 calls.)

Completion recomputes:

| capability | before | after |
|---|---|---|
| `us-company-data` | 64% (7/11) — **quarantinable** | **100%** (7/7) — no longer |
| `tech-stack-detect` | 78% (162/207) | **94%** (162/172) |
| `github-repo-analyze` | 94% (32/34) | 100% (32/32) |
| `url-to-text` | 40% (6/15) — quarantinable | **60%** (6/10) — **still quarantinable**, correctly |
| `price-compare` | 44% (4/9) | 50% (4/8) — still below |
| `sitemap-parse` | 73% (8/11) | 80% (8/10) |
| `company-enrich` | 75% (6/8) | 86% (6/7) |

`url-to-text` and `price-compare` staying below the floor is the result that matters most: the fix removes misattribution without whitewashing capabilities that really are failing. `brazilian-company-data` and `screenshot-url` are unchanged — their failures are upstream 429s and a bug of ours respectively.

**No capability's floor verdict changes today**, because nothing currently sits over the 10-call minimum and under 70%. The value is preventing the recurrence: the `us-company-data` quarantine that did happen would not happen under this taxonomy.

## Verification

- **59 tests**; every census string taken verbatim from production, plus the review's hazard strings and invented internal-defect shapes. `tsc --noEmit` clean; **full suite 1640 green**; PII, cost-class, SSRF-inventory, bare-catch and console gates clean.
- **29 of the 59 fail against `origin/main`** (DEC-20260504-A, both directions).
- **Mutation-verified in the dangerous direction** — each broken separately, suite re-run:

  | mutation | caught |
  |---|---|
  | disable the raw-payload guard (LLM parse errors excuse themselves) | 1 failed |
  | widen caller 403/404 to all 4xx | 1 failed |
  | drop the scope-refusal pattern | 2 failed |
  | drop the not-found refusal pattern | 6 failed |
  | **swap the upstream/caller check order** (the review-H-2 hazard) | 1 failed |

  The ordering mutation initially passed — the existing 5xx assertions could not detect it, because no tested string matched both lists. A real `HTTP 429` string from `product-search` does, and that test was added. Recorded because "mutation-verified" is worth nothing if the mutations are the ones you knew you would catch.

## Follow-through, not in this PR

`us-company-data` is still `visible=false` from the 2026-08-12 quarantine, and neither the floor nor the promotion job re-lists it — the promotion job correctly refuses to overturn a takedown. Re-listing it is now a supported decision with evidence behind it, and it is the next action after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
