### PR TITLE
feat(x402): record what paying agents asked for and could not get

### DIFF
--- a/apps/api/src/lib/x402-demand.test.ts
+++ b/apps/api/src/lib/x402-demand.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Demand capture on the rail that actually earns.
+ *
+ * `failed_requests` is the table for "demand we could not serve", and until
+ * 2026-08-15 only `/v1/do` wrote to it. x402 is ~99% of revenue, so the
+ * paying rail recorded nothing while the table filled with our own probes —
+ * which is why "unmet demand" was never usable as a build signal.
+ *
+ * These tests pin the properties that make the signal trustworthy: the two
+ * miss kinds stay distinguishable, the write can never break the request it
+ * observes, and the caller's input is never stored.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const execute = vi.fn();
+const logWarn = vi.fn();
+vi.mock("../db/index.js", () => ({ getDb: () => ({ execute }) }));
+vi.mock("./log.js", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logWarn, logError: vi.fn(),
+}));
+vi.mock("./attribution.js", () => ({ saltedIpHash: (ip?: string) => (ip ? "hashed" : null) }));
+
+const { recordX402Miss } = await import("./x402-demand.js");
+
+/** Flatten a drizzle sql template into text plus its bind values. */
+function captured() {
+  const q = execute.mock.calls[0]?.[0] as { queryChunks?: unknown[] } | undefined;
+  const text: string[] = [];
+  const params: unknown[] = [];
+  const walk = (chunks: unknown[]) => {
+    for (const ch of chunks) {
+      const val = (ch as { value?: unknown } | null)?.value;
+      const nested = (ch as { queryChunks?: unknown[] } | null)?.queryChunks;
+      if (Array.isArray(val) && val.every((v) => typeof v === "string")) text.push(val.join(""));
+      else if (Array.isArray(nested)) walk(nested);
+      else params.push(ch);
+    }
+  };
+  walk(q?.queryChunks ?? []);
+  return { sql: text.join(""), params };
+}
+
+beforeEach(() => {
+  execute.mockReset();
+  execute.mockResolvedValue([]);
+  logWarn.mockReset();
+});
+
+describe("the two misses stay distinguishable", () => {
+  it("records a slug we do not sell as a catalogue signal", () => {
+    recordX402Miss({ slug: "mexican-company-data", kind: "x402_unknown_slug",
+      detail: "no such x402 capability", userAgent: "agent/1", ip: "1.2.3.4" });
+    const { sql, params } = captured();
+    expect(sql).toContain("INSERT INTO failed_requests");
+    expect(params).toContain("mexican-company-data");
+    expect(params).toContain("x402_unknown_slug");
+  });
+
+  it("records rejected input on a capability we DO sell as a product signal", () => {
+    // Nine paying attempts at tech-stack-detect died this way in one week.
+    recordX402Miss({ slug: "tech-stack-detect", kind: "x402_bad_input",
+      detail: "Provide one of: url, domain" });
+    const { params } = captured();
+    expect(params).toContain("x402_bad_input");
+    expect(params).toContain("Provide one of: url, domain");
+  });
+
+  it("tags every row to the x402 rail so it cannot be confused with /v1/do", () => {
+    recordX402Miss({ slug: "x", kind: "x402_unknown_slug" });
+    expect(captured().params).toContain("x402");
+  });
+});
+
+describe("it never stores the caller's content", () => {
+  it("has no parameter for input, because the type has no field for it", () => {
+    // The slug and the error answer the question; the customer-data boundary
+    // says we do not retain their content to answer a question already
+    // answered. This asserts the shape rather than a value, so adding an
+    // `input` field later fails here.
+    recordX402Miss({ slug: "translate", kind: "x402_bad_input", detail: "bad param" });
+    const { params } = captured();
+    for (const p of params) {
+      expect(String(p)).not.toMatch(/SIGNAL_ATLAS|<<</);
+    }
+    expect(params.length).toBeLessThanOrEqual(6);
+  });
+
+  it("clips an overlong error so one caller cannot bloat the table", () => {
+    recordX402Miss({ slug: "s", kind: "x402_bad_input", detail: "e".repeat(5000) });
+    const long = captured().params.find((p) => typeof p === "string" && (p as string).length > 100);
+    expect((long as string).length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe("it can never break the request it is observing", () => {
+  it("does not throw when the insert rejects, and logs the swallow", async () => {
+    execute.mockReturnValue(Promise.reject(new Error("db down")));
+    expect(() => recordX402Miss({ slug: "s", kind: "x402_unknown_slug" })).not.toThrow();
+    await new Promise((r) => setImmediate(r));
+    expect(logWarn, "a silent recorder reads as an absence of demand").toHaveBeenCalled();
+  });
+
+  it("does not throw when the database is unavailable entirely", () => {
+    execute.mockImplementation(() => { throw new Error("no db"); });
+    expect(() => recordX402Miss({ slug: "s", kind: "x402_bad_input" })).not.toThrow();
+    expect(logWarn).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/lib/x402-demand.ts
+++ b/apps/api/src/lib/x402-demand.ts
@@ -1,0 +1,77 @@
+/**
+ * Recording what x402 buyers asked for and could not get.
+ *
+ * `failed_requests` — the table whose entire purpose is "demand we could not
+ * serve" — is written only by `/v1/do`. x402 is where essentially all our
+ * revenue comes from, and on that rail an agent that asks for a capability we
+ * do not have, or sends input we reject, is turned away silently. We keep the
+ * money we did earn and throw away the sentence telling us what to build next.
+ *
+ * That gap is why "unmet demand" has been unusable as a build signal: what it
+ * contains is mostly our own probes on the rail nobody pays for, while the
+ * paying rail records nothing. This closes it.
+ *
+ * Two distinct misses, deliberately distinguished, because they call for
+ * opposite responses:
+ *
+ *   - `x402_unknown_slug` — they wanted something we do not sell. That is a
+ *     *catalogue* signal: build it, or learn the name they expected.
+ *   - `x402_bad_input` — we sell it and they could not use it. That is a
+ *     *product* signal: our schema, examples or error text failed them. Nine
+ *     paying attempts at tech-stack-detect died this way in one week.
+ *
+ * Fire-and-forget: a demand-capture write must never add latency to, or fail,
+ * a request that is already being refused. The swallow is logged, per the
+ * visibility discipline in DEC-20260504-A — a silent recorder is worse than
+ * none, because it looks like an absence of demand.
+ */
+import { sql } from "drizzle-orm";
+import { getDb } from "../db/index.js";
+import { logWarn } from "./log.js";
+import { saltedIpHash } from "./attribution.js";
+
+export type X402MissKind = "x402_unknown_slug" | "x402_bad_input";
+
+export interface X402MissContext {
+  /** What they asked for — the slug from the URL, even if we have no such thing. */
+  slug: string;
+  kind: X402MissKind;
+  /** Why we refused, in the words the caller received. */
+  detail?: string | null;
+  userAgent?: string | null;
+  ip?: string | null;
+}
+
+/**
+ * Records one unmet x402 request. Never throws, never awaited by the caller.
+ *
+ * Note what is NOT stored: the caller's input. This table exists to tell us
+ * which capability was wanted and why the call failed, and the customer-data
+ * boundary in CHARTER.md means we do not retain their content to answer a
+ * question that the slug and the error already answer.
+ */
+export function recordX402Miss(ctx: X402MissContext): void {
+  try {
+    const db = getDb();
+    void db
+      .execute(sql`
+        INSERT INTO failed_requests (task, category, failure_type, error_detail, user_agent, ip_hash)
+        VALUES (
+          ${ctx.slug},
+          ${"x402"},
+          ${ctx.kind},
+          ${ctx.detail ? String(ctx.detail).slice(0, 500) : null},
+          ${ctx.userAgent ? String(ctx.userAgent).slice(0, 255) : null},
+          ${saltedIpHash(ctx.ip ?? undefined) ?? null}
+        )`)
+      .catch((err) => {
+        logWarn("x402-demand-write-failed", "failed_requests insert failed", {
+          slug: ctx.slug,
+          kind: ctx.kind,
+          err: (err as Error).message,
+        });
+      });
+  } catch (err) {
+    logWarn("x402-demand-capture-failed", (err as Error).message, { slug: ctx.slug });
+  }
+}

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -49,6 +49,7 @@ import { getProcessingLocation } from "../lib/processing-location.js";
 import { getShareableUrl } from "../lib/audit-token.js";
 import { TRANSACTION_RETENTION_DAYS } from "../lib/data-retention.js";
 import { validateX402Input } from "../lib/x402-input-validation.js";
+import { recordX402Miss } from "../lib/x402-demand.js";
 import { createHash } from "node:crypto";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -940,6 +941,10 @@ x402GatewayV2.on(["GET", "POST"], ["/solutions/:slug", "/v2/solutions/:slug"], a
 
   const sol = _solCache.get(slug);
   if (!sol) {
+    recordX402Miss({ slug, kind: "x402_unknown_slug",
+      detail: "no such x402 solution", ...{ userAgent: c.req.header("user-agent") ?? null,
+        ip: c.req.header("x-forwarded-for")?.split(",")[0]?.trim()
+          ?? c.req.header("cf-connecting-ip") ?? null } });
     return c.json(
       { error: "Solution not found or not available via x402.", hint: `${BASE_URL}/x402/catalog` },
       404,
@@ -1159,6 +1164,11 @@ x402GatewayV2.on(["GET", "POST"], ["/:slug", "/v2/:slug"], async (c) => {
 
   const cap = _capCache.get(slug);
   if (!cap) {
+    // Demand signal: a paying-capable agent asked for something we do not sell.
+    recordX402Miss({ slug, kind: "x402_unknown_slug",
+      detail: "no such x402 capability", ...{ userAgent: c.req.header("user-agent") ?? null,
+        ip: c.req.header("x-forwarded-for")?.split(",")[0]?.trim()
+          ?? c.req.header("cf-connecting-ip") ?? null } });
     return c.json(
       { error: "Capability not found or not available via x402.", hint: `${BASE_URL}/x402/catalog` },
       404,
@@ -1287,6 +1297,12 @@ x402GatewayV2.on(["GET", "POST"], ["/:slug", "/v2/:slug"], async (c) => {
   // input never costs the caller).
   const validation = validateX402Input(inputs, cap.inputSchema);
   if (!validation.ok) {
+    // Distinct from the unknown-slug case: we sell this and they could not use
+    // it. A product signal, not a catalogue one.
+    recordX402Miss({ slug, kind: "x402_bad_input", detail: validation.error,
+      ...{ userAgent: c.req.header("user-agent") ?? null,
+        ip: c.req.header("x-forwarded-for")?.split(",")[0]?.trim()
+          ?? c.req.header("cf-connecting-ip") ?? null } });
     return schemaBadRequest(c, validation.error, cap.inputSchema);
   }
 


### PR DESCRIPTION
We were blind to unmet demand on the rail that earns 99% of revenue. Three rejection sites instrumented, two miss kinds kept distinct, no customer content stored. 7 tests incl. both failure-swallow paths.