### PR TITLE
docs: DQ-9 answered — no re-pointing, compliance keeps its investment

### DIFF
--- a/docs/company/DECISION-QUEUE.md
+++ b/docs/company/DECISION-QUEUE.md
@@ -14,29 +14,6 @@ fill the expanded panel.
 
 ## OPEN
 
-**DQ-9** · `your_call` · owner Petter · raised 2026-08-16T12:00Z · no deadline
-Everything we sell to real customers is one product, and it is not the one we
-have been building. Do we re-point at it?
-*What this is:* All the money comes from SEO and growth research — search, SERP
-analysis, keywords, backlinks, brand mentions, email verification. €129 over the
-last 30 days, which is half of everything we earned in the last 90, so it is
-accelerating. The compliance and company-data catalogue earns essentially
-nothing: we have 98 bundles built and exactly one is still selling, a 20-cent
-growth bundle bought 60 times, most recently yesterday. The expensive compliance
-bundles sold in April and stopped.
-*What I need:* a yes or no on describing Strale as an SEO/growth research layer
-for agents, and treating compliance as a track we no longer invest in.
-*What is NOT in this question:* building the five bundles. Bundle design and
-pricing inside our existing band is my call and I will ship them either way —
-they are the highest-return work available. This is only about what we say we
-are, and about stopping the compliance work.
-*If you do nothing:* I build the bundles, leave the compliance track alone, and
-do not change how we describe ourselves.
-*What would change my mind:* if you know something about where these buyers came
-from that the data does not show, or if compliance is load-bearing for a reason
-that is not revenue yet.
-*The evidence, in full:* https://claude.ai/code/artifact/80499816-1719-4584-97ee-a70a88d50e59
-
 **DQ-10** · `decided` · owner Claude · 2026-08-16 — **a correction, not a reversal**
 The "one paying customer" figure in DQ-3 below is not measured, and should not
 be carried into other decisions.
@@ -97,6 +74,26 @@ statistical indicators are a different product from a company registry, and
 nobody has asked for those either — so it stays unused unless demand appears.
 
 ## DECIDED — visible so you can reverse them
+
+**DQ-9** · `answered` · owner Petter · asked 2026-08-16, answered same day
+Do we describe Strale as an SEO/growth layer for agents and stop investing in
+compliance? **Petter: no.**
+*What that settles:* we keep describing Strale as we do today, and the compliance
+and company-data track keeps its investment. The evidence behind the question is
+unchanged and still on file — it just does not carry the day.
+*What happens anyway, because it was never part of the question:* I build the
+five growth bundles. Bundle design and pricing inside the existing €0.02–€1.00
+band is my call, they are composed entirely from capabilities we already run, and
+they are the highest-return work available. Building them does not re-point the
+company; it sells more of what is already selling.
+*The consequence, stated plainly:* we now run two tracks — a compliance catalogue
+that earns ~€2 per quarter externally, and a growth cluster that earns ~€129 a
+month and is accelerating. That is a real cost in attention, and the €230/week
+milestone does not move. I am not re-raising it; I am recording it so the next
+person to read the revenue numbers knows the question was asked and answered
+rather than overlooked.
+*Evidence, for the record:* https://claude.ai/code/artifact/80499816-1719-4584-97ee-a70a88d50e59
+
 
 **DQ-1** · `decided` · owner Claude · 2026-08-15
 Taking the Italian company-lookup service to completion myself.

--- a/docs/company/GOALS.md
+++ b/docs/company/GOALS.md
@@ -39,6 +39,25 @@ conversion.
   refusal. Measure whether it moves.
 - **x402 buyers buy utility primitives** (google-search, email-validate,
   keyword-suggest, translate), not the KYB wedge. Follow the money.
+- **All revenue is one cluster — SEO and growth research.** Measured 2026-08-16:
+  €129.09 over 30 days, which is half of the last 90 days' €252.73, so it is
+  accelerating. The six biggest earners (`google-search`, `serp-analyze`,
+  `email-validate`, `email-deliverability-check`, `brand-mention-search`,
+  `keyword-suggest`) had **zero** failures. Of 98 active bundles exactly one is
+  still selling — `lead-email-verify`, 60 sales, €0.20 — and it is a growth
+  bundle; the €2.50 compliance bundles sold in April and stopped. Bundling
+  raises revenue per call ~6.7× (`email-validate` €11.01/368 calls vs
+  `lead-email-verify` €12.00/60).
+- **Asked and answered, do not re-raise:** whether to re-point the company at
+  SEO/growth and stop investing in compliance. Petter said **no** on 2026-08-16
+  (DQ-9). Positioning is unchanged and compliance keeps its investment. The
+  growth bundles are being built regardless — that was never part of the
+  question. A future session reading the revenue table will reach the same
+  conclusion I did; it has been put to him already.
+- **Bundles that sell are cheap and narrow.** €0.20 is the only proven price.
+  Everything at €0.27 and above has sold ≤4 times; `competitor-snapshot` at
+  €1.54 has never sold. One question, three cheap steps, ~1.8× markup over
+  parts.
 - **Distinct-payer count is not yet measurable.** `x402_payer_hash` shipped
   2026-08-15; as of that date it holds **1 hash / 2 calls / €0.06** — that is
   the age of the instrument, not the size of the customer base. Any dashboard


### PR DESCRIPTION
Petter's call on [DQ-9](https://github.com/strale-io/strale/pull/290): **no.** We do not describe Strale as an SEO/growth layer for agents, and we do not stop investing in compliance. Recorded and closed.

**The bundles still get built.** That was never part of the question — design and pricing inside the existing €0.02–€1.00 band is my call, the five bundles are composed entirely from capabilities we already run, and they sell more of what is already selling rather than re-pointing anything. That work follows in its own PR.

## Why GOALS.md gains a "do not re-raise" note

Without it, the next session to read the revenue table reaches exactly the conclusion I did and puts the same question to Petter again. The evidence is unchanged and stays on file; it just does not carry the day. Recording that it was *asked and answered* rather than overlooked is the difference between a settled decision and a recurring one.

GOALS.md also gains the finding itself, because it is true regardless of the decision: €129.09 over 30 days is half of the last 90 days' €252.73, the six biggest earners had zero failures, and of 98 active bundles exactly one is still selling.

And the design constraint worth keeping: **bundles that sell are cheap and narrow.** €0.20 is the only proven price; everything from €0.27 up has sold four times or fewer; `competitor-snapshot` at €1.54 has never sold.

## The consequence, stated once and not re-litigated

We now run two tracks — a compliance catalogue earning ~€2 per quarter externally, and a growth cluster earning ~€129/month and accelerating — and the €230/week milestone does not move. That is in the DQ-9 entry as a recorded consequence, not as an argument.

Docs only. `check-pii.mjs --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)