### PR TITLE
fix(budget): stop the daily alerts training the inbox to ignore them

### DIFF
--- a/apps/api/src/capabilities/budget-alert-fatigue.test.ts
+++ b/apps/api/src/capabilities/budget-alert-fatigue.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Budget alerts must not train their reader to ignore them.
+ *
+ * On 2026-08-16 four `[Strale WARNING] [budget]` emails arrived overnight, for
+ * capabilities whose daily caps were doing exactly what they exist to do. The
+ * window resets every day, so a harness that reliably consumes 80% of it
+ * produces an identical warning every morning, for ever. Measured that week:
+ * 107,007 test executions against 674 customer calls — 159 tests per customer
+ * call — every one of the alerting capabilities on a `free_quota` vendor with
+ * zero external cost.
+ *
+ * None of that was a customer-facing problem. The cap protected customer
+ * traffic from our own testing, and it worked. But an inbox that receives the
+ * same correct warning daily stops being an alerting channel, and the next
+ * genuine one arrives in a stream the reader has learned to skip.
+ *
+ * These tests pin the fix at the level that matters — the alert path is
+ * rate-limited, the per-window record is not — rather than asserting on
+ * behaviour a stub could fake either way.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SRC = readFileSync(
+  resolve(process.cwd(), "src/capabilities/guarded-executor.ts"),
+  "utf8",
+);
+
+describe("repeated budget alerts are rate-limited", () => {
+  it("sends threshold alerts through the cooldown, not straight to the mailer", () => {
+    // `sendAlert` emails immediately; `alertOnce` consults a cooldown first.
+    // A daily-resetting window makes the difference between one email and
+    // 365.
+    const block = SRC.slice(SRC.indexOf("const tryFire"), SRC.indexOf("// Mark fired"));
+    expect(block).toContain("alertOnce(");
+    expect(block, "the un-throttled mailer must not be used here").not.toContain("sendAlert(");
+  });
+
+  it("rate-limits the hard-stop alert too", () => {
+    const block = SRC.slice(SRC.indexOf("async function fireBudgetHardStopAlert"));
+    expect(block.slice(0, 900)).toContain("alertOnce(");
+  });
+
+  it("keys the cooldown per capability and per threshold", () => {
+    // A single shared key would let one noisy capability mask every other
+    // capability's first alert — the failure mode this fix exists to prevent,
+    // reintroduced one level up.
+    expect(SRC).toMatch(/budget-threshold:\$\{slug\}:\$\{threshold\}/);
+    expect(SRC).toMatch(/budget-hard-stop:\$\{slug\}/);
+  });
+
+  it("uses a week, which is longer than the window that resets daily", () => {
+    const m = SRC.match(/ALERT_COOLDOWN_DAYS\s*=\s*(\d+)/);
+    expect(m, "cooldown constant must exist").not.toBeNull();
+    expect(Number(m![1]), "must exceed a daily window or dailies still get through")
+      .toBeGreaterThan(1);
+  });
+});
+
+describe("suppressing the email does not suppress the record", () => {
+  it("still marks the per-window flag, so history stays queryable", () => {
+    // The database flags are the audit trail. Rate-limiting the inbox must not
+    // cost us the ability to ask "how often did this actually happen".
+    const block = SRC.slice(SRC.indexOf("const tryFire"), SRC.indexOf("await tryFire(30"));
+    expect(block).toContain("alert_30_fired_at = NOW()");
+  });
+
+  it("tells the reader why a repeat did not arrive", () => {
+    // Otherwise a suppressed alert looks like the problem stopped.
+    expect(SRC).toMatch(/logged\\n\s*\+\s*`but not emailed|are logged/);
+  });
+});

--- a/apps/api/src/capabilities/guarded-executor.ts
+++ b/apps/api/src/capabilities/guarded-executor.ts
@@ -34,6 +34,7 @@ import { sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { log, logError, logWarn } from "../lib/log.js";
 import { sendAlert } from "../lib/alerting.js";
+import { alertOnce } from "../lib/alert-once.js";
 import {
   type CapabilityExecutor,
   type CapabilityInput,
@@ -74,6 +75,14 @@ export type InvocationContext =
   | { kind: "internal_test"; suiteId: string; reason: "scheduled" | "manual" }
   | { kind: "health_probe"; probeId: string }
   | { kind: "ci"; workflowRunId: string };
+
+/**
+ * How long before the same budget alert may reach an inbox again. Seven days:
+ * long enough that a daily-resetting window cannot produce a daily email, short
+ * enough that a genuinely new or worsening situation still surfaces within a
+ * week.
+ */
+const ALERT_COOLDOWN_DAYS = 7;
 
 type Decision = "allow" | "refuse" | "budget_check";
 
@@ -450,18 +459,33 @@ async function maybeFireThresholdAlerts(
   ): Promise<void> => {
     if (alreadyFired) return;
     if (pct < threshold / 100) return;
-    await sendAlert({
-      subject: `[budget] ${slug} reached ${threshold}% of ${meta.quota_window} test budget`,
-      body:
-        `Capability: ${slug}\n` +
-        `Cost class: ${meta.cost_class}\n` +
-        `Quota window: ${meta.quota_window}\n` +
-        `Quota cap: ${meta.quota_cap}\n` +
-        `Budget cap (this window): ${budgetCap}\n` +
-        `Test count so far: ${row.test_count}\n` +
-        `Percentage: ${(pct * 100).toFixed(1)}%`,
-      severity: threshold === 80 ? "warning" : "info",
-    });
+    // A daily budget window resets every day, so a harness that reliably
+    // consumes 80% of it produces an identical WARNING every morning. Four
+    // arrived overnight on 2026-08-16, for capabilities whose caps were doing
+    // exactly what they exist to do. Recurrence is not news — the first one is,
+    // and the ones after it teach the reader to ignore the channel. The
+    // per-window database flags below are unchanged, so the full history stays
+    // queryable even when the email is suppressed.
+    await alertOnce(
+      `budget-threshold:${slug}:${threshold}`,
+      ALERT_COOLDOWN_DAYS * 24 * 60 * 60 * 1000,
+      {
+        subject: `[budget] ${slug} reached ${threshold}% of ${meta.quota_window} test budget`,
+        body:
+          `Capability: ${slug}\n` +
+          `Cost class: ${meta.cost_class}\n` +
+          `Quota window: ${meta.quota_window}\n` +
+          `Quota cap: ${meta.quota_cap}\n` +
+          `Budget cap (this window): ${budgetCap}\n` +
+          `Test count so far: ${row.test_count}\n` +
+          `Percentage: ${(pct * 100).toFixed(1)}%\n\n` +
+          `This is our own test harness consuming a vendor free allowance, not a\n` +
+          `customer problem: the cap exists so customer traffic is never starved\n` +
+          `by our testing, and it is working. Repeats within ${ALERT_COOLDOWN_DAYS} days are logged\n` +
+          `but not emailed.`,
+        severity: threshold === 80 ? "warning" : "info",
+      },
+    );
     // Mark fired so subsequent calls don't re-alert. Composite-PK UPDATE
     // is atomic; if two callers race, only the first NULL→NOW() wins.
     if (column === "alert_30_fired_at") {
@@ -498,7 +522,15 @@ async function fireBudgetHardStopAlert(
   budgetCap: number,
   ctx: InvocationContext,
 ): Promise<void> {
-  await sendAlert({
+  // Rate-limited for the same reason as the thresholds, and more so: a
+  // capability whose harness exhausts a daily budget does it again tomorrow.
+  // `swedish-company-data` hit its cap on three consecutive days in August.
+  // The refusal still happens and is still logged every time — only the email
+  // is throttled.
+  await alertOnce(
+    `budget-hard-stop:${slug}`,
+    ALERT_COOLDOWN_DAYS * 24 * 60 * 60 * 1000,
+    {
     subject: `[budget-hard-stop] ${slug} exhausted ${meta.quota_window} test budget`,
     body:
       `Capability: ${slug}\n` +
@@ -508,9 +540,12 @@ async function fireBudgetHardStopAlert(
       `Budget cap (this window): ${budgetCap}\n` +
       `Refused context: ${ctx.kind}\n` +
       `Customer traffic is unaffected. Strale's own test/CI usage paused ` +
-      `until next ${meta.quota_window} window.`,
+      `until next ${meta.quota_window} window.\n\n` +
+      `Repeats within ${ALERT_COOLDOWN_DAYS} days are logged but not emailed — the refusal ` +
+      `still happens every time.`,
     severity: "critical",
-  });
+    },
+  );
 }
 
 // ─── The gate ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Four overnight WARNINGs for caps working as designed; all free_quota, zero cost. Seven-day cooldown per capability+threshold, DB flags untouched. 6 tests, two of which caught that I had only converted half the alert paths.