### PR TITLE
docs(handoff): part two of the session

### DIFF
--- a/handoff/_general/from-code/2026-08-15-operating-charter-and-measurement-rebuild.md
+++ b/handoff/_general/from-code/2026-08-15-operating-charter-and-measurement-rebuild.md
@@ -116,3 +116,87 @@ JSON parse failure (ours, ~€1.50/90d). Smithery crawls us but the public URL
 
 Notion was unreachable earlier in the session and reachable at close, so both were
 filed then rather than deferred to the next session.
+
+---
+
+# Part two — after the close-out (2026-08-16)
+
+The session continued past what looked like its end. Five more things happened,
+and three of them are refusals to build, which is the pattern worth noticing.
+
+## Mexico: right token, wrong API, and parked anyway
+
+Petter's INEGI token is valid — it returns HTTP 200 and real data (Mexico's 2020
+population). It is an **Indicadores** (statistics) token. DENUE, the business
+directory we wanted, is a separate service needing its own. **I sent him to a
+generic INEGI registration page** because DENUE's own link was unreachable in
+its docs, and my follow-up advice — check for an activation link, verify the
+characters — could never have found it, since nothing was wrong with the token.
+Only the email he forwarded named the API.
+
+Parked rather than re-registered, on evidence: **zero** requests mentioning
+Mexico in 180 days, and the 17 company-data capabilities we already run earned
+**€2.15 externally over 90 days** while our one paying customer has never made a
+single company-data call. The DENUE method signatures are banked in DQ-3.
+
+## The Coinbase email: withdrawn before sending
+
+Petter asked whether "41 of 334 endpoints indexed" was real. It was not. A
+complete walk of all 14,946 Bazaar entries finds **95**, and the email's own
+"not indexed" worked example was indexed. The mechanism is now established:
+**the Bazaar lists exactly what settled an x402 payment in the trailing 30
+days** — exact fit both directions, zero exceptions, sharp boundary at 28 and
+35 days.
+
+Consequence: Bazaar presence is **earned by sales and expires when they stop**.
+The "8× shelf presence" plan was circular — it needed sales to produce the
+sales it was meant to produce. Treat the listing count as a trailing indicator
+of revenue, never a lever on it.
+
+## Four growth initiatives, run down
+
+1. **Unmet demand on the paying rail — SHIPPED.** `failed_requests` only ever
+   recorded misses from `/v1/do`; x402 recorded nothing. Three rejection sites
+   now record, splitting *unknown slug* (catalogue signal) from *rejected input*
+   (product signal). No customer content stored. First readings within a week.
+2. **`company-enrich` parse bug — already fixed** in PR #214. Ten minutes of
+   checking saved building a fix for a fixed bug.
+3. **Other x402 registries — mostly not a lever.** Most mirror the CDP index and
+   inherit its settlement-derived property.
+4. **Free tier — not a funnel.** Only **2 external actors** used it in 90 days.
+   The finding is not "it doesn't convert" but "nobody finds it". The storefront
+   now names all eleven free capabilities; re-measure in a fortnight.
+
+## Budget alerts: the guard was right, the channel was wrong
+
+Four `[Strale WARNING] [budget]` emails overnight. All eleven alerting
+capabilities are `free_quota` with **zero external cost** — no money was being
+spent. A daily window resets daily, so a harness that reliably consumes 80% of
+it warns every morning for ever. Now rate-limited to once per capability per
+threshold per week; the per-window flags and the refusals are untouched.
+
+**Found while looking, and not acted on: 107,007 test executions against 674
+customer calls in seven days — 159 tests per customer call — with 15% of tests
+on capabilities no customer has ever bought.** Set against the earlier finding
+that the harness passes while customers hit ~9% failures, the picture is that we
+test enormously, uniformly, and not for the thing that matters. **This is the
+single biggest open question and belongs on the Sunday agenda**, not to a
+reflexive trim of something that protects us.
+
+## The pattern in part two
+
+Five investigations, three of which ended in *not building*: Mexico, the
+Coinbase email, and `company-enrich`. Each was killed by a cheap check that
+came before the work. The one thing built — demand capture — exists precisely
+because we had no way to know what to build.
+
+## Still open
+
+**Petter:** Talentino, Gryhat, Pave (registered, therefore contactable).
+Add the Indicadores token to Railway only if we ever use it. Sunday review.
+
+**Claude:** PR #135 (Italian, owned, deadline the next check-in). The 159:1
+testing ratio, for Sunday. Smithery's real listing URL.
+
+**Time, not people:** trustworthy payer numbers ~22 August. Nothing shipped
+today about distribution is measurable before then.


### PR DESCRIPTION
Handoff covered only the first half. Adds Mexico, Bazaar mechanism, growth results, budget alerts, and the 159:1 testing ratio for Sunday. Docs only.