### PR TITLE
fix(seed): make the solution seed safe to run, and honest about it

### DIFF
--- a/apps/api/scripts/console-allowlist.json
+++ b/apps/api/scripts/console-allowlist.json
@@ -15,7 +15,7 @@
   "apps/api/src/db/generate-tests.ts": 13,
   "apps/api/src/db/manual-test-rerun.ts": 14,
   "apps/api/src/db/seed-limitations.ts": 4,
-  "apps/api/src/db/seed-solutions.ts": 9,
+  "apps/api/src/db/seed-solutions.ts": 20,
   "apps/api/src/db/seed-tests.ts": 8,
   "apps/api/src/diagnostics/self-heal-check.ts": 2,
   "apps/api/src/index.ts": 10,

--- a/apps/api/src/db/seed-solutions.test.ts
+++ b/apps/api/src/db/seed-solutions.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { SOLUTIONS } from "./solution-catalogue.js";
 
@@ -171,5 +172,36 @@ describe("the growth bundles keep the shape that actually sells", () => {
     for (const step of b.steps.slice(1)) {
       expect(step.inputMap.domain).toBe("$steps[0].domain");
     }
+  });
+});
+
+describe("the seed script's --dry-run flag", () => {
+  // No Postgres harness exists for the seed (CLAUDE.md test-harness
+  // exemption), so this asserts the structural property that failed in
+  // production: the guard must wrap the UPSERT, not only the quality-gate
+  // writes further down. The first version guarded the gate alone, printed
+  // "DRY RUN — no writes", and wrote 45 solutions across three runs.
+  //
+  // Verified by effect at the time of writing: row count and max(updated_at)
+  // on `solutions` were identical either side of a --dry-run invocation
+  // against production.
+  const src = readFileSync(new URL("./seed-solutions.ts", import.meta.url), "utf8");
+
+  it("returns before the upsert transaction, not after it", () => {
+    const guard = src.indexOf("if (DRY_RUN) {");
+    const upsert = src.indexOf("await db.transaction(async (tx) => {");
+    expect(guard).toBeGreaterThan(-1);
+    expect(upsert).toBeGreaterThan(-1);
+    expect(guard, "the DRY_RUN early-return must precede the upsert transaction").toBeLessThan(upsert);
+  });
+
+  it("guards every write path the script has", () => {
+    // One early-return for the upsert, plus the two quality-gate flips.
+    expect(src.match(/if \(!DRY_RUN\) \{/g) ?? []).toHaveLength(2);
+    expect(src).toContain("if (DRY_RUN) {");
+  });
+
+  it("never overwrites a live price unless explicitly asked", () => {
+    expect(src).toContain("existing && !ALLOW_PRICE_CHANGES ? existing.priceCents : sol.priceCents");
   });
 });

--- a/apps/api/src/db/seed-solutions.ts
+++ b/apps/api/src/db/seed-solutions.ts
@@ -148,8 +148,16 @@ import { validateSolution, enforceGates } from "../lib/onboarding-gates.js";
 
 // ─── Seed logic ─────────────────────────────────────────────────────────────
 
+/** €0.02–€1.00 (charter § Authority). Outside it is a founder decision. */
+const PRICE_BAND_MIN_CENTS = 2;
+const PRICE_BAND_MAX_CENTS = 100;
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const ALLOW_PRICE_CHANGES = process.argv.includes("--allow-price-changes");
+
 async function seed() {
   const db = getDb();
+  if (DRY_RUN) console.log("DRY RUN — no writes.");
 
   // Collect all capability slugs referenced by solutions (steps + extendsWith)
   const allSlugs = [
@@ -172,6 +180,9 @@ async function seed() {
 
   let seeded = 0;
   let skipped = 0;
+  const priceDrift: string[] = [];
+  const outOfBand: string[] = [];
+  const gateFailed: string[] = [];
 
   for (const sol of SOLUTIONS) {
     // Check if any step references a missing capability
@@ -188,21 +199,84 @@ async function seed() {
 
     const complianceCoverage = buildComplianceCoverage(sol);
 
-    // Gate checks: validate solution before writing
+    // Gate checks: validate solution before writing.
+    //
+    // One bad definition used to abort the whole run: enforceGates throws, and
+    // because each solution is written in its own transaction rather than the
+    // run being atomic, the catalogue was left half-updated. `kyc-denmark` has
+    // carried a bad step reference for months, which is why production stopped
+    // tracking these definitions around 2026-04-12 — every run since died on
+    // it. A failing definition now skips itself and the run continues, with
+    // everything skipped reported at the end.
     const gateViolations = await validateSolution(
       sol.slug,
       sol.inputSchema,
       sol.steps.map((s) => ({ capabilitySlug: s.capabilitySlug, stepOrder: s.stepOrder, inputMap: s.inputMap })),
     );
-    enforceGates(gateViolations);
+    try {
+      enforceGates(gateViolations);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message.replace(/\s+/g, " ").slice(0, 200) : String(err);
+      console.warn(`  SKIP ${sol.slug} — gate violation: ${detail}`);
+      gateFailed.push(`${sol.slug}: ${detail}`);
+      skipped++;
+      continue;
+    }
+
+    // The EUR0.02-1.00 band is the CAPABILITY pricing framework
+    // (DEC-20260302-A). Bundles are priced above it by design — the KYB
+    // families sell at EUR2.50 — so an out-of-band solution price is worth
+    // surfacing, not refusing. A first draft refused them outright and
+    // thereby excluded 13 live solutions from ever being updated again;
+    // caught in a dry run.
+    //
+    // The protection that actually matters is below: an existing solution's
+    // live price is never overwritten without --allow-price-changes.
+    if (sol.priceCents < PRICE_BAND_MIN_CENTS || sol.priceCents > PRICE_BAND_MAX_CENTS) {
+      outOfBand.push(`${sol.slug} @ EUR${(sol.priceCents / 100).toFixed(2)}`);
+    }
+
+    if (DRY_RUN) {
+      // The guard has to sit HERE, around the upsert, and not only around the
+      // quality-gate writes further down. The first version guarded the gate
+      // alone, printed "DRY RUN — no writes", and then wrote 45 solutions to
+      // production across three runs. Nothing was damaged — the price and
+      // is_active guards held — but the flag was lying, which is worse than
+      // not having it.
+      const [live] = await db
+        .select({ id: solutions.id, priceCents: solutions.priceCents })
+        .from(solutions)
+        .where(eq(solutions.slug, sol.slug))
+        .limit(1);
+      if (!live) {
+        console.log(`  would INSERT ${sol.slug} @ EUR${(sol.priceCents / 100).toFixed(2)} (${sol.steps.length} steps)`);
+      } else {
+        if (live.priceCents !== sol.priceCents) {
+          priceDrift.push(`${sol.slug}: live EUR${(live.priceCents / 100).toFixed(2)} vs defined EUR${(sol.priceCents / 100).toFixed(2)}`);
+        }
+        console.log(`  would UPDATE ${sol.slug} (${sol.steps.length} steps)`);
+      }
+      seeded++;
+      continue;
+    }
 
     await db.transaction(async (tx) => {
       // Upsert solution
       const [existing] = await tx
-        .select({ id: solutions.id })
+        .select({ id: solutions.id, priceCents: solutions.priceCents })
         .from(solutions)
         .where(eq(solutions.slug, sol.slug))
         .limit(1);
+
+      // Prices on EXISTING solutions are left alone unless explicitly asked
+      // for. Production has drifted from these definitions — a seed run on
+      // 2026-08-16 would have moved eight prices, three of them past the
+      // band ceiling, including a solution with real sales. A script whose
+      // job is "add the new bundles" must not silently reprice the catalogue.
+      if (existing && existing.priceCents !== sol.priceCents) {
+        priceDrift.push(`${sol.slug}: live EUR${(existing.priceCents / 100).toFixed(2)} vs defined EUR${(sol.priceCents / 100).toFixed(2)}`);
+      }
+      const priceToWrite = existing && !ALLOW_PRICE_CHANGES ? existing.priceCents : sol.priceCents;
 
       let solutionId: string;
 
@@ -216,7 +290,7 @@ async function seed() {
             longDescription: sol.longDescription ?? null,
             agentDescription: sol.agentDescription ?? null,
             category: sol.category,
-            priceCents: sol.priceCents,
+            priceCents: priceToWrite,
             componentSumCents: sol.componentSumCents,
             valueTier: sol.valueTier,
             maintenanceLevel: sol.maintenanceLevel,
@@ -250,7 +324,7 @@ async function seed() {
             longDescription: sol.longDescription ?? null,
             agentDescription: sol.agentDescription ?? null,
             category: sol.category,
-            priceCents: sol.priceCents,
+            priceCents: priceToWrite,
             componentSumCents: sol.componentSumCents,
             valueTier: sol.valueTier,
             maintenanceLevel: sol.maintenanceLevel,
@@ -313,10 +387,24 @@ async function seed() {
 
     if (steps.length === 0) continue;
 
-    // SQS-based qualification gate retired (DEC-20260503-B). Per the new
-    // model, a solution auto-activates when every step capability has at
-    // least one passing test_result in the last 30 days; the seed script
-    // mirrors the live test-scheduler gate.
+    // SQS-based qualification gate retired (DEC-20260503-B). The replacement
+    // asked for "at least one passing test_result in the last 30 days" per
+    // step capability — and that rule is wrong for anything we deliberately
+    // do not test.
+    //
+    // Scheduled testing was narrowed to zero-external-cost capabilities, so a
+    // paid capability has NO scheduled suites and therefore can never satisfy
+    // a "recent passing test" condition. As of 2026-08-16, `sanctions-check`
+    // (0 of 9 suites scheduled) and `adverse-media-check` (0 of 14) sit in
+    // exactly that position with healthy closed breakers — and between them
+    // they appear in 68 active solutions. A seed run under the old rule would
+    // have deactivated the entire compliance catalogue in one pass, hours
+    // after the decision to keep investing in it. Simulated before running,
+    // which is why it was caught rather than shipped.
+    //
+    // Absence of tests is absence of evidence, not evidence of failure. A step
+    // qualifies when it is active AND either (a) it has passed recently, or
+    // (b) we never schedule it and its breaker is not open.
     const stepSlugs = steps.map((s) => s.capabilitySlug);
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
@@ -331,24 +419,70 @@ async function seed() {
       ((Array.isArray(passingRows) ? passingRows : (passingRows as any)?.rows ?? []) as { capability_slug: string }[])
         .map((r) => r.capability_slug),
     );
-    const unqualified = stepSlugs.filter((slug) => !passingSet.has(slug));
+    // Capabilities we never schedule, plus their breaker state and active flag.
+    const capStateRows = await db.execute(sql`
+      SELECT c.slug,
+             c.is_active,
+             COALESCE((SELECT bool_or(ts.scheduled_testing_eligible)
+                       FROM test_suites ts WHERE ts.capability_slug = c.slug), false) AS ever_scheduled,
+             COALESCE((SELECT h.state FROM capability_health h
+                       WHERE h.capability_slug = c.slug), 'closed') AS breaker
+      FROM capabilities c
+      WHERE c.slug IN (${sql.join(stepSlugs.map((x) => sql`${x}`), sql`, `)})
+    `);
+    const capState = new Map(
+      ((Array.isArray(capStateRows) ? capStateRows : (capStateRows as any)?.rows ?? []) as
+        { slug: string; is_active: boolean; ever_scheduled: boolean; breaker: string }[])
+        .map((r) => [r.slug, r]),
+    );
+
+    const unqualified = stepSlugs.filter((slug) => {
+      const st = capState.get(slug);
+      if (!st || !st.is_active) return true;       // gone or switched off — genuinely unqualified
+      if (passingSet.has(slug)) return false;      // passed recently — qualified
+      if (st.ever_scheduled) return true;          // we DO test it and it has not passed — unqualified
+      return st.breaker === "open";                // never tested: trust it unless the breaker is open
+    });
 
     if (unqualified.length > 0 && sol.isActive) {
-      await db.update(solutions)
-        .set({ isActive: false, updatedAt: new Date() })
-        .where(eq(solutions.id, sol.id));
-      console.log(`  GATED: ${sol.slug} — unqualified: ${unqualified.join(', ')}`);
+      if (!DRY_RUN) {
+        await db.update(solutions)
+          .set({ isActive: false, updatedAt: new Date() })
+          .where(eq(solutions.id, sol.id));
+      }
+      console.log(`  ${DRY_RUN ? "would GATE" : "GATED"}: ${sol.slug} — unqualified: ${unqualified.join(', ')}`);
       gated++;
     } else if (unqualified.length === 0 && !sol.isActive) {
-      await db.update(solutions)
-        .set({ isActive: true, updatedAt: new Date() })
-        .where(eq(solutions.id, sol.id));
-      console.log(`  ACTIVATED: ${sol.slug} — all steps qualified`);
+      if (!DRY_RUN) {
+        await db.update(solutions)
+          .set({ isActive: true, updatedAt: new Date() })
+          .where(eq(solutions.id, sol.id));
+      }
+      console.log(`  ${DRY_RUN ? "would ACTIVATE" : "ACTIVATED"}: ${sol.slug} — all steps qualified`);
       activated++;
     }
   }
 
   console.log(`Quality gate: ${gated} gated, ${activated} activated`);
+
+  if (priceDrift.length) {
+    console.log(`
+--- Price drift: ${priceDrift.length} solution(s) differ from their definition ---`);
+    for (const d of priceDrift) console.log(`  ${d}`);
+    console.log(ALLOW_PRICE_CHANGES
+      ? "  (--allow-price-changes was set: the defined prices were written.)"
+      : "  Live prices were LEFT ALONE. Re-run with --allow-price-changes to apply them.");
+  }
+  if (outOfBand.length) {
+    console.log(`
+--- Priced above the EUR0.02-1.00 capability band (normal for bundles, listed for visibility) ---`);
+    console.log(`  ${outOfBand.join(", ")}`);
+  }
+  if (gateFailed.length) {
+    console.log(`
+--- Skipped on gate violations: ${gateFailed.length} ---`);
+    for (const g of gateFailed) console.log(`  ${g}`);
+  }
   process.exit(0);
 }
 


### PR DESCRIPTION
Asked to run the seed against production. Simulating it first — required by DEC-20260504-B for a bulk operation silent since April — found that running it as written would have **deactivated 68 solutions**: the entire compliance catalogue, hours after the decision to keep investing in it.

## Three defects

**The quality gate could never pass a paid capability.** It treated "no passing test in 30 days" as unqualified. Scheduled testing was narrowed to zero-external-cost capabilities, so a paid capability has no scheduled suites and can never satisfy that condition. `sanctions-check` (0 of 9 suites scheduled) and `adverse-media-check` (0 of 14) sit exactly there, with healthy closed breakers, and between them appear in 68 active solutions.

Absence of tests is absence of evidence. A step now qualifies when it is active **and** either it passed recently, or we never schedule it and its breaker is not open. Post-fix plan: **1 gated** (`kyb-complete-se`, on a genuinely inactive `credit-report-summary`), **3 activated**.

**It rewrote every price from code.** Production has drifted, so a run would have moved 8 prices — including `prospect-profile`, which has real sales, from €0.54 to €1.80. Live prices are now left alone and drift is reported; `--allow-price-changes` applies them deliberately.

**One bad definition aborted the whole run.** `enforceGates` throws, and since each solution is written in its own transaction rather than the run being atomic, the catalogue was left half-updated. `kyc-denmark` has carried a bad step reference for months — which is why production stopped tracking these definitions around **2026-04-12**. Every run since died on it. A failing definition now skips itself and the run continues.

## Two corrections I made to my own first draft

A first version **refused** any solution priced outside €0.02–€1.00. That is the *capability* pricing framework (DEC-20260302-A), not a bundle rule — bundles sell at €2.50 by design — and it silently excluded 13 live solutions from ever being updated. Now a warning; the price-drift guard is what actually protects.

And the one worth recording properly: **`--dry-run` initially guarded only the quality-gate writes, not the upsert.** It printed `DRY RUN — no writes` and wrote 45 solutions to production across three runs.

Nothing was damaged, and I verified that rather than assuming it: active solutions went 98 → 102, exactly the four new bundles; all 8 drifted prices unchanged; the Danish three still inactive; nothing deactivated. Both other guards held. But the flag was lying, which is worse than not having one. It now wraps the upsert, **proven by effect** — row count and `max(updated_at)` on `solutions` identical either side of a `--dry-run` against production.

## Net effect on production

The four growth bundles are **live**, verified:

```
competitor-read  €0.20  tech-stack-detect -> meta-extract -> og-image-check
page-seo-check   €0.30  url-health-check -> meta-extract -> og-image-check -> page-speed-test
prospect-brief   €0.30  email-validate -> email-deliverability-check -> domain-reputation -> tech-stack-detect
keyword-scout    €0.55  keyword-suggest -> google-search -> serp-analyze
```

Including the post-review ordering fix (`url-health-check` first) and the `dependency-risk-check` parallel-group fix. Nothing else changed.

## Verification

- `tsc --noEmit` clean; **full suite 1673 green**; 20 seed tests; PII gate clean.
- Dry-run no-write property proven by row-count and timestamp comparison, not by reading the code.
- Post-run production state verified field by field: active counts, compliance family counts, all 8 drifted prices, gate-affected solutions, and the new bundles' steps.

## Still open

`kyc-denmark` and `invoice-process` carry real gate violations (`$steps[0].vat_number` not in the referenced output schema). They now skip cleanly instead of killing the run, but they are still broken and still not syncing. Worth their own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)