### PR TITLE
fix: stop the storefront advertising doors that 404, and give customers back their history

### DIFF
--- a/apps/api/scripts/ceo-dashboard.ts
+++ b/apps/api/scripts/ceo-dashboard.ts
@@ -167,18 +167,33 @@ async function main() {
         delta >= 0 ? "+" : ""}${delta.toFixed(1)}%</span>`;
 
   const buyers = renderMeasurement(actors, (v) => String(v.total));
-  const buyersNote = actors.status === "observed"
-    ? (actors.value.total === 1
-        ? `<span class="chip chip-warn">all from one buyer</span> we need more`
-        : `${actors.value.returning} came back · biggest is ${(actors.value.topShare * 100).toFixed(0)}% of the money`)
-    : esc(buyers.note);
+  // `unavailable` has no value at all, by design — render the reason, never a
+  // fabricated 0. `estimated` has a value but is a lower bound, so it is shown
+  // with the reason attached rather than as a fact.
+  const buyersNote = actors.status === "unavailable"
+    ? esc(buyers.note)
+    : [
+        actors.value.total === 1
+          ? `<span class="chip chip-warn">all from one buyer</span>`
+          : `biggest is ${(actors.value.topShare * 100).toFixed(0)}% of the money`,
+        actors.value.returning === null
+          ? `too early to tell how many came back`
+          : `${actors.value.returning} came back`,
+        actors.status === "estimated" ? esc(buyers.note) : "",
+      ].filter(Boolean).join(" · ");
 
   const cov = renderMeasurement(coverage, (v) => `${(v * 100).toFixed(1)}%`);
-  const hv = health.status === "observed"
-    ? health.value : { breakersOpen: 0, active: 0, quarantined: 0 };
-  const sp = spend.status === "estimated" || spend.status === "observed"
-    ? spend.value : { harnessCents: 0, settlementCents: 0, totalCents: 0 };
-  const budgetPct = Math.min(100, (sp.totalCents / 100 / BUDGET_ENVELOPE_EUR) * 100);
+  // Deliberately nullable rather than zero-filled. A zero here reads as
+  // "nothing is switched off" and "we spent nothing" — both are claims, and
+  // an unavailable measurement entitles us to neither.
+  const hv = health.status === "unavailable" ? null : health.value;
+  const sp = spend.status === "unavailable" ? null : spend.value;
+  const budgetPct = sp === null ? null
+    : Math.min(100, (sp.totalCents / 100 / BUDGET_ENVELOPE_EUR) * 100);
+  const healthNote = health.status === "unavailable"
+    ? esc(renderMeasurement(health, () => "").note) : "";
+  const spendNote = spend.status === "unavailable"
+    ? esc(renderMeasurement(spend, () => "").note) : "";
 
   const icons: Record<string, string> = {
     wallet: `<path d="M2.5 5.5A1.5 1.5 0 014 4h8a1.5 1.5 0 011.5 1.5v5A1.5 1.5 0 0112 12H4a1.5 1.5 0 01-1.5-1.5z"/><path d="M10.5 8h1.5"/>`,
@@ -253,14 +268,19 @@ async function main() {
         <div class="kfoot">${esc(cov.note || "of calls can be traced back to a buyer")}</div></div>
 
       <div class="kpi"><div class="krow"><span class="klabel">Services with problems</span>${
-        icon("pulse", hv.breakersOpen > 0 ? "i-warn" : "i-good")}</div>
-        <div class="kval">${hv.breakersOpen}<span class="unit"> switched off</span></div>
-        <div class="kfoot">${hv.active} data services working · ${hv.quarantined} paused</div></div>
+        icon("pulse", hv && hv.breakersOpen > 0 ? "i-warn" : "i-good")}</div>
+        <div class="kval">${hv ? `${hv.breakersOpen}<span class="unit"> switched off</span>` : "—"}</div>
+        <div class="kfoot">${hv
+          ? `${hv.active} data services working · ${hv.quarantined} paused`
+          : healthNote}</div></div>
 
       <div class="kpi"><div class="krow"><span class="klabel">Money spent this week</span>${
-        icon("coin", budgetPct > 80 ? "i-warn" : "i-good")}</div>
-        <div class="kval">${eur(sp.totalCents)}<span class="unit"> / €${BUDGET_ENVELOPE_EUR}</span></div>
-        <div class="kfoot">${budgetPct.toFixed(0)}% of the weekly limit · estimate</div></div>
+        icon("coin", budgetPct !== null && budgetPct > 80 ? "i-warn" : "i-good")}</div>
+        <div class="kval">${sp
+          ? `${eur(sp.totalCents)}<span class="unit"> / €${BUDGET_ENVELOPE_EUR}</span>` : "—"}</div>
+        <div class="kfoot">${budgetPct !== null
+          ? `${budgetPct.toFixed(0)}% of the weekly limit · estimate`
+          : spendNote}</div></div>
     </div>
 
     <div class="row row-2">
@@ -316,14 +336,15 @@ async function main() {
           <span class="pill" style="margin-left:auto">€${BUDGET_ENVELOPE_EUR}/wk</span></div>
         <div class="csub">What we pay other companies each week</div>
         <div class="cbody">
-          <div class="benv"><i style="width:${budgetPct}%"></i></div>
-          <div class="rlabels"><span>${eur(sp.totalCents)} spent</span>
-            <span>€${(BUDGET_ENVELOPE_EUR - sp.totalCents / 100).toFixed(2)} left</span></div>
+          <div class="benv"><i style="width:${budgetPct ?? 0}%"></i></div>
+          <div class="rlabels"><span>${sp ? `${eur(sp.totalCents)} spent` : spendNote}</span>
+            <span>${sp
+              ? `€${(BUDGET_ENVELOPE_EUR - sp.totalCents / 100).toFixed(2)} left` : ""}</span></div>
           <div class="blines">
             <div class="bline"><span class="bkey" style="background:var(--acc)"></span>
-              Our own automatic testing<span class="amt">${eur(sp.harnessCents)}</span></div>
+              Our own automatic testing<span class="amt">${sp ? eur(sp.harnessCents) : "—"}</span></div>
             <div class="bline"><span class="bkey" style="background:var(--acc-line)"></span>
-              Payment processing fees<span class="amt">${eur(sp.settlementCents)}</span></div>
+              Payment processing fees<span class="amt">${sp ? eur(sp.settlementCents) : "—"}</span></div>
             <div class="bline"><span class="bkey" style="background:var(--line)"></span>
               My thinking time<span class="amt">included in your plan</span></div>
           </div>
@@ -390,7 +411,7 @@ async function main() {
     `  buyers    ${actors.status}: ${buyers.text}${buyers.note ? ` — ${buyers.note}` : ""}\n` +
     `  funnel    ${funnel.status}${funnel.status === "observed" ? ` over ${funnel.window.label}` : ""}\n` +
     `  identity  ${coverage.status}: ${cov.text}\n` +
-    `  spend     ${spend.status}: ${eur(sp.totalCents)}`,
+    `  spend     ${spend.status}: ${sp ? eur(sp.totalCents) : "—"}`,
   );
   await closeDbPool();
 }

--- a/apps/api/src/capabilities/guarded-executor.ts
+++ b/apps/api/src/capabilities/guarded-executor.ts
@@ -33,7 +33,6 @@
 import { sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { log, logError, logWarn } from "../lib/log.js";
-import { sendAlert } from "../lib/alerting.js";
 import { alertOnce } from "../lib/alert-once.js";
 import {
   type CapabilityExecutor,
@@ -472,13 +471,12 @@ async function maybeFireThresholdAlerts(
       {
         subject: `[budget] ${slug} reached ${threshold}% of ${meta.quota_window} test budget`,
         body:
-          `Capability: ${slug}\n` +
-          `Cost class: ${meta.cost_class}\n` +
-          `Quota window: ${meta.quota_window}\n` +
-          `Quota cap: ${meta.quota_cap}\n` +
-          `Budget cap (this window): ${budgetCap}\n` +
-          `Test count so far: ${row.test_count}\n` +
-          `Percentage: ${(pct * 100).toFixed(1)}%\n\n` +
+          // Written for Petter, who is non-technical. The raw enum values
+          // (cost_class, quota_window, ctx.kind) stay out of the email; the
+          // slug stays in because it is the one token he can search for.
+          `Data service: ${slug}\n` +
+          `Our own testing has used ${row.test_count} of the ${budgetCap} daily calls we allow ` +
+          `ourselves against this supplier (${(pct * 100).toFixed(1)}%).\n\n` +
           `This is our own test harness consuming a vendor free allowance, not a\n` +
           `customer problem: the cap exists so customer traffic is never starved\n` +
           `by our testing, and it is working. Repeats within ${ALERT_COOLDOWN_DAYS} days are logged\n` +
@@ -533,14 +531,12 @@ async function fireBudgetHardStopAlert(
     {
     subject: `[budget-hard-stop] ${slug} exhausted ${meta.quota_window} test budget`,
     body:
-      `Capability: ${slug}\n` +
-      `Cost class: ${meta.cost_class}\n` +
-      `Quota window: ${meta.quota_window}\n` +
-      `Quota cap: ${meta.quota_cap}\n` +
-      `Budget cap (this window): ${budgetCap}\n` +
-      `Refused context: ${ctx.kind}\n` +
-      `Customer traffic is unaffected. Strale's own test/CI usage paused ` +
-      `until next ${meta.quota_window} window.\n\n` +
+      `Data service: ${slug}\n` +
+      `Our own testing has used its entire ${meta.quota_window} allowance with this ` +
+      `supplier (${budgetCap} calls), so further testing of it is paused until the ` +
+      `allowance resets.\n\n` +
+      `Customers are unaffected — this only stops Strale testing itself. ` +
+      `Nothing needs doing unless you see it every week.\n\n` +
       `Repeats within ${ALERT_COOLDOWN_DAYS} days are logged but not emailed — the refusal ` +
       `still happens every time.`,
     severity: "critical",

--- a/apps/api/src/jobs/revenue-heartbeat.test.ts
+++ b/apps/api/src/jobs/revenue-heartbeat.test.ts
@@ -67,17 +67,27 @@ describe("it fires when an established customer breaks their own rhythm", () => 
 });
 
 describe("the floor and the multiple both apply", () => {
-  it("never pages before 24 hours, however tight the rhythm", async () => {
-    // A customer calling every 30 minutes has an expected gap under an hour;
-    // without the floor, a two-hour lull would page at 3am for nothing.
+  // The floor was 24 hours until 2026-08-16, which — combined with a cadence
+  // estimate that could not return under ~24h — meant the minimum possible
+  // alert latency was ~72 hours. The 21-hour settlement outage this job was
+  // built for could not have fired it. The floor is now 6.
+  it("does not page a half-hourly customer over a brief lull", async () => {
     execute.mockResolvedValue([
-      row({ expected_gap_hours: 0.5, hours_silent: 6 }),
+      row({ expected_gap_hours: 0.5, hours_silent: 3 }),
     ]);
     expect(await findSilentPayers()).toHaveLength(0);
   });
 
-  it("does page that same customer once a full day has passed", async () => {
-    execute.mockResolvedValue([row({ expected_gap_hours: 0.5, hours_silent: 25 })]);
+  it("pages that customer well inside the 21-hour incident window", async () => {
+    execute.mockResolvedValue([row({ expected_gap_hours: 0.5, hours_silent: 7 })]);
+    expect(await findSilentPayers()).toHaveLength(1);
+  });
+
+  it("still respects the multiple for a genuinely slow caller", async () => {
+    // Daily caller, silent two days: within their own rhythm, no page.
+    execute.mockResolvedValue([row({ expected_gap_hours: 24, hours_silent: 48 })]);
+    expect(await findSilentPayers()).toHaveLength(0);
+    execute.mockResolvedValue([row({ expected_gap_hours: 24, hours_silent: 80 })]);
     expect(await findSilentPayers()).toHaveLength(1);
   });
 });

--- a/apps/api/src/jobs/revenue-heartbeat.ts
+++ b/apps/api/src/jobs/revenue-heartbeat.ts
@@ -26,6 +26,7 @@ import { getDb } from "../db/index.js";
 import { alertOnce } from "../lib/alert-once.js";
 import { log, logWarn } from "../lib/log.js";
 import { externalCustomers } from "../lib/metrics/populations.js";
+import { ACTOR_KEY_SQL } from "../lib/metrics/actor-identity.js";
 
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // hourly — the gap we care about is hours
 const ALERT_COOLDOWN_MS = 12 * 60 * 60 * 1000;
@@ -39,13 +40,29 @@ const MIN_ACTIVE_DAYS = 5;
 const TRAILING_DAYS = 14;
 
 /**
- * How many times their own typical daily gap must elapse before we care.
- * Set from the observed 177-hour legitimate gap: an established daily caller
- * silent for ~3× their normal cadence is unusual enough to look at, without
- * firing on the ordinary weekend lull.
+ * How many times their own typical gap must elapse before we care. Set from
+ * the observed 177-hour legitimate gap: a caller silent for ~3× their normal
+ * cadence is unusual enough to look at, without firing on an ordinary lull.
  */
 const SILENCE_MULTIPLE = 3;
-const MIN_SILENCE_HOURS = 24;
+
+/**
+ * Floor, so a very chatty caller does not page us over a brief lull.
+ *
+ * Was 24, which made the whole job unable to detect the outage in the
+ * docstring above. The old cadence estimate was `TRAILING_DAYS × 24 ÷
+ * distinct_active_days`; since active days cannot exceed the window's days,
+ * that expression cannot return less than ~24 — so the threshold
+ * `max(24, cadence × 3)` could never drop below ~72 hours, and the 21-hour
+ * settlement outage this job exists to catch would have passed unnoticed. The
+ * floor was unreachable dead code for the same reason.
+ *
+ * Now the cadence is the mean gap BETWEEN CALLS (below), which for the real
+ * wallet is ~0.5h rather than ~22h, so the floor is what actually governs
+ * chatty callers — 6 hours of silence from someone who normally calls every
+ * half hour is worth a look, and is under the 21-hour bar.
+ */
+const MIN_SILENCE_HOURS = 6;
 
 export interface HeartbeatFinding {
   actor: string;
@@ -64,23 +81,28 @@ export async function findSilentPayers(): Promise<HeartbeatFinding[]> {
   const rows = (await getDb().execute(sql`
     WITH paid AS (
       SELECT
-        COALESCE(t.user_id::text, 'x402:' || t.x402_payer_hash) AS actor,
+        ${sql.raw(ACTOR_KEY_SQL)} AS actor,
         t.created_at,
         t.price_cents
       FROM transactions t
       WHERE t.status = 'completed' AND t.price_cents > 0
         AND t.created_at > now() - (${String(TRAILING_DAYS)} || ' days')::interval
-        AND COALESCE(t.user_id::text, t.x402_payer_hash) IS NOT NULL
+        AND ${sql.raw(ACTOR_KEY_SQL)} IS NOT NULL
         AND ${externalCustomers("t")}
     )
     SELECT actor,
            COUNT(DISTINCT date_trunc('day', created_at))::int AS active_days,
            SUM(price_cents)::int                              AS revenue_cents,
            ROUND(EXTRACT(EPOCH FROM (now() - MAX(created_at))) / 3600.0, 1) AS hours_silent,
-           -- Their own rhythm: the trailing window divided by the days they
-           -- actually used us. A five-day-a-week caller expects ~a day.
-           ROUND((${String(TRAILING_DAYS)} * 24.0)
-                 / GREATEST(COUNT(DISTINCT date_trunc('day', created_at)), 1), 1) AS expected_gap_hours
+           -- Their own rhythm: the mean gap BETWEEN CALLS — the span from
+           -- their first to their last call divided by the number of gaps in
+           -- it. A wallet calling every 31 minutes reports ~0.5, which is the
+           -- point: a days-based estimate is floored at ~24h by construction
+           -- and made the alert unable to fire inside a day. Single-call
+           -- actors cannot reach MIN_ACTIVE_DAYS, so the GREATEST guard is
+           -- belt-and-braces against a divide-by-zero, not a real case.
+           ROUND((EXTRACT(EPOCH FROM (MAX(created_at) - MIN(created_at))) / 3600.0)
+                 / GREATEST(COUNT(*) - 1, 1), 2) AS expected_gap_hours
     FROM paid
     GROUP BY actor
     HAVING COUNT(DISTINCT date_trunc('day', created_at)) >= ${MIN_ACTIVE_DAYS}
@@ -125,8 +147,9 @@ async function tick(): Promise<void> {
           `${f.expectedGapHours} hours. They are worth €${(f.revenueCents / 100).toFixed(2)} ` +
           `over that period.\n\n` +
           `This fires for either cause and does not distinguish them: they may have ` +
-          `stopped, or we may be broken. Check x402 settlement health and the ` +
-          `circuit breakers first — a 21-hour settlement outage on 2026-08-14 stopped ` +
+          `stopped, or we may be broken. Check first whether payments are going ` +
+          `through and whether any data service has switched itself off — a 21-hour ` +
+          `payment outage on 2026-08-14 stopped ` +
           `this exact revenue and went unnoticed at the time.\n\n` +
           `Do not contact the customer on the strength of this alert; see the ` +
           `customer-data boundary in docs/company/CHARTER.md.`,

--- a/apps/api/src/lib/customer-content.ts
+++ b/apps/api/src/lib/customer-content.ts
@@ -107,10 +107,19 @@ export const CUSTOMER_CONTENT_CLEAR_SQL: SQL = sql.raw(
  */
 export function customerContentMatches(pattern: string, alias = "t"): SQL {
   const a = alias ? `${alias}.` : "";
-  return sql.join(
+  // `%` and `_` are ILIKE wildcards. A pattern containing either would silently
+  // over-match, and an audit that over-matches answers "is X in our data?" with
+  // a false yes. Escaped so the caller's string is searched literally.
+  const literal = pattern.replace(/([\\%_])/g, "\\$1");
+  const clauses = sql.join(
     CUSTOMER_CONTENT_COLUMNS.map(
-      (c) => sql`${sql.raw(`${a}${c.column}`)}::text ILIKE ${`%${pattern}%`}`,
+      (c) => sql`${sql.raw(`${a}${c.column}`)}::text ILIKE ${`%${literal}%`} ESCAPE '\\'`,
     ),
     sql` OR `,
   );
+  // Wrapped. Unparenthesised, a caller writing
+  // `WHERE deleted_at IS NULL AND ${customerContentMatches(p)}` gets
+  // `AND a OR b OR c`, and AND binds tighter than OR — the filter silently
+  // stops applying to every column but the first.
+  return sql`(${clauses})`;
 }

--- a/apps/api/src/lib/data-retention.test.ts
+++ b/apps/api/src/lib/data-retention.test.ts
@@ -161,7 +161,7 @@ describe("PII sweep selection scope", () => {
     // but could not close: solution executions carry `solution_slug` with a
     // NULL `capability_id`, so an inner join could never see them.
     await cleanupOldTestData();
-    const sweep = statements().find((s) => s.includes("pii_retention_purge"));
+    const sweep = statements().find((s) => s.includes("content_retention_purge"));
     expect(sweep, "content sweep statement was not emitted").toBeDefined();
     expect(sweep).not.toContain("processes_personal_data");
     expect(sweep).not.toMatch(/JOIN\s+capabilities/i);
@@ -177,15 +177,33 @@ describe("PII sweep selection scope", () => {
   it("skips already-redacted rows so a re-run is a no-op", async () => {
     await cleanupOldTestData();
     for (const s of statements().filter((x) => x.includes("deletion_reason"))) {
-      expect(s).toContain("deleted_at IS NULL");
+      expect(s).toMatch(/deleted_at IS NULL|redacted_at IS NULL/);
     }
+  });
+
+  it("the 90-day content sweep never marks a row logically deleted", async () => {
+    // `deleted_at` means "the row is gone" and every customer read path filters
+    // on it — the transaction list, transaction detail, the audit-record
+    // endpoint behind every shareable audit URL. A content redaction that set
+    // it took the customer's whole history and every audit record away at 90
+    // days, while the docstring promised the Art. 30 skeleton survived 1095.
+    await cleanupOldTestData();
+    const content = statements().find((x) => x.includes("content_retention_purge"))!;
+    expect(content).not.toContain("deleted_at = ");
+    expect(content).toContain("redacted_at = ");
+
+    // The 1095-day sweep still does, because there the row really is gone.
+    const hard = statements().find(
+      (x) => x.includes("'retention_purge'") && !x.includes("content_retention_purge"),
+    )!;
+    expect(hard).toContain("deleted_at = ");
   });
 
   it("self-throttles with a LIMIT rather than one unbounded statement", async () => {
     // DEC-20260504-B: the first run after introducing a window is a
     // workload-resumption event. The LIMIT is what bounds it.
     await cleanupOldTestData();
-    const pii = statements().find((s) => s.includes("pii_retention_purge"));
+    const pii = statements().find((s) => s.includes("content_retention_purge"));
     expect(pii).toContain("LIMIT");
   });
 
@@ -194,13 +212,13 @@ describe("PII sweep selection scope", () => {
     // have different justifications and different review consequences.
     await cleanupOldTestData();
     const all = statements().join(" | ");
-    expect(all).toContain("pii_retention_purge");
+    expect(all).toContain("content_retention_purge");
     expect(all).toContain("retention_purge");
   });
 
   it("zeroes every PII column, not just input", async () => {
     await cleanupOldTestData();
-    const pii = statements().find((s) => s.includes("pii_retention_purge"))!;
+    const pii = statements().find((s) => s.includes("content_retention_purge"))!;
     for (const col of ["input", "output", "error", "audit_trail", "provenance", "idempotency_key"]) {
       expect(pii).toContain(col);
     }
@@ -210,7 +228,7 @@ describe("PII sweep selection scope", () => {
     // A hard DELETE here broke the integrity-hash chain once already (CRIT-7).
     // The statement must be an UPDATE, and must not clear the hash columns.
     await cleanupOldTestData();
-    const pii = statements().find((s) => s.includes("pii_retention_purge"))!;
+    const pii = statements().find((s) => s.includes("content_retention_purge"))!;
     expect(pii).toContain("UPDATE transactions");
     expect(pii).not.toContain("DELETE FROM transactions");
     expect(pii).not.toContain("integrity_hash =");

--- a/apps/api/src/lib/data-retention.ts
+++ b/apps/api/src/lib/data-retention.ts
@@ -5,6 +5,33 @@ import { log } from "./log.js";
 
 const BATCH_SIZE = 1000;
 const BATCH_DELAY_MS = 100;
+/**
+ * DEC-20260504-B: a hard per-invocation ceiling, so no single sweep can run
+ * unbounded however large the backlog has grown. 50 × 1000 = 50,000 rows and
+ * ~5s of deliberate pause. Whatever is left is picked up by the next sweep.
+ */
+const MAX_BATCHES_PER_RUN = 50;
+
+/**
+ * Rows affected by a `db.execute()`.
+ *
+ * postgres-js returns a `RowList` whose affected-row count is `.count`. Every
+ * loop in this file read `.rowCount` — a node-postgres name this driver never
+ * sets — so the value was `undefined`, coalesced to 0, and:
+ *
+ *  - `if (count < BATCH_SIZE) break` fired on the **first** iteration, so each
+ *    sweep processed at most one batch and the backlog never drained;
+ *  - every counter in the summary log reported 0 forever, which is exactly the
+ *    silent-failure shape DEC-20260504-A exists to catch — in the file whose
+ *    own comments cite it.
+ *
+ * `db-retention.ts:152` and 15 sites in `startup-migrations.ts` already read
+ * `.count`; this file was the un-fixed twin. Centralised here so there is one
+ * place to be wrong.
+ */
+function affected(result: unknown): number {
+  return (result as { count?: number }).count ?? 0;
+}
 
 /**
  * Transaction retention window for GDPR Art. 30 record-of-processing
@@ -54,6 +81,7 @@ export const PII_RETENTION_DAYS = 90;
 async function purgeTestResults(cutoff: Date): Promise<number> {
   const db = getDb();
   let deleted = 0;
+  let batches = 0;
   while (true) {
     const result = await db.execute(sql`
       DELETE FROM test_results
@@ -63,9 +91,9 @@ async function purgeTestResults(cutoff: Date): Promise<number> {
         LIMIT ${BATCH_SIZE}
       )
     `);
-    const count = (result as any).rowCount ?? 0;
+    const count = affected(result);
     deleted += count;
-    if (count < BATCH_SIZE) break;
+    if (count < BATCH_SIZE || ++batches >= MAX_BATCHES_PER_RUN) break;
     await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
   }
   return deleted;
@@ -74,6 +102,7 @@ async function purgeTestResults(cutoff: Date): Promise<number> {
 async function purgeTransactionQuality(cutoff: Date): Promise<number> {
   const db = getDb();
   let deleted = 0;
+  let batches = 0;
   while (true) {
     // Skip transaction_quality rows linked to transactions with legal_hold
     const result = await db.execute(sql`
@@ -86,9 +115,9 @@ async function purgeTransactionQuality(cutoff: Date): Promise<number> {
         LIMIT ${BATCH_SIZE}
       )
     `);
-    const count = (result as any).rowCount ?? 0;
+    const count = affected(result);
     deleted += count;
-    if (count < BATCH_SIZE) break;
+    if (count < BATCH_SIZE || ++batches >= MAX_BATCHES_PER_RUN) break;
     await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
   }
   return deleted;
@@ -97,6 +126,7 @@ async function purgeTransactionQuality(cutoff: Date): Promise<number> {
 async function purgeTransactions(cutoff: Date): Promise<number> {
   const db = getDb();
   let redacted = 0;
+  let batches = 0;
   while (true) {
     // NEVER touch transactions with legal_hold = true.
     //
@@ -137,9 +167,9 @@ async function purgeTransactions(cutoff: Date): Promise<number> {
         LIMIT ${BATCH_SIZE}
       )
     `);
-    const count = (result as any).rowCount ?? 0;
+    const count = affected(result);
     redacted += count;
-    if (count < BATCH_SIZE) break;
+    if (count < BATCH_SIZE || ++batches >= MAX_BATCHES_PER_RUN) break;
     await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
   }
   return redacted;
@@ -148,6 +178,7 @@ async function purgeTransactions(cutoff: Date): Promise<number> {
 async function purgeHealthMonitorEvents(cutoff: Date): Promise<number> {
   const db = getDb();
   let deleted = 0;
+  let batches = 0;
   while (true) {
     const result = await db.execute(sql`
       DELETE FROM health_monitor_events
@@ -157,9 +188,9 @@ async function purgeHealthMonitorEvents(cutoff: Date): Promise<number> {
         LIMIT ${BATCH_SIZE}
       )
     `);
-    const count = (result as any).rowCount ?? 0;
+    const count = affected(result);
     deleted += count;
-    if (count < BATCH_SIZE) break;
+    if (count < BATCH_SIZE || ++batches >= MAX_BATCHES_PER_RUN) break;
     await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
   }
   return deleted;
@@ -216,33 +247,60 @@ async function purgeHealthMonitorEvents(cutoff: Date): Promise<number> {
  * — prove what happened, do not re-derive what was said.
  *
  * DEC-20260504-B re-audit for the widened window, 2026-08-15: 3,032 rows /
- * ~9.6 MB of payload on the first run, 0 on legal hold. The existing
- * LIMIT/BATCH_SIZE self-throttle bounds each tick to 1000 rows, so the
- * backlog drains over ~4 batches. Strategy unchanged: SELF-THROTTLE, no
- * pre-drain script needed at this volume.
+ * ~9.6 MB of payload on the first run, 0 on legal hold. Strategy: SELF-THROTTLE
+ * — BATCH_SIZE rows per statement, BATCH_DELAY_MS between statements, and
+ * MAX_BATCHES_PER_RUN as the per-invocation ceiling. (An earlier version of
+ * this note said the batch loop "bounds each tick to 1000 rows". It did not:
+ * the loop drained the whole backlog in one invocation, rate-limited but not
+ * capped. MAX_BATCHES_PER_RUN is what makes the claim true.)
+ *
+ * 2026-08-16 — STOPPED SETTING `deleted_at`.
+ *
+ * This is a *content* redaction, and `deleted_at` does not mean that. Per
+ * schema.ts: "deletedAt marks the row logically gone; redactedAt marks
+ * input/output/audit_trail zeroed." Setting both meant every customer read
+ * path — the transaction list, transaction detail, the audit-record endpoint
+ * behind every shareable audit URL, and the A2A task lookup, all of which
+ * filter `deleted_at IS NULL` — dropped the row entirely at 90 days.
+ *
+ * Under the old narrow selector that hit the ~90 personal-data capabilities.
+ * Widening it to all transactions on 2026-08-15 quietly turned it into: every
+ * customer loses their whole history, and every audit record stops resolving,
+ * at 90 days. Audit Trail is a product we sell. The docstring above says the
+ * Art. 30 skeleton "survives for the full 1095 days" — true in the table,
+ * false through the API, which is the only place a customer can see it.
+ *
+ * Masked at the time by the `.rowCount` bug above, which capped each sweep at
+ * one batch. Fixing that without this would have detonated it.
+ *
+ * `redacted_at` alone now marks these rows, and the chain walker in
+ * routes/verify.ts classifies on either column — see the note there. The
+ * hard-deletion path at TRANSACTION_RETENTION_DAYS (1095) still sets
+ * `deleted_at`, because there the row genuinely is gone.
  */
 async function purgeCustomerContent(cutoff: Date): Promise<number> {
   const db = getDb();
   let redacted = 0;
+  let batches = 0;
   while (true) {
     const result = await db.execute(sql`
       UPDATE transactions
       SET
         ${CUSTOMER_CONTENT_CLEAR_SQL},
-        deleted_at = NOW(),
         redacted_at = NOW(),
-        deletion_reason = 'pii_retention_purge'
+        deletion_reason = 'content_retention_purge'
       WHERE id IN (
         SELECT t.id FROM transactions t
         WHERE t.created_at < ${cutoff.toISOString()}::timestamptz
           AND t.legal_hold = false
+          AND t.redacted_at IS NULL
           AND t.deleted_at IS NULL
         LIMIT ${BATCH_SIZE}
       )
     `);
-    const count = (result as any).rowCount ?? 0;
+    const count = affected(result);
     redacted += count;
-    if (count < BATCH_SIZE) break;
+    if (count < BATCH_SIZE || ++batches >= MAX_BATCHES_PER_RUN) break;
     await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
   }
   return redacted;

--- a/apps/api/src/lib/go-review-regressions.test.ts
+++ b/apps/api/src/lib/go-review-regressions.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Regression tests for the 2026-08-16 close-out review findings.
+ *
+ * Per DEC-20260504-A every audit-follow-up that introduces a code path ships a
+ * test that fails against the un-applied fix and passes against the applied
+ * one. Each block below names the finding, states the failure it locks out,
+ * and asserts on the *structural shape* of the fix rather than on a live
+ * database — the same approach the PR-43 bind-encoder test took, and for the
+ * same reason: these are all bugs where the code read fine and the shape was
+ * wrong.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+import { customerContentMatches } from "./customer-content.js";
+import { rankBySales } from "./seller-rank.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const readSrc = (rel: string) => readFileSync(join(HERE, "..", rel), "utf8");
+
+/**
+ * Source with comments removed. These assertions are about what the code does;
+ * a docstring that *describes* the old bug (and every fix here carries one)
+ * would otherwise match the pattern that proves the bug is present.
+ */
+const readCode = (rel: string) =>
+  readSrc(rel)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+const dialect = new PgDialect();
+
+// ── H1 · every retention loop read a field this driver never sets ───────────
+describe("data-retention: affected-row counting", () => {
+  const src = readCode("lib/data-retention.ts");
+
+  it("never reads .rowCount — postgres-js reports affected rows as .count", () => {
+    // The bug: `(result as any).rowCount ?? 0` is always 0 on this driver, so
+    // `if (count < BATCH_SIZE) break` fired on the first iteration and every
+    // summary counter logged 0 forever.
+    expect(src).not.toMatch(/\.rowCount/);
+    expect(src).toMatch(/function affected\(result: unknown\): number/);
+  });
+
+  it("every drain loop is capped per invocation (DEC-20260504-B)", () => {
+    const loops = src.match(/if \(count < BATCH_SIZE/g) ?? [];
+    const capped = src.match(/if \(count < BATCH_SIZE \|\| \+\+batches >= MAX_BATCHES_PER_RUN\)/g) ?? [];
+    expect(loops.length).toBeGreaterThan(0);
+    expect(capped.length).toBe(loops.length);
+  });
+});
+
+// ── H2 · a content redaction was marking rows logically deleted ─────────────
+describe("data-retention: the 90-day sweep redacts, it does not delete", () => {
+  const src = readCode("lib/data-retention.ts");
+  const purge = src.slice(src.indexOf("async function purgeCustomerContent"));
+
+  // The two chain-classification cases this fix depends on live in
+  // routes/verify.test.ts, next to the module they exercise — importing a route
+  // module from a lib test drags its module-level rate-limiter state into the
+  // shared worker and destabilises unrelated route suites.
+  it("purgeCustomerContent does not set deleted_at", () => {
+    // Setting it hid the whole row from the transaction list, transaction
+    // detail, the audit-record endpoint behind every shareable audit URL, and
+    // the A2A task lookup — all of which filter `deleted_at IS NULL`. The
+    // docstring promises the Art. 30 skeleton survives 1095 days; setting
+    // deleted_at made that true in the table and false through the API.
+    expect(purge).not.toMatch(/deleted_at = NOW\(\)/);
+    expect(purge).toMatch(/redacted_at = NOW\(\)/);
+  });
+
+  it("the 1095-day deletion still sets deleted_at — there the row IS gone", () => {
+    const hard = src.slice(
+      src.indexOf("async function purgeTransactions"),
+      src.indexOf("async function purgeHealthMonitorEvents"),
+    );
+    expect(hard).toMatch(/deleted_at = NOW\(\)/);
+  });
+
+});
+
+// ── H3/H4 · the agent card advertised endpoints the gateway would 404 ───────
+describe("agent card: only advertise what the gateway serves", () => {
+  const src = readCode("routes/a2a.ts");
+
+  it("reads the two columns the gateway gates on", () => {
+    // Measured against production 2026-08-16: the card listed 307 capabilities
+    // and 98 solutions; the gateway would serve 249 and 79. 66 advertised
+    // endpoints 404'd — and each 404 wrote a false `x402_unknown_slug` row
+    // into the demand table, so the card manufactured build-signal from its
+    // own bug.
+    expect(src).toMatch(/x402Enabled: capabilities\.x402Enabled/);
+    expect(src).toMatch(/lifecycleState: capabilities\.lifecycleState/);
+    expect(src).toMatch(/x402Enabled: solutions\.x402Enabled/);
+  });
+
+  it("gates every x402_endpoint on payableViaX402", () => {
+    const emits = src.match(/x402_endpoint: [^\n]*/g) ?? [];
+    expect(emits.length).toBeGreaterThan(0);
+    for (const line of emits) expect(line).toMatch(/payable/);
+  });
+
+  it("advertises solutions at the solutions path, not the capability wildcard", () => {
+    // `/x402/{slug}` is the capability wildcard. Solutions live at
+    // `/x402/v2/solutions/{slug}`; the old form fell through and 404'd for
+    // every solution on the card.
+    expect(src).toMatch(/\/x402\/v2\/solutions\/\$\{slug\}/);
+    expect(src).not.toMatch(/x402_endpoint: payableViaX402\(sol\) \? `\$\{PUBLIC_API_BASE\}\/x402\/\$\{sol\.slug\}`/);
+  });
+
+  it("uses the shared ranker rather than a private copy", () => {
+    // The copy had neither the 15-minute cache (this surface is fetched ~520×
+    // a week) nor the fail-open catch, so a ranking-query failure 500'd the
+    // card — the exact outcome seller-rank.ts says it exists to prevent.
+    expect(src).toMatch(/from "\.\.\/lib\/seller-rank\.js"/);
+    expect(src).not.toMatch(/async function externalRevenueBySlug/);
+  });
+});
+
+// ── M6 · an OR chain with no parentheses inverts the caller's WHERE ─────────
+describe("customerContentMatches", () => {
+  it("is parenthesised, so AND/OR precedence cannot silently invert", () => {
+    const q = dialect.sqlToQuery(sql`SELECT 1 WHERE deleted_at IS NULL AND ${customerContentMatches("x")}`);
+    expect(q.sql).toMatch(/AND \(/);
+    // Unwrapped this renders `AND a ILIKE .. OR b ILIKE ..`, and AND binds
+    // tighter than OR — the deleted_at filter would apply to the first column
+    // only.
+    expect(q.sql).not.toMatch(/AND [a-z_.]+::text ILIKE \$1 OR/);
+  });
+
+  it("escapes ILIKE wildcards so an audit cannot over-match", () => {
+    const q = dialect.sqlToQuery(customerContentMatches("100%_off"));
+    expect(q.params[0]).toBe("%100\\%\\_off%");
+    expect(q.sql).toMatch(/ESCAPE/);
+  });
+});
+
+// ── M10 · a ranker that claimed solutions but could only see capabilities ───
+describe("seller-rank", () => {
+  it("reads solution_slug, so solutions can actually rank", () => {
+    // Solution executions carry `capability_id IS NULL` (schema.ts:244), so the
+    // old `JOIN capabilities` could never match one: every solution scored 0
+    // and `rankBySales` over a solution catalogue was an alphabetical sort
+    // wearing a revenue label.
+    const src = readCode("lib/seller-rank.ts");
+    // The selected slug, specifically — a solution row has no capability to
+    // join to, so an inner join drops it before it can be summed.
+    expect(src).toMatch(/COALESCE\(t\.solution_slug, c\.slug\) AS slug/);
+    expect(src).toMatch(/LEFT JOIN capabilities c/);
+  });
+
+  it("orders paid sellers by revenue, then free, then alphabetically", () => {
+    const items = [
+      { slug: "zeta", free: false },
+      { slug: "alpha", free: false },
+      { slug: "free-thing", free: true },
+      { slug: "earner", free: false },
+    ];
+    const ranked = rankBySales(
+      items,
+      new Map([["earner", 500]]),
+      (i) => i.slug,
+      (i) => i.free,
+    );
+    expect(ranked.map((i) => i.slug)).toEqual(["earner", "free-thing", "alpha", "zeta"]);
+  });
+});
+
+// ── M3 · the heartbeat's threshold could never fire ─────────────────────────
+describe("revenue heartbeat: the alert can detect the outage it cites", () => {
+  const src = readCode("jobs/revenue-heartbeat.ts");
+
+  it("measures cadence between calls, not across days", () => {
+    // The old estimate was `TRAILING_DAYS × 24 ÷ distinct_active_days`. Active
+    // days cannot exceed the window, so it could not return under ~24h, so
+    // `max(24, cadence × 3)` could not drop under ~72h — and the 21-hour
+    // settlement outage named in the file's own docstring would not have
+    // fired.
+    expect(src).not.toMatch(/\$\{String\(TRAILING_DAYS\)\} \* 24\.0/);
+    expect(src).toMatch(/MAX\(created_at\) - MIN\(created_at\)/);
+    expect(src).toMatch(/GREATEST\(COUNT\(\*\) - 1, 1\)/);
+  });
+
+  it("the floor is below the 21-hour incident it was built for", () => {
+    const m = src.match(/const MIN_SILENCE_HOURS = (\d+)/);
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBeLessThan(21);
+  });
+
+  it("derives the actor key from the identity spine, not a local copy", () => {
+    // Two key formats created the same day (`x402:abc` vs `x402:v1:abc`) in a
+    // module whose whole point is that the two definitions cannot drift.
+    expect(src).toMatch(/ACTOR_KEY_SQL/);
+    expect(src).not.toMatch(/'x402:' \|\| t\.x402_payer_hash/);
+  });
+});
+
+// ── M1 · a comment claimed a test that did not exist ────────────────────────
+describe("metrics: window bounds are bound as strings", () => {
+  it("no Date instance is interpolated into a metrics query", () => {
+    // metrics.ts said "a test asserts the source contains no raw Date
+    // interpolation." No such test existed. This is it. The failure mode is
+    // the PR-43 defect: postgres-js cannot encode a Date passed through a
+    // drizzle sql`` template, and the query throws ERR_INVALID_ARG_TYPE at
+    // runtime — invisible to tsc.
+    const src = readCode("lib/metrics/metrics.ts");
+    // A bare Date reaching a bind slot is the failure. Anything ending in
+    // .toISOString() or coming from bounds() is a string and binds fine.
+    const binds = src.match(/\$\{[^}]*\b(?:from|to)\b[^}]*\}/g) ?? [];
+    expect(binds.length).toBeGreaterThan(0);
+    for (const b of binds) {
+      expect(b, `unencoded Date bind: ${b}`).toMatch(/toISOString\(\)|bounds\(/);
+    }
+    expect(src).toMatch(/function bounds\(w: Window\)/);
+    expect(src).toMatch(/w\.from\.toISOString\(\), to: w\.to\.toISOString\(\)/);
+  });
+});

--- a/apps/api/src/lib/metrics/metrics.ts
+++ b/apps/api/src/lib/metrics/metrics.ts
@@ -211,10 +211,24 @@ export async function identityCoverage(w: Window): Promise<Measurement<number>> 
  *
  * Rolling 28 days by default: at this volume a weekly count is dominated by
  * one buyer's schedule rather than by anything we did.
+ *
+ * **Instrument age is handled, not ignored.** Half the actor key comes from
+ * `user_id`, which is as old as the table; the other half from
+ * `x402_payer_hash`, enabled 2026-08-15. While that half is younger than the
+ * window the wallet side is truncated — some x402 revenue is unattributable
+ * only because the column did not exist yet, and *no* actor can have been
+ * first seen before the window opened, so `returning` would be a structural
+ * zero rather than a measurement.
+ *
+ * So: `estimated` (not `observed`) with the truncation stated, and `returning`
+ * is `null` — "we cannot tell yet" — rather than 0. Reporting a one-day-old
+ * instrument as a 28-day fact is the 2026-08-15 "1 paying customer" error, and
+ * this metric is the one the dashboard actually calls.
  */
 export async function payingActors(
   w: Window,
-): Promise<Measurement<{ total: number; returning: number; topShare: number; byKind: Record<string, number> }>> {
+): Promise<Measurement<{ total: number; returning: number | null; topShare: number; unattributedCents: number; byKind: Record<string, number> }>> {
+  const guard = coversWindow("x402_payer_identity", w.from);
   const r = await rows<{ actor_key: string; actor_kind: string; cents: string; first_seen: string }>(sql`
     SELECT ${sql.raw(ACTOR_KEY_SQL)} AS actor_key,
            ${sql.raw(ACTOR_KIND_SQL)} AS actor_kind,
@@ -230,23 +244,49 @@ export async function payingActors(
     return { status: "unavailable", population: "external_customers", requestedWindow: w,
              reason: { kind: "no_data" } };
   }
-  const totalCents = identified.reduce((a, x) => a + Number(x.cents), 0);
+  const identifiedCents = identified.reduce((a, x) => a + Number(x.cents), 0);
+  // Revenue we could not attribute to anyone. `topShare` MUST be a share of
+  // all external revenue, not of the attributed slice: dividing by the slice
+  // turns "one wallet, plus a lot we cannot see" into a confident 100%.
+  const unattributedCents = r
+    .filter((x) => x.actor_key === null)
+    .reduce((a, x) => a + Number(x.cents), 0);
+  const totalCents = identifiedCents + unattributedCents;
   const byKind: Record<string, number> = {};
   for (const x of identified) byKind[x.actor_kind] = (byKind[x.actor_kind] ?? 0) + 1;
+  const topShare = totalCents === 0 ? 0
+    : Math.max(...identified.map((x) => Number(x.cents))) / totalCents;
+  const caveat = identified.length === 1
+    ? (unattributedCents > 0
+        ? "One identified buyer, and money we cannot yet trace to anyone."
+        : "All of it from a single buyer.")
+    : undefined;
+  const value = {
+    total: identified.length,
+    // "Returning" = first seen before this window opened, which is only
+    // answerable once the identity instrument is older than the window.
+    returning: guard.ok
+      ? identified.filter((x) => new Date(x.first_seen) < w.from).length
+      : null,
+    topShare,
+    unattributedCents,
+    byKind,
+  };
+  if (!guard.ok) {
+    return {
+      status: "estimated", value, window: w, population: "external_customers",
+      methodology:
+        "A lower bound. Wallet identity has only been recorded since " +
+        (guard.enabledAt ? guard.enabledAt.toISOString().slice(0, 10) : "recently") +
+        ", so buyers active earlier in this window are not counted, and whether " +
+        "anyone came back cannot be answered yet",
+      instruments: evidenceFor(["x402_payer_identity"]),
+      caveat,
+    };
+  }
   return {
-    status: "observed",
-    value: {
-      total: identified.length,
-      // "Returning" means first seen before this window opened — so it is only
-      // meaningful once the identity instrument is older than the window.
-      returning: identified.filter((x) => new Date(x.first_seen) < w.from).length,
-      topShare: totalCents === 0 ? 0
-        : Math.max(...identified.map((x) => Number(x.cents))) / totalCents,
-      byKind,
-    },
-    window: w, population: "external_customers",
-    instruments: evidenceFor(["x402_payer_identity"]),
-    caveat: identified.length === 1 ? "All of it from a single buyer." : undefined,
+    status: "observed", value, window: w, population: "external_customers",
+    instruments: evidenceFor(["x402_payer_identity"]), caveat,
   };
 }
 

--- a/apps/api/src/lib/seller-rank.ts
+++ b/apps/api/src/lib/seller-rank.ts
@@ -44,10 +44,21 @@ export async function sellerRevenueBySlug(windowDays = 28): Promise<Map<string, 
       INTERNAL_EMAIL_LIKE_PATTERNS.map((p) => sql`email LIKE ${p}`), sql` OR `);
     const eqAny = sql.join(
       EXTRA_EXCLUDED_EMAILS.map((e) => sql`email = ${e}`), sql` OR `);
+    // COALESCE, not a JOIN on capabilities.
+    //
+    // The join form was capabilities-only, so every solution scored 0 and
+    // `rankBySales` over a solution catalogue collapsed to an alphabetical
+    // sort wearing a revenue label. Solution executions carry
+    // `solution_slug` with `capability_id IS NULL` (schema.ts:244), so they
+    // could never match the join — the function's own docstring said
+    // "capability/solution slug" while the query could only ever return one
+    // of the two.
     const rows = (await getDb().execute(sql`
-      SELECT c.slug, COALESCE(SUM(t.price_cents), 0)::int AS cents
-      FROM transactions t JOIN capabilities c ON c.id = t.capability_id
+      SELECT COALESCE(t.solution_slug, c.slug) AS slug,
+             COALESCE(SUM(t.price_cents), 0)::int AS cents
+      FROM transactions t LEFT JOIN capabilities c ON c.id = t.capability_id
       WHERE t.status = 'completed' AND t.price_cents > 0
+        AND COALESCE(t.solution_slug, c.slug) IS NOT NULL
         AND t.created_at > now() - (${String(windowDays)} || ' days')::interval
         AND (t.user_id IS NULL OR t.user_id NOT IN (
           SELECT id FROM users WHERE (${likeAny}) OR (${eqAny})))

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -63,6 +63,7 @@ import {
   runMigration0077_classifyFreeQuotaOverrides,
   runMigration0078_transactionsCapabilityIdCreatedAtIdx,
   runMigration0082_reclassifyThrottledFreeUnlimited,
+  runMigration0087_unhideRedactedRows,
   runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
@@ -1156,8 +1157,42 @@ describe("startup-migrations — phase-b5 slug lists (invariants)", () => {
   });
 });
 
+describe("startup-migrations — block 0087 (un-hide content-redacted rows)", () => {
+  it("clears deleted_at only for this sweep's own signature", async () => {
+    // Narrow by construction: a user-requested erasure and the 1095-day hard
+    // purge both legitimately set deleted_at and must survive untouched.
+    const stub = makeStub({ default: { count: 2004 } });
+    const result = await runMigration0087_unhideRedactedRows(stub);
+    const [unhide] = stub.renderedSql;
+    expect(unhide).toMatch(/set "?deleted_at"? = null/i);
+    expect(unhide).toMatch(/redacted_at is not null/i);
+    expect(unhide).toMatch(/pii_retention_purge|content_retention_purge/);
+    expect(unhide).not.toMatch(/user_request/);
+    expect(result.rows_affected).toBeGreaterThan(0);
+  });
+
+  it("un-hides without un-redacting — no payload column is written", async () => {
+    const stub = makeStub({ default: { count: 0 } });
+    await runMigration0087_unhideRedactedRows(stub);
+    for (const s of stub.renderedSql) {
+      for (const col of ["input", "output", "audit_trail", "provenance"]) {
+        expect(s, `payload column ${col} must not be written`).not.toMatch(
+          new RegExp(`"?${col}"?\s*=`, "i"),
+        );
+      }
+    }
+  });
+
+  it("is a no-op on re-run once the repair has landed", async () => {
+    const stub = makeStub({ default: { count: 0 } });
+    const result = await runMigration0087_unhideRedactedRows(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toMatch(/no change/);
+  });
+});
+
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 29 blocks in historical order", () => {
+  it("exports the expected 30 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1193,6 +1228,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0084_danishQuotaHeadroom",
       "runMigration0085_actorIdentity",
       "runMigration0086_srcBasis",
+      "runMigration0087_unhideRedactedRows",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1549,6 +1549,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0084_danishQuotaHeadroom,
   runMigration0085_actorIdentity,
   runMigration0086_srcBasis,
+  runMigration0087_unhideRedactedRows,
 ];
 
 /**
@@ -2031,4 +2032,74 @@ export async function runStartupMigrations(): Promise<BlockResult[]> {
   );
 
   return results;
+}
+
+
+/**
+ * Block 0087 — give customers back the history a content redaction took.
+ *
+ * The 90-day customer-content sweep in `data-retention.ts` set BOTH
+ * `redacted_at` and `deleted_at`. Only the first was correct. Per schema.ts,
+ * `deleted_at` means "the row is logically gone", and every customer read path
+ * filters on it: the transaction list, transaction detail, the audit-record
+ * endpoint behind every shareable audit URL, and the A2A task lookup. So a
+ * redaction that was supposed to zero the payload and keep the Art. 30
+ * skeleton readable for 1095 days instead made the whole row vanish from the
+ * API at 90 — for Audit Trail, a product we sell.
+ *
+ * Under the old narrow selector this hit only personal-data capabilities.
+ * Widening it to all transactions on 2026-08-15 made it universal. A separate
+ * bug (every loop read `.rowCount`, which this driver never sets, so each
+ * sweep stopped after one batch) capped the damage at roughly one batch per
+ * run — which is the only reason this is a repair and not an incident.
+ *
+ * The repair is narrow by construction: it clears `deleted_at` ONLY where the
+ * row carries this sweep's exact signature — a retention content-redaction
+ * reason, `redacted_at` set, and `deleted_at` set. It cannot touch a
+ * user-requested erasure (`deletion_reason = 'user_request'`), and it cannot
+ * touch the 1095-day hard-retention purge, which writes `'retention_purge'`
+ * and where `deleted_at` is correct. Nothing is un-redacted: the payload
+ * columns stay zeroed, permanently. Only the row's visibility comes back.
+ *
+ * DEC-20260504-B: this is an UPDATE of a few thousand rows setting one column
+ * to NULL, run once inside the migration transaction. No payload is written,
+ * nothing is deleted, and the WHERE clause is self-limiting — after the first
+ * successful run it matches nothing, which is what makes re-running on every
+ * boot a no-op.
+ */
+export async function runMigration0087_unhideRedactedRows(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const res = await tx.execute(sql`
+    UPDATE transactions
+    SET deleted_at = NULL
+    WHERE deleted_at IS NOT NULL
+      AND redacted_at IS NOT NULL
+      AND deletion_reason IN ('pii_retention_purge', 'content_retention_purge')
+  `);
+  const restored = (res as { count?: number }).count ?? 0;
+
+  // Bring the old reason string in line with what the column now means, so an
+  // operator reading `deletion_reason` is not told a row was deleted for PII
+  // when it was redacted for content. Chain verification buckets both under
+  // retention (routes/verify.ts isRetentionReason), so this is cosmetic to the
+  // public response and load-bearing for whoever reads the table directly.
+  const renamed = await tx.execute(sql`
+    UPDATE transactions
+    SET deletion_reason = 'content_retention_purge'
+    WHERE deletion_reason = 'pii_retention_purge'
+  `);
+  const renamedCount = (renamed as { count?: number }).count ?? 0;
+
+  return {
+    block: "0087_unhideRedactedRows",
+    outcome:
+      restored === 0
+        ? "no change (no content-redacted rows were marked deleted)"
+        : `${restored} redacted transactions made visible again to their owners; payload stays zeroed`,
+    rows_affected: restored + renamedCount,
+    duration_ms: Date.now() - startedAt,
+  };
 }

--- a/apps/api/src/routes/a2a-card.test.ts
+++ b/apps/api/src/routes/a2a-card.test.ts
@@ -43,13 +43,25 @@ describe("the card itself, built against a stubbed catalogue", () => {
     // sees a small known catalogue instead of production.
     const capRows = [
       { slug: "google-search", name: "Google Search", description: "Search Google.",
-        category: "web", priceCents: 5, isFreeTier: false },
+        category: "web", priceCents: 5, isFreeTier: false,
+        x402Enabled: true, lifecycleState: "active" },
       { slug: "email-validate", name: "Email Validation", description: "Validate email.",
-        category: "validation", priceCents: 0, isFreeTier: true },
+        category: "validation", priceCents: 0, isFreeTier: true,
+        x402Enabled: false, lifecycleState: "active" },
       { slug: "rare-lookup", name: "Rare Lookup", description: "Rarely bought.",
-        category: "data", priceCents: 10, isFreeTier: false },
+        category: "data", priceCents: 10, isFreeTier: false,
+        x402Enabled: true, lifecycleState: "active" },
+      // Real, sellable, on the card — but the gateway would not take money for
+      // it. 66 rows looked like this in production on 2026-08-16.
+      { slug: "api-key-only", name: "Key Only", description: "Paid, but not on x402.",
+        category: "data", priceCents: 20, isFreeTier: false,
+        x402Enabled: false, lifecycleState: "active" },
+      { slug: "degraded-thing", name: "Degraded", description: "Quarantined service.",
+        category: "data", priceCents: 20, isFreeTier: false,
+        x402Enabled: true, lifecycleState: "quarantined" },
       { slug: "test-solution-delete-me", name: "Internal", description: "Scaffolding.",
-        category: "internal", priceCents: 1, isFreeTier: false },
+        category: "internal", priceCents: 1, isFreeTier: false,
+        x402Enabled: true, lifecycleState: "active" },
     ];
     const select = () => ({
       from: (table: unknown) => ({
@@ -86,6 +98,23 @@ describe("the card itself, built against a stubbed catalogue", () => {
     expect(paid.description).toContain("/x402/google-search");
     expect(paid.price_cents).toBe(5);
     expect(paid.x402_endpoint).toContain("/x402/google-search");
+  });
+
+  it("never advertises a payment endpoint the gateway would 404", async () => {
+    // The card filtered on is_active + marketplace_eligible; the gateway
+    // requires x402_enabled AND an active/probation lifecycle. 66 endpoints sat
+    // in that gap in production — each 404'd, and each 404 wrote a false
+    // `x402_unknown_slug` row into the demand table the same session added, so
+    // the card was manufacturing build-signal out of its own bug.
+    const card = await buildStubbed();
+    for (const id of ["api-key-only", "degraded-thing"]) {
+      const skill = card.skills.find((s) => s.id === id)!;
+      expect(skill, `${id} should stay on the card`).toBeDefined();
+      expect(skill.x402_endpoint, `${id} must not advertise x402`).toBeUndefined();
+      expect(skill.description).not.toContain("/x402/");
+      // Still sellable — it just needs an API key.
+      expect(skill.description).toContain("per call");
+    }
   });
 
   it("marks the free tier as free rather than pricing it at €0.00", async () => {

--- a/apps/api/src/routes/a2a.ts
+++ b/apps/api/src/routes/a2a.ts
@@ -11,18 +11,15 @@
 
 import { Hono } from "hono";
 import { recordDiscoveryHit } from "../lib/attribution.js";
-import { eq, and, isNull, sql as sqlRaw } from "drizzle-orm";
+import { eq, and, isNull } from "drizzle-orm";
 import { createHash, timingSafeEqual } from "node:crypto";
 import { getDb } from "../db/index.js";
 import { capabilities, solutions, transactions, users } from "../db/schema.js";
 import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
 import { suggest, MAX_SUGGEST_QUERY_CHARS } from "../lib/suggest.js";
 import { rateLimitByIp } from "../lib/rate-limit.js";
-import {
-  INTERNAL_EMAIL_LIKE_PATTERNS,
-  EXTRA_EXCLUDED_EMAILS,
-} from "../lib/internal-accounts.js";
 import { computePlatformFacts } from "../lib/platform-facts.js";
+import { sellerRevenueBySlug, rankBySales } from "../lib/seller-rank.js";
 import type { AppEnv } from "../types.js";
 
 // ─── Config ─────────────────────────────────────────────────────────────────
@@ -98,36 +95,6 @@ function generateExamples(
 const PUBLIC_API_BASE = "https://api.strale.io";
 
 /**
- * External revenue per slug over the last 28 days, used to order the card.
- *
- * Why ordering matters: this card is Strale's most-read machine surface
- * (~520 fetches/week — 5× the x402 discovery file), and it listed 406 skills
- * in near-arbitrary order. An agent skimming the top saw whatever happened to
- * come first, not what other agents actually buy. Revenue order puts the
- * proven sellers where a shallow reader lands.
- *
- * Excludes internal accounts via the canonical filter — the test harness is
- * ~98% of traffic and would otherwise rank the catalog by what WE test, which
- * is the exact wrong-population mistake catalogued in docs/company/MEASUREMENT.md.
- */
-async function externalRevenueBySlug(): Promise<Map<string, number>> {
-  const db = getDb();
-  const likeAny = sqlRaw.join(
-    INTERNAL_EMAIL_LIKE_PATTERNS.map((p) => sqlRaw`email LIKE ${p}`), sqlRaw` OR `);
-  const eqAny = sqlRaw.join(
-    EXTRA_EXCLUDED_EMAILS.map((e) => sqlRaw`email = ${e}`), sqlRaw` OR `);
-  const rows = (await db.execute(sqlRaw`
-    SELECT c.slug, COALESCE(SUM(t.price_cents), 0)::int AS cents
-    FROM transactions t JOIN capabilities c ON c.id = t.capability_id
-    WHERE t.status = 'completed' AND t.price_cents > 0
-      AND t.created_at > now() - interval '28 days'
-      AND (t.user_id IS NULL OR t.user_id NOT IN (
-        SELECT id FROM users WHERE (${likeAny}) OR (${eqAny})))
-    GROUP BY 1`)) as unknown as Array<{ slug: string; cents: number }>;
-  return new Map(rows.map((r) => [r.slug, Number(r.cents)]));
-}
-
-/**
  * Internal artifacts must never reach the public card. A solution named
  * `test-solution-delete-me` was live on it until 2026-08-15 — a storefront
  * showing the shop's own scaffolding. Belt (this filter) and braces (the DB
@@ -140,6 +107,51 @@ export function isInternalArtifact(slug: string): boolean {
   // (delete-me suffixes, zzz- probes, test-solution names) rather than the
   // word "test" keeps real services safe.
   return /-delete-me$|^zzz-|test-solution/.test(slug);
+}
+
+/**
+ * Whether the x402 gateway would actually serve this slug.
+ *
+ * The card and the gateway had different ideas about what is buyable. The card
+ * listed anything `is_active AND marketplace_eligible`; the gateway requires
+ * `x402_enabled` AND a lifecycle state of active/probation, because it refuses
+ * to take money for a capability it knows is degraded. Measured against
+ * production on 2026-08-16, that gap was **66 endpoints** — 47 capabilities and
+ * 19 solutions — each advertised with a price and a POST target that returns
+ * 404 "Capability not found or not available via x402."
+ *
+ * Two harms, and the second is the nastier one. An agent that trusts the card
+ * gets a dead endpoint. And that 404 is recorded as `x402_unknown_slug` in
+ * `failed_requests` — the unmet-demand signal added the same day — so our own
+ * card manufactures "an agent wanted something we do not sell" entries for
+ * capabilities we *do* sell. A build queue fed by that is fed by our own bug.
+ *
+ * Entries that fail this stay on the card: they are real capabilities, still
+ * reachable with an API key. They simply stop claiming a payment route that
+ * does not exist.
+ */
+function payableViaX402(row: {
+  isFreeTier?: boolean;
+  x402Enabled?: boolean | null;
+  lifecycleState?: string | null;
+}): boolean {
+  if (row.isFreeTier) return false; // free tier needs no payment endpoint
+  if (!row.x402Enabled) return false;
+  // Solutions carry no lifecycle column; absence means "not gated on it".
+  if (row.lifecycleState && !["active", "probation"].includes(row.lifecycleState)) return false;
+  return true;
+}
+
+/**
+ * Solutions are NOT served at `/x402/{slug}` — that is the capability
+ * wildcard. The gateway mounts them at `/x402/solutions/{slug}` and
+ * `/x402/v2/solutions/{slug}` (x402-gateway-v2.ts), and the v2 form is what
+ * the discovery file and the OpenAPI paths publish. The card advertised the
+ * capability path for every solution: each one fell through to the wildcard,
+ * 404'd, and logged a false `x402_unknown_slug` demand row.
+ */
+function solutionEndpoint(slug: string): string {
+  return `${PUBLIC_API_BASE}/x402/v2/solutions/${slug}`;
 }
 
 export async function buildAgentCard(): Promise<{ card: object; etag: string }> {
@@ -159,6 +171,10 @@ export async function buildAgentCard(): Promise<{ card: object; etag: string }> 
       category: capabilities.category,
       priceCents: capabilities.priceCents,
       isFreeTier: capabilities.isFreeTier,
+      // Needed to decide whether a pay-per-call endpoint may be advertised —
+      // see payableViaX402 below.
+      x402Enabled: capabilities.x402Enabled,
+      lifecycleState: capabilities.lifecycleState,
     })
     .from(capabilities)
     .where(
@@ -177,11 +193,14 @@ export async function buildAgentCard(): Promise<{ card: object; etag: string }> 
       description: solutions.description,
       category: solutions.category,
       priceCents: solutions.priceCents,
+      x402Enabled: solutions.x402Enabled,
     })
     .from(solutions)
     .where(eq(solutions.isActive, true));
 
-  const revenue = await externalRevenueBySlug();
+  // Shared ranker: 15-minute cache (this surface is fetched ~520×/week) and
+  // fail-open on a query error, neither of which the private copy had.
+  const revenue = await sellerRevenueBySlug();
 
   // Build capability skills. Every paid skill carries its price and an
   // absolute pay-per-call URL — before 2026-08-15, 396 of 406 skills had no
@@ -192,10 +211,14 @@ export async function buildAgentCard(): Promise<{ card: object; etag: string }> 
   const capSkills = capRows
     .filter((cap) => !isInternalArtifact(cap.slug))
     .map((cap) => {
+      const payable = payableViaX402(cap);
       const priceStr = cap.isFreeTier
         ? " FREE — no API key, no payment, no signup."
-        : ` €${((cap.priceCents ?? 0) / 100).toFixed(2)} per call — pay per use` +
-          ` with USDC (x402) at POST ${PUBLIC_API_BASE}/x402/${cap.slug}, no signup needed.`;
+        : payable
+          ? ` €${((cap.priceCents ?? 0) / 100).toFixed(2)} per call — pay per use` +
+            ` with USDC (x402) at POST ${PUBLIC_API_BASE}/x402/${cap.slug}, no signup needed.`
+          : ` €${((cap.priceCents ?? 0) / 100).toFixed(2)} per call via API key.` +
+            ` Pay-per-call is not available for this one.`;
       return {
         id: cap.slug,
         name: cap.name,
@@ -205,7 +228,7 @@ export async function buildAgentCard(): Promise<{ card: object; etag: string }> 
         // Extension fields (ignored by strict A2A parsers, actionable by the rest)
         price_cents: cap.isFreeTier ? 0 : cap.priceCents ?? 0,
         currency: "EUR",
-        x402_endpoint: cap.isFreeTier ? undefined : `${PUBLIC_API_BASE}/x402/${cap.slug}`,
+        x402_endpoint: payable ? `${PUBLIC_API_BASE}/x402/${cap.slug}` : undefined,
       };
     });
 
@@ -215,29 +238,24 @@ export async function buildAgentCard(): Promise<{ card: object; etag: string }> 
     .map((sol) => ({
       id: `solution-${sol.slug}`,
       name: sol.name,
-      description: `${sol.description} €${((sol.priceCents ?? 0) / 100).toFixed(2)}` +
-        ` per call — pay per use with USDC (x402) at POST ${PUBLIC_API_BASE}/x402/${sol.slug},` +
-        ` no signup needed.`,
+      description: `${sol.description} €${((sol.priceCents ?? 0) / 100).toFixed(2)} per call` +
+        (payableViaX402(sol)
+          ? ` — pay per use with USDC (x402) at POST ${solutionEndpoint(sol.slug)},` +
+            ` no signup needed.`
+          : ` via API key. Pay-per-call is not available for this one.`),
       tags: ["solution", sol.category],
       examples: [sol.description.split(/\.\s/)[0].replace(/\.$/, "")],
       price_cents: sol.priceCents ?? 0,
       currency: "EUR",
-      x402_endpoint: `${PUBLIC_API_BASE}/x402/${sol.slug}`,
+      x402_endpoint: payableViaX402(sol) ? solutionEndpoint(sol.slug) : undefined,
     }));
 
   // Order: proven sellers first (28-day external revenue), then the free tier
   // (an agent's cheapest first step), then the rest alphabetically. A shallow
   // reader now lands on what other agents actually buy.
-  const revOf = (skill: { id: string }) =>
-    revenue.get(skill.id.replace(/^solution-/, "")) ?? 0;
+  const slugOfSkill = (skill: { id: string }) => skill.id.replace(/^solution-/, "");
   const bySales = <T extends { id: string; price_cents?: number }>(skills: T[]): T[] =>
-    [...skills].sort((a, b) => {
-      const ra = revOf(a), rb = revOf(b);
-      if (ra !== rb) return rb - ra;
-      const fa = a.price_cents === 0 ? 0 : 1, fb = b.price_cents === 0 ? 0 : 1;
-      if (fa !== fb) return fa - fb;
-      return a.id.localeCompare(b.id);
-    });
+    rankBySales(skills, revenue, slugOfSkill, (s) => s.price_cents === 0);
 
   const productSkills = [
     {

--- a/apps/api/src/routes/a2a.ts
+++ b/apps/api/src/routes/a2a.ts
@@ -289,6 +289,19 @@ export async function buildAgentCard(): Promise<{ card: object; etag: string }> 
         "Gate an inbound x402 buyer before delivering service",
         "Verify a DeFi protocol's audit history and recent exploits",
       ],
+      // Every other entry on this card carries a price and a callable target.
+      // This one carried neither, so an agent parsing the card learned the
+      // product exists and had no way to act on it — a brochure on a machine
+      // surface. There is genuinely no price to quote: the route is
+      // auth-gated and takes no payment (app.ts mounts it at
+      // /v1/web3-assurance behind authMiddleware, with no wallet debit), so
+      // the card says that rather than implying a pay-per-call rail it does
+      // not have.
+      endpoint: `${PUBLIC_API_BASE}/v1/web3-assurance`,
+      mcp_tool: "strale_web3_assurance",
+      price_cents: 0,
+      currency: "EUR",
+      access: "api_key",
     },
   ];
 

--- a/apps/api/src/routes/verify.test.ts
+++ b/apps/api/src/routes/verify.test.ts
@@ -255,6 +255,32 @@ describe("classifyChainLink — F-AUDIT-13/16 redacted-aware verify", () => {
     expect(result).toBe("redacted");
   });
 
+  it("classifies as 'redacted' when only redactedAt is set (90-day content sweep)", async () => {
+    // 2026-08-16: the 90-day customer-content sweep stopped setting deleted_at
+    // - it is a content redaction, and deleted_at means "the row is gone",
+    // which hid every customer's history and every audit record at 90 days.
+    // The classifier has to honour redactedAt, or dropping deleted_at would
+    // report every row past the window as a BROKEN link. Broken must stay
+    // reserved for tamper.
+    const { classifyChainLink } = await import("./verify.js");
+    expect(
+      classifyChainLink({
+        deletedAt: null,
+        redactedAt: new Date("2026-05-18T10:00:00Z"),
+        integrityHash: "abc123",
+        recomputedHash: "def456",
+      }),
+    ).toBe("redacted");
+  });
+
+  it("buckets both retention reasons as retention, never as 'other'", async () => {
+    const { isRetentionReason } = await import("./verify.js");
+    expect(isRetentionReason("retention_purge")).toBe(true);
+    expect(isRetentionReason("content_retention_purge")).toBe(true);
+    expect(isRetentionReason("user_request")).toBe(false);
+    expect(isRetentionReason(null)).toBe(false);
+  });
+
   it("classifies as 'verified' when hash matches and not deleted", async () => {
     const { classifyChainLink } = await import("./verify.js");
     const result = classifyChainLink({

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -115,7 +115,12 @@ verifyRoute.get("/:transactionId", async (c) => {
   // F-AUDIT-13/16: target transaction itself may also be redacted.
   // If so, hash_valid is meaningless — the source data is gone — but
   // the chain link itself is preserved.
-  const targetRedacted = txn.deletedAt != null;
+  // Either column means "the source data this hash was computed over is gone":
+  // deletedAt for the 1095-day deletion, redactedAt for the 90-day content
+  // redaction, which deliberately leaves the row readable (data-retention.ts).
+  // Classifying on deletedAt alone would report every 90-day-old row as a
+  // BROKEN link once that purge stopped setting it.
+  const targetRedacted = txn.deletedAt != null || txn.redactedAt != null;
   const targetVerifiedLink = !targetRedacted && hashValid;
   const targetDeletionReason = txn.deletionReason ?? null;
 
@@ -168,8 +173,8 @@ verifyRoute.get("/:transactionId", async (c) => {
       // chain sees how many links are GDPR-erasure vs. retention-purge.
       redacted_by_reason: {
         user_request: chain.redactedByReason.user_request + (targetRedacted && targetDeletionReason === "user_request" ? 1 : 0),
-        retention_purge: chain.redactedByReason.retention_purge + (targetRedacted && targetDeletionReason === "retention_purge" ? 1 : 0),
-        other: chain.redactedByReason.other + (targetRedacted && targetDeletionReason !== "user_request" && targetDeletionReason !== "retention_purge" ? 1 : 0),
+        retention_purge: chain.redactedByReason.retention_purge + (targetRedacted && isRetentionReason(targetDeletionReason) ? 1 : 0),
+        other: chain.redactedByReason.other + (targetRedacted && targetDeletionReason !== "user_request" && !isRetentionReason(targetDeletionReason) ? 1 : 0),
       },
       reaches_genesis: chain.reachesGenesis,
       chain_start_date: chain.startDate,
@@ -268,11 +273,11 @@ export async function walkChain(
     // now will mismatch by design. Treat as a third category — neither
     // verified nor broken. World-class #6: tally by deletion_reason so
     // the response can report user_request vs retention_purge separately.
-    if (prev.deletedAt != null) {
+    if (prev.deletedAt != null || prev.redactedAt != null) {
       redactedLinks++;
       const reason = prev.deletionReason ?? "";
       if (reason === "user_request") redactedByUserRequest++;
-      else if (reason === "retention_purge") redactedByRetentionPurge++;
+      else if (isRetentionReason(reason)) redactedByRetentionPurge++;
       else redactedByOther++;
       startDate = prev.createdAt instanceof Date
         ? prev.createdAt.toISOString().slice(0, 10)
@@ -350,12 +355,23 @@ export async function walkChain(
 // the redacted-vs-broken-vs-verified decision without spinning up a DB.
 export type ChainLinkClassification = "verified" | "redacted" | "broken";
 
+/**
+ * Both retention paths bucket as retention, never as "other": the 1095-day
+ * deletion writes 'retention_purge', the 90-day content redaction writes
+ * 'content_retention_purge'. A regulator walking the chain should see one
+ * retention count, not a mystery bucket.
+ */
+export function isRetentionReason(reason: string | null): boolean {
+  return reason === "retention_purge" || reason === "content_retention_purge";
+}
+
 export function classifyChainLink(prev: {
   deletedAt: Date | null;
+  redactedAt?: Date | null;
   integrityHash: string | null;
   recomputedHash: string | null;
 }): ChainLinkClassification {
-  if (prev.deletedAt != null) return "redacted";
+  if (prev.deletedAt != null || prev.redactedAt != null) return "redacted";
   if (prev.integrityHash != null && prev.recomputedHash === prev.integrityHash) return "verified";
   return "broken";
 }

--- a/apps/api/tsconfig.scripts.json
+++ b/apps/api/tsconfig.scripts.json
@@ -1,0 +1,32 @@
+{
+  // Type-checking only, for the operator scripts that are actively maintained.
+  //
+  // `scripts/` cannot live in tsconfig.json because that config sets
+  // `rootDir: ./src` for the build output — so until now `npx tsc --noEmit
+  // --project tsconfig.json` reported "clean" for changes it had never looked
+  // at. The CEO dashboard is the one Petter reads; it was ungated.
+  //
+  // The include list is deliberately narrow rather than `scripts/**/*`: a
+  // repo-wide sweep reports 127 pre-existing errors (dead archive scripts,
+  // drifted imports, duplicate top-level declarations across one-off files).
+  // Fixing those is its own task; widening this glob before then would produce
+  // a gate that is red on arrival and therefore ignored. Add files here as
+  // they are cleaned up.
+  //
+  // Run as: npx tsc --noEmit --project tsconfig.scripts.json
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["scripts/ceo-dashboard.ts", "scripts/lib/**/*", "src/**/*"],
+  // Same test excludes as tsconfig.json — vitest type-checks its own files, and
+  // several existing tests use casts tsc rejects but vitest accepts.
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx"
+  ]
+}


### PR DESCRIPTION
## Summary

Close-out review of the ~20 PRs merged today found five ship-blockers. Four I introduced today; one had been silently on for weeks.

- **66 advertised x402 endpoints returned 404** — the agent card gated on `is_active AND marketplace_eligible`, the gateway requires `x402_enabled` AND an active/probation lifecycle. Each 404 also wrote a false `x402_unknown_slug` row into the unmet-demand table added this morning, so the card was manufacturing build-signal from its own bug. Separately every solution was advertised at the capability path (`/x402/{slug}`) rather than `/x402/v2/solutions/{slug}`, so all 98 404'd regardless.
- **Every customer would have lost their transaction history and every audit record at 90 days.** The content-redaction sweep set `deleted_at`, which means "row is logically gone" and is filtered by every customer read path — transaction list, transaction detail, the audit-record endpoint behind every shareable audit URL, the A2A task lookup. Harmless while the sweep only covered personal-data capabilities; universal once it was widened yesterday. Now only `redacted_at` is set; the chain walker classifies on either column so a redacted row stays "redacted", never "broken".
- **Every retention loop read `.rowCount`**, which postgres-js never sets. Each sweep stopped after one batch and every counter logged 0 forever — the silent-failure shape DEC-20260504-A exists to catch, in the file whose comments cite it. This is also why the point above is a repair rather than an incident.
- **The dashboard reported a one-day-old instrument as a 28-day fact** and zero-filled unavailable measurements — the exact failure the metrics module was built to prevent, in its only consumer.
- **`scripts/` was never type-checked.** `tsconfig.json` is scoped to `src/**`, so every "typecheck clean" reported for the CEO dashboard had looked at nothing.

## Verification

| gate | result |
|---|---|
| `tsc -p tsconfig.json` | clean |
| `tsc -p tsconfig.scripts.json` (new) | clean |
| full vitest suite | **1,694 passed, 0 failed** (baseline on `main`: 1,688 / 0) |
| mutation check of the new tests | **7/7** — each fix reverted in turn, each caught, all files restored |
| migration | block 0087 added to `BLOCKS`, canonical-list test updated 29 → 30 |

`data-retention.test.ts`, `revenue-heartbeat.test.ts`, `startup-migrations.test.ts` and `a2a-card.test.ts` were updated where they pinned the old (incorrect) behaviour — notably the heartbeat test that asserted a 24-hour floor, which is what made the alert unable to fire inside the 21-hour incident it was written for.

## Migration 0087 — read this before merging

Clears `deleted_at` on rows this sweep had hidden. Narrow by construction: it matches only `redacted_at IS NOT NULL AND deleted_at IS NOT NULL AND deletion_reason IN ('pii_retention_purge','content_retention_purge')`. It cannot touch a user-requested erasure or the 1095-day hard purge, and it **un-hides without un-redacting** — no payload column is written, and a test asserts that. Self-limiting, so re-running on every boot is a no-op.

DEC-20260504-B: an UPDATE setting one column to NULL on a few thousand rows, run once. The drain loops also gained `MAX_BATCHES_PER_RUN` — the docstring previously claimed the batch loop bounded each tick, which it did not; it rate-limited but never capped.

## Reviewer findings

Fixed here beyond the five above: the heartbeat re-derived the actor key in a second format (`x402:abc` vs the spine's `x402:v1:abc`); the card carried a private un-cached, non-fail-open copy of `seller-rank`; the ranker claimed to rank solutions but only joined capabilities, so every solution catalogue was an alphabetical sort wearing a revenue label; `customerContentMatches` returned an unparenthesised OR chain that inverts any caller's `WHERE`, and did not escape ILIKE wildcards; budget alert emails were written in raw enum values.

Deferred, deliberately:

- **127 pre-existing type errors elsewhere in `scripts/`** — dead archive scripts, drifted imports, duplicate top-level declarations. Noted in `tsconfig.scripts.json` rather than hidden; widening the glob before fixing them would produce a gate that is red on arrival and therefore ignored.
- `recordX402Miss` fires on an unauthenticated, unrate-limited route, so the demand signal is writable by anyone. Bounded by the 90-day rule, but it feeds build prioritisation.
- `resolveActor()` still has no production consumers — only the SQL half runs.
- Migration 0085's docstring claims `CREATE INDEX CONCURRENTLY`; the code is a plain `CREATE INDEX` inside the transaction.

## Test plan

1. After deploy, `GET /.well-known/agent-card.json` and POST a paid skill's `x402_endpoint` — it should return a 402 challenge, not a 404. Pick a skill that has no `x402_endpoint` and confirm it still appears with a price and an API-key note.
2. `SELECT count(*) FROM transactions WHERE deleted_at IS NOT NULL AND redacted_at IS NOT NULL AND deletion_reason LIKE '%retention_purge'` should be 0.
3. Confirm a customer's transaction list returns rows older than 90 days, with empty payload fields.
4. `GET /v1/verify/{id}` on such a row: `redacted: true`, `broken_links: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
