### PR TITLE
feat(solutions): gate conditions — stop early, and don't charge

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -548,6 +548,13 @@ export const solutionSteps = pgTable(
     canParallel: boolean("can_parallel").notNull().default(false),
     parallelGroup: integer("parallel_group"),
     inputMap: jsonb("input_map").notNull(),
+    /**
+     * Optional precondition. When this step's output matches, the rest of the
+     * solution is skipped and the caller is refunded — the bundle could not do
+     * the work it was paid for. Shape: {field, equals}. See
+     * lib/solution-executor.ts and migration block 0087.
+     */
+    gateCondition: jsonb("gate_condition"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/api/src/db/seed-solutions.ts
+++ b/apps/api/src/db/seed-solutions.ts
@@ -352,6 +352,7 @@ async function seed() {
           canParallel: step.canParallel,
           parallelGroup: step.parallelGroup,
           inputMap: step.inputMap,
+            gateCondition: step.gateCondition ?? null,
         })),
       );
 

--- a/apps/api/src/db/solution-catalogue.ts
+++ b/apps/api/src/db/solution-catalogue.ts
@@ -24,6 +24,13 @@ export interface SolutionStep {
   canParallel: boolean;
   parallelGroup: number | null;
   inputMap: Record<string, string>;
+  /**
+   * Optional precondition. If this step's output matches, the remaining steps
+   * are not executed and the caller is refunded — the bundle could not do the
+   * work it was sold for. A literal comparison rather than an expression, on
+   * purpose: a bundle definition is not a place to accept arbitrary code.
+   */
+  gateCondition?: { field: string; equals: unknown; reason?: string };
 }
 
 export interface SolutionDef {
@@ -2888,19 +2895,23 @@ export const SOLUTIONS: SolutionDef[] = [
       status_code: 200,
     },
     steps: [
-      // Availability runs alone and first. There is no conditional-step
-      // support, so an unreachable page still runs the other three and still
-      // bills — but ordering it first guarantees `is_up`/`status_code` are in
-      // the merged result rather than racing three slower checks that will
-      // all fail. The wider gap (skip-and-refund on an unreachable target) is
-      // a platform limitation, recorded in the PR, not something a bundle
-      // definition can fix.
+      // Availability runs alone and first, and gates the rest. If the page is
+      // not reachable there is nothing to analyse: metadata, social preview
+      // and performance would each fail, and — because the platform refunds
+      // only when EVERY step fails — this one success was enough to bill the
+      // caller €0.30 for four failures. The gate stops the run and refunds.
+      // This bundle is why gate conditions exist (migration block 0087).
       {
         capabilitySlug: "url-health-check",
         stepOrder: 1,
         canParallel: false,
         parallelGroup: null,
         inputMap: { url: "$input.url" },
+        gateCondition: {
+          field: "is_up",
+          equals: false,
+          reason: "The page is not reachable, so nothing further could be checked. You were not charged.",
+        },
       },
       {
         capabilitySlug: "meta-extract",

--- a/apps/api/src/lib/solution-executor.ts
+++ b/apps/api/src/lib/solution-executor.ts
@@ -231,9 +231,21 @@ export interface SolutionExecutionResult {
  *  bundle definition is not a place to accept arbitrary code. */
 export interface GateCondition {
   field: string;
-  equals: unknown;
+  /**
+   * A JSON SCALAR. Objects and arrays are rejected at parse time rather than
+   * supported: the persisted value and the step's output are deserialized
+   * separately, so `===` between two structurally-equal objects is always
+   * false. Such a gate would be accepted, stored, and then silently never
+   * trip — protecting nothing while looking like protection.
+   */
+  equals: string | number | boolean | null;
   /** Caller-facing sentence explaining why the rest was skipped. */
   reason?: string;
+}
+
+/** JSON scalars are the only values `===` can compare meaningfully here. */
+export function isGateScalar(v: unknown): v is string | number | boolean | null {
+  return v === null || ["string", "number", "boolean"].includes(typeof v);
 }
 
 /** Parse a persisted gate_condition. Anything malformed is treated as absent —
@@ -244,11 +256,60 @@ export function parseGateCondition(raw: unknown): GateCondition | null {
   const g = obj as Record<string, unknown>;
   if (typeof g.field !== "string" || !g.field) return null;
   if (!("equals" in g)) return null;
+  if (!isGateScalar(g.equals)) return null;
   return { field: g.field, equals: g.equals, reason: typeof g.reason === "string" ? g.reason : undefined };
 }
 
 function safeJson(s: string): unknown {
   try { return JSON.parse(s); } catch { return null; }
+}
+
+/** A step as the gate evaluator needs to see it. */
+export interface GateEvaluable {
+  capabilitySlug: string;
+  gateCondition: unknown;
+  output: Record<string, unknown> | null;
+}
+
+/**
+ * Pure gate evaluation over one settled group. Extracted from the execution
+ * loop so enforcement — not just parsing and comparison — is testable without
+ * a database. Cross-provider review pointed out that the first version of
+ * these tests would still pass if the whole enforcement block were deleted.
+ *
+ * Returns the first tripped gate in group order, or null.
+ */
+export function evaluateGates(
+  group: GateEvaluable[],
+): SolutionExecutionResult["gated"] | null {
+  for (const step of group) {
+    const gate = parseGateCondition(step.gateCondition);
+    if (!gate) continue;
+    if (!gateTrips(step.output, gate)) continue;
+    return {
+      capabilitySlug: step.capabilitySlug,
+      field: gate.field,
+      observed: (step.output as Record<string, unknown>)[gate.field],
+      reason: gate.reason
+        ?? `${step.capabilitySlug} reported ${gate.field}=${JSON.stringify(gate.equals)}; the remaining checks could not be performed.`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Fill in the steps a tripped gate prevented. Never overwrites a step that
+ * already ran — a gate stops what is left, it does not rewrite history.
+ */
+export function markSkippedByGate(
+  allSlugs: string[],
+  stepResults: Record<string, unknown>,
+  reason: string,
+): void {
+  for (const slug of allSlugs) {
+    if (slug in stepResults) continue;
+    stepResults[slug] = { skipped: true, reason: `Not run — ${reason}` };
+  }
 }
 
 /** Does this step's output trip its gate? */
@@ -445,29 +506,16 @@ export async function executeSolution(
     // and the caller is refunded upstream (routes/solution-execute.ts). Without
     // this, a bundle whose first step legitimately reports "there is nothing
     // here" ran and billed for every step behind it.
-    for (const step of groupSteps) {
-      const gate = parseGateCondition(step.gateCondition);
-      if (!gate) continue;
-      const output = completedSteps[stepIndex.get(step)!];
-      if (!gateTrips(output, gate)) continue;
-
-      gated = {
-        capabilitySlug: step.capabilitySlug,
-        field: gate.field,
-        observed: (output as Record<string, unknown>)[gate.field],
-        reason: gate.reason
-          ?? `${step.capabilitySlug} reported ${gate.field}=${JSON.stringify(gate.equals)}; the remaining checks could not be performed.`,
-      };
-      logWarn("solution-executor-gated", "gate condition tripped; skipping remaining steps", {
-        capability_slug: step.capabilitySlug, field: gate.field,
-      });
-      break;
-    }
+    gated = evaluateGates(groupSteps.map((step) => ({
+      capabilitySlug: step.capabilitySlug,
+      gateCondition: step.gateCondition,
+      output: completedSteps[stepIndex.get(step)!],
+    }))) ?? undefined;
     if (gated) {
-      for (const step of steps) {
-        if (step.capabilitySlug in stepResults) continue;
-        stepResults[step.capabilitySlug] = { skipped: true, reason: `Not run — ${gated.reason}` };
-      }
+      logWarn("solution-executor-gated", "gate condition tripped; skipping remaining steps", {
+        capability_slug: gated.capabilitySlug, field: gated.field,
+      });
+      markSkippedByGate(steps.map((s) => s.capabilitySlug), stepResults, gated.reason);
       break;
     }
 

--- a/apps/api/src/lib/solution-executor.ts
+++ b/apps/api/src/lib/solution-executor.ts
@@ -218,6 +218,44 @@ export interface SolutionExecutionResult {
   latency_ms: number;
   step_count: number;
   stepTimings: StepTiming[];
+  /**
+   * Set when a gate step's precondition tripped. The remaining steps were not
+   * executed and the caller must not be charged: the bundle could not do the
+   * work it was sold for. The answer it CAN give is still in `steps`.
+   */
+  gated?: { capabilitySlug: string; field: string; observed: unknown; reason: string };
+}
+
+/** A step's optional precondition. Deliberately a literal comparison and not
+ *  an expression language — the value comes from a seeded definition, and a
+ *  bundle definition is not a place to accept arbitrary code. */
+export interface GateCondition {
+  field: string;
+  equals: unknown;
+  /** Caller-facing sentence explaining why the rest was skipped. */
+  reason?: string;
+}
+
+/** Parse a persisted gate_condition. Anything malformed is treated as absent —
+ *  a broken gate must not silently start blocking a working bundle. */
+export function parseGateCondition(raw: unknown): GateCondition | null {
+  const obj = typeof raw === "string" ? safeJson(raw) : raw;
+  if (!obj || typeof obj !== "object" || Array.isArray(obj)) return null;
+  const g = obj as Record<string, unknown>;
+  if (typeof g.field !== "string" || !g.field) return null;
+  if (!("equals" in g)) return null;
+  return { field: g.field, equals: g.equals, reason: typeof g.reason === "string" ? g.reason : undefined };
+}
+
+function safeJson(s: string): unknown {
+  try { return JSON.parse(s); } catch { return null; }
+}
+
+/** Does this step's output trip its gate? */
+export function gateTrips(output: unknown, gate: GateCondition): boolean {
+  if (!output || typeof output !== "object" || Array.isArray(output)) return false;
+  const value = (output as Record<string, unknown>)[gate.field];
+  return value === gate.equals;
 }
 
 /**
@@ -239,6 +277,7 @@ export async function executeSolution(
       inputMap: solutionSteps.inputMap,
       canParallel: solutionSteps.canParallel,
       parallelGroup: solutionSteps.parallelGroup,
+      gateCondition: solutionSteps.gateCondition,
     })
     .from(solutionSteps)
     .where(eq(solutionSteps.solutionId, solutionId))
@@ -251,6 +290,7 @@ export async function executeSolution(
   const startMs = Date.now();
   const stepResults: Record<string, unknown> = {};
   const stepErrors: string[] = [];
+  let gated: SolutionExecutionResult["gated"] = undefined;
   // F-B-016: Preallocate by sorted-steps length and assign by each step's
   // index in the sorted array (stepOrder-sorted, see `orderBy` above).
   // Previously this was `.push(output)` inside a Promise.all map callback,
@@ -400,6 +440,37 @@ export async function executeSolution(
 
     await Promise.all(executions);
 
+    // Gate evaluation, after the group settles. A tripped gate stops the run:
+    // the remaining steps are recorded as skipped-by-gate rather than executed,
+    // and the caller is refunded upstream (routes/solution-execute.ts). Without
+    // this, a bundle whose first step legitimately reports "there is nothing
+    // here" ran and billed for every step behind it.
+    for (const step of groupSteps) {
+      const gate = parseGateCondition(step.gateCondition);
+      if (!gate) continue;
+      const output = completedSteps[stepIndex.get(step)!];
+      if (!gateTrips(output, gate)) continue;
+
+      gated = {
+        capabilitySlug: step.capabilitySlug,
+        field: gate.field,
+        observed: (output as Record<string, unknown>)[gate.field],
+        reason: gate.reason
+          ?? `${step.capabilitySlug} reported ${gate.field}=${JSON.stringify(gate.equals)}; the remaining checks could not be performed.`,
+      };
+      logWarn("solution-executor-gated", "gate condition tripped; skipping remaining steps", {
+        capability_slug: step.capabilitySlug, field: gate.field,
+      });
+      break;
+    }
+    if (gated) {
+      for (const step of steps) {
+        if (step.capabilitySlug in stepResults) continue;
+        stepResults[step.capabilitySlug] = { skipped: true, reason: `Not run — ${gated.reason}` };
+      }
+      break;
+    }
+
     // After first group completes, extract entity context for downstream propagation
     if (entityContext && Object.keys(entityContext).length === 0 && completedSteps[0] != null) {
       const step0 = completedSteps[0];
@@ -422,5 +493,6 @@ export async function executeSolution(
     latency_ms: latencyMs,
     step_count: steps.length,
     stepTimings,
+    ...(gated ? { gated } : {}),
   };
 }

--- a/apps/api/src/lib/solution-gate.test.ts
+++ b/apps/api/src/lib/solution-gate.test.ts
@@ -1,5 +1,6 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { parseGateCondition, gateTrips } from "./solution-executor.js";
+import { parseGateCondition, gateTrips, evaluateGates, markSkippedByGate } from "./solution-executor.js";
 import { SOLUTIONS } from "../db/solution-catalogue.js";
 import { runMigration0087_solutionGateCondition } from "./startup-migrations.js";
 import { sql, type SQL } from "drizzle-orm";
@@ -39,6 +40,12 @@ describe("parseGateCondition", () => {
     [{ field: "", equals: false }, "empty field"],
     [{ equals: false }, "no field"],
     [[{ field: "is_up", equals: false }], "an array, not an object"],
+    // `equals` must be a JSON scalar. A structured value is accepted-looking
+    // but useless: the persisted JSONB and the step output are deserialized
+    // separately, so === between two structurally-equal objects is always
+    // false. Such a gate would protect nothing while looking like protection.
+    [{ field: "state", equals: { reachable: false } }, "object equals"],
+    [{ field: "codes", equals: [1, 2] }, "array equals"],
   ])("treats %s as no gate (%s)", (raw) => {
     // A malformed gate must read as ABSENT, never as "trips". A gate that
     // fails open leaves one bundle billing wrongly; a gate that fails closed
@@ -137,5 +144,105 @@ describe("migration block 0087", () => {
       fs.readFileSync(new URL("./startup-migrations.ts", import.meta.url), "utf8"));
     const registry = src.slice(src.indexOf("const BLOCKS"), src.indexOf("];", src.indexOf("const BLOCKS")));
     expect(registry).toContain("runMigration0087_solutionGateCondition");
+  });
+});
+
+describe("the refund path, structurally", () => {
+  // No route-level harness exists (CLAUDE.md test-harness exemption), so this
+  // pins the property that actually broke: the late "transaction could not be
+  // finalized" refund guards on `allFailed`, and a GATED run has
+  // allFailed === false because the gate step succeeded. Guarding on
+  // `allFailed` there refunds a gated caller twice.
+  const src = readFileSync(
+    new URL("../routes/solution-execute.ts", import.meta.url), "utf8");
+
+  it("guards the late refund on refundRequired, not allFailed", () => {
+    expect(src).toContain("if (!refundRequired) {");
+    expect(src).not.toMatch(/if \(!allFailed\) \{\s*\n\s*await refundWallet/);
+  });
+
+  it("refunds a gated run exactly once", () => {
+    // One refund call on the main path, and it covers both reasons.
+    expect(src).toContain("const refundRequired = allFailed || gated !== undefined;");
+    expect(src).toContain("if (refundRequired) {");
+  });
+
+  it("charges nothing when the gate trips", () => {
+    expect(src).toContain("const chargedPrice = refundRequired ? 0 : sol.priceCents;");
+  });
+
+  it("tells the caller they were not charged", () => {
+    expect(src).toContain("charged: false");
+  });
+});
+
+describe("evaluateGates — enforcement, not just comparison", () => {
+  const gate = { field: "is_up", equals: false, reason: "down. You were not charged." };
+
+  it("returns the tripped gate with what it observed", () => {
+    const g = evaluateGates([
+      { capabilitySlug: "url-health-check", gateCondition: gate, output: { is_up: false, status_code: 0 } },
+    ]);
+    expect(g).toMatchObject({ capabilitySlug: "url-health-check", field: "is_up", observed: false });
+    expect(g!.reason).toContain("not charged");
+  });
+
+  it("returns null when nothing trips — the ordinary path", () => {
+    expect(evaluateGates([
+      { capabilitySlug: "url-health-check", gateCondition: gate, output: { is_up: true } },
+    ])).toBeNull();
+    expect(evaluateGates([
+      { capabilitySlug: "meta-extract", gateCondition: null, output: { title: "x" } },
+    ])).toBeNull();
+  });
+
+  it("does not trip on a step that errored or never produced output", () => {
+    expect(evaluateGates([
+      { capabilitySlug: "url-health-check", gateCondition: gate, output: { error: "boom" } },
+    ])).toBeNull();
+    expect(evaluateGates([
+      { capabilitySlug: "url-health-check", gateCondition: gate, output: null },
+    ])).toBeNull();
+  });
+
+  it("returns the FIRST trip when a group carries two gates", () => {
+    const g = evaluateGates([
+      { capabilitySlug: "a", gateCondition: { field: "ok", equals: false }, output: { ok: false } },
+      { capabilitySlug: "b", gateCondition: { field: "ok", equals: false }, output: { ok: false } },
+    ]);
+    expect(g!.capabilitySlug).toBe("a");
+  });
+
+  it("synthesises a reason when the definition omits one", () => {
+    const g = evaluateGates([
+      { capabilitySlug: "url-health-check", gateCondition: { field: "is_up", equals: false }, output: { is_up: false } },
+    ]);
+    expect(g!.reason).toContain("url-health-check");
+    expect(g!.reason).toContain("is_up");
+  });
+});
+
+describe("markSkippedByGate", () => {
+  it("fills only the steps that never ran", () => {
+    const results: Record<string, unknown> = { "url-health-check": { is_up: false } };
+    markSkippedByGate(["url-health-check", "meta-extract", "og-image-check"], results, "page is down");
+    expect(results["url-health-check"]).toEqual({ is_up: false });   // untouched
+    expect(results["meta-extract"]).toEqual({ skipped: true, reason: "Not run — page is down" });
+    expect(results["og-image-check"]).toEqual({ skipped: true, reason: "Not run — page is down" });
+  });
+
+  it("never overwrites a result that already exists, even a failed one", () => {
+    // A gate stops what is left; it does not rewrite history. Overwriting a
+    // recorded error would hide a real failure behind a skip marker.
+    const results: Record<string, unknown> = { a: { error: "real failure" } };
+    markSkippedByGate(["a", "b"], results, "stopped");
+    expect(results.a).toEqual({ error: "real failure" });
+  });
+
+  it("accounts for every step, so an audit trail claiming N steps lists N", () => {
+    const results: Record<string, unknown> = {};
+    const slugs = ["a", "b", "c", "d"];
+    markSkippedByGate(slugs, results, "stopped");
+    expect(Object.keys(results).sort()).toEqual(slugs);
   });
 });

--- a/apps/api/src/lib/solution-gate.test.ts
+++ b/apps/api/src/lib/solution-gate.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { parseGateCondition, gateTrips } from "./solution-executor.js";
+import { SOLUTIONS } from "../db/solution-catalogue.js";
+import { runMigration0087_solutionGateCondition } from "./startup-migrations.js";
+import { sql, type SQL } from "drizzle-orm";
+
+/**
+ * Gate conditions let a bundle stop early and refund.
+ *
+ * The gap they close: the platform refunds only when EVERY step fails, so a
+ * bundle whose first step legitimately reports "there is nothing here"
+ * succeeded — and one success was enough to bill in full for the wasted steps
+ * behind it. `page-seo-check` on an unreachable URL is the worked example:
+ * `url-health-check` returns `is_up: false` (a true answer), the other three
+ * fail, the caller pays €0.30.
+ *
+ * Both directions matter. A gate that never trips leaves the billing bug in
+ * place; a gate that trips too easily refunds work we actually did.
+ */
+
+describe("parseGateCondition", () => {
+  it("accepts the documented shape", () => {
+    expect(parseGateCondition({ field: "is_up", equals: false })).toEqual({
+      field: "is_up", equals: false, reason: undefined,
+    });
+    expect(parseGateCondition({ field: "is_up", equals: false, reason: "down" })?.reason).toBe("down");
+  });
+
+  it("accepts it as persisted JSON text", () => {
+    expect(parseGateCondition('{"field":"is_up","equals":false}')?.field).toBe("is_up");
+  });
+
+  it.each([
+    [null, "absent"],
+    [undefined, "absent"],
+    ["not json", "unparseable"],
+    [{}, "no field"],
+    [{ field: "is_up" }, "no equals — would otherwise match every output"],
+    [{ field: "", equals: false }, "empty field"],
+    [{ equals: false }, "no field"],
+    [[{ field: "is_up", equals: false }], "an array, not an object"],
+  ])("treats %s as no gate (%s)", (raw) => {
+    // A malformed gate must read as ABSENT, never as "trips". A gate that
+    // fails open leaves one bundle billing wrongly; a gate that fails closed
+    // silently stops every call to a working bundle and refunds all of it.
+    expect(parseGateCondition(raw)).toBeNull();
+  });
+});
+
+describe("gateTrips", () => {
+  const gate = { field: "is_up", equals: false };
+
+  it("trips on an exact match", () => {
+    expect(gateTrips({ is_up: false, status_code: 0 }, gate)).toBe(true);
+  });
+
+  it("does not trip when the page is up — the ordinary case", () => {
+    expect(gateTrips({ is_up: true, status_code: 200 }, gate)).toBe(false);
+  });
+
+  it("does not trip on a missing field", () => {
+    // The step errored, or returned a different shape. That is a failure for
+    // the normal path to handle, not a precondition result.
+    expect(gateTrips({ status_code: 500 }, gate)).toBe(false);
+    expect(gateTrips({ error: "boom" }, gate)).toBe(false);
+  });
+
+  it("compares strictly — falsy is not false", () => {
+    // `undefined == false` and `0 == false` under loose equality. A step
+    // returning is_up: 0 or omitting it must not refund the caller.
+    expect(gateTrips({ is_up: 0 }, gate)).toBe(false);
+    expect(gateTrips({ is_up: null }, gate)).toBe(false);
+    expect(gateTrips({ is_up: undefined }, gate)).toBe(false);
+    expect(gateTrips({ is_up: "false" }, gate)).toBe(false);
+  });
+
+  it("handles non-object outputs without throwing", () => {
+    for (const out of [null, undefined, "string", 42, [1, 2]]) {
+      expect(gateTrips(out, gate)).toBe(false);
+    }
+  });
+});
+
+describe("the catalogue's use of gates", () => {
+  it("gates page-seo-check on reachability, and nothing else yet", () => {
+    const gated = SOLUTIONS.filter((s) => s.steps.some((st) => st.gateCondition));
+    expect(gated.map((s) => s.slug)).toEqual(["page-seo-check"]);
+
+    const step = SOLUTIONS.find((s) => s.slug === "page-seo-check")!.steps
+      .find((st) => st.gateCondition)!;
+    expect(step.capabilitySlug).toBe("url-health-check");
+    expect(step.gateCondition).toMatchObject({ field: "is_up", equals: false });
+  });
+
+  it("only ever gates on a step that runs before the ones it protects", () => {
+    for (const sol of SOLUTIONS) {
+      const ordered = [...sol.steps].sort((a, b) => a.stepOrder - b.stepOrder);
+      ordered.forEach((step, i) => {
+        if (!step.gateCondition) return;
+        // A gate on the last step protects nothing, and a gate sharing a
+        // parallel group with the steps behind it cannot stop them in time.
+        expect(i, `${sol.slug}: gate on the final step protects nothing`).toBeLessThan(ordered.length - 1);
+        expect(step.parallelGroup, `${sol.slug}: a gate step must not share a parallel group`).toBeNull();
+      });
+    }
+  });
+
+  it("declares a caller-facing reason wherever it gates", () => {
+    for (const sol of SOLUTIONS) {
+      for (const step of sol.steps) {
+        if (!step.gateCondition) continue;
+        expect(step.gateCondition.reason, `${sol.slug} gate reason`).toBeTruthy();
+        // The caller's first question is whether they paid.
+        expect(step.gateCondition.reason!.toLowerCase()).toContain("not charged");
+      }
+    }
+  });
+});
+
+describe("migration block 0087", () => {
+  it("is idempotent and additive", async () => {
+    const executed: string[] = [];
+    const stub = { execute: async (q: SQL) => { executed.push(JSON.stringify(q)); return []; } };
+    const first = await runMigration0087_solutionGateCondition(stub);
+    const second = await runMigration0087_solutionGateCondition(stub);
+    expect(first.block).toBe("0087_solutionGateCondition");
+    expect(second.outcome).toBe("applied");
+    // Idempotency marker present — a re-run on a healthy database is a no-op.
+    expect(executed[0]).toContain("ADD COLUMN IF NOT EXISTS");
+    expect(executed[0]).toContain("gate_condition");
+    // Additive only: no DROP, no NOT NULL, no DEFAULT that would rewrite rows.
+    expect(executed.join(" ")).not.toMatch(/DROP|NOT NULL|SET DEFAULT/i);
+  });
+
+  it("is registered, or it never runs", async () => {
+    const src = await import("node:fs").then((fs) =>
+      fs.readFileSync(new URL("./startup-migrations.ts", import.meta.url), "utf8"));
+    const registry = src.slice(src.indexOf("const BLOCKS"), src.indexOf("];", src.indexOf("const BLOCKS")));
+    expect(registry).toContain("runMigration0087_solutionGateCondition");
+  });
+});

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1157,7 +1157,7 @@ describe("startup-migrations — phase-b5 slug lists (invariants)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 29 blocks in historical order", () => {
+  it("exports the expected 30 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1193,6 +1193,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0084_danishQuotaHeadroom",
       "runMigration0085_actorIdentity",
       "runMigration0086_srcBasis",
+      "runMigration0087_solutionGateCondition",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1549,6 +1549,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0084_danishQuotaHeadroom,
   runMigration0085_actorIdentity,
   runMigration0086_srcBasis,
+  runMigration0087_solutionGateCondition,
 ];
 
 /**
@@ -2031,4 +2032,25 @@ export async function runStartupMigrations(): Promise<BlockResult[]> {
   );
 
   return results;
+}
+
+/**
+ * Block 0087 — gate conditions on solution steps.
+ *
+ * A bundle had no way to say "if this precondition fails, stop and do not
+ * charge". Combined with the billing rule — refund only when EVERY step fails
+ * — any bundle whose first step can legitimately report "there is nothing
+ * here" billed in full for the remaining wasted steps. `page-seo-check` on an
+ * unreachable URL is the worked example: url-health-check succeeds reporting
+ * is_up=false, the other three fail, one success is enough to bill.
+ *
+ * Additive nullable column; existing rows keep NULL and behave exactly as
+ * before. No backlog to drain (DEC-20260504-B does not apply).
+ */
+export async function runMigration0087_solutionGateCondition(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  await tx.execute(sql`ALTER TABLE solution_steps ADD COLUMN IF NOT EXISTS gate_condition JSONB`);
+  return { block: "0087_solutionGateCondition", outcome: "applied", duration_ms: Date.now() - startedAt };
 }

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -385,15 +385,18 @@ solutionExecuteRoute.post(
           transaction_id: transactionId,
           solution_slug: slug,
           all_failed: allFailed,
+          gated: gated !== undefined,
           err: e instanceof Error ? { message: e.message, stack: e.stack } : e,
         },
         "solutions-tx-update-failed",
       );
 
-      // allFailed path already refunded at line ~270. Non-allFailed means
-      // wallet is still debited; refund now so the customer isn't left
-      // paying for a transaction we can't confirm.
-      if (!allFailed) {
+      // Anything on the refundRequired path already refunded above. Guarding
+      // on `allFailed` alone was correct until gates existed: a gated run has
+      // allFailed === false (the gate step succeeded), so it would have been
+      // refunded here a SECOND time. Caught by auditing the whole route rather
+      // than only the block being edited.
+      if (!refundRequired) {
         await refundWallet(db, walletId, walletBalanceBefore, sol.priceCents, sol.slug, "phase2 update failed");
       }
 

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -299,17 +299,27 @@ solutionExecuteRoute.post(
     const stepsSucceeded = Object.values(execResult.steps).filter(isSuccessfulStepOutput).length;
     const allFailed = stepsSucceeded === 0;
 
-    // /v1/do vocabulary: "completed" or "failed". Partial success maps to "completed"
-    // with per-step detail in audit_trail.
-    const txStatus = allFailed ? "failed" : "completed";
-    const chargedPrice = allFailed ? 0 : sol.priceCents;
+    // A tripped gate is NOT a failure — the gate step did its job and returned
+    // a true answer ("the page is down"). It is a refund, because the bundle
+    // could not perform the work it was sold for. Before gates existed the
+    // caller paid in full here: the gate step counts as a success, one success
+    // is enough to bill, and the steps behind it had already run and failed.
+    const gated = execResult.gated;
+    const refundRequired = allFailed || gated !== undefined;
 
-    // Full failure — refund
-    if (allFailed) {
-      await refundWallet(db, walletId, walletBalanceBefore, sol.priceCents, sol.slug, "all steps failed");
+    // /v1/do vocabulary: "completed" or "failed". Partial success maps to "completed"
+    // with per-step detail in audit_trail. A gated run completed — it answered.
+    const txStatus = allFailed ? "failed" : "completed";
+    const chargedPrice = refundRequired ? 0 : sol.priceCents;
+
+    if (refundRequired) {
+      await refundWallet(
+        db, walletId, walletBalanceBefore, sol.priceCents, sol.slug,
+        gated ? `gate tripped: ${gated.capabilitySlug}.${gated.field}` : "all steps failed",
+      );
     }
 
-    const finalBalance = allFailed ? walletBalanceBefore : balanceAfter;
+    const finalBalance = refundRequired ? walletBalanceBefore : balanceAfter;
 
     // Build per-step audit breakdown with per-step latency. Every step now
     // appears (the executor records skipped/unavailable markers instead of
@@ -426,6 +436,20 @@ solutionExecuteRoute.post(
         latency_ms: latencyMs,
         price_cents: chargedPrice,
         wallet_balance_cents: finalBalance,
+        // Present only when a precondition stopped the run. Says which step
+        // stopped it, what it saw, and — because the caller's next question is
+        // always "was I charged?" — that they were not.
+        ...(gated
+          ? {
+              gated: {
+                stopped_at: gated.capabilitySlug,
+                field: gated.field,
+                observed: gated.observed,
+                reason: gated.reason,
+                charged: false,
+              },
+            }
+          : {}),
       },
       meta: {
         solution_used: sol.slug,


### PR DESCRIPTION
Closes the platform gap identified in [#293](https://github.com/strale-io/strale/pull/293).

## The gap

The platform refunds a bundle only when **every** step fails. So a bundle whose first step legitimately reports "there is nothing here" *succeeded* — one success is enough to bill — and the caller paid in full for the wasted steps behind it.

`page-seo-check` is the worked example: on an unreachable URL, `url-health-check` returns `is_up: false` (a true answer) while metadata, social preview and performance each fail. Four calls, €0.30, one useful bit. Every bundle whose first step can legitimately come back empty has the same shape.

## The fix

A step may carry a **gate condition**. When its output matches, the remaining steps are not executed and the caller is refunded — the bundle could not do the work it was sold for. The answer it *can* give is still returned, with a `gated` block naming the step that stopped the run, what it saw, why, and that they were not charged (the caller's next question).

```json
{ "field": "is_up", "equals": false, "reason": "The page is not reachable, so nothing further could be checked. You were not charged." }
```

A literal comparison, not an expression language. A bundle definition is seeded data; it is not a place to accept arbitrary code.

## Which way it fails, chosen deliberately

A malformed gate parses as **absent**, never as "trips":

- fails **open** → one bundle keeps billing wrongly (the bug we already have)
- fails **closed** → every call to a working bundle silently stops and refunds

Comparison is strict for the same reason: `is_up: 0`, `null`, `undefined` or a missing field must not refund the caller. Under loose equality every one of those would.

## Scope

Applied to `page-seo-check` only. Every other bundle is unchanged, and an existing row with `NULL gate_condition` behaves exactly as before.

Pieces: migration block 0087 (additive nullable JSONB, `IF NOT EXISTS`, registered in `BLOCKS`), drizzle schema, executor evaluation after each group settles, refund wiring in `routes/solution-execute.ts`, catalogue type, seed persistence.

## Verification

- **Full suite 1693 green**; 20 new gate tests; typecheck, PII, console and SCF-3 gates clean.
- The pre-existing canonical-block-list test caught the new block and was updated — that guard working as designed.
- **Mutation-verified**, each broken separately:

  | mutation | caught |
  |---|---|
  | loose equality (`0`/`undefined` would refund) | 1 failed |
  | malformed gate fails **closed** instead of open | 1 failed |
  | gate matches when `equals` is absent | 1 failed |
  | gate step moved into the parallel group it protects | 1 failed |
  | drop the non-object guard in `gateTrips` | **equivalent, not uncaught** — indexing an array or string by the gate field yields `undefined`, which already fails the strict compare |

- **Deploy mechanism verified by file path** (DEC-20260504-C): `runMigration0087_solutionGateCondition` is registered in `BLOCKS`, which `runStartupMigrations` walks, invoked at `index.ts:112` before the API listens.

## Rollout

The column arrives on deploy. `page-seo-check`'s gate only takes effect after the next seed run writes it — until then that bundle behaves exactly as it does today. Safe in either state, in either order.

Post-deploy proof queries:

```
SELECT column_name FROM information_schema.columns
 WHERE table_name='solution_steps' AND column_name='gate_condition';

SELECT ss.capability_slug, ss.gate_condition FROM solution_steps ss
  JOIN solutions so ON so.id = ss.solution_id WHERE so.slug='page-seo-check';
```

Draft until cross-provider review returns — this is a refund path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)