### PR TITLE
fix: the demand table was still being filled with things we already sell

### DIFF
--- a/apps/api/src/lib/data-retention.ts
+++ b/apps/api/src/lib/data-retention.ts
@@ -247,7 +247,22 @@ async function purgeHealthMonitorEvents(cutoff: Date): Promise<number> {
  * — prove what happened, do not re-derive what was said.
  *
  * DEC-20260504-B re-audit for the widened window, 2026-08-15: 3,032 rows /
- * ~9.6 MB of payload on the first run, 0 on legal hold. Strategy: SELF-THROTTLE
+ * ~9.6 MB of payload on the first run, 0 on legal hold.
+ *
+ * **That estimate was wrong by roughly sixty-fold, and production is the
+ * record.** The first sweep after the `.count` fix redacted **173,000 rows**
+ * in a day, with ~8,000 still queued. The 2026-08-12 audit of the *narrower*
+ * selector had said 57,345 — and a widened selector is a strict superset, so
+ * 3,032 could never have been right. The contradiction was flagged in review
+ * and waved through, because the smaller number was the more convenient one.
+ * MAX_BATCHES_PER_RUN is what made the miss survivable: it capped each run at
+ * 50,000 rows regardless of how wrong the estimate was.
+ *
+ * The lesson for the next DEC-20260504-B audit: when two measurements of
+ * nested populations disagree in the wrong direction, the superset is not the
+ * smaller one — re-measure before choosing a deploy strategy.
+ *
+ * Strategy: SELF-THROTTLE
  * — BATCH_SIZE rows per statement, BATCH_DELAY_MS between statements, and
  * MAX_BATCHES_PER_RUN as the per-invocation ceiling. (An earlier version of
  * this note said the batch loop "bounds each tick to 1000 rows". It did not:

--- a/apps/api/src/lib/post-deploy-regressions.test.ts
+++ b/apps/api/src/lib/post-deploy-regressions.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression tests for what the 2026-08-16 post-deploy verification found.
+ *
+ * The deploy checks passed on their own terms — the card stopped advertising
+ * dead endpoints, the retention repair landed, the chain still verifies — but
+ * production then contradicted three things the code believed about itself.
+ * Each of those is locked out below.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const readCode = (rel: string) =>
+  readFileSync(join(HERE, "..", rel), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+// ── "unmet demand" must not mean "we sell it, just not for USDC" ───────────
+describe("x402 demand signal", () => {
+  const gw = readCode("routes/x402-gateway-v2.ts");
+
+  it("separates a slug we do not sell from one that is merely off this rail", () => {
+    // After the card stopped advertising unservable endpoints, the misses did
+    // NOT stop: 202 in 24 hours, and every missed slug was a real capability
+    // or solution of ours, probed by third-party discovery crawlers walking
+    // our public catalogue — which lists everything regardless of rail. Filed
+    // as "unknown slug", those read as demand for what we already sell.
+    expect(readCode("lib/x402-demand.ts")).toMatch(/"x402_not_on_rail"/);
+    const misses = gw.match(/recordX402Miss\(\{[^}]*kind:[^,]*/g) ?? [];
+    expect(misses.length).toBeGreaterThanOrEqual(3);
+    const slugMisses = misses.filter((m) => /unknown_slug/.test(m));
+    expect(slugMisses.length).toBeGreaterThan(0);
+    for (const m of slugMisses) {
+      expect(m, "an unknown-slug miss must first check whether we know the slug")
+        .toMatch(/known \? "x402_not_on_rail" : "x402_unknown_slug"/);
+    }
+  });
+
+  it("the known-slug lookup is cached and fails toward the quieter answer", () => {
+    // This runs on an unauthenticated route that crawlers hammer, so an
+    // uncached lookup would be a DB round-trip per stray 404. And on failure
+    // it must return true: an unclassified miss recorded as "unknown" is a
+    // false build signal, which is the harm being fixed.
+    const fn = gw.slice(gw.indexOf("async function isKnownSlug"));
+    expect(fn).toMatch(/KNOWN_SLUG_TTL_MS/);
+    expect(fn.slice(0, fn.indexOf("return _knownSlugs.has"))).toMatch(/catch\s*\{[\s\S]*?return true;/);
+  });
+});
+
+// ── a public integrity endpoint must not contradict its own structured field ─
+describe("verify: redaction prose", () => {
+  const src = readCode("routes/verify.ts");
+
+  it("recognises the renamed retention reason in prose, not just in the tally", () => {
+    // Live response, 2026-08-16: `deletion_reason: "content_retention_purge"`
+    // sitting beside `redaction_reason: "...deletion_reason unknown — flagged
+    // for operator review"`. The rename updated the counter and left the prose
+    // behind.
+    const fn = src.slice(src.indexOf("function redactionReasonText"));
+    const body = fn.slice(0, fn.indexOf("Unknown reason") > 0 ? fn.indexOf("Unknown reason") : 2000);
+    expect(body).toMatch(/isRetentionReason\(reason\)/);
+    expect(body).not.toMatch(/if \(reason === "retention_purge"\)/);
+  });
+
+  it("explains to a reader that the record itself survived", () => {
+    // The 90-day sweep redacts content and leaves the row readable. Someone
+    // following an audit URL needs that said plainly, not inferred.
+    expect(src).toMatch(/content_retention_purge/);
+    expect(readCode("routes/verify.ts")).toMatch(/still readable/);
+  });
+});
+
+// ── an audited backlog figure production has since falsified ────────────────
+describe("data-retention: the DEC-20260504-B audit note", () => {
+  it("records what the sweep actually did, not only what was predicted", () => {
+    // Predicted 3,032. The first sweep after the .count fix redacted 173,000.
+    // The contradiction was visible before the deploy — the narrower selector
+    // had been audited at 57,345, and a widened selector is a strict superset
+    // — and it was waved through because the smaller number was convenient.
+    const src = readFileSync(join(HERE, "data-retention.ts"), "utf8");
+    expect(src).toMatch(/173,000/);
+    expect(src).toMatch(/MAX_BATCHES_PER_RUN is what made the miss survivable/);
+  });
+});

--- a/apps/api/src/lib/x402-demand.ts
+++ b/apps/api/src/lib/x402-demand.ts
@@ -30,7 +30,24 @@ import { getDb } from "../db/index.js";
 import { logWarn } from "./log.js";
 import { saltedIpHash } from "./attribution.js";
 
-export type X402MissKind = "x402_unknown_slug" | "x402_bad_input";
+/**
+ * `x402_unknown_slug` — we do not sell this at all. A build signal.
+ * `x402_not_on_rail`  — we sell it, just not for USDC. A pricing/rail signal,
+ *                       and emphatically NOT a request to build anything.
+ * `x402_bad_input`    — we sell it and the caller could not use it.
+ *
+ * The middle kind exists because production disagreed with the first
+ * measurement. After the agent card stopped advertising unservable endpoints
+ * (2026-08-16), the misses did not stop — 202 in 24 hours, and **every single
+ * missed slug was a real capability or solution of ours**, probed by third-
+ * party discovery crawlers (hermes-contact-discovery, 402explorer,
+ * x402-observer, vale-census-probe and friends) walking our public catalogue,
+ * which lists everything regardless of rail. Filed under "unknown slug", those
+ * would have read as overwhelming demand for things we already sell, and a
+ * build queue reading this table would have been steered by a crawler's
+ * enumeration order.
+ */
+export type X402MissKind = "x402_unknown_slug" | "x402_not_on_rail" | "x402_bad_input";
 
 export interface X402MissContext {
   /** What they asked for — the slug from the URL, even if we have no such thing. */

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -130,9 +130,19 @@ verifyRoute.get("/:transactionId", async (c) => {
   // policy purge (system-initiated). Pre-fix, both rendered the same
   // generic "redacted under GDPR Art. 17" text — wrong for retention rows.
   function redactionReasonText(reason: string | null): string {
-    if (reason === "retention_purge") {
+    // isRetentionReason, not an equality check. Renaming the 90-day sweep's
+    // reason to 'content_retention_purge' updated the structured tally and
+    // left this prose behind, so a live verify response said "deletion_reason
+    // unknown — flagged for operator review" in the same body where
+    // `deletion_reason` read `content_retention_purge`. A public integrity
+    // endpoint contradicting itself is worse than one that says less.
+    if (isRetentionReason(reason)) {
       return (
-        "Row redacted by Strale's retention policy after the configured retention window. " +
+        (reason === "content_retention_purge"
+          ? "Row content redacted by Strale's 90-day customer-content retention policy. The record " +
+            "itself is intact and still readable — what was removed is the payload (input, output, " +
+            "provenance and audit detail). "
+          : "Row redacted by Strale's retention policy after the configured retention window. ") +
         "Original chain hash is preserved for chain continuity; per-row content hash no longer matches " +
         "because the row's input/output/audit_trail were zeroed by design. This is routine and not tampering."
       );

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -11,7 +11,7 @@
 
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { eq, and, inArray } from "drizzle-orm";
+import { eq, and, inArray, sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { capabilities, solutions, transactions, x402OrphanSettlements } from "../db/schema.js";
 import { getExecutor } from "../capabilities/index.js";
@@ -927,6 +927,38 @@ x402GatewayV2.get("/catalog", rateLimitByIp(120, 60_000), async (c) => {
   });
 });
 
+/**
+ * Does this slug name anything we sell, on any rail?
+ *
+ * Cached for the same reason the catalogue caches: this runs on an
+ * unauthenticated route that discovery crawlers hammer, and it must not turn
+ * every stray 404 into a database round-trip. A miss on the cache is a single
+ * indexed lookup; the cache itself is rebuilt lazily.
+ */
+const KNOWN_SLUG_TTL_MS = 15 * 60 * 1000;
+let _knownSlugs: Set<string> | null = null;
+let _knownSlugsAt = 0;
+
+async function isKnownSlug(slug: string): Promise<boolean> {
+  const now = Date.now();
+  if (!_knownSlugs || now - _knownSlugsAt > KNOWN_SLUG_TTL_MS) {
+    try {
+      const rows = (await getDb().execute(sql`
+        SELECT slug FROM capabilities
+        UNION ALL
+        SELECT slug FROM solutions`)) as unknown as Array<{ slug: string }>;
+      _knownSlugs = new Set(rows.map((r) => r.slug));
+      _knownSlugsAt = now;
+    } catch {
+      // Fail toward the safer classification: an unclassified miss recorded as
+      // "unknown" is a false build signal, so treat a lookup failure as
+      // "probably known" and keep it out of the build queue.
+      return true;
+    }
+  }
+  return _knownSlugs.has(slug);
+}
+
 // ─── Solution execution: /x402/solutions/:slug ──────────────────────────────
 
 x402GatewayV2.on(["GET", "POST"], ["/solutions/:slug", "/v2/solutions/:slug"], async (c) => {
@@ -941,8 +973,10 @@ x402GatewayV2.on(["GET", "POST"], ["/solutions/:slug", "/v2/solutions/:slug"], a
 
   const sol = _solCache.get(slug);
   if (!sol) {
-    recordX402Miss({ slug, kind: "x402_unknown_slug",
-      detail: "no such x402 solution", ...{ userAgent: c.req.header("user-agent") ?? null,
+    const known = await isKnownSlug(slug);
+    recordX402Miss({ slug, kind: known ? "x402_not_on_rail" : "x402_unknown_slug",
+      detail: known ? "known solution, not enabled for x402" : "no such x402 solution",
+      ...{ userAgent: c.req.header("user-agent") ?? null,
         ip: c.req.header("x-forwarded-for")?.split(",")[0]?.trim()
           ?? c.req.header("cf-connecting-ip") ?? null } });
     return c.json(
@@ -1164,9 +1198,13 @@ x402GatewayV2.on(["GET", "POST"], ["/:slug", "/v2/:slug"], async (c) => {
 
   const cap = _capCache.get(slug);
   if (!cap) {
-    // Demand signal: a paying-capable agent asked for something we do not sell.
-    recordX402Miss({ slug, kind: "x402_unknown_slug",
-      detail: "no such x402 capability", ...{ userAgent: c.req.header("user-agent") ?? null,
+    // Two very different things wear the same 404. Distinguish them before
+    // recording, or the demand table fills with "someone wanted X" for every
+    // X we already sell — see X402MissKind.
+    const known = await isKnownSlug(slug);
+    recordX402Miss({ slug, kind: known ? "x402_not_on_rail" : "x402_unknown_slug",
+      detail: known ? "known capability, not enabled for x402" : "no such x402 capability",
+      ...{ userAgent: c.req.header("user-agent") ?? null,
         ip: c.req.header("x-forwarded-for")?.split(",")[0]?.trim()
           ?? c.req.header("cf-connecting-ip") ?? null } });
     return c.json(


### PR DESCRIPTION
Follow-up to #296, driven by its post-deploy verification.

## The four checks passed

| check | result |
|---|---|
| advertised endpoints answer, not 404 | **13/13 sampled return a 402 challenge** (8 capabilities, 5 solutions). Card now advertises 328 x402 endpoints and 69 paid entries as API-key-only; **0 solution endpoints on the wrong path** (all 98 were wrong before) |
| no row hidden by the content sweep | **0** — migration 0087 ran; `user_request` erasure correctly still hidden |
| redacted rows visible and emptied | **242,037 redacted · 242,037 visible to owner · 0 with payload remaining · 242,037 skeleton intact · 204,086 chain-hashed** |
| chain verifies across redactions | live `GET /v1/verify/{id}`: `verified: true`, `redacted: true`, **`broken_links: 0`**, 19 redacted links all bucketed under `retention_purge` |

## Then production disagreed with the code, three times

**1. The misses did not stop — 202 in 24h, and every missed slug is ours.**

```
missed capability slugs, last 3h: 21   →  all x402_enabled = false
missed solution slugs,   last 3h: 12   →  all x402_enabled = false
callers: hermes-contact-discovery, 402explorer, x402-observer,
         vale-census-probe, entropy-daemon-trust-oracle, node, axios
```

Third-party discovery crawlers walk our public catalogue — which lists everything regardless of rail — and probe each slug on x402. Recorded as `x402_unknown_slug`, that reads as overwhelming demand for capabilities we already sell. Removing our own 404s fixed our contribution and exposed a larger one underneath.

New kind **`x402_not_on_rail`**: we sell it, just not for USDC. A pricing signal, not a build request. The lookup is cached (this is an unauthenticated route that crawlers hammer) and fails toward "probably known", because a misfiled miss is the harm being fixed.

**2. A public integrity endpoint contradicted its own structured field.** Renaming the 90-day sweep's reason in #296 updated the tally and left the prose mapper behind, so a live response carried `deletion_reason: "content_retention_purge"` next to *"deletion_reason unknown — flagged for operator review"*. Now matched via `isRetentionReason`, and it says plainly that the record survived and only the payload was removed.

**3. The DEC-20260504-B audit was wrong by sixtyfold.** Predicted 3,032 rows; the first sweep after the `.count` fix redacted **173,000**, ~8,000 still queued. The contradiction was visible before merge — the *narrower* selector had been audited at 57,345, and a widened selector is a strict superset — and the review flagged it. It was waved through because the smaller number was convenient. `MAX_BATCHES_PER_RUN` is the only reason it was survivable. The docstring now records what happened rather than what was predicted.

## Verification

`tsc` clean on both projects · full suite **1,736 passed / 0 failed** · **5/5 mutations caught**.

## Test plan

After deploy, re-run the miss breakdown: `SELECT failure_type, count(*) FROM failed_requests WHERE created_at > now() - interval '1 hour' GROUP BY 1`. `x402_unknown_slug` should fall close to zero and `x402_not_on_rail` should carry the crawler traffic. Any slug still filed as unknown is then a genuine catalogue gap worth reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
