### PR TITLE
fix(solutions): kyc-denmark and invoice-process — the seed completes again

### DIFF
--- a/apps/api/src/db/seed-solutions.test.ts
+++ b/apps/api/src/db/seed-solutions.test.ts
@@ -205,3 +205,42 @@ describe("the seed script's --dry-run flag", () => {
     expect(src).toContain("existing && !ALLOW_PRICE_CHANGES ? existing.priceCents : sol.priceCents");
   });
 });
+
+describe("step references that named fields their source never returned", () => {
+  // Both of these aborted the seed run — `enforceGates` throws, and since each
+  // solution writes in its own transaction rather than the run being atomic,
+  // the catalogue was left half-updated. Production stopped tracking these
+  // definitions around 2026-04-12 because every run since died here.
+  //
+  // Both were declaration failures rather than missing data: the capability
+  // returned the field, the manifest did not know about it. The lesson is that
+  // a `$steps[N].field` reference is only as good as the source manifest, so
+  // these pin the exact names.
+
+  it("invoice-process reads the supplier VAT under the name it is actually returned", () => {
+    // invoice-extract's extraction schema calls it `vendor_vat`. There has
+    // never been a `vat_number` field, so the old map could only pass null.
+    const step = SOLUTIONS.find((s) => s.slug === "invoice-process")!
+      .steps.find((st) => st.capabilitySlug === "vat-validate")!;
+    expect(step.inputMap.vat_number).toBe("$steps[0].vendor_vat");
+  });
+
+  it("invoice-process reads iban and total_amount, which invoice-extract does return", () => {
+    const sol = SOLUTIONS.find((s) => s.slug === "invoice-process")!;
+    expect(sol.steps.find((s) => s.capabilitySlug === "iban-validate")!.inputMap.iban)
+      .toBe("$steps[0].iban");
+    expect(sol.steps.find((s) => s.capabilitySlug === "currency-convert")!.inputMap.amount)
+      .toBe("$steps[0].total_amount");
+  });
+
+  it("kyc-denmark takes the Danish VAT number from the company lookup", () => {
+    // In Denmark the VAT number IS the CVR with a DK prefix — cvrapi.dk even
+    // returns it under the key `vat`. The executor has derived it since
+    // deriveVatDK landed; only the declaration was missing.
+    const step = SOLUTIONS.find((s) => s.slug === "kyc-denmark")!
+      .steps.find((st) => st.capabilitySlug === "vat-validate")!;
+    expect(step.inputMap.vat_number).toBe("$steps[0].vat_number");
+    expect(SOLUTIONS.find((s) => s.slug === "kyc-denmark")!.steps[0].capabilitySlug)
+      .toBe("danish-company-data");
+  });
+});

--- a/apps/api/src/db/solution-catalogue.ts
+++ b/apps/api/src/db/solution-catalogue.ts
@@ -1884,7 +1884,10 @@ export const SOLUTIONS: SolutionDef[] = [
         stepOrder: 2,
         canParallel: true,
         parallelGroup: 1,
-        inputMap: { vat_number: "$steps[0].vat_number" },
+        // invoice-extract returns the supplier's VAT as `vendor_vat`; there has
+        // never been a `vat_number` field. The map named a field that does not
+        // exist, so this step could only ever receive null.
+        inputMap: { vat_number: "$steps[0].vendor_vat" },
       },
       {
         capabilitySlug: "iban-validate",

--- a/manifests/danish-company-data.yaml
+++ b/manifests/danish-company-data.yaml
@@ -109,6 +109,13 @@ output_schema:
       type: string
     employee_range:
       type: string
+    # Danish VAT registration number. Not a separate lookup: in Denmark the VAT
+    # number IS the CVR number with a DK prefix, and cvrapi.dk literally returns
+    # it under the key `vat`. The executor has derived and returned it since
+    # deriveVatDK landed; the declaration never caught up, so kyc-denmark's
+    # $steps[0].vat_number failed the onboarding gate and aborted every seed run.
+    vat_number:
+      type: string
 data_source: CVR / Danish Business Authority (Erhvervsstyrelsen)
 data_source_type: api
 transparency_tag: mixed
@@ -135,6 +142,10 @@ output_field_reliability:
   status: guaranteed
   address: guaranteed
   cvr_number: guaranteed
+  # `common`, not `guaranteed`: deriveVatDK returns null unless the CVR is
+  # exactly 8 digits, so a malformed upstream value yields null rather than a
+  # string. Only guaranteed fields are asserted non-null.
+  vat_number: common
   start_date: guaranteed
   company_name: guaranteed
   business_type: guaranteed

--- a/manifests/invoice-extract.yaml
+++ b/manifests/invoice-extract.yaml
@@ -43,19 +43,42 @@ output_schema:
     total_amount: null
     invoice_number: null
     payment_reference: null
+  # Matches the executor's extraction schema. `date`, `total` and `vendor`
+  # were declared here and never returned; the real names are invoice_date,
+  # total_amount and vendor_name. See output_field_reliability below.
   properties:
-    date:
+    vendor_name:
       type: string
-    total:
-      type: number
-    vendor:
+    vendor_vat:
+      type: string
+    buyer_name:
+      type: string
+    buyer_vat:
+      type: string
+    invoice_number:
+      type: string
+    invoice_date:
+      type: string
+    due_date:
       type: string
     currency:
       type: string
-    line_items:
-      type: array
+    subtotal:
+      type: number
     vat_amount:
       type: number
+    vat_rate:
+      type: number
+    total_amount:
+      type: number
+    iban:
+      type: string
+    payment_reference:
+      type: string
+    line_items:
+      type: array
+    confidence:
+      type: object
 data_source: Claude API (document analysis and data extraction)
 data_source_type: api
 transparency_tag: ai_generated
@@ -75,24 +98,49 @@ test_fixtures:
     expected_fields:
       # Invoice-extract tested with a non-invoice image (smoke fixture).
       # Assert structural type only — AI extraction may return nulls on non-invoice input.
-      - field: date
+      - field: invoice_date
         operator: type
         value: string
         reliability: common
-      - field: vendor
+      - field: vendor_name
         operator: type
         value: string
         reliability: common
   health_check_input:
     url: https://httpbin.org/image/jpeg
+# Corrected 2026-08-16. The previous list declared `date`, `total` and
+# `vendor` — three fields this capability has never returned. The executor's
+# extraction schema names them `invoice_date`, `total_amount` and
+# `vendor_name`, and returns eleven more besides. The fiction went unnoticed
+# because all three were `common`, and common fields are type-checked rather
+# than asserted non-null, so an absent field always passed.
+#
+# It stopped being harmless when a bundle tried to use the real fields:
+# invoice-process maps $steps[0].iban and $steps[0].total_amount, both of
+# which the capability genuinely returns, and the onboarding gate rejected the
+# whole solution because the declaration did not know about them. That gate
+# failure aborted every seed run since roughly 2026-04-12.
+#
+# Everything below is `common` rather than `guaranteed`: the extractor returns
+# the full object shape on every call, but an LLM reading a real invoice
+# routinely leaves individual fields null.
 output_field_reliability:
-  date: common
-  total: common
-  vendor: common
   currency: common
-  line_items: rare
-  vat_amount: rare
+  due_date: common
+  subtotal: common
+  vat_rate: common
+  buyer_vat: common
+  buyer_name: common
+  vat_amount: common
+  vendor_vat: common
+  vendor_name: common
+  invoice_date: common
+  total_amount: common
   invoice_number: common
+  payment_reference: common
+  iban: common
+  confidence: rare
+  line_items: rare
 limitations:
   - title: Best results with standard invoice layouts — handwritten or heavily stylized invoices have lower accuracy
     text: >-


### PR DESCRIPTION
Both carried step references the onboarding gate rejected. Because `enforceGates` throws while each solution writes in its **own** transaction rather than the run being atomic, **every seed run since roughly 2026-04-12 died on them** and left the catalogue half-updated. That is why production had drifted from these definitions for four months.

## Neither was missing data

Both capabilities **return** the fields. The manifests never declared them, and the gate checks the declaration.

### invoice-extract declared three fields it has never returned

The manifest declared `date`, `total`, `vendor`. The executor's extraction schema names them `invoice_date`, `total_amount`, `vendor_name` — and returns eleven more besides, including `iban` and `vendor_vat`.

The fiction survived because all three were `common`, and common fields are type-checked rather than asserted non-null, so an absent field always passed. It only became visible when a bundle tried to use the real fields.

| invoice-process step | before | after |
|---|---|---|
| `vat-validate.vat_number` | `$steps[0].vat_number` — never existed, could only resolve to null | `$steps[0].vendor_vat` |
| `iban-validate.iban` | `$steps[0].iban` — **already correct** | unchanged; only the declaration was missing |
| `currency-convert.amount` | `$steps[0].total_amount` — **already correct** | unchanged; only the declaration was missing |

### danish-company-data already returns the VAT number

In Denmark the VAT number **is** the CVR with a `DK` prefix — cvrapi.dk returns it under the key `vat` and we rename it to `cvr_number`. The executor has derived it since `deriveVatDK` landed; only the declaration was missing. Declared `common` rather than `guaranteed`, because `deriveVatDK` returns null unless the CVR is exactly eight digits.

## Verification

- Both manifests synced to production with `sync-manifest-canonical-to-db.ts`.
- Gate re-run afterwards: **zero violations on both solutions**.
- Seed dry-run: **`48 solutions seeded, 0 skipped`** — the first complete run in four months. Previously 46 seeded, 2 skipped.
- Full suite **1739 green**; typecheck, manifest-guaranteed-consistency `--strict`, PII `--strict`, identity-fixture-shape `--strict` and tier-coverage gates clean.
- Regression tests pin the exact field names, because a `$steps[N].field` reference is only as good as its source manifest. **Mutation-verified**: reverting `invoice-process` to `vat_number` fails the suite.

## After merge

A seed run writes the corrected step definitions to production — `kyc-denmark`'s steps have never been written at all, since it was skipped every time. Both solutions are live and x402-enabled (€1.50 and €0.50), so this is a real repair, not housekeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)