### PR TITLE
fix(quality-floor): promotion grace — recovered capabilities stay re-listed

### DIFF
--- a/apps/api/src/jobs/capability-promotion.test.ts
+++ b/apps/api/src/jobs/capability-promotion.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Round-2 fix (2026-08-16) — external (Codex) review of the "promotion
+ * grace" fix found a TOCTOU gap in the promotion write (blocker #3): the
+ * conditional UPDATE re-asserted isActive/visible/deactivation_reason/
+ * breaker-state but not lifecycle_state, maintenance_class, or the identity
+ * of the listing-state event the decision was evaluated against. A human
+ * suspension, a maintenance_class change, or a fresh floor quarantine
+ * landing between evidence collection and the write could be silently
+ * overwritten back to active/visible.
+ *
+ * There is no Postgres-backed harness for jobs/capability-promotion.ts (the
+ * evidence query and the write both run through a hand-built `postgres`
+ * client / drizzle transaction, not a mockable call) — per the CLAUDE.md
+ * test-harness exemption, coverage here is a structural pin on the source
+ * text of the write's WHERE clause: it fails the instant any of the four
+ * re-asserted preconditions (lifecycle_state, maintenance_class,
+ * deactivation_reason, listing-event identity) is dropped, and it fails if
+ * the listing-event re-check ever stops sharing LISTING_EVENT_MATCH_SQL with
+ * the evidence query (the drift PROMOTION_EVIDENCE_SQL's own docstring warns
+ * against).
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** Source with comments stripped — these assertions are about what the code
+ * does, and the fix's own docstring names the bug pattern it replaces. */
+const readCode = (rel: string) =>
+  readFileSync(join(HERE, rel), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+describe("capability-promotion write — TOCTOU re-check (Codex blocker #3)", () => {
+  const src = readCode("capability-promotion.ts");
+
+  it("re-asserts lifecycle_state exactly as evaluated", () => {
+    expect(src).toContain("eq(capabilities.lifecycleState, d.lifecycleState)");
+  });
+
+  it("re-asserts maintenance_class exactly as evaluated, null-safe", () => {
+    expect(src).toContain("${capabilities.maintenanceClass} IS NOT DISTINCT FROM ${d.maintenanceClass}");
+  });
+
+  it("re-derives the latest listing-state event at write time and requires it to still be the one evaluated", () => {
+    // Must reuse the SAME condition text the evidence query used — a
+    // hand-copied second condition is exactly the drift PROMOTION_EVIDENCE_SQL
+    // warns about pinning against.
+    expect(src).toContain("dsql.raw(LISTING_EVENT_MATCH_SQL)");
+    expect(src).toContain("IS NOT DISTINCT FROM ${d.lastListingEventId}::uuid");
+    expect(src).toMatch(/ORDER BY e\.created_at DESC\s*\n\s*LIMIT 1\s*\n\s*\) IS NOT DISTINCT FROM/);
+  });
+
+  it("still re-asserts the three original preconditions (isActive, visible, deactivation_reason, breaker) — the hardening is additive", () => {
+    expect(src).toContain("eq(capabilities.isActive, true)");
+    expect(src).toContain("eq(capabilities.visible, false)");
+    expect(src).toContain("isNull(capabilities.deactivationReason)");
+    expect(src).toContain("h.state <> 'closed'");
+  });
+
+  it("any race still rolls back via PromotionRaced rather than silently overwriting", () => {
+    expect(src).toMatch(/if \(affected !== 1\) \{[\s\S]*?throw new PromotionRaced/);
+  });
+});

--- a/apps/api/src/jobs/capability-promotion.ts
+++ b/apps/api/src/jobs/capability-promotion.ts
@@ -32,12 +32,20 @@
  * the normal brake: dry-run until a human has read a tick's worth of
  * `dry_run_would_promote` events.
  *
- * RACE HANDLING (review finding 5): the evidence query and the write are not
- * atomic — a floor quarantine, an operator unpublish, or a breaker trip can
- * land in between. The UPDATE therefore re-asserts every eligibility
- * precondition in its WHERE clause and the transaction is rolled back unless
- * exactly one row changed. A promotion recorded against a stale snapshot would
- * silently overwrite a newer safety decision.
+ * RACE HANDLING (review finding 5, hardened round-2 2026-08-16 — Codex
+ * blocker #3): the evidence query and the write are not atomic — a floor
+ * quarantine, an operator unpublish, or a breaker trip can land in between.
+ * The UPDATE re-asserts isActive/visible/lifecycle_state/deactivation_reason/
+ * maintenance_class exactly as evaluated, AND re-derives "the latest
+ * listing-state event for this slug" at write time via the same
+ * LISTING_EVENT_MATCH_SQL the evidence query used, requiring it to still be
+ * the exact event (by id) this decision was evaluated against. The original
+ * version only re-checked isActive/visible/deactivation_reason/breaker —
+ * a human suspension, a maintenance_class change, or a fresh floor quarantine
+ * landing after evidence collection but before the write would have been
+ * silently overwritten back to active/visible. The transaction is rolled
+ * back unless exactly one row changed. A promotion recorded against a stale
+ * snapshot would silently overwrite a newer safety decision.
  *
  * Bulk-operation note (DEC-20260504-B): the first enforcing tick is a
  * workload-resumption event — a backlog accumulated since May 2026, not a
@@ -73,6 +81,12 @@ export interface PromotionEvidenceRow {
   has_x402_method: boolean;
   breaker_state: string | null;
   last_listing_event: string | null;
+  /** uuid of the matched event, for the write-time TOCTOU re-check (round-2 fix, Codex blocker #3). */
+  last_listing_event_id: string | null;
+  /** `details->>'mode'` of the matched event — structured provenance (Codex blocker #2), not inferred from the action string alone. */
+  last_listing_event_mode: string | null;
+  /** How many times the floor has EVER enforce-quarantined this slug (Codex blocker #1b — repeat-bounce refusal). */
+  floor_quarantine_count: number;
   total_tests: number;
   passed_tests: number;
   distinct_test_days: number;
@@ -93,19 +107,24 @@ export interface PromotionEvidenceRow {
  *
  * `last_listing_event` collapses to the two things the core needs: was this a
  * takedown, and what was it. A capability that has never been listed has no
- * such event and is a dark launch, not a reinstatement. `wasFloorQuarantine`
- * narrows further: 'quarantined' is written only by
- * `jobs/quality-floor.ts`'s enforce-mode apply path (event_type
- * 'quality_floor', action_taken 'quarantined' — see PROMOTION_EVIDENCE_SQL's
- * lateral join below), so it can never collide with a human/operator
- * lifecycle_transition action_taken ('Unpublished...', 'Suspended...',
- * 'Published...'). This is the signal that lets evaluatePromotion
- * auto-reverse a floor takedown while still refusing to touch a human one
- * ("promotion grace" fix, 2026-08-16).
+ * such event and is a dark launch, not a reinstatement.
+ *
+ * `wasFloorQuarantine` (round-2 fix, 2026-08-16 — Codex blocker #2) requires
+ * BOTH the action_taken string AND the matched event's own recorded mode to
+ * be 'enforce'. The SQL's `le` lateral already filters the quality_floor
+ * branch on `details->>'mode' = 'enforce'`, so `last_listing_event_mode`
+ * check here is structured provenance, not the sole gate — defense in depth
+ * against a future query edit that drops the WHERE-clause filter, or an
+ * ad-hoc/manual health_monitor_events insert with action_taken='quarantined'
+ * and no mode field (the real screenshot-url reinstatement event on
+ * 2026-08-13 was exactly this shape: 'capability_promoted', no `mode` key —
+ * proof this class of row exists in prod, not a hypothetical).
  */
 export function toPromotionStats(rows: PromotionEvidenceRow[]): PromotionStats[] {
   return rows.map((r) => {
     const wasDelisted = r.last_listing_event !== null && !r.last_listing_event.startsWith("promoted");
+    const wasFloorQuarantine =
+      wasDelisted && r.last_listing_event === "quarantined" && r.last_listing_event_mode === "enforce";
     return {
       slug: r.slug,
       lifecycleState: r.lifecycle_state,
@@ -119,7 +138,9 @@ export function toPromotionStats(rows: PromotionEvidenceRow[]): PromotionStats[]
       breakerState: r.breaker_state,
       wasDelisted,
       delistingReason: wasDelisted ? r.last_listing_event : null,
-      wasFloorQuarantine: wasDelisted && r.last_listing_event === "quarantined",
+      wasFloorQuarantine,
+      lastListingEventId: r.last_listing_event_id,
+      floorQuarantineCount: r.floor_quarantine_count,
       totalTests: r.total_tests,
       passedTests: r.passed_tests,
       distinctTestDays: r.distinct_test_days,
@@ -139,6 +160,25 @@ export function isEnforceMode(): boolean {
 }
 
 /**
+ * The event_type/action_taken/mode conditions that identify "a listing-state
+ * change" for a capability. Shared VERBATIM between PROMOTION_EVIDENCE_SQL's
+ * `le` lateral below (reads the latest such event per candidate) and the
+ * promotion write's TOCTOU re-check in runCapabilityPromotionOnce (round-2
+ * fix, Codex blocker #3) — the two must never drift, or the write could
+ * silently accept a listing-event identity the evidence query would have
+ * rejected. Requires `details->>'mode' = 'enforce'` on the quality_floor and
+ * capability_promotion branches (Codex blocker #2): the floor also emits
+ * dry_run rows with the same action_taken shape, and ad-hoc/manual ops
+ * writes with the same shape exist in repo history (screenshot-url's actual
+ * 2026-08-13 reinstatement event has no `mode` key at all).
+ */
+export const LISTING_EVENT_MATCH_SQL = `(   (e.event_type = 'quality_floor'        AND e.action_taken = 'quarantined' AND e.details->>'mode' = 'enforce')
+        OR (e.event_type = 'capability_promotion' AND e.action_taken LIKE 'promoted%' AND e.details->>'mode' = 'enforce')
+        OR (e.event_type = 'lifecycle_transition' AND (e.action_taken LIKE 'Unpublished%'
+                                                    OR e.action_taken LIKE 'Suspended%'
+                                                    OR e.action_taken LIKE 'Published%')))`;
+
+/**
  * The evidence query, shared with scripts/preview-promotions.ts so the preview
  * cannot drift from what the job will actually decide.
  *
@@ -147,6 +187,25 @@ export function isEnforceMode(): boolean {
  * it cannot fan the aggregate out or split a capability across grouped rows
  * (verified against prod 2026-08-16 — max 1 row/slug over 298 rows).
  * `test_suites` joins on the result's own suite id, one-to-one by primary key.
+ *
+ * Round-2 fix (2026-08-16, external review of the "promotion grace" fix —
+ * Codex blockers #1 and #2):
+ *   - `le` now filters on `LISTING_EVENT_MATCH_SQL` (enforce-mode only) and
+ *     exposes the matched event's id and mode as structured provenance.
+ *   - `le.quarantined_at` — the matched event's timestamp, but ONLY when it
+ *     resolved to the floor's own quarantine — clamps the `tr` join and the
+ *     `lk` lateral to evidence dated AFTER that quarantine. Without this, a
+ *     capability that was harness-green WHILE customer traffic was failing
+ *     (the exact pre-quarantine state) could supply its own "recovery"
+ *     evidence from before it was ever quarantined, oscillating forever:
+ *     quarantine -> promote on stale-but-in-window evidence -> new customer
+ *     failures -> quarantine -> promote again on the same leftover evidence.
+ *   - `fq` counts every enforce-mode quarantine this slug has ever had. A
+ *     second quarantine can only happen after an intervening promotion
+ *     re-listed the capability (the floor's own candidate filter requires
+ *     visible=true), so floor_quarantine_count >= 2 is unambiguous proof of
+ *     a prior auto-reversal that bounced back — evaluatePromotion refuses to
+ *     retry it (see lib/capability-promotion.ts).
  */
 export const PROMOTION_EVIDENCE_SQL = `
   SELECT c.slug,
@@ -160,6 +219,9 @@ export const PROMOTION_EVIDENCE_SQL = `
          (c.x402_method IS NOT NULL)             AS has_x402_method,
          h.state                                 AS breaker_state,
          le.action_taken                         AS last_listing_event,
+         le.id                                   AS last_listing_event_id,
+         le.mode                                 AS last_listing_event_mode,
+         COALESCE(fq.n, 0)::int                  AS floor_quarantine_count,
          COUNT(tr.id)::int                                          AS total_tests,
          COUNT(tr.id) FILTER (WHERE tr.passed)::int                 AS passed_tests,
          COUNT(DISTINCT date_trunc('day', tr.executed_at))::int     AS distinct_test_days,
@@ -172,31 +234,45 @@ export const PROMOTION_EVIDENCE_SQL = `
          COUNT(tr.id) FILTER (WHERE ts.test_type = 'piggyback' AND tr.passed)::int    AS piggyback_passed
   FROM capabilities c
   LEFT JOIN capability_health h ON h.capability_slug = c.slug
-  LEFT JOIN test_results tr
-         ON tr.capability_slug = c.slug
-        AND tr.executed_at > NOW() - INTERVAL '7 days'
-  LEFT JOIN test_suites ts ON ts.id = tr.test_suite_id
   -- The most recent event that changed whether this capability was listed.
   -- Distinguishes "never listed" (dark launch) from "taken down".
   LEFT JOIN LATERAL (
-    SELECT e.action_taken
+    SELECT e.id, e.action_taken, e.details->>'mode' AS mode,
+           CASE WHEN e.event_type = 'quality_floor' AND e.action_taken = 'quarantined'
+                THEN e.created_at END AS quarantined_at
     FROM health_monitor_events e
     WHERE e.capability_slug = c.slug
-      AND (   (e.event_type = 'quality_floor'        AND e.action_taken = 'quarantined')
-           OR (e.event_type = 'capability_promotion' AND e.action_taken LIKE 'promoted%')
-           OR (e.event_type = 'lifecycle_transition' AND (e.action_taken LIKE 'Unpublished%'
-                                                       OR e.action_taken LIKE 'Suspended%'
-                                                       OR e.action_taken LIKE 'Published%')))
+      AND ${LISTING_EVENT_MATCH_SQL}
     ORDER BY e.created_at DESC
     LIMIT 1
   ) le ON true
-  -- Did the single most recent known_answer result pass? An average survives a
-  -- fresh break; this does not.
+  -- How many times the floor has EVER enforce-quarantined this slug — see
+  -- floor_quarantine_count doc above.
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*)::int AS n
+    FROM health_monitor_events e
+    WHERE e.capability_slug = c.slug
+      AND e.event_type = 'quality_floor'
+      AND e.action_taken = 'quarantined'
+      AND e.details->>'mode' = 'enforce'
+  ) fq ON true
+  LEFT JOIN test_results tr
+         ON tr.capability_slug = c.slug
+        AND tr.executed_at > GREATEST(
+              NOW() - INTERVAL '7 days',
+              COALESCE(le.quarantined_at, '-infinity'::timestamptz)
+            )
+  LEFT JOIN test_suites ts ON ts.id = tr.test_suite_id
+  -- Did the single most recent known_answer result pass? An average survives
+  -- a fresh break; this does not. Also bounded to since-quarantine, same
+  -- reason as the tr join above — a stale pre-quarantine pass must not stand
+  -- in for "broken now".
   LEFT JOIN LATERAL (
     SELECT tr2.passed
     FROM test_results tr2
     JOIN test_suites ts2 ON ts2.id = tr2.test_suite_id
     WHERE tr2.capability_slug = c.slug AND ts2.test_type = 'known_answer'
+      AND tr2.executed_at > COALESCE(le.quarantined_at, '-infinity'::timestamptz)
     ORDER BY tr2.executed_at DESC
     LIMIT 1
   ) lk ON true
@@ -204,7 +280,7 @@ export const PROMOTION_EVIDENCE_SQL = `
     AND c.visible = false
   GROUP BY c.slug, c.lifecycle_state, c.visible, c.x402_enabled, c.is_free_tier,
            c.maintenance_class, c.marketplace_eligible, c.deactivation_reason,
-           c.x402_method, h.state, le.action_taken, lk.passed`;
+           c.x402_method, h.state, le.id, le.action_taken, le.mode, fq.n, lk.passed`;
 
 export async function runCapabilityPromotionOnce(): Promise<{
   outcome: string;
@@ -248,9 +324,13 @@ export async function runCapabilityPromotionOnce(): Promise<{
         };
 
         if (d.action === "promote" && mode === "enforce") {
-          // Conditional write (review finding 5). Every precondition the
-          // decision rested on is re-asserted here, so a quarantine or
-          // unpublish that landed after the evidence query wins the race
+          // Conditional write (review finding 5, hardened round-2 — Codex
+          // blocker #3). Every precondition the decision rested on is
+          // re-asserted here, including lifecycle_state and maintenance_class
+          // (exact match to what was evaluated — IS NOT DISTINCT FROM handles
+          // the null case) and the listing-event identity check below, so a
+          // quarantine, an unpublish, a maintenance_class change, or a fresh
+          // takedown that landed after the evidence query wins the race
           // rather than being silently overwritten. Anything other than
           // exactly one affected row rolls the event back with it.
           let applied = false;
@@ -271,11 +351,29 @@ export async function runCapabilityPromotionOnce(): Promise<{
                   eq(capabilities.slug, d.slug),
                   eq(capabilities.isActive, true),
                   eq(capabilities.visible, false),
+                  eq(capabilities.lifecycleState, d.lifecycleState),
                   isNull(capabilities.deactivationReason),
+                  dsql`${capabilities.maintenanceClass} IS NOT DISTINCT FROM ${d.maintenanceClass}`,
                   dsql`NOT EXISTS (
                     SELECT 1 FROM capability_health h
                     WHERE h.capability_slug = ${d.slug} AND h.state <> 'closed'
                   )`,
+                  // Listing-event identity (Codex blocker #3): re-derive "the
+                  // latest listing-state event for this slug" using the exact
+                  // same match the evidence query used, and require it to
+                  // still be the event (by id) this decision was evaluated
+                  // against. A human suspension or a fresh floor quarantine
+                  // inserted between evidence collection and this write
+                  // changes the answer, so the write is rejected (raced)
+                  // instead of overwriting a decision made after ours.
+                  dsql`(
+                    SELECT e.id
+                    FROM health_monitor_events e
+                    WHERE e.capability_slug = ${d.slug}
+                      AND ${dsql.raw(LISTING_EVENT_MATCH_SQL)}
+                    ORDER BY e.created_at DESC
+                    LIMIT 1
+                  ) IS NOT DISTINCT FROM ${d.lastListingEventId}::uuid`,
                 ),
               );
             const affected = (res as unknown as { count?: number; rowCount?: number }).count

--- a/apps/api/src/jobs/capability-promotion.ts
+++ b/apps/api/src/jobs/capability-promotion.ts
@@ -171,12 +171,62 @@ export function isEnforceMode(): boolean {
  * dry_run rows with the same action_taken shape, and ad-hoc/manual ops
  * writes with the same shape exist in repo history (screenshot-url's actual
  * 2026-08-13 reinstatement event has no `mode` key at all).
+ *
+ * The lifecycle_transition branch matches on the arrow ('→') shape, not an
+ * enumerated prefix list (round-3 fix, 2026-08-16 — Codex MAJOR): the
+ * canonical writer (lib/lifecycle.ts) and four other emit sites
+ * (routes/internal-health-monitor.ts ×3, routes/reply-webhook.ts) all write
+ * `${fromState} → ${toState}: ${reason}` — none of them start with
+ * "Suspended", so the old prefix-only match silently never caught a real
+ * suspend/restore transition. `Unpublished%`/`Published%` stay as literal
+ * prefixes because those two emit sites (internal-health-monitor.ts publish/
+ * unpublish) genuinely write that literal text, not arrow-form. ADDING A NEW
+ * EMIT SITE for event_type='lifecycle_transition'? Its action_taken string
+ * MUST match one of these four shapes, or extend both this constant AND
+ * `isListingStateEvent` below (kept in sync by hand) — the "producer
+ * coverage" describe block in capability-promotion.test.ts is fixture-driven
+ * from the real strings each site emits and will catch a sixth format that
+ * bypasses one but not the other.
  */
 export const LISTING_EVENT_MATCH_SQL = `(   (e.event_type = 'quality_floor'        AND e.action_taken = 'quarantined' AND e.details->>'mode' = 'enforce')
         OR (e.event_type = 'capability_promotion' AND e.action_taken LIKE 'promoted%' AND e.details->>'mode' = 'enforce')
         OR (e.event_type = 'lifecycle_transition' AND (e.action_taken LIKE 'Unpublished%'
                                                     OR e.action_taken LIKE 'Suspended%'
-                                                    OR e.action_taken LIKE 'Published%')))`;
+                                                    OR e.action_taken LIKE 'Published%'
+                                                    OR e.action_taken LIKE '%→%')))`;
+
+/**
+ * Pure JS mirror of LISTING_EVENT_MATCH_SQL's boolean logic. Exists ONLY to
+ * make the matcher's actual behavior testable against real producer output
+ * (round-3 fix — Codex's critique of round 2 was that the tests asserted the
+ * SQL's own text, which proves the pattern exists, not that it matches what
+ * the real emit sites actually write). There is no shared runtime between
+ * Postgres LIKE and JS string matching, so this MUST be kept in exact sync
+ * with LISTING_EVENT_MATCH_SQL by hand — see the comment there. Not used by
+ * the actual query (Postgres evaluates LISTING_EVENT_MATCH_SQL server-side);
+ * used only by capability-promotion.test.ts's producer-coverage suite.
+ */
+export function isListingStateEvent(
+  eventType: string,
+  actionTaken: string,
+  detailsMode: string | null,
+): boolean {
+  if (eventType === "quality_floor") {
+    return actionTaken === "quarantined" && detailsMode === "enforce";
+  }
+  if (eventType === "capability_promotion") {
+    return actionTaken.startsWith("promoted") && detailsMode === "enforce";
+  }
+  if (eventType === "lifecycle_transition") {
+    return (
+      actionTaken.startsWith("Unpublished")
+      || actionTaken.startsWith("Suspended")
+      || actionTaken.startsWith("Published")
+      || actionTaken.includes("→")
+    );
+  }
+  return false;
+}
 
 /**
  * The evidence query, shared with scripts/preview-promotions.ts so the preview

--- a/apps/api/src/jobs/capability-promotion.ts
+++ b/apps/api/src/jobs/capability-promotion.ts
@@ -13,7 +13,10 @@
  *      capability, with the known_answer subset, the piggyback subset, the
  *      trailing-24h subset and the last listing-state event broken out, plus
  *      the circuit-breaker state.
- *   2. evaluatePromotion() → at most maxPromotionsPerRun promotions/tick.
+ *   2. evaluatePromotion() → at most maxPromotionsPerRun promotions/tick. A
+ *      quality-floor quarantine that clears every gate is auto-reversed here
+ *      ("promotion grace" fix, 2026-08-16 — DEC-20260812-A auto-promote-on-
+ *      recovery); a human/operator takedown still only ever gets flagged.
  *   3. Apply: lifecycle_state='active', visible=true, x402_enabled set to the
  *      decision's value — inside a transaction with its event.
  *   4. Always emit per-decision events plus a tick_complete heartbeat.
@@ -90,7 +93,15 @@ export interface PromotionEvidenceRow {
  *
  * `last_listing_event` collapses to the two things the core needs: was this a
  * takedown, and what was it. A capability that has never been listed has no
- * such event and is a dark launch, not a reinstatement.
+ * such event and is a dark launch, not a reinstatement. `wasFloorQuarantine`
+ * narrows further: 'quarantined' is written only by
+ * `jobs/quality-floor.ts`'s enforce-mode apply path (event_type
+ * 'quality_floor', action_taken 'quarantined' — see PROMOTION_EVIDENCE_SQL's
+ * lateral join below), so it can never collide with a human/operator
+ * lifecycle_transition action_taken ('Unpublished...', 'Suspended...',
+ * 'Published...'). This is the signal that lets evaluatePromotion
+ * auto-reverse a floor takedown while still refusing to touch a human one
+ * ("promotion grace" fix, 2026-08-16).
  */
 export function toPromotionStats(rows: PromotionEvidenceRow[]): PromotionStats[] {
   return rows.map((r) => {
@@ -108,6 +119,7 @@ export function toPromotionStats(rows: PromotionEvidenceRow[]): PromotionStats[]
       breakerState: r.breaker_state,
       wasDelisted,
       delistingReason: wasDelisted ? r.last_listing_event : null,
+      wasFloorQuarantine: wasDelisted && r.last_listing_event === "quarantined",
       totalTests: r.total_tests,
       passedTests: r.passed_tests,
       distinctTestDays: r.distinct_test_days,

--- a/apps/api/src/jobs/capability-promotion.ts
+++ b/apps/api/src/jobs/capability-promotion.ts
@@ -251,11 +251,13 @@ export function isListingStateEvent(
  *     quarantine -> promote on stale-but-in-window evidence -> new customer
  *     failures -> quarantine -> promote again on the same leftover evidence.
  *   - `fq` counts every enforce-mode quarantine this slug has ever had. A
- *     second quarantine can only happen after an intervening promotion
- *     re-listed the capability (the floor's own candidate filter requires
- *     visible=true), so floor_quarantine_count >= 2 is unambiguous proof of
- *     a prior auto-reversal that bounced back — evaluatePromotion refuses to
- *     retry it (see lib/capability-promotion.ts).
+ *     second quarantine can only happen after an intervening re-list —
+ *     whether this job's own auto-reversal or a manual/admin publish (the
+ *     floor's candidate filter requires visible=true) — so
+ *     floor_quarantine_count >= 2 proves the capability was re-listed and
+ *     re-quarantined, without asserting the re-list was automatic.
+ *     evaluatePromotion refuses to auto-retry and flags for human review
+ *     (see lib/capability-promotion.ts).
  */
 export const PROMOTION_EVIDENCE_SQL = `
   SELECT c.slug,

--- a/apps/api/src/jobs/quality-floor.test.ts
+++ b/apps/api/src/jobs/quality-floor.test.ts
@@ -1,0 +1,119 @@
+/**
+ * "Promotion grace" fix (2026-08-16, DEC-20260812-A) — regression tests for
+ * the quality-floor evidence-window clamp.
+ *
+ * Real incident this locks out: screenshot-url was quarantined 2026-08-12 on
+ * a real 55%/30d completion driven by a bug that had already been fixed
+ * 2026-08-05. Promoted 2026-08-13T07:34; the floor's next enforce tick
+ * (07:47) re-quarantined it 13 minutes later because its 30d completion
+ * window still averaged in the pre-fix failures — a promotion can never
+ * survive its own tick under a flat 30-day window, however clean the traffic
+ * since promotion. The fix clamps the window per capability to
+ * max(now-30d, its own last ENFORCE-mode promotion timestamp).
+ *
+ * Per DEC-20260504-A every audit-follow-up ships a test that fails against
+ * the un-applied fix and passes against the applied one. There is no
+ * Postgres-backed harness for jobs/quality-floor.ts (it runs a hand-built
+ * `postgres` tagged-template query directly, not through a mockable ORM
+ * call) — per the CLAUDE.md test-harness exemption, coverage here is:
+ *   (a) a structural pin on the SQL text itself (fails the instant the GREATEST
+ *       clamp regresses to a flat 30-day WHERE, or the dry-run gate is
+ *       dropped) — mirrors the pattern in lib/go-review-regressions.test.ts;
+ *   (b) a behavioral pin at the foldTrafficRows/evaluateFloor layer, feeding
+ *       in exactly the rows the SQL would return before vs. after the clamp,
+ *       to prove what the clamp is actually FOR: it is the difference between
+ *       the bounce happening and not happening on identical underlying data.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { evaluateFloor } from "../lib/quality-floor.js";
+import { foldTrafficRows, type FloorTrafficRow } from "./quality-floor.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** Source with comments stripped — these assertions are about what the code
+ * does, and the fix's own docstring names the bug pattern it replaces. */
+const readCode = (rel: string) =>
+  readFileSync(join(HERE, rel), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+describe("quality-floor evidence window — the SQL clamp itself", () => {
+  const src = readCode("quality-floor.ts");
+
+  it("clamps the 30d floor to since-last-enforce-promotion, never widening it", () => {
+    expect(src).toMatch(
+      /GREATEST\(\s*NOW\(\) - INTERVAL '30 days',\s*COALESCE\(lp\.promoted_at, '-infinity'::timestamptz\)\s*\)/,
+    );
+  });
+
+  it("only an ENFORCE-mode promotion can move the window — a dry-run promotion grants no grace period", () => {
+    expect(src).toContain(`e.details->>'mode' = 'enforce'`);
+    expect(src).not.toMatch(/details->>'mode' = 'dry_run'/);
+  });
+
+  it("reads the promotion event per capability, and only 'promoted%' events", () => {
+    expect(src).toContain("WHERE e.capability_slug = c.slug");
+    expect(src).toContain("e.event_type = 'capability_promotion'");
+    expect(src).toContain("e.action_taken LIKE 'promoted%'");
+  });
+});
+
+describe("quality-floor evidence window — the bounce it must not reproduce", () => {
+  // 30d of real customer traffic BEFORE the 2026-08-13T07:34 promotion:
+  // 10 completed, 20 failed (upstream — non-caller-attributable) spread over
+  // two calendar days so the burst guard doesn't defer it. Completion
+  // 10/30 = 33%, matching the real prod incident's <70% figure.
+  const prePromotionRows: FloorTrafficRow[] = [
+    { slug: "screenshot-url", lifecycle_state: "active", visible: true, x402_enabled: true,
+      status: "completed", error: null, price_cents: 5, day: "2026-08-01", recent: false, n: 10 },
+    { slug: "screenshot-url", lifecycle_state: "active", visible: true, x402_enabled: true,
+      status: "failed", error: "upstream unavailable", price_cents: 5, day: "2026-08-06", recent: false, n: 10 },
+    { slug: "screenshot-url", lifecycle_state: "active", visible: true, x402_enabled: true,
+      status: "failed", error: "upstream unavailable", price_cents: 5, day: "2026-08-09", recent: false, n: 10 },
+  ];
+  // The 07:47 tick, 13 minutes after promotion: essentially no new real
+  // traffic has landed yet. One clean call, dated "recent" (< 7d old).
+  const tinyPostPromotionRows: FloorTrafficRow[] = [
+    { slug: "screenshot-url", lifecycle_state: "active", visible: true, x402_enabled: true,
+      status: "completed", error: null, price_cents: 5, day: "2026-08-13", recent: true, n: 1 },
+  ];
+
+  it("WITHOUT the clamp (SQL returns pre- and post-promotion rows together) the tick re-quarantines — this is the bounce", () => {
+    const stats = foldTrafficRows([...prePromotionRows, ...tinyPostPromotionRows]);
+    const [d] = evaluateFloor(stats);
+    expect(d.action).toBe("quarantine");
+  });
+
+  it("WITH the clamp (SQL returns only rows since the capability's own promotion) the tick has no verdict yet — the grace period", () => {
+    // The clamp doesn't need to "know" the capability is healthy — it simply
+    // never sees the contaminated pre-promotion rows, so eligibleCalls (1)
+    // stays under minCalls (10) and evaluateFloor emits nothing at all: not
+    // a quarantine, not a proposal. The ≥10-eligible-calls threshold is the
+    // grace period.
+    const stats = foldTrafficRows(tinyPostPromotionRows);
+    expect(evaluateFloor(stats)).toEqual([]);
+  });
+});
+
+describe("quality-floor evidence window — genuine new failures still re-quarantine", () => {
+  // Days later: 15 NEW eligible calls have landed since promotion (well past
+  // minCalls), and they are genuinely bad — 5 completed, 10 failed across two
+  // distinct days. The clamp resets the window; it does not grant immunity.
+  const genuinelyFailingPostPromotionRows: FloorTrafficRow[] = [
+    { slug: "screenshot-url", lifecycle_state: "active", visible: true, x402_enabled: true,
+      status: "completed", error: null, price_cents: 5, day: "2026-08-15", recent: true, n: 5 },
+    { slug: "screenshot-url", lifecycle_state: "active", visible: true, x402_enabled: true,
+      status: "failed", error: "upstream unavailable", price_cents: 5, day: "2026-08-15", recent: true, n: 5 },
+    { slug: "screenshot-url", lifecycle_state: "active", visible: true, x402_enabled: true,
+      status: "failed", error: "upstream unavailable", price_cents: 5, day: "2026-08-16", recent: true, n: 5 },
+  ];
+
+  it("re-quarantines on ≥10 genuinely-failing NEW calls, evaluated purely on post-promotion evidence", () => {
+    const stats = foldTrafficRows(genuinelyFailingPostPromotionRows);
+    const [d] = evaluateFloor(stats);
+    expect(d.eligibleCalls).toBe(15);
+    expect(d.action).toBe("quarantine");
+  });
+});

--- a/apps/api/src/jobs/quality-floor.ts
+++ b/apps/api/src/jobs/quality-floor.ts
@@ -11,10 +11,25 @@
  * boot.
  *
  * Per tick:
- *   1. Aggregate 30d external PAID traffic per active/degraded capability
- *      (internal accounts excluded by the canonical suffix rule; free-tier
- *      rows excluded — anonymous €0 traffic is the cheapest failure-
- *      fabrication vector, review H-1; soft-deleted rows excluded, M-8).
+ *   1. Aggregate external PAID traffic per active/degraded capability over a
+ *      window that is 30d, CLAMPED to since-last-promotion when that's more
+ *      recent ("promotion grace" fix, 2026-08-16). Without the clamp, a
+ *      capability promoted mid-window still carries its pre-promotion
+ *      failures in the same 30d completion rate, so the very next tick could
+ *      re-quarantine it on stale evidence — observed in prod on
+ *      screenshot-url: promoted 2026-08-13 07:34, re-quarantined 07:47 by
+ *      contaminated-window arithmetic, even though the underlying bug had
+ *      been fixed on 2026-08-05. The clamp reads the latest *enforce-mode*
+ *      `capability_promoted`/`promoted_with_x402` event per slug from
+ *      `health_monitor_events` (dry_run events never move the window — a
+ *      promotion that was never applied must not grant a grace period) and
+ *      only counts traffic from that timestamp forward. The existing
+ *      `minCalls` (≥10) eligibility gate then acts as the grace period itself:
+ *      a freshly promoted capability simply has no verdict until 10 NEW
+ *      eligible calls land post-promotion (internal accounts excluded by the
+ *      canonical suffix rule; free-tier rows excluded — anonymous €0 traffic
+ *      is the cheapest failure-fabrication vector, review H-1; soft-deleted
+ *      rows excluded, M-8).
  *   2. Classify failures (lib/transaction-failure-taxonomy.ts); caller-
  *      attributable ones don't count. Distinct failure days feed the pure
  *      core's burst guard.
@@ -28,8 +43,14 @@
  *      even on a zero-decision tick (M-3).
  *
  * Deactivation is NEVER applied here — proposals only (escalation contract).
- * Promotion/recovery is doctor-driven in v1. Solution-step traffic is out of
- * scope (M-6; see lib/quality-floor.ts header).
+ * Promotion/recovery is handled by jobs/capability-promotion.ts, which is
+ * explicitly allowed to auto-reverse a floor quarantine on recovery
+ * (DEC-20260812-A "auto-promote on recovery" is a platform-acts-alone
+ * action) — this clamp is what makes that safe: if an auto-reversal turns
+ * out wrong, the floor re-quarantines on fresh post-promotion evidence
+ * rather than replaying the same contaminated window that caused the
+ * original bounce. Solution-step traffic is out of scope (M-6; see
+ * lib/quality-floor.ts header).
  */
 import postgres from "postgres";
 import { getDb } from "../db/index.js";
@@ -126,6 +147,13 @@ export async function runQualityFloorOnce(): Promise<{
 
     const mode = isEnforceMode() ? "enforce" : "dry_run";
     try {
+      // `lp.promoted_at`: the latest ENFORCE-mode promotion for this slug,
+      // per the "promotion grace" fix (2026-08-16). Dry-run promotions never
+      // wrote a real listing change, so they must never move the window —
+      // filtered via `details->>'mode' = 'enforce'`. GREATEST() keeps the
+      // window's upper bound at 30d when there is no promotion (or it is
+      // older than 30d): the clamp can only ever narrow the window, never
+      // widen it past the DEC-20260812-A default.
       const rows = await sql<FloorTrafficRow[]>`
         SELECT c.slug, c.lifecycle_state, c.visible, c.x402_enabled,
                t.status, t.error, t.price_cents,
@@ -133,9 +161,20 @@ export async function runQualityFloorOnce(): Promise<{
                (t.created_at > NOW() - INTERVAL '7 days') AS recent,
                COUNT(*)::int AS n
         FROM capabilities c
+        LEFT JOIN LATERAL (
+          SELECT MAX(e.created_at) AS promoted_at
+          FROM health_monitor_events e
+          WHERE e.capability_slug = c.slug
+            AND e.event_type = 'capability_promotion'
+            AND e.action_taken LIKE 'promoted%'
+            AND e.details->>'mode' = 'enforce'
+        ) lp ON true
         JOIN transactions t ON t.capability_id = c.id
         WHERE c.is_active = true
-          AND t.created_at > NOW() - INTERVAL '30 days'
+          AND t.created_at > GREATEST(
+                NOW() - INTERVAL '30 days',
+                COALESCE(lp.promoted_at, '-infinity'::timestamptz)
+              )
           AND t.status IN ('completed', 'failed')
           AND t.deleted_at IS NULL
           AND COALESCE(t.is_free_tier, false) = false

--- a/apps/api/src/lib/capability-promotion.test.ts
+++ b/apps/api/src/lib/capability-promotion.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   toPromotionStats,
   isEnforceMode,
+  isListingStateEvent,
   PROMOTION_EVIDENCE_SQL,
   LISTING_EVENT_MATCH_SQL,
   type PromotionEvidenceRow,
@@ -176,11 +177,10 @@ describe("evaluatePromotion — human takedowns are never overturned; floor take
 
   // Round-2 fix (2026-08-16, Codex blocker #1b — oscillation). The floor's
   // own candidate filter requires visible=true to quarantine at all, so a
-  // SECOND enforce quarantine can only happen after an intervening promotion
-  // re-listed this exact slug: floorQuarantineCount >= 2 is proof a prior
-  // auto-reversal already bounced back on real customer traffic. Even
-  // genuinely fresh, post-quarantine, harness-green evidence must not
-  // auto-reverse a second time.
+  // SECOND enforce quarantine can only happen after an intervening RE-LIST of
+  // this exact slug: floorQuarantineCount >= 2 is proof it was re-listed and
+  // re-quarantined at least once before. Even genuinely fresh, post-
+  // quarantine, harness-green evidence must not auto-reverse a second time.
   it("refuses to auto-reverse a REPEAT floor quarantine — flags for human instead", () => {
     const d = only([cap({
       wasDelisted: true, wasFloorQuarantine: true, delistingReason: "quarantined",
@@ -196,6 +196,19 @@ describe("evaluatePromotion — human takedowns are never overturned; floor take
     const d = only([cap({ wasDelisted: true, wasFloorQuarantine: true, floorQuarantineCount: 5 })]);
     expect(d.action).toBe("flag");
     expect(d.reason).toContain("quarantined 5 times");
+  });
+
+  // Round-3 fix (2026-08-16, Codex MINOR). floorQuarantineCount >= 2 proves
+  // an intervening RE-LIST — the admin publish endpoint can do that
+  // manually, not only this job's own auto-reversal — so the recorded
+  // reason must say "re-listed and re-quarantined" and must NOT claim a
+  // prior auto-reversal specifically failed. The refusal itself is
+  // unchanged (still conservative); only the claim in the text is narrowed.
+  it("the repeat-bounce reason says re-listed-and-re-quarantined, and does not claim the prior re-list was this job's own auto-reversal", () => {
+    const d = only([cap({ wasDelisted: true, wasFloorQuarantine: true, floorQuarantineCount: 2 })]);
+    expect(d.reason).toContain("re-listed and re-quarantined");
+    expect(d.reason).not.toContain("auto-reversal already failed");
+    expect(d.reason).not.toMatch(/prior auto-reversal/i);
   });
 
   it("a human deactivation_reason refuses promotion even for an otherwise-eligible floor quarantine", () => {
@@ -324,6 +337,15 @@ describe("the evidence query", () => {
     it("PROMOTION_EVIDENCE_SQL embeds the shared constant verbatim rather than a copy that can drift", () => {
       expect(PROMOTION_EVIDENCE_SQL).toContain(LISTING_EVENT_MATCH_SQL);
     });
+
+    // Round-3 (Codex MAJOR): the SQL side of the arrow-form fix. The
+    // isListingStateEvent producer-coverage suite below proves the JS
+    // mirror's BEHAVIOR against real strings; this proves the actual SQL
+    // constant carries the equivalent pattern, so the two can't silently
+    // diverge (one fixed, the other not).
+    it("the lifecycle_transition branch also matches the arrow ('→') shape the real producers write, not just literal prefixes", () => {
+      expect(LISTING_EVENT_MATCH_SQL).toContain("e.action_taken LIKE '%→%'");
+    });
   });
 
   // Round-2 fix (2026-08-16, Codex blocker #1a — oscillation). Without this,
@@ -362,6 +384,63 @@ describe("the evidence query", () => {
         /FROM health_monitor_events e\s+WHERE e\.capability_slug = c\.slug\s+AND e\.event_type = 'quality_floor'\s+AND e\.action_taken = 'quarantined'\s+AND e\.details->>'mode' = 'enforce'/,
       );
     });
+  });
+});
+
+// Round-3 fix (2026-08-16, Codex MAJOR). The round-2 tests above assert on
+// LISTING_EVENT_MATCH_SQL's own text — they prove the SQL contains a
+// pattern, not that the pattern matches what the real event producers
+// actually write. These fixtures are the LITERAL strings each real emit
+// site constructs, copied from source as of this fix:
+//   - lib/lifecycle.ts:121 (canonical writer, arbitrary toState)
+//   - routes/internal-health-monitor.ts:94 (restore for re-validation)
+//   - routes/internal-health-monitor.ts:408 (suspend)
+//   - routes/internal-health-monitor.ts:463 (suspended → validating)
+//   - routes/reply-webhook.ts:368 (restore via email reply)
+// The old prefix-only matcher (`'Unpublished%' OR 'Suspended%' OR
+// 'Published%'`) matched NONE of these five — every real suspend/restore
+// transition would have failed the TOCTOU listing-event-identity re-check
+// silently, since a suspend→revalidate cycle between evidence collection
+// and the promotion write would leave the (wrongly unmatched) most-recent
+// listing event unchanged from the job's perspective.
+describe("isListingStateEvent — producer coverage (Codex round-3 MAJOR)", () => {
+  const realProducerFixtures: Array<{ site: string; actionTaken: string }> = [
+    { site: "lib/lifecycle.ts:121 (canonical writer)", actionTaken: "active → degraded: circuit breaker opened" },
+    { site: "routes/internal-health-monitor.ts:94 (restore for re-validation)", actionTaken: "active → validating: restored for re-validation" },
+    { site: "routes/internal-health-monitor.ts:408 (suspend)", actionTaken: "active → suspended: repeated dependency failures" },
+    { site: "routes/internal-health-monitor.ts:463 (suspended → validating)", actionTaken: "suspended → validating: re-entered onboarding pipeline" },
+    { site: "routes/reply-webhook.ts:368 (restore via email reply)", actionTaken: "suspended → validating: restored via email reply" },
+  ];
+
+  it.each(realProducerFixtures)("matches the real string from $site", ({ actionTaken }) => {
+    expect(isListingStateEvent("lifecycle_transition", actionTaken, null)).toBe(true);
+  });
+
+  it("still matches the two literal-prefix producers (publish/unpublish) that are NOT arrow-form", () => {
+    expect(isListingStateEvent("lifecycle_transition", "Published: now visible in catalog", null)).toBe(true);
+    expect(
+      isListingStateEvent(
+        "lifecycle_transition",
+        "Unpublished: removed from catalog (lifecycle_state remains 'active')",
+        null,
+      ),
+    ).toBe(true);
+  });
+
+  it("negative fixture: an unrelated lifecycle_transition-shaped string with no arrow and no known prefix does NOT match", () => {
+    // Deliberately NOT one of the six known shapes — proves the matcher
+    // isn't accidentally matching event_type alone.
+    expect(isListingStateEvent("lifecycle_transition", "Reindexed test_suite ordering", null)).toBe(false);
+  });
+
+  it("event_type scopes the arrow-shape match — a '→' in an unrelated event_type never matches", () => {
+    // Codex's caution: "be careful not to over-match unrelated event rows;
+    // scope by the event_type(s) these producers write". A quality_floor or
+    // capability_promotion row that happened to contain '→' in its reason
+    // text (neither producer does this today, but nothing stops a future
+    // one) must still fail unless it independently satisfies ITS OWN branch.
+    expect(isListingStateEvent("quality_floor", "quarantined: escalated → reviewed", "enforce")).toBe(false);
+    expect(isListingStateEvent("capability_promotion", "held: passRate → 0.94", "enforce")).toBe(false);
   });
 });
 

--- a/apps/api/src/lib/capability-promotion.test.ts
+++ b/apps/api/src/lib/capability-promotion.test.ts
@@ -8,6 +8,7 @@ import {
   toPromotionStats,
   isEnforceMode,
   PROMOTION_EVIDENCE_SQL,
+  LISTING_EVENT_MATCH_SQL,
   type PromotionEvidenceRow,
 } from "../jobs/capability-promotion.js";
 
@@ -30,6 +31,8 @@ function cap(partial: Partial<PromotionStats>): PromotionStats {
     wasDelisted: false,
     delistingReason: null,
     wasFloorQuarantine: false,
+    lastListingEventId: null,
+    floorQuarantineCount: 0,
     totalTests: 100,
     passedTests: 100,
     distinctTestDays: 7,
@@ -51,7 +54,8 @@ function row(partial: Partial<PromotionEvidenceRow>): PromotionEvidenceRow {
     slug: "s", lifecycle_state: "validating", visible: false, x402_enabled: false,
     is_free_tier: false, maintenance_class: "free-stable-api", marketplace_eligible: true,
     deactivation_reason: null, has_x402_method: true, breaker_state: "closed",
-    last_listing_event: null, total_tests: 100, passed_tests: 100, distinct_test_days: 7,
+    last_listing_event: null, last_listing_event_id: null, last_listing_event_mode: null,
+    floor_quarantine_count: 0, total_tests: 100, passed_tests: 100, distinct_test_days: 7,
     ka_total: 20, ka_passed: 20, latest_ka_passed: true, recent_total: 14, recent_passed: 14,
     piggyback_total: 0, piggyback_passed: 0, ...partial,
   };
@@ -156,7 +160,9 @@ describe("evaluatePromotion — human takedowns are never overturned; floor take
   // 2026-08-12 for real completion driven by a bug fixed 2026-08-05, then
   // 100% over 520 harness runs across 7 days.
   it("auto-reverses (promotes) a quality-floor quarantine that clears the bar", () => {
-    const d = only([cap({ wasDelisted: true, wasFloorQuarantine: true, delistingReason: "quarantined" })]);
+    // floorQuarantineCount: 1 — this is the capability's FIRST quarantine
+    // (the count includes the current/most-recent one), not a repeat.
+    const d = only([cap({ wasDelisted: true, wasFloorQuarantine: true, delistingReason: "quarantined", floorQuarantineCount: 1 })]);
     expect(d.action).toBe("promote");
     expect(d.reason).toContain("auto-reversed on recovery per DEC-20260812-A");
     expect(d.reason).toContain("quarantined");
@@ -166,6 +172,30 @@ describe("evaluatePromotion — human takedowns are never overturned; floor take
     const d = only([cap({ wasDelisted: true, wasFloorQuarantine: false, delistingReason: "Unpublished: removed from catalog" })]);
     expect(d.action).toBe("flag");
     expect(d.reason).toContain("taken down, not merely never listed");
+  });
+
+  // Round-2 fix (2026-08-16, Codex blocker #1b — oscillation). The floor's
+  // own candidate filter requires visible=true to quarantine at all, so a
+  // SECOND enforce quarantine can only happen after an intervening promotion
+  // re-listed this exact slug: floorQuarantineCount >= 2 is proof a prior
+  // auto-reversal already bounced back on real customer traffic. Even
+  // genuinely fresh, post-quarantine, harness-green evidence must not
+  // auto-reverse a second time.
+  it("refuses to auto-reverse a REPEAT floor quarantine — flags for human instead", () => {
+    const d = only([cap({
+      wasDelisted: true, wasFloorQuarantine: true, delistingReason: "quarantined",
+      floorQuarantineCount: 2,
+    })]);
+    expect(d.action).toBe("flag");
+    expect(d.reason).toContain("bounced before");
+    expect(d.reason).toContain("quarantined 2 times");
+    expect(d.enableX402).toBe(false);
+  });
+
+  it("a third-plus repeat is refused the same way, and the count is named in the reason", () => {
+    const d = only([cap({ wasDelisted: true, wasFloorQuarantine: true, floorQuarantineCount: 5 })]);
+    expect(d.action).toBe("flag");
+    expect(d.reason).toContain("quarantined 5 times");
   });
 
   it("a human deactivation_reason refuses promotion even for an otherwise-eligible floor quarantine", () => {
@@ -191,7 +221,7 @@ describe("evaluatePromotion — human takedowns are never overturned; floor take
   });
 
   it("a fragile maintenance class still refuses auto-reversal of a floor quarantine", () => {
-    const d = only([cap({ slug: "screenshot-url", wasDelisted: true, wasFloorQuarantine: true, delistingReason: "quarantined", maintenanceClass: "scraping-fragile-target" })]);
+    const d = only([cap({ slug: "screenshot-url", wasDelisted: true, wasFloorQuarantine: true, delistingReason: "quarantined", floorQuarantineCount: 1, maintenanceClass: "scraping-fragile-target" })]);
     expect(d.action).toBe("flag");
     expect(d.enableX402).toBe(false);
   });
@@ -260,11 +290,78 @@ describe("the evidence query", () => {
   });
 
   it("scopes the aggregate to the promotion window rather than all history", () => {
-    expect(PROMOTION_EVIDENCE_SQL).toContain("tr.executed_at > NOW() - INTERVAL '7 days'");
+    // Round-2 fix (2026-08-16): the flat 7-day window is now the upper bound
+    // of a GREATEST(), clamped down to since-the-quarantine when relevant —
+    // see "evidence is clamped to since-the-quarantine" below for that half.
+    expect(PROMOTION_EVIDENCE_SQL).toContain("NOW() - INTERVAL '7 days'");
   });
 
   it("the last-listing-event lateral pins 'quarantined' to quality_floor only — the string wasFloorQuarantine relies on", () => {
     expect(PROMOTION_EVIDENCE_SQL).toContain("e.event_type = 'quality_floor'        AND e.action_taken = 'quarantined'");
+  });
+
+  // Round-2 fix (2026-08-16, Codex blocker #2): matching action_taken='quarantined'
+  // alone is not enough — the floor also emits dry_run rows with the same
+  // shape, and ad-hoc/manual writes with the same shape exist in prod (the
+  // real screenshot-url reinstatement event had no `mode` key at all).
+  describe("LISTING_EVENT_MATCH_SQL requires enforce mode (Codex blocker #2)", () => {
+    it("the quality_floor branch requires details->>'mode' = 'enforce'", () => {
+      expect(LISTING_EVENT_MATCH_SQL).toContain(
+        "e.event_type = 'quality_floor'        AND e.action_taken = 'quarantined' AND e.details->>'mode' = 'enforce'",
+      );
+    });
+
+    it("the capability_promotion branch also requires enforce mode", () => {
+      expect(LISTING_EVENT_MATCH_SQL).toContain(
+        "e.event_type = 'capability_promotion' AND e.action_taken LIKE 'promoted%' AND e.details->>'mode' = 'enforce'",
+      );
+    });
+
+    it("exactly two branches carry the mode filter — lifecycle_transition (human events) is unfiltered", () => {
+      expect((LISTING_EVENT_MATCH_SQL.match(/details->>'mode' = 'enforce'/g) ?? []).length).toBe(2);
+    });
+
+    it("PROMOTION_EVIDENCE_SQL embeds the shared constant verbatim rather than a copy that can drift", () => {
+      expect(PROMOTION_EVIDENCE_SQL).toContain(LISTING_EVENT_MATCH_SQL);
+    });
+  });
+
+  // Round-2 fix (2026-08-16, Codex blocker #1a — oscillation). Without this,
+  // a capability that was harness-green WHILE customer traffic was failing
+  // (the exact pre-quarantine state) could supply its own "recovery"
+  // evidence from before it was ever quarantined.
+  describe("evidence is clamped to since-the-quarantine (Codex blocker #1a)", () => {
+    it("the test_results join is bounded by GREATEST(7d, since-quarantine)", () => {
+      expect(PROMOTION_EVIDENCE_SQL).toMatch(
+        /GREATEST\(\s*NOW\(\) - INTERVAL '7 days',\s*COALESCE\(le\.quarantined_at, '-infinity'::timestamptz\)\s*\)/,
+      );
+    });
+
+    it("the latest-known_answer lateral is bounded the same way, so a stale pre-quarantine pass can't stand in for 'broken now'", () => {
+      expect(PROMOTION_EVIDENCE_SQL).toContain(
+        "tr2.executed_at > COALESCE(le.quarantined_at, '-infinity'::timestamptz)",
+      );
+    });
+
+    it("quarantined_at resolves ONLY for the floor's own quarantine, never a promotion or human takedown", () => {
+      expect(PROMOTION_EVIDENCE_SQL).toContain(
+        "CASE WHEN e.event_type = 'quality_floor' AND e.action_taken = 'quarantined'",
+      );
+    });
+  });
+
+  // Round-2 fix (2026-08-16, Codex blocker #1b — repeat-bounce refusal).
+  describe("floor_quarantine_count counts every enforce quarantine ever, for this slug", () => {
+    it("is exposed as a dedicated column, defaulted to 0 rather than left null", () => {
+      expect(PROMOTION_EVIDENCE_SQL).toContain("COALESCE(fq.n, 0)::int");
+      expect(PROMOTION_EVIDENCE_SQL).toContain("AS floor_quarantine_count");
+    });
+
+    it("counts enforce-mode quarantine events only", () => {
+      expect(PROMOTION_EVIDENCE_SQL).toMatch(
+        /FROM health_monitor_events e\s+WHERE e\.capability_slug = c\.slug\s+AND e\.event_type = 'quality_floor'\s+AND e\.action_taken = 'quarantined'\s+AND e\.details->>'mode' = 'enforce'/,
+      );
+    });
   });
 });
 
@@ -286,6 +383,8 @@ describe("toPromotionStats", () => {
       wasDelisted: false,
       delistingReason: null,
       wasFloorQuarantine: false,
+      lastListingEventId: null,
+      floorQuarantineCount: 0,
       totalTests: 90,
       passedTests: 89,
       distinctTestDays: 6,
@@ -306,15 +405,41 @@ describe("toPromotionStats", () => {
     expect(toPromotionStats([row({ last_listing_event: null })])[0].wasDelisted).toBe(false);
   });
 
-  it("narrows wasFloorQuarantine to exactly the quality-floor's own 'quarantined' event", () => {
+  it("narrows wasFloorQuarantine to exactly the quality-floor's own ENFORCE-mode 'quarantined' event", () => {
     // 'quarantined' is written only by jobs/quality-floor.ts's enforce apply
     // path — no lifecycle_transition (human) action_taken can ever equal it,
     // so this signal cannot be spoofed by an operator unpublish/suspend.
-    expect(toPromotionStats([row({ last_listing_event: "quarantined" })])[0].wasFloorQuarantine).toBe(true);
-    expect(toPromotionStats([row({ last_listing_event: "Unpublished: removed from catalog" })])[0].wasFloorQuarantine).toBe(false);
-    expect(toPromotionStats([row({ last_listing_event: "Suspended: breaker open" })])[0].wasFloorQuarantine).toBe(false);
-    expect(toPromotionStats([row({ last_listing_event: "promoted_with_x402" })])[0].wasFloorQuarantine).toBe(false);
+    expect(toPromotionStats([row({ last_listing_event: "quarantined", last_listing_event_mode: "enforce" })])[0].wasFloorQuarantine).toBe(true);
+    expect(toPromotionStats([row({ last_listing_event: "Unpublished: removed from catalog", last_listing_event_mode: "enforce" })])[0].wasFloorQuarantine).toBe(false);
+    expect(toPromotionStats([row({ last_listing_event: "Suspended: breaker open", last_listing_event_mode: "enforce" })])[0].wasFloorQuarantine).toBe(false);
+    expect(toPromotionStats([row({ last_listing_event: "promoted_with_x402", last_listing_event_mode: "enforce" })])[0].wasFloorQuarantine).toBe(false);
     expect(toPromotionStats([row({ last_listing_event: null })])[0].wasFloorQuarantine).toBe(false);
+  });
+
+  // Round-2 fix (2026-08-16, Codex blocker #2). This is the actual failure
+  // mode named in the finding: the floor emits a dry_run row with
+  // action_taken='quarantined' on every tick it's NOT armed to enforce, and
+  // an ad-hoc/manual health_monitor_events insert could carry the same
+  // action_taken with no mode key at all (the real screenshot-url
+  // reinstatement event on 2026-08-13 was exactly this shape).
+  it("a dry_run quarantine event does NOT set wasFloorQuarantine, even with the right action_taken string", () => {
+    expect(
+      toPromotionStats([row({ last_listing_event: "quarantined", last_listing_event_mode: "dry_run" })])[0].wasFloorQuarantine,
+    ).toBe(false);
+  });
+
+  it("a 'quarantined' event with no recorded mode (ad-hoc/manual write) does NOT set wasFloorQuarantine", () => {
+    expect(
+      toPromotionStats([row({ last_listing_event: "quarantined", last_listing_event_mode: null })])[0].wasFloorQuarantine,
+    ).toBe(false);
+  });
+
+  it("maps last_listing_event_id and floor_quarantine_count straight through", () => {
+    const mapped = toPromotionStats([
+      row({ last_listing_event_id: "11111111-1111-1111-1111-111111111111", floor_quarantine_count: 3 }),
+    ])[0];
+    expect(mapped.lastListingEventId).toBe("11111111-1111-1111-1111-111111111111");
+    expect(mapped.floorQuarantineCount).toBe(3);
   });
 
   it("carries a correctness failure through the mapping into a refusal", () => {

--- a/apps/api/src/lib/capability-promotion.test.ts
+++ b/apps/api/src/lib/capability-promotion.test.ts
@@ -29,6 +29,7 @@ function cap(partial: Partial<PromotionStats>): PromotionStats {
     breakerState: "closed",
     wasDelisted: false,
     delistingReason: null,
+    wasFloorQuarantine: false,
     totalTests: 100,
     passedTests: 100,
     distinctTestDays: 7,
@@ -136,7 +137,7 @@ describe("evaluatePromotion — real customers outrank our own harness", () => {
   });
 });
 
-describe("evaluatePromotion — human and floor decisions are never overturned", () => {
+describe("evaluatePromotion — human takedowns are never overturned; floor takedowns can be, on recovery", () => {
   it("never promotes a capability that carries a deactivation reason", () => {
     expect(evaluatePromotion([cap({ deactivationReason: "CourtListener token expired" })])).toEqual([]);
   });
@@ -145,18 +146,37 @@ describe("evaluatePromotion — human and floor decisions are never overturned",
     expect(evaluatePromotion([cap({ marketplaceEligible: false })])).toEqual([]);
   });
 
-  it("flags rather than promotes something the quality floor took down", () => {
-    // The floor delists on real paid traffic and leaves lifecycle_state
-    // 'active' with no deactivation_reason — indistinguishable from a dark
-    // launch except for this signal. Without it the two jobs would fight
-    // nightly, and the harness would win an argument it cannot see.
-    const d = only([cap({ wasDelisted: true, delistingReason: "quarantined" })]);
+  // "Promotion grace" fix (2026-08-16): a quality-floor quarantine that
+  // clears every gate above it (correctness, recency, piggyback) is now
+  // auto-reversed rather than flagged — DEC-20260812-A lists "auto-promote
+  // on recovery" as a platform-acts-alone action, and jobs/quality-floor.ts's
+  // window clamp (since-last-promotion) is what makes a wrong reversal safe
+  // to make: it gets caught on fresh evidence, not stale evidence. This is
+  // the screenshot-url case verified in prod 2026-08-16: quarantined
+  // 2026-08-12 for real completion driven by a bug fixed 2026-08-05, then
+  // 100% over 520 harness runs across 7 days.
+  it("auto-reverses (promotes) a quality-floor quarantine that clears the bar", () => {
+    const d = only([cap({ wasDelisted: true, wasFloorQuarantine: true, delistingReason: "quarantined" })]);
+    expect(d.action).toBe("promote");
+    expect(d.reason).toContain("auto-reversed on recovery per DEC-20260812-A");
+    expect(d.reason).toContain("quarantined");
+  });
+
+  it("still flags rather than promotes something an operator unpublished (not a floor quarantine)", () => {
+    const d = only([cap({ wasDelisted: true, wasFloorQuarantine: false, delistingReason: "Unpublished: removed from catalog" })]);
     expect(d.action).toBe("flag");
     expect(d.reason).toContain("taken down, not merely never listed");
   });
 
-  it("flags rather than promotes something an operator unpublished", () => {
-    expect(only([cap({ wasDelisted: true, delistingReason: "Unpublished: removed from catalog" })]).action).toBe("flag");
+  it("a human deactivation_reason refuses promotion even for an otherwise-eligible floor quarantine", () => {
+    // deactivation_reason is checked before wasDelisted/wasFloorQuarantine
+    // are ever consulted — a human "no" always wins, regardless of how the
+    // capability was taken down or what the harness now says about it.
+    expect(
+      evaluatePromotion([
+        cap({ wasDelisted: true, wasFloorQuarantine: true, deactivationReason: "Petter: shut off pending vendor review" }),
+      ]),
+    ).toEqual([]);
   });
 
   it("still promotes a capability whose last listing event was a promotion", () => {
@@ -166,6 +186,12 @@ describe("evaluatePromotion — human and floor decisions are never overturned",
 
   it("flags rather than promotes a fragile maintenance class", () => {
     const d = only([cap({ slug: "screenshot-url", maintenanceClass: "scraping-fragile-target" })]);
+    expect(d.action).toBe("flag");
+    expect(d.enableX402).toBe(false);
+  });
+
+  it("a fragile maintenance class still refuses auto-reversal of a floor quarantine", () => {
+    const d = only([cap({ slug: "screenshot-url", wasDelisted: true, wasFloorQuarantine: true, delistingReason: "quarantined", maintenanceClass: "scraping-fragile-target" })]);
     expect(d.action).toBe("flag");
     expect(d.enableX402).toBe(false);
   });
@@ -236,6 +262,10 @@ describe("the evidence query", () => {
   it("scopes the aggregate to the promotion window rather than all history", () => {
     expect(PROMOTION_EVIDENCE_SQL).toContain("tr.executed_at > NOW() - INTERVAL '7 days'");
   });
+
+  it("the last-listing-event lateral pins 'quarantined' to quality_floor only — the string wasFloorQuarantine relies on", () => {
+    expect(PROMOTION_EVIDENCE_SQL).toContain("e.event_type = 'quality_floor'        AND e.action_taken = 'quarantined'");
+  });
 });
 
 describe("toPromotionStats", () => {
@@ -255,6 +285,7 @@ describe("toPromotionStats", () => {
       breakerState: "closed",
       wasDelisted: false,
       delistingReason: null,
+      wasFloorQuarantine: false,
       totalTests: 90,
       passedTests: 89,
       distinctTestDays: 6,
@@ -273,6 +304,17 @@ describe("toPromotionStats", () => {
     expect(toPromotionStats([row({ last_listing_event: "Unpublished: removed from catalog" })])[0].wasDelisted).toBe(true);
     expect(toPromotionStats([row({ last_listing_event: "promoted_with_x402" })])[0].wasDelisted).toBe(false);
     expect(toPromotionStats([row({ last_listing_event: null })])[0].wasDelisted).toBe(false);
+  });
+
+  it("narrows wasFloorQuarantine to exactly the quality-floor's own 'quarantined' event", () => {
+    // 'quarantined' is written only by jobs/quality-floor.ts's enforce apply
+    // path — no lifecycle_transition (human) action_taken can ever equal it,
+    // so this signal cannot be spoofed by an operator unpublish/suspend.
+    expect(toPromotionStats([row({ last_listing_event: "quarantined" })])[0].wasFloorQuarantine).toBe(true);
+    expect(toPromotionStats([row({ last_listing_event: "Unpublished: removed from catalog" })])[0].wasFloorQuarantine).toBe(false);
+    expect(toPromotionStats([row({ last_listing_event: "Suspended: breaker open" })])[0].wasFloorQuarantine).toBe(false);
+    expect(toPromotionStats([row({ last_listing_event: "promoted_with_x402" })])[0].wasFloorQuarantine).toBe(false);
+    expect(toPromotionStats([row({ last_listing_event: null })])[0].wasFloorQuarantine).toBe(false);
   });
 
   it("carries a correctness failure through the mapping into a refusal", () => {

--- a/apps/api/src/lib/capability-promotion.test.ts
+++ b/apps/api/src/lib/capability-promotion.test.ts
@@ -338,13 +338,25 @@ describe("the evidence query", () => {
       expect(PROMOTION_EVIDENCE_SQL).toContain(LISTING_EVENT_MATCH_SQL);
     });
 
-    // Round-3 (Codex MAJOR): the SQL side of the arrow-form fix. The
-    // isListingStateEvent producer-coverage suite below proves the JS
-    // mirror's BEHAVIOR against real strings; this proves the actual SQL
-    // constant carries the equivalent pattern, so the two can't silently
-    // diverge (one fixed, the other not).
-    it("the lifecycle_transition branch also matches the arrow ('→') shape the real producers write, not just literal prefixes", () => {
-      expect(LISTING_EVENT_MATCH_SQL).toContain("e.action_taken LIKE '%→%'");
+    // Round-3/4 (Codex MAJOR, twice): the SQL side of the arrow-form fix.
+    // The isListingStateEvent producer-coverage suite below proves the JS
+    // mirror's BEHAVIOR against real strings; this pins the COMPLETE grouped
+    // lifecycle branch of the SQL constant (whitespace-normalized) — the
+    // event-type scoping, all three literal prefixes, AND the arrow clause
+    // together. Round 3's pin only asserted the arrow clause existed
+    // somewhere, so dropping a prefix, or moving the arrow clause outside
+    // the lifecycle_transition scope, would have left every test green while
+    // SQL and mirror disagreed. Now any edit inside this branch breaks the
+    // pin, forcing a matching update to isListingStateEvent (and vice versa
+    // via the fixture suite).
+    it("the lifecycle_transition branch carries the complete grouped clause: event-type scope, all three prefixes, and the arrow shape", () => {
+      const normalize = (s: string) => s.replace(/\s+/g, " ");
+      expect(normalize(LISTING_EVENT_MATCH_SQL)).toContain(
+        normalize(`(e.event_type = 'lifecycle_transition' AND (e.action_taken LIKE 'Unpublished%'
+                                                    OR e.action_taken LIKE 'Suspended%'
+                                                    OR e.action_taken LIKE 'Published%'
+                                                    OR e.action_taken LIKE '%→%')))`),
+      );
     });
   });
 

--- a/apps/api/src/lib/capability-promotion.ts
+++ b/apps/api/src/lib/capability-promotion.ts
@@ -155,14 +155,16 @@ export interface PromotionStats {
   lastListingEventId: string | null;
   /**
    * How many times the quality floor has EVER enforce-quarantined this slug.
-   * A second quarantine can only happen after an intervening promotion
-   * re-listed the capability (the floor's own candidate filter requires
-   * visible=true), so >=2 is unambiguous proof of a prior auto-reversal that
-   * bounced back. evaluatePromotion refuses to retry the auto-reversal when
-   * this holds (round-2 fix, Codex blocker #1b) — a repeat bounce is itself
-   * evidence the harness isn't measuring what customers experience for this
-   * specific slug (see module header, "Why the test harness is the
-   * instrument here").
+   * A second quarantine can only happen after an intervening RE-LIST of the
+   * capability (the floor's own candidate filter requires visible=true), so
+   * >=2 is proof the slug was re-listed and re-quarantined at least once
+   * before — NOT specifically proof this job's own auto-reversal caused the
+   * re-listing (the admin publish endpoint can re-list a slug manually too;
+   * corrected round-3, Codex MINOR — the reason text previously overclaimed
+   * this). evaluatePromotion refuses to retry the auto-reversal when this
+   * holds regardless of which re-listing path fired (round-2 fix, Codex
+   * blocker #1b) — a slug with this history is not one this job keeps
+   * guessing on, whatever put it back on the shelf the first time.
    */
   floorQuarantineCount: number;
   totalTests: number;
@@ -339,22 +341,27 @@ export function evaluatePromotion(
         continue;
       }
 
-      // Repeat-bounce refusal (round-2 fix, Codex blocker #1b). The floor's
-      // own candidate filter requires visible=true to quarantine at all, so
-      // a SECOND enforce quarantine can only happen after an intervening
-      // promotion re-listed this exact slug — i.e. floorQuarantineCount >= 2
-      // is proof a prior auto-reversal already bounced back. Post-dating
-      // evidence to the quarantine (#1a) closes the *stale-evidence* half of
-      // the oscillation; this closes the other half: even genuinely-NEW
-      // harness-green evidence has already been wrong once for this slug,
-      // which is direct proof the harness isn't measuring what customers
-      // experience for it (module header, "why the test harness is the
-      // instrument here"). Auto-reversal is not tried again; human call.
+      // Repeat-bounce refusal (round-2 fix, Codex blocker #1b; reason text
+      // corrected round-3 — Codex MINOR). The floor's own candidate filter
+      // requires visible=true to quarantine at all, so a SECOND enforce
+      // quarantine can only happen after an intervening RE-LIST of this
+      // exact slug — i.e. floorQuarantineCount >= 2 is proof the slug was
+      // re-listed and re-quarantined at least once before. That re-listing
+      // is NOT necessarily this job's own auto-reversal: the admin publish
+      // endpoint (routes/internal-health-monitor.ts) can re-list a slug
+      // manually too, and the evidence available here cannot distinguish the
+      // two. The refusal itself stays conservative either way — auto-
+      // reversal is not tried again on a slug with this history, human call
+      // — but the recorded reason must not claim more than the evidence
+      // supports. Post-dating evidence to the quarantine (#1a) closes the
+      // *stale-evidence* half of the oscillation; this closes the other
+      // half: a slug that has already cycled through quarantine once before
+      // is not one this job gets to keep guessing on.
       if (r.floorQuarantineCount >= 2) {
         decisions.push({
           slug: r.slug, action: "flag", enableX402: false,
           passRate: r.passRate, totalTests: r.totalTests,
-          reason: `clears the bar (${pct(r.passRate)} over ${r.totalTests}) on evidence since the latest quarantine, but this slug has bounced before — quarantined ${r.floorQuarantineCount} times total, meaning a prior auto-reversal already failed on real customer traffic. The harness has already been wrong once for this specific capability; human call`,
+          reason: `clears the bar (${pct(r.passRate)} over ${r.totalTests}) on evidence since the latest quarantine, but this slug has bounced before — quarantined ${r.floorQuarantineCount} times total, meaning it was re-listed and re-quarantined at least once already. Auto-reversal is not tried again for a capability with this history; human call`,
           lifecycleState: r.lifecycleState, maintenanceClass: r.maintenanceClass,
           lastListingEventId: r.lastListingEventId,
         });

--- a/apps/api/src/lib/capability-promotion.ts
+++ b/apps/api/src/lib/capability-promotion.ts
@@ -55,16 +55,29 @@
  * reason several gates exist that a reading of DEC-20260812-A alone would not
  * suggest:
  *
- * 1. **A floor quarantine must not be undone by harness evidence.** The floor
- *    delists on real paid traffic and leaves `lifecycle_state='active'`,
- *    `deactivation_reason` NULL — which is exactly the shape of a promotable
- *    dark launch. Without an interlock this job would re-list a capability
- *    every day that the floor delists every night, on evidence from a harness
- *    that never sees the failing customer calls. `wasDelisted` distinguishes
- *    "never listed" (a dark launch, promotable) from "taken down" (a floor
- *    quarantine, a human unpublish, or a suspension — flagged, never
- *    auto-promoted). The floor has really quarantined 6 times, so this is not
- *    hypothetical.
+ * 1. **A floor quarantine must not be undone by harness evidence — unless the
+ *    floor itself now agrees.** The floor delists on real paid traffic and
+ *    leaves `lifecycle_state='active'`, `deactivation_reason` NULL — which is
+ *    exactly the shape of a promotable dark launch. Without an interlock this
+ *    job would re-list a capability every day that the floor delists every
+ *    night, on evidence from a harness that never sees the failing customer
+ *    calls. `wasDelisted` distinguishes "never listed" (a dark launch,
+ *    promotable) from "taken down" (a floor quarantine, a human unpublish, or
+ *    a suspension). A human/operator takedown (`wasDelisted &&
+ *    !wasFloorQuarantine`) is still flagged, never auto-promoted — this job
+ *    does not overturn a person's decision. A *floor* takedown
+ *    (`wasFloorQuarantine`) is different as of the 2026-08-16 "promotion
+ *    grace" fix: DEC-20260812-A lists "auto-promote on recovery" as a
+ *    platform-acts-alone action, and `jobs/quality-floor.ts` now clamps its
+ *    own evidence window to since-last-promotion — so if this job reverses a
+ *    floor quarantine wrongly, the floor re-quarantines on fresh
+ *    post-promotion traffic instead of replaying the same contaminated 30d
+ *    window that caused the original bounce (screenshot-url,
+ *    2026-08-13T07:34 → re-quarantined 07:47 on stale pre-fix data). Every
+ *    other gate in this function — correctness, recency, piggyback — still
+ *    applies before a floor takedown is reversed; only the flag-instead-of-
+ *    promote branch is skipped. The floor has really quarantined 6 times, so
+ *    this is not hypothetical.
  * 2. **Harness volume must not outvote real customers.** ~98% of platform
  *    traffic is our own harness. A capability with 100 green harness results
  *    and 2 failing piggyback results — piggyback being real customer calls —
@@ -121,6 +134,14 @@ export interface PromotionStats {
   wasDelisted: boolean;
   /** What that takedown was, for the flag message. */
   delistingReason: string | null;
+  /**
+   * True when `wasDelisted` and the takedown specifically was the quality
+   * floor's own quarantine (`health_monitor_events.action_taken =
+   * 'quarantined'`) — never true for a human unpublish/suspend. This is the
+   * only class of takedown DEC-20260812-A permits this job to auto-reverse;
+   * see the "promotion grace" note in the module header (finding 1).
+   */
+  wasFloorQuarantine: boolean;
   totalTests: number;
   passedTests: number;
   /** Distinct calendar days carrying at least one result — the "week" in "green week". */
@@ -262,9 +283,16 @@ export function evaluatePromotion(
       }
     }
 
-    // A takedown is a decision, and this job does not overturn decisions
-    // (review finding 1). Never having been listed is not a takedown.
-    if (r.wasDelisted) {
+    // A human/operator takedown is a decision, and this job does not
+    // overturn decisions (review finding 1). Never having been listed is not
+    // a takedown. A *floor* takedown (wasFloorQuarantine) is the one
+    // exception DEC-20260812-A carves out — "promotion grace" fix,
+    // 2026-08-16: it falls through to the normal promote path below instead
+    // of being flagged, because every gate above it (correctness, recency,
+    // piggyback) already had to pass, and jobs/quality-floor.ts now clamps
+    // its own window to since-last-promotion so a wrong reversal gets caught
+    // on fresh evidence rather than replayed stale evidence.
+    if (r.wasDelisted && !r.wasFloorQuarantine) {
       decisions.push({
         slug: r.slug, action: "flag", enableX402: false,
         passRate: r.passRate, totalTests: r.totalTests,
@@ -293,13 +321,22 @@ export function evaluatePromotion(
     // marketplace-eligible goes onto x402 with the promotion: DEC-20260812-A
     // dark-launches "invisible + non-x402", and one green week ends both.
     const enableX402 = r.hasX402Method && !r.isFreeTier;
+    // "Promotion grace" fix (2026-08-16): a floor takedown that reaches here
+    // cleared every gate above, including piggyback (real customer traffic)
+    // when there was any — so this is an auto-reversal of the quarantine, not
+    // a first listing. Named explicitly in the reason and cited to the DEC
+    // clause that authorizes it, so a `health_monitor_events` reader can tell
+    // the two apart without cross-referencing the floor's own log.
+    const recoveryNote = r.wasFloorQuarantine
+      ? ` — was quarantined by the quality floor ("${r.delistingReason}"); auto-reversed on recovery per DEC-20260812-A`
+      : "";
     decisions.push({
       slug: r.slug,
       action: "promote",
       enableX402,
       passRate: r.passRate,
       totalTests: r.totalTests,
-      reason: `${pct(r.passRate)} over ${r.totalTests} results across ${r.distinctTestDays} days, known_answer ${pct(kaRate)} (${r.knownAnswerPassed}/${r.knownAnswerTotal}), last 24h ${pct(recentRate)}, breaker ${r.breakerState ?? "no row"} — green week met${enableX402 ? "; x402 opened" : r.isFreeTier ? "; free tier, x402 stays closed" : "; no x402 method, catalog only"}`,
+      reason: `${pct(r.passRate)} over ${r.totalTests} results across ${r.distinctTestDays} days, known_answer ${pct(kaRate)} (${r.knownAnswerPassed}/${r.knownAnswerTotal}), last 24h ${pct(recentRate)}, breaker ${r.breakerState ?? "no row"} — green week met${enableX402 ? "; x402 opened" : r.isFreeTier ? "; free tier, x402 stays closed" : "; no x402 method, catalog only"}${recoveryNote}`,
     });
   }
 

--- a/apps/api/src/lib/capability-promotion.ts
+++ b/apps/api/src/lib/capability-promotion.ts
@@ -136,12 +136,35 @@ export interface PromotionStats {
   delistingReason: string | null;
   /**
    * True when `wasDelisted` and the takedown specifically was the quality
-   * floor's own quarantine (`health_monitor_events.action_taken =
-   * 'quarantined'`) — never true for a human unpublish/suspend. This is the
-   * only class of takedown DEC-20260812-A permits this job to auto-reverse;
-   * see the "promotion grace" note in the module header (finding 1).
+   * floor's own ENFORCE-mode quarantine (`health_monitor_events.action_taken
+   * = 'quarantined'`, `details->>'mode' = 'enforce'`) — never true for a
+   * human unpublish/suspend, a dry-run quarantine, or an ad-hoc/manual event
+   * with the same action_taken string but no (or a different) mode. This is
+   * the only class of takedown DEC-20260812-A permits this job to
+   * auto-reverse; see the "promotion grace" note in the module header
+   * (finding 1).
    */
   wasFloorQuarantine: boolean;
+  /**
+   * uuid of the matched listing-state event (see jobs/capability-promotion.ts
+   * LISTING_EVENT_MATCH_SQL), or null when the capability has never been
+   * listed. Carried through to PromotionDecision so the write can re-derive
+   * "is this still the latest listing event" at write time — the TOCTOU
+   * close (round-2 fix, Codex blocker #3).
+   */
+  lastListingEventId: string | null;
+  /**
+   * How many times the quality floor has EVER enforce-quarantined this slug.
+   * A second quarantine can only happen after an intervening promotion
+   * re-listed the capability (the floor's own candidate filter requires
+   * visible=true), so >=2 is unambiguous proof of a prior auto-reversal that
+   * bounced back. evaluatePromotion refuses to retry the auto-reversal when
+   * this holds (round-2 fix, Codex blocker #1b) — a repeat bounce is itself
+   * evidence the harness isn't measuring what customers experience for this
+   * specific slug (see module header, "Why the test harness is the
+   * instrument here").
+   */
+  floorQuarantineCount: number;
   totalTests: number;
   passedTests: number;
   /** Distinct calendar days carrying at least one result — the "week" in "green week". */
@@ -201,6 +224,14 @@ export interface PromotionDecision {
   passRate: number;
   totalTests: number;
   reason: string;
+  /**
+   * Carried through from PromotionStats purely so the job's write can
+   * re-assert them at write time (TOCTOU close, round-2 fix, Codex blocker
+   * #3) — not used in this module's own decision logic beyond pass-through.
+   */
+  lifecycleState: string;
+  maintenanceClass: string | null;
+  lastListingEventId: string | null;
 }
 
 /** Breaker states that permit promotion. `null` = no breaker row recorded yet. */
@@ -239,6 +270,8 @@ export function evaluatePromotion(
       decisions.push({
         slug: r.slug, action: "none", enableX402: false,
         passRate: r.passRate, totalTests: r.totalTests, reason,
+        lifecycleState: r.lifecycleState, maintenanceClass: r.maintenanceClass,
+        lastListingEventId: r.lastListingEventId,
       });
 
     // Correctness gate. An aggregate pass rate is dominated by schema,
@@ -289,16 +322,44 @@ export function evaluatePromotion(
     // exception DEC-20260812-A carves out — "promotion grace" fix,
     // 2026-08-16: it falls through to the normal promote path below instead
     // of being flagged, because every gate above it (correctness, recency,
-    // piggyback) already had to pass, and jobs/quality-floor.ts now clamps
-    // its own window to since-last-promotion so a wrong reversal gets caught
-    // on fresh evidence rather than replayed stale evidence.
-    if (r.wasDelisted && !r.wasFloorQuarantine) {
-      decisions.push({
-        slug: r.slug, action: "flag", enableX402: false,
-        passRate: r.passRate, totalTests: r.totalTests,
-        reason: `clears the bar (${pct(r.passRate)} over ${r.totalTests}) but was taken down, not merely never listed — "${r.delistingReason}". Re-listing after a takedown needs the evidence that the takedown was wrong, which the harness cannot supply; human call`,
-      });
-      continue;
+    // piggyback) already had to pass on evidence dated strictly AFTER the
+    // quarantine (jobs/quality-floor.ts's `le.quarantined_at` clamp — round-2
+    // fix, Codex blocker #1a), and jobs/quality-floor.ts's own window is
+    // clamped to since-last-promotion so a wrong reversal gets caught on
+    // fresh evidence rather than replayed stale evidence.
+    if (r.wasDelisted) {
+      if (!r.wasFloorQuarantine) {
+        decisions.push({
+          slug: r.slug, action: "flag", enableX402: false,
+          passRate: r.passRate, totalTests: r.totalTests,
+          reason: `clears the bar (${pct(r.passRate)} over ${r.totalTests}) but was taken down, not merely never listed — "${r.delistingReason}". Re-listing after a takedown needs the evidence that the takedown was wrong, which the harness cannot supply; human call`,
+          lifecycleState: r.lifecycleState, maintenanceClass: r.maintenanceClass,
+          lastListingEventId: r.lastListingEventId,
+        });
+        continue;
+      }
+
+      // Repeat-bounce refusal (round-2 fix, Codex blocker #1b). The floor's
+      // own candidate filter requires visible=true to quarantine at all, so
+      // a SECOND enforce quarantine can only happen after an intervening
+      // promotion re-listed this exact slug — i.e. floorQuarantineCount >= 2
+      // is proof a prior auto-reversal already bounced back. Post-dating
+      // evidence to the quarantine (#1a) closes the *stale-evidence* half of
+      // the oscillation; this closes the other half: even genuinely-NEW
+      // harness-green evidence has already been wrong once for this slug,
+      // which is direct proof the harness isn't measuring what customers
+      // experience for it (module header, "why the test harness is the
+      // instrument here"). Auto-reversal is not tried again; human call.
+      if (r.floorQuarantineCount >= 2) {
+        decisions.push({
+          slug: r.slug, action: "flag", enableX402: false,
+          passRate: r.passRate, totalTests: r.totalTests,
+          reason: `clears the bar (${pct(r.passRate)} over ${r.totalTests}) on evidence since the latest quarantine, but this slug has bounced before — quarantined ${r.floorQuarantineCount} times total, meaning a prior auto-reversal already failed on real customer traffic. The harness has already been wrong once for this specific capability; human call`,
+          lifecycleState: r.lifecycleState, maintenanceClass: r.maintenanceClass,
+          lastListingEventId: r.lastListingEventId,
+        });
+        continue;
+      }
     }
 
     if (r.maintenanceClass !== null && config.manualReviewClasses.includes(r.maintenanceClass)) {
@@ -306,6 +367,8 @@ export function evaluatePromotion(
         slug: r.slug, action: "flag", enableX402: false,
         passRate: r.passRate, totalTests: r.totalTests,
         reason: `clears the bar (${pct(r.passRate)} over ${r.totalTests}, known_answer ${pct(kaRate)}) but maintenance_class '${r.maintenanceClass}' is never auto-promoted — a fragile target passing all week is the one that breaks next week; human call`,
+        lifecycleState: r.lifecycleState, maintenanceClass: r.maintenanceClass,
+        lastListingEventId: r.lastListingEventId,
       });
       continue;
     }
@@ -337,6 +400,8 @@ export function evaluatePromotion(
       passRate: r.passRate,
       totalTests: r.totalTests,
       reason: `${pct(r.passRate)} over ${r.totalTests} results across ${r.distinctTestDays} days, known_answer ${pct(kaRate)} (${r.knownAnswerPassed}/${r.knownAnswerTotal}), last 24h ${pct(recentRate)}, breaker ${r.breakerState ?? "no row"} — green week met${enableX402 ? "; x402 opened" : r.isFreeTier ? "; free tier, x402 stays closed" : "; no x402 method, catalog only"}${recoveryNote}`,
+      lifecycleState: r.lifecycleState, maintenanceClass: r.maintenanceClass,
+      lastListingEventId: r.lastListingEventId,
     });
   }
 


### PR DESCRIPTION
## Summary
- The quality floor's evidence window is now clamped to since-last-promotion: a capability re-listed after a verified recovery is judged only on new calls, ending the promote→re-quarantine-in-13-minutes bounce observed in prod on 2026-08-13 (screenshot-url).
- The promotion job may now auto-reverse floor-driven takedowns when the recovery bar clears (DEC-20260812-A auto-promote-on-recovery); human/doctrine takedowns (deactivation_reason, fragile maintenance_class) remain human-only.
- Hardened through 4 external review rounds: recovery evidence must postdate the quarantine; a second bounce permanently escalates to a human; event provenance requires enforce-mode; the promotion write re-asserts lifecycle/maintenance/listing-event identity (TOCTOU); the listing-event matcher now recognizes the arrow-form transition strings all five real producers emit (the old prefix-only match had never matched a real suspend event).

## Verification
- Typecheck: clean (mcp-server dist built).
- Full suite: 1766 passed / 33 skipped; targeted suites 68/68.
- Fail-before/pass-after verified per round for every new gate, incl. a mutation check on the SQL structural pin (removing any prefix or displacing the arrow clause breaks it).
- Cross-provider review (Codex): 2 blockers + 1 major found and fixed across rounds; final verdict "APPROVE — no findings" with its own mutation checks.
- Bind-parameter walk: no Date/Buffer reaches sql template params.
- Deploy mechanism (DEC-20260504-C): both jobs already wired at apps/api/src/index.ts:151-160, unchanged; no new deploy dependency. Post-merge verification: /health commit hash, then health_monitor_events after the next promotion tick.

## Reviewer findings
- MEDIUM (accepted, documented): floorQuarantineCount counts enforce-mode quarantines only; historical ad-hoc/manual quarantine rows predating this fix are invisible to the repeat-bounce guard. Judged out of scope for a backfill.
- Note: the promotion job remains dry-run until CAPABILITY_PROMOTION_ENFORCE=true is set (separate operational step, charter decide-then-tell).

## Test plan
- Merge → deploy → watch one dry-run tick (expect dry_run_would_promote for screenshot-url with post-quarantine evidence) → arm enforce → verify screenshot-url visible+x402 with an enforce-mode capability_promotion event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)