### PR TITLE
fix(web-extract): shared resilience layer, honest provenance, safe errors

### DIFF
--- a/apps/api/src/capabilities/lib/web-provider.ts
+++ b/apps/api/src/capabilities/lib/web-provider.ts
@@ -68,6 +68,14 @@ export interface WebProviderOptions {
    * fetch that never ran the page's scripts.
    */
   skipFallback?: boolean;
+  /**
+   * Minimum accepted HTML length in bytes for the Browserless tier (default:
+   * 100). Below this, the response is treated as empty/broken and retried
+   * (or thrown after the last attempt). Callers with a looser pre-existing
+   * contract can lower this explicitly rather than silently inheriting the
+   * shared default.
+   */
+  minHtmlLength?: number;
 }
 
 export interface WebProviderResult {
@@ -92,29 +100,66 @@ const MAX_CACHE_ENTRIES = 200;
 
 const cache = new Map<string, CacheEntry>();
 
-function getCached(url: string): string | null {
-  const entry = cache.get(url);
+/**
+ * Cache-key namespace for a given call's rendering semantics.
+ *
+ * BLOCKER fix (external review, 2026-08-16): the cache used to be keyed by
+ * URL alone, shared across every tier and every `waitUntil`. That let a
+ * `skipFallback` caller (web-extract, whose contract promises full JS
+ * rendering) read back plain-fetch or Jina HTML cached by an unrelated
+ * caller for the same URL — and let a non-default `waitUntil` render (e.g.
+ * fetchCompanyPage's `domcontentloaded`) get served to a caller that
+ * expected `networkidle0`. Namespacing by (skipFallback, waitUntil)
+ * partitions the cache so:
+ *   - a `skipFallback: true` call only ever reads/writes entries also
+ *     written by a `skipFallback: true` call at the same `waitUntil` (i.e.
+ *     genuine Browserless-only renders — tiers 1/2 never run when
+ *     skipFallback is set, so they can never populate this namespace);
+ *   - a call with a non-default `waitUntil` never reads/writes an entry
+ *     produced under a different `waitUntil`.
+ * Tiers 1 (plain fetch) and 2 (Jina) only ever run for the default
+ * `networkidle0`/unset case with `skipFallback` false, so they always land
+ * in the same namespace as a same-shaped Browserless render — preserving
+ * the pre-existing "any tier is interchangeable for an equivalent call"
+ * caching behavior for the 47+ non-skipFallback callers.
+ */
+function cacheNamespace(skipFallback: boolean, waitUntil: string): string {
+  return `${skipFallback ? "skipFallback" : "default"}:${waitUntil}`;
+}
+
+function cacheKey(namespace: string, url: string): string {
+  return `${namespace}::${url}`;
+}
+
+function getCached(namespace: string, url: string): string | null {
+  const key = cacheKey(namespace, url);
+  const entry = cache.get(key);
   if (!entry) return null;
   if (Date.now() - entry.createdAt > DEFAULT_TTL_MS) {
-    cache.delete(url);
+    cache.delete(key);
     return null;
   }
   return entry.html;
 }
 
-function setCache(url: string, html: string): void {
+function setCache(namespace: string, url: string, html: string): void {
+  const key = cacheKey(namespace, url);
   // Evict oldest entries if cache is full
   if (cache.size >= MAX_CACHE_ENTRIES) {
     const oldest = cache.keys().next().value;
     if (oldest !== undefined) cache.delete(oldest);
   }
-  cache.set(url, { html, createdAt: Date.now() });
+  cache.set(key, { html, createdAt: Date.now() });
 }
 
 // ─── Retry with exponential backoff + jitter ────────────────────────────────
 
+// MAJOR fix (external review, 2026-08-16): 408 (Request Timeout) is exactly
+// the class of failure this layer exists to absorb — Browserless returns it
+// for slow-but-alive target pages — but it was missing from the transient
+// set, so a 408 never got the retry that would likely have recovered it.
 function isTransient(status: number): boolean {
-  return status === 429 || status >= 500;
+  return status === 408 || status === 429 || status >= 500;
 }
 
 /** Map a non-OK Browserless response status into an honest, actionable message. */
@@ -199,7 +244,13 @@ export async function fetchPage(
     maxRetries = 2,
     skipCache = false,
     skipFallback = false,
+    minHtmlLength = 100,
   } = options ?? {};
+
+  // See cacheNamespace() — partitions the cache so skipFallback callers
+  // never read/write a fallback-tier entry, and different waitUntil
+  // renders never collide.
+  const renderMode = cacheNamespace(skipFallback, waitUntil);
 
   // Per-source ToS policy enforced at the pipeline entry (P2, 2026-08-12):
   // tiers 2/3 (Jina, Browserless) never touch safeFetch, so its gate alone
@@ -212,7 +263,7 @@ export async function fetchPage(
 
   // Check cache first (before acquiring browser slot)
   if (!skipCache) {
-    const cached = getCached(targetUrl);
+    const cached = getCached(renderMode, targetUrl);
     if (cached) {
       return { html: cached, cached: true, fetchTimeMs: 0, attempt: 0 };
     }
@@ -259,7 +310,7 @@ export async function fetchPage(
           // silently returned "no results" for weeks (P2 triage, 2026-08-12).
           if (!looksLikeJsChallenge(html) && html.length > 2000 && bodyText.length > 200) {
             const fetchTimeMs = Date.now() - start;
-            if (!skipCache) setCache(targetUrl, html);
+            if (!skipCache) setCache(renderMode, targetUrl, html);
             return { html, cached: false, fetchTimeMs, attempt: 0 };
           }
         }
@@ -324,7 +375,7 @@ export async function fetchPage(
         const html = await jinaResp.text();
         if (html.length > 500 && !looksLikeJsChallenge(html)) {
           const fetchTimeMs = Date.now() - start;
-          if (!skipCache) setCache(targetUrl, html);
+          if (!skipCache) setCache(renderMode, targetUrl, html);
           return { html, cached: false, fetchTimeMs, attempt: 0 };
         }
       }
@@ -382,7 +433,7 @@ export async function fetchPage(
         const html = await response.text();
         const fetchTimeMs = Date.now() - start;
 
-        if (!html || html.length < 100) {
+        if (!html || html.length < minHtmlLength) {
           if (attempt < maxRetries - 1) {
             lastError = new Error("Browserless returned empty or too-short HTML.");
             continue;
@@ -403,7 +454,7 @@ export async function fetchPage(
 
         // Cache the result
         if (!skipCache) {
-          setCache(targetUrl, html);
+          setCache(renderMode, targetUrl, html);
         }
 
         return { html, cached: false, fetchTimeMs, attempt: attempt + 1 };

--- a/apps/api/src/capabilities/lib/web-provider.ts
+++ b/apps/api/src/capabilities/lib/web-provider.ts
@@ -162,8 +162,51 @@ function isTransient(status: number): boolean {
   return status === 408 || status === 429 || status >= 500;
 }
 
+/**
+ * Strip markup and control characters from an upstream error body and cap
+ * its length, so it's safe to splice into a user-facing message — no raw
+ * HTML/script tags, no ANSI/control bytes, bounded size. Six-lens review
+ * finding Medium 2a (2026-08-16): uncommon statuses (400/405/413/422…) had
+ * no dedicated branch and fell through to a diagnostically mute generic
+ * message. Returns "" when nothing useful survives sanitization.
+ */
+function sanitizeDetail(bodyText: string, maxLen = 120): string {
+  const stripped = bodyText
+    .replace(/<[^>]*>/g, " ")
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1F\x7F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!stripped) return "";
+  return stripped.length > maxLen ? `${stripped.slice(0, maxLen)}…` : stripped;
+}
+
+/**
+ * Chrome/Browserless navigation-level net errors embedded in the response
+ * body — Browserless wraps these in a 5xx HTTP status when Chrome itself
+ * fails to navigate (DNS doesn't resolve, TCP connection refused, TLS cert
+ * invalid), which is a different failure class from "the target's server
+ * errored" and is NOT transient. Six-lens review finding Medium 2b
+ * (2026-08-16): these were getting the 5xx branch's "usually transient —
+ * try again" advice, which is actively wrong for a domain that will never
+ * resolve. Returns null when no known net-error pattern matches.
+ */
+function netErrorMessage(bodyText: string, domain: string): string | null {
+  if (/ERR_NAME_NOT_RESOLVED/.test(bodyText)) {
+    return `The domain${domain} does not resolve. This is a permanent failure — retrying will not help.`;
+  }
+  if (/ERR_CONNECTION_REFUSED/.test(bodyText)) {
+    return `The connection to the target site${domain} was refused. This is a permanent failure — retrying will not help.`;
+  }
+  const certMatch = bodyText.match(/ERR_CERT_[A-Z_]+/);
+  if (certMatch) {
+    return `The target site${domain}'s TLS certificate is invalid (${certMatch[0]}). This is a permanent failure — retrying will not help.`;
+  }
+  return null;
+}
+
 /** Map a non-OK Browserless response status into an honest, actionable message. */
-function humanizeBrowserlessStatus(status: number, targetUrl: string): string {
+function humanizeBrowserlessStatus(status: number, targetUrl: string, bodyText = ""): string {
   let hostname = "";
   try { hostname = new URL(targetUrl).hostname; } catch { /* ignore */ }
   const domain = hostname ? ` (${hostname})` : "";
@@ -184,12 +227,15 @@ function humanizeBrowserlessStatus(status: number, targetUrl: string): string {
     return `This page requires authentication (HTTP ${status})${domain}. Only publicly available pages can be scraped.`;
   }
   if (status === 403) {
-    return `The site${domain} blocks automated access (HTTP 403 Forbidden). This is bot protection on the target site, not a Strale issue.`;
+    return `The site${domain} blocks automated access (HTTP 403 Forbidden). This is bot protection on the target site, not a Strale issue. Retrying will not help.`;
   }
   if (status >= 500) {
+    const netErr = netErrorMessage(bodyText, domain);
+    if (netErr) return netErr;
     return `The target site${domain} returned a server error (HTTP ${status}). This is usually transient — try again in a few minutes.`;
   }
-  return `The web page${domain} could not be loaded (HTTP ${status}).`;
+  const detail = sanitizeDetail(bodyText);
+  return `The web page${domain} could not be loaded (HTTP ${status}).${detail ? ` ${detail}` : ""}`;
 }
 
 function backoffMs(attempt: number): number {
@@ -264,7 +310,16 @@ export async function fetchPage(
   // Check cache first (before acquiring browser slot)
   if (!skipCache) {
     const cached = getCached(renderMode, targetUrl);
-    if (cached) {
+    // Six-lens review finding Medium 3 (2026-08-16): a cache entry is
+    // written under whatever minHtmlLength the writer used, but a later
+    // caller in the same namespace with a stricter minHtmlLength has no
+    // guarantee the cached HTML actually clears ITS bar — getCached()
+    // returns whatever was stored regardless of length. Treat a
+    // too-short hit as a miss and fall through to a fresh fetch rather
+    // than silently handing back HTML this caller would have rejected
+    // from a live response. The stale-short entry is left in place —
+    // another caller with a looser minHtmlLength may still want it.
+    if (cached && cached.length >= minHtmlLength) {
       return { html: cached, cached: true, fetchTimeMs: 0, attempt: 0 };
     }
   }
@@ -426,7 +481,7 @@ export async function fetchPage(
             );
             continue;
           }
-          const humanMsg = humanizeBrowserlessStatus(response.status, targetUrl);
+          const humanMsg = humanizeBrowserlessStatus(response.status, targetUrl, errText);
           throw new Error(humanMsg);
         }
 

--- a/apps/api/src/capabilities/lib/web-provider.ts
+++ b/apps/api/src/capabilities/lib/web-provider.ts
@@ -163,35 +163,38 @@ function isTransient(status: number): boolean {
 }
 
 /**
- * Strip markup and control characters from an upstream error body and cap
- * its length, so it's safe to splice into a user-facing message — no raw
- * HTML/script tags, no ANSI/control bytes, bounded size. Six-lens review
- * finding Medium 2a (2026-08-16): uncommon statuses (400/405/413/422…) had
- * no dedicated branch and fell through to a diagnostically mute generic
- * message. Returns "" when nothing useful survives sanitization.
+ * Chrome/Browserless navigation-level net-error patterns embedded in a
+ * response body — Browserless wraps these in a 5xx HTTP status when Chrome
+ * itself fails to navigate (DNS doesn't resolve, TCP connection refused,
+ * TLS cert invalid). This is a different failure class from "the target's
+ * server errored", and it is NOT transient: retrying does not change DNS
+ * resolution, TCP refusal, or a broken certificate.
+ *
+ * Shared between the retry-decision site in the Browserless loop below
+ * (skip the retry — classify immediately) and netErrorMessage() (construct
+ * the user-facing message), so the two can never drift out of sync: a
+ * six-lens review round (2026-08-16) flagged that the message said
+ * "retrying will not help" while the code retried once anyway.
  */
-function sanitizeDetail(bodyText: string, maxLen = 120): string {
-  const stripped = bodyText
-    .replace(/<[^>]*>/g, " ")
-    // eslint-disable-next-line no-control-regex
-    .replace(/[\x00-\x1F\x7F]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!stripped) return "";
-  return stripped.length > maxLen ? `${stripped.slice(0, maxLen)}…` : stripped;
+function isPermanentNetError(bodyText: string): boolean {
+  return (
+    /ERR_NAME_NOT_RESOLVED/.test(bodyText) ||
+    /ERR_CONNECTION_REFUSED/.test(bodyText) ||
+    /ERR_CERT_[A-Z_]+/.test(bodyText)
+  );
 }
 
 /**
- * Chrome/Browserless navigation-level net errors embedded in the response
- * body — Browserless wraps these in a 5xx HTTP status when Chrome itself
- * fails to navigate (DNS doesn't resolve, TCP connection refused, TLS cert
- * invalid), which is a different failure class from "the target's server
- * errored" and is NOT transient. Six-lens review finding Medium 2b
- * (2026-08-16): these were getting the 5xx branch's "usually transient —
- * try again" advice, which is actively wrong for a domain that will never
- * resolve. Returns null when no known net-error pattern matches.
+ * Build the permanent-failure message for a body matched by
+ * isPermanentNetError(). Six-lens review finding Medium 2b (2026-08-16):
+ * these were getting the 5xx branch's "usually transient — try again"
+ * advice, which is actively wrong for a domain that will never resolve.
+ * Returns null when no known net-error pattern matches. Fixed strings only
+ * — no upstream bytes are echoed into the message (the ERR_CERT_* match is
+ * itself a fixed, narrow token pattern, not free text from the body).
  */
 function netErrorMessage(bodyText: string, domain: string): string | null {
+  if (!isPermanentNetError(bodyText)) return null;
   if (/ERR_NAME_NOT_RESOLVED/.test(bodyText)) {
     return `The domain${domain} does not resolve. This is a permanent failure — retrying will not help.`;
   }
@@ -234,8 +237,13 @@ function humanizeBrowserlessStatus(status: number, targetUrl: string, bodyText =
     if (netErr) return netErr;
     return `The target site${domain} returned a server error (HTTP ${status}). This is usually transient — try again in a few minutes.`;
   }
-  const detail = sanitizeDetail(bodyText);
-  return `The web page${domain} could not be loaded (HTTP ${status}).${detail ? ` ${detail}` : ""}`;
+  // Six-lens review finding HIGH (2026-08-16, round 3): a prior version of
+  // this branch appended a sanitized snippet of the upstream response body
+  // to this message. A denylist sanitizer (strip markup/control chars)
+  // cannot be made secret-safe — a token, signed URL, or credential in a
+  // Browserless error body would survive markup-stripping untouched. Fixed
+  // string, HTTP status only. No upstream bytes reach the caller here.
+  return `The web page${domain} could not be loaded (HTTP ${status}).`;
 }
 
 function backoffMs(attempt: number): number {
@@ -475,7 +483,20 @@ export async function fetchPage(
 
         if (!response.ok) {
           const errText = await response.text().catch(() => "");
-          if (isTransient(response.status) && attempt < maxRetries - 1) {
+          // Six-lens review finding Medium (2026-08-16, round 3): a
+          // Chrome/Browserless net-error (DNS doesn't resolve, connection
+          // refused, bad cert) arrives wrapped in a 5xx/408/429 status that
+          // isTransient() would otherwise retry — making the resulting
+          // "retrying will not help" message a lie for the one internal
+          // retry's worth of time it takes to find that out.
+          // isPermanentNetError() gates the retry decision on the SAME
+          // patterns netErrorMessage() uses to build that message, so
+          // "classified transient" and "worded as permanent" can't diverge.
+          if (
+            isTransient(response.status) &&
+            !isPermanentNetError(errText) &&
+            attempt < maxRetries - 1
+          ) {
             lastError = new Error(
               `Browserless HTTP ${response.status}: ${errText.slice(0, 200)}`,
             );

--- a/apps/api/src/capabilities/lib/web-provider.ts
+++ b/apps/api/src/capabilities/lib/web-provider.ts
@@ -58,6 +58,16 @@ export interface WebProviderOptions {
   maxRetries?: number;
   /** Skip the response cache (default: false). */
   skipCache?: boolean;
+  /**
+   * Skip the plain-fetch and Jina Reader tiers and go straight to Browserless
+   * (default: false). Tiers 1/2 substitute non-rendered HTML (tier 1) or a
+   * reformatted document (Jina, tier 2) for what a real headless-Chrome
+   * render would produce. Callers whose output contract promises actual
+   * rendered-DOM content (e.g. web-extract's "full JavaScript rendering")
+   * must set this so a JS-heavy page never silently falls back to a plain
+   * fetch that never ran the page's scripts.
+   */
+  skipFallback?: boolean;
 }
 
 export interface WebProviderResult {
@@ -188,6 +198,7 @@ export async function fetchPage(
     fetchTimeout = 35000,
     maxRetries = 2,
     skipCache = false,
+    skipFallback = false,
   } = options ?? {};
 
   // Per-source ToS policy enforced at the pipeline entry (P2, 2026-08-12):
@@ -213,7 +224,7 @@ export async function fetchPage(
   // Browserless if the response looks like an SPA shell or is too short.
   // IMPORTANT: DNS failures and connection refused are fatal — don't waste
   // 30+ seconds on Browserless for a URL that doesn't resolve.
-  if (!options?.waitUntil || options.waitUntil === "networkidle0") {
+  if (!skipFallback && (!options?.waitUntil || options.waitUntil === "networkidle0")) {
     try {
       const start = Date.now();
       // F-0-006: safeFetch validates, re-validates every redirect, and
@@ -292,7 +303,7 @@ export async function fetchPage(
   // Jina converts URLs to clean text/HTML. Free at 200 RPM with API key.
   // Skip Jina for non-default waitUntil (caller needs specific rendering behavior)
   // and for URLs that need full browser features (screenshot, PDF, cookie analysis).
-  if (!options?.waitUntil || options.waitUntil === "networkidle0") {
+  if (!skipFallback && (!options?.waitUntil || options.waitUntil === "networkidle0")) {
     try {
       const start = Date.now();
       const jinaUrl = `https://r.jina.ai/${targetUrl}`;

--- a/apps/api/src/capabilities/lib/web-provider.ts
+++ b/apps/api/src/capabilities/lib/web-provider.ts
@@ -177,10 +177,13 @@ function isTransient(status: number): boolean {
  * "retrying will not help" while the code retried once anyway.
  */
 function isPermanentNetError(bodyText: string): boolean {
+  // Anchored on Chrome's canonical `net::` prefix (round-5 review): an error
+  // body that merely *mentions* a bare token in prose should not suppress a
+  // retry; real Chrome navigation failures always surface as `net::ERR_*`.
   return (
-    /ERR_NAME_NOT_RESOLVED/.test(bodyText) ||
-    /ERR_CONNECTION_REFUSED/.test(bodyText) ||
-    /ERR_CERT_[A-Z_]+/.test(bodyText)
+    /net::ERR_NAME_NOT_RESOLVED/.test(bodyText) ||
+    /net::ERR_CONNECTION_REFUSED/.test(bodyText) ||
+    /net::ERR_CERT_[A-Z_]+/.test(bodyText)
   );
 }
 
@@ -189,21 +192,22 @@ function isPermanentNetError(bodyText: string): boolean {
  * isPermanentNetError(). Six-lens review finding Medium 2b (2026-08-16):
  * these were getting the 5xx branch's "usually transient — try again"
  * advice, which is actively wrong for a domain that will never resolve.
- * Returns null when no known net-error pattern matches. Fixed strings only
- * — no upstream bytes are echoed into the message (the ERR_CERT_* match is
- * itself a fixed, narrow token pattern, not free text from the body).
+ * Returns null when no known net-error pattern matches. Fixed strings only —
+ * no upstream bytes are echoed into the message. Round-5 review caught the
+ * previous version interpolating the matched ERR_CERT_* token (unbounded,
+ * body-controlled — `net::ERR_CERT_FAKE_SECRET` would have been echoed
+ * verbatim); the cert branch is now a fixed string like every other branch.
  */
 function netErrorMessage(bodyText: string, domain: string): string | null {
   if (!isPermanentNetError(bodyText)) return null;
-  if (/ERR_NAME_NOT_RESOLVED/.test(bodyText)) {
+  if (/net::ERR_NAME_NOT_RESOLVED/.test(bodyText)) {
     return `The domain${domain} does not resolve. This is a permanent failure — retrying will not help.`;
   }
-  if (/ERR_CONNECTION_REFUSED/.test(bodyText)) {
+  if (/net::ERR_CONNECTION_REFUSED/.test(bodyText)) {
     return `The connection to the target site${domain} was refused. This is a permanent failure — retrying will not help.`;
   }
-  const certMatch = bodyText.match(/ERR_CERT_[A-Z_]+/);
-  if (certMatch) {
-    return `The target site${domain}'s TLS certificate is invalid (${certMatch[0]}). This is a permanent failure — retrying will not help.`;
+  if (/net::ERR_CERT_[A-Z_]+/.test(bodyText)) {
+    return `The target site${domain}'s TLS certificate is invalid. This is a permanent failure — retrying will not help.`;
   }
   return null;
 }
@@ -492,9 +496,15 @@ export async function fetchPage(
           // isPermanentNetError() gates the retry decision on the SAME
           // patterns netErrorMessage() uses to build that message, so
           // "classified transient" and "worded as permanent" can't diverge.
+          // Scoped to >=500 (round-5 review): Browserless wraps Chrome
+          // navigation failures in 5xx — that is where a net-error body means
+          // "this will never work". A 408/429 keeps its own retry semantics
+          // (timeout / rate-limit) regardless of what the body text mentions,
+          // matching humanizeBrowserlessStatus, which only consults
+          // netErrorMessage() inside its >=500 branch.
           if (
             isTransient(response.status) &&
-            !isPermanentNetError(errText) &&
+            !(response.status >= 500 && isPermanentNetError(errText)) &&
             attempt < maxRetries - 1
           ) {
             lastError = new Error(

--- a/apps/api/src/capabilities/web-extract-resilience.test.ts
+++ b/apps/api/src/capabilities/web-extract-resilience.test.ts
@@ -1,7 +1,8 @@
 /**
  * Regression tests for routing web-extract through the shared web-provider
- * layer (T0.3 investigation, 2026-08-16), plus fixes from the external
- * (Codex) review of that change (2026-08-16).
+ * layer (T0.3 investigation, 2026-08-16), plus fixes from two review rounds
+ * on that change (external/Codex review, then a six-lens review round;
+ * both 2026-08-16).
  *
  * Before the original fix, web-extract called Browserless with a bare
  * `fetch()`: one attempt, no retry, no backoff, no cache — unlike the other
@@ -16,6 +17,16 @@
  * (only `@anthropic-ai/sdk` and `url-validator.js` are mocked) so they
  * assert the actual wiring, not a mocked-away stand-in. See the handoff
  * report for the fail-before verification transcript for each test.
+ *
+ * web-extract is a live-fetch capability (manifest: freshness_category:
+ * live-fetch) and opts OUT of the shared cache entirely (skipCache: true —
+ * see web-extract.ts). A cache hit would return HTML rendered up to 5
+ * minutes earlier stamped with a fresh `provenance.fetched_at`, i.e.
+ * fabricated provenance (six-lens review, HIGH). Because of that, tests
+ * that exercise cache BEHAVIOR (namespace isolation, minHtmlLength
+ * revalidation on hit) call `fetchRenderedHtml`/`fetchPage` directly rather
+ * than through the web-extract executor, which never reads or writes the
+ * cache.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,7 +45,7 @@ vi.mock("../lib/url-validator.js", () => ({ validateUrl: vi.fn(async () => {}) }
 
 import { getDirectExecutor } from "./index.js";
 import "./web-extract.js";
-import { fetchRenderedHtml } from "./lib/web-provider.js";
+import { fetchPage, fetchRenderedHtml } from "./lib/web-provider.js";
 
 const RENDERED_HTML = `<html><head><title>Example Domain</title></head><body>${"Real page content. ".repeat(20)}</body></html>`;
 
@@ -109,33 +120,41 @@ describe("web-extract shared resilience", () => {
     expect(result.output.page_title).toBe("Example Domain");
   }, 10000);
 
-  it("serves a repeat render of the same URL from the shared TTL cache — one upstream call for two capability calls (bare fetch had no cache and would call Browserless twice)", async () => {
-    fetchMock.mockResolvedValueOnce(new Response(RENDERED_HTML, { status: 200 }));
+  it("never caches — two identical web-extract calls make two independent Browserless renders (six-lens review, HIGH: a cache hit would fabricate provenance.fetched_at on a live-fetch capability)", async () => {
+    const FIRST_RENDER = `<html><head><title>Example Domain</title></head><body>${"First render. ".repeat(30)}</body></html>`;
+    const SECOND_RENDER = `<html><head><title>Example Domain</title></head><body>${"Second render, different bytes. ".repeat(30)}</body></html>`;
+    fetchMock
+      .mockResolvedValueOnce(new Response(FIRST_RENDER, { status: 200 }))
+      .mockResolvedValueOnce(new Response(SECOND_RENDER, { status: 200 }));
 
     const first = await exec()({
-      url: "https://example.com/cache-test",
+      url: "https://example.com/no-cache-test",
       extract: "headline",
     });
     const second = await exec()({
-      url: "https://example.com/cache-test",
+      url: "https://example.com/no-cache-test",
       extract: "headline",
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Pre-fix (cache enabled), this would be 1 call and both provenance
+    // timestamps would describe the SAME render — the second one lying
+    // about when its (stale) HTML was actually fetched.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expectBrowserlessContentPost(fetchMock.mock.calls[0]);
-    expect(second.output.page_title).toBe(first.output.page_title);
-    expect(second.output.page_title).toBe("Example Domain");
+    expectBrowserlessContentPost(fetchMock.mock.calls[1]);
+    expect(first.provenance.fetched_at).toBeTruthy();
+    expect(second.provenance.fetched_at).toBeTruthy();
   }, 10000);
 
-  it("keeps the skipFallback cache namespace separate from the fallback-tier namespace — a plain-fetch-warmed entry for the same URL is never read by web-extract (external review finding 1, BLOCKER)", async () => {
+  it("keeps the skipFallback cache namespace separate from the fallback-tier namespace at the shared-layer level (external review finding 1, BLOCKER — driven via direct fetchRenderedHtml calls per six-lens review, since web-extract itself no longer reads/writes cache)", async () => {
     const url = "https://example.com/shared-cache-test";
     const PLAIN_FETCH_HTML = `<html><head><title>Plain Fetch Version</title></head><body>${"Plain-fetch content, definitely not what Browserless would render. ".repeat(
       40,
     )}</body></html>`;
 
-    // Warm the cache via a NON-skipFallback call — this is served by tier 1
-    // (plain fetch through safeFetch, which also goes through the stubbed
-    // global fetch), not Browserless.
+    // Warm the cache via a NON-skipFallback call — served by tier 1 (plain
+    // fetch through safeFetch, which also goes through the stubbed global
+    // fetch), not Browserless. Lands in the "default:networkidle0" namespace.
     fetchMock.mockResolvedValueOnce(
       new Response(PLAIN_FETCH_HTML, {
         status: 200,
@@ -145,22 +164,20 @@ describe("web-extract shared resilience", () => {
     const warmed = await fetchRenderedHtml(url);
     expect(warmed).toContain("Plain Fetch Version");
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    // That one call must NOT have been a Browserless render — confirms the
-    // warm-up really went through the fallback tier, not tier 3.
     expect(String(fetchMock.mock.calls[0][0])).not.toContain("/content");
 
-    // web-extract (skipFallback: true) requests the SAME url. Pre-fix, the
-    // single URL-keyed cache would return the plain-fetch HTML above with
-    // zero further fetch calls — silently violating web-extract's "full
-    // JavaScript rendering" contract. Post-fix, the namespaces are disjoint,
-    // so this must make its own Browserless render.
+    // A skipFallback caller for the SAME url, called directly against the
+    // shared layer (not through web-extract). Pre-fix, the single
+    // URL-keyed cache would return the plain-fetch HTML above with zero
+    // further fetch calls. Post-fix, the namespaces are disjoint, so this
+    // must make its own Browserless render.
     fetchMock.mockResolvedValueOnce(new Response(RENDERED_HTML, { status: 200 }));
-    const result = await exec()({ url, extract: "headline" });
+    const rendered = await fetchRenderedHtml(url, { skipFallback: true, maxRetries: 1 });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expectBrowserlessContentPost(fetchMock.mock.calls[1]);
-    expect(result.output.page_title).toBe("Example Domain");
-    expect(result.output.page_title).not.toBe("Plain Fetch Version");
+    expect(rendered).toContain("Example Domain");
+    expect(rendered).not.toContain("Plain Fetch Version");
   }, 10000);
 
   it("accepts a Browserless render between 50 and 100 bytes — web-extract's pre-existing 50-byte floor is preserved via minHtmlLength, not silently tightened to the shared layer's default of 100 (external review finding 4)", async () => {
@@ -183,6 +200,37 @@ describe("web-extract shared resilience", () => {
     expect(result.output.page_title).toBe("Hi");
   }, 10000);
 
+  it("a cache hit shorter than the caller's minHtmlLength is treated as a miss, not silently handed back (six-lens review, Medium 3)", async () => {
+    const url = "https://example.com/min-length-cache-test";
+    const shortHtml = "<html>short</html>"; // 19 bytes
+
+    // A caller with a loose minHtmlLength (10) renders and caches 19 bytes
+    // under the "skipFallback:networkidle0" namespace.
+    fetchMock.mockResolvedValueOnce(new Response(shortHtml, { status: 200 }));
+    const first = await fetchRenderedHtml(url, {
+      skipFallback: true,
+      maxRetries: 1,
+      minHtmlLength: 10,
+    });
+    expect(first).toBe(shortHtml);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // A second caller in the SAME namespace needs at least 100 bytes. Pre-fix,
+    // getCached() would hand back the 19-byte entry regardless — a value
+    // this caller would have rejected from a live response. Post-fix, the
+    // stale-short hit is treated as a miss and a fresh render happens.
+    fetchMock.mockResolvedValueOnce(new Response(RENDERED_HTML, { status: 200 }));
+    const second = await fetchRenderedHtml(url, {
+      skipFallback: true,
+      maxRetries: 1,
+      minHtmlLength: 100,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expectBrowserlessContentPost(fetchMock.mock.calls[1]);
+    expect(second).toContain("Example Domain");
+  }, 10000);
+
   it("maps a permanent Browserless failure (404) to a structured, human-readable error with no raw response body embedded (bare fetch spliced up to 200 raw chars of the body straight into the thrown message)", async () => {
     const rawErrorBody = `<html><body><h1>Not Found</h1><p>${"filler text ".repeat(30)}</p></body></html>`;
     fetchMock.mockResolvedValueOnce(new Response(rawErrorBody, { status: 404 }));
@@ -201,5 +249,75 @@ describe("web-extract shared resilience", () => {
     expect(message).toMatch(/404/);
     // 404 is not a transient status — the shared layer does not retry it.
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  }, 10000);
+
+  it("sanitizes an uncommon-status error body into a bounded, markup-free detail snippet instead of a diagnostically mute generic message (six-lens review, Medium 2a)", async () => {
+    const markupBody = `<html><body><script>alert(1)</script>Field "url" ${"is invalid, ".repeat(20)}</body></html>\x00\x01control-bytes`;
+    fetchMock.mockResolvedValueOnce(new Response(markupBody, { status: 422 }));
+
+    let message = "";
+    await fetchPage("https://example.com/sanitize-test", {
+      skipFallback: true,
+      maxRetries: 1,
+    }).catch((err: unknown) => {
+      message = err instanceof Error ? err.message : String(err);
+    });
+
+    expect(message).toContain("422");
+    // No script/html tags, no control bytes, survived into the message.
+    expect(message).not.toMatch(/<script|<html|<body|\x00|\x01/);
+    expect(message).toMatch(/Field "url" is invalid/);
+    // Capped length: the message shouldn't just re-embed the entire
+    // (much longer) markupBody unbounded.
+    expect(message.length).toBeLessThan(300);
+  }, 10000);
+
+  it("maps a Browserless net-error (ERR_NAME_NOT_RESOLVED) to a non-retryable message, not the 5xx 'usually transient' framing (six-lens review, Medium 2b)", async () => {
+    const netErrorBody = "net::ERR_NAME_NOT_RESOLVED at https://this-domain-does-not-exist.invalid/";
+    fetchMock.mockResolvedValueOnce(new Response(netErrorBody, { status: 502 }));
+
+    let message = "";
+    await fetchPage("https://example.com/net-error-test", {
+      skipFallback: true,
+      maxRetries: 1,
+    }).catch((err: unknown) => {
+      message = err instanceof Error ? err.message : String(err);
+    });
+
+    expect(message).toMatch(/does not resolve/i);
+    expect(message).toMatch(/retrying will not help/i);
+    expect(message).not.toMatch(/usually transient/i);
+  }, 10000);
+
+  it("maps a Browserless connection-refused net-error to a non-retryable message (six-lens review, Medium 2b)", async () => {
+    const netErrorBody = "net::ERR_CONNECTION_REFUSED";
+    fetchMock.mockResolvedValueOnce(new Response(netErrorBody, { status: 502 }));
+
+    let message = "";
+    await fetchPage("https://example.com/net-error-refused-test", {
+      skipFallback: true,
+      maxRetries: 1,
+    }).catch((err: unknown) => {
+      message = err instanceof Error ? err.message : String(err);
+    });
+
+    expect(message).toMatch(/connection.*refused/i);
+    expect(message).toMatch(/retrying will not help/i);
+    expect(message).not.toMatch(/usually transient/i);
+  }, 10000);
+
+  it("appends 'Retrying will not help.' to the 403 message for consistency with the other permanent-failure statuses (six-lens review, LOW)", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }));
+
+    let message = "";
+    await fetchPage("https://example.com/forbidden-test", {
+      skipFallback: true,
+      maxRetries: 1,
+    }).catch((err: unknown) => {
+      message = err instanceof Error ? err.message : String(err);
+    });
+
+    expect(message).toMatch(/403/);
+    expect(message).toMatch(/Retrying will not help\./);
   }, 10000);
 });

--- a/apps/api/src/capabilities/web-extract-resilience.test.ts
+++ b/apps/api/src/capabilities/web-extract-resilience.test.ts
@@ -251,12 +251,14 @@ describe("web-extract shared resilience", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   }, 10000);
 
-  it("sanitizes an uncommon-status error body into a bounded, markup-free detail snippet instead of a diagnostically mute generic message (six-lens review, Medium 2a)", async () => {
-    const markupBody = `<html><body><script>alert(1)</script>Field "url" ${"is invalid, ".repeat(20)}</body></html>\x00\x01control-bytes`;
-    fetchMock.mockResolvedValueOnce(new Response(markupBody, { status: 422 }));
+  it("the generic-status branch never echoes upstream body content into the message — no secrets/tokens/markup can leak (six-lens review, HIGH, round 3: a denylist sanitizer cannot be made secret-safe, so the appended-detail approach was removed entirely)", async () => {
+    const bodyWithSecrets =
+      `<html><body><script>alert(1)</script>Bearer sk_live_FAKESECRETTOKEN1234 ` +
+      `signed_url=https://internal.example/secret?token=abc123 ${"padding ".repeat(20)}</body></html>`;
+    fetchMock.mockResolvedValueOnce(new Response(bodyWithSecrets, { status: 422 }));
 
     let message = "";
-    await fetchPage("https://example.com/sanitize-test", {
+    await fetchPage("https://example.com/no-body-leak-test", {
       skipFallback: true,
       maxRetries: 1,
     }).catch((err: unknown) => {
@@ -264,46 +266,113 @@ describe("web-extract shared resilience", () => {
     });
 
     expect(message).toContain("422");
-    // No script/html tags, no control bytes, survived into the message.
-    expect(message).not.toMatch(/<script|<html|<body|\x00|\x01/);
-    expect(message).toMatch(/Field "url" is invalid/);
-    // Capped length: the message shouldn't just re-embed the entire
-    // (much longer) markupBody unbounded.
-    expect(message.length).toBeLessThan(300);
+    // Fixed string, status only — none of the upstream body survives.
+    expect(message).not.toMatch(/sk_live_FAKESECRETTOKEN1234/);
+    expect(message).not.toMatch(/internal\.example/);
+    expect(message).not.toMatch(/token=abc123/);
+    expect(message).not.toMatch(/<script|<html|<body|padding/i);
   }, 10000);
 
-  it("maps a Browserless net-error (ERR_NAME_NOT_RESOLVED) to a non-retryable message, not the 5xx 'usually transient' framing (six-lens review, Medium 2b)", async () => {
+  it("pins the retry count to exactly maxRetries attempts — two failing transient (non-net-error) responses make exactly 2 calls then throw (six-lens review, LOW coverage gap a)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response("server error 1", { status: 500 }))
+      .mockResolvedValueOnce(new Response("server error 2", { status: 500 }));
+
+    let message = "";
+    await fetchPage("https://example.com/two-attempts-pin-test", {
+      skipFallback: true,
+      // default maxRetries = 2
+    }).catch((err: unknown) => {
+      message = err instanceof Error ? err.message : String(err);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(message).toMatch(/HTTP 500/);
+    expect(message).toMatch(/usually transient/i);
+  }, 10000);
+
+  it("maps a Browserless net-error (ERR_NAME_NOT_RESOLVED) to a non-retryable message with exactly 1 call, not the 5xx 'usually transient' framing (six-lens review, Medium 2b + retry-site fix)", async () => {
     const netErrorBody = "net::ERR_NAME_NOT_RESOLVED at https://this-domain-does-not-exist.invalid/";
     fetchMock.mockResolvedValueOnce(new Response(netErrorBody, { status: 502 }));
 
     let message = "";
     await fetchPage("https://example.com/net-error-test", {
       skipFallback: true,
-      maxRetries: 1,
+      // default maxRetries = 2 — proves the net-error short-circuits the
+      // retry budget rather than merely being the only attempt available.
     }).catch((err: unknown) => {
       message = err instanceof Error ? err.message : String(err);
     });
 
+    // Retrying was NOT attempted, even though the retry budget allowed it —
+    // this is what makes "retrying will not help" true.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(message).toMatch(/does not resolve/i);
     expect(message).toMatch(/retrying will not help/i);
     expect(message).not.toMatch(/usually transient/i);
   }, 10000);
 
-  it("maps a Browserless connection-refused net-error to a non-retryable message (six-lens review, Medium 2b)", async () => {
+  it("maps a Browserless connection-refused net-error to a non-retryable message with exactly 1 call (six-lens review, Medium 2b + retry-site fix)", async () => {
     const netErrorBody = "net::ERR_CONNECTION_REFUSED";
     fetchMock.mockResolvedValueOnce(new Response(netErrorBody, { status: 502 }));
 
     let message = "";
     await fetchPage("https://example.com/net-error-refused-test", {
       skipFallback: true,
-      maxRetries: 1,
+      // default maxRetries = 2
     }).catch((err: unknown) => {
       message = err instanceof Error ? err.message : String(err);
     });
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(message).toMatch(/connection.*refused/i);
     expect(message).toMatch(/retrying will not help/i);
     expect(message).not.toMatch(/usually transient/i);
+  }, 10000);
+
+  it("maps a Browserless TLS-certificate net-error to the permanent (non-retryable) path with exactly 1 call (six-lens review, LOW coverage gap b)", async () => {
+    const certErrorBody = "net::ERR_CERT_AUTHORITY_INVALID";
+    fetchMock.mockResolvedValueOnce(new Response(certErrorBody, { status: 502 }));
+
+    let message = "";
+    await fetchPage("https://example.com/cert-error-test", {
+      skipFallback: true,
+      // default maxRetries = 2
+    }).catch((err: unknown) => {
+      message = err instanceof Error ? err.message : String(err);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(message).toMatch(/TLS certificate is invalid/i);
+    expect(message).toMatch(/ERR_CERT_AUTHORITY_INVALID/);
+    expect(message).toMatch(/retrying will not help/i);
+    expect(message).not.toMatch(/usually transient/i);
+  }, 10000);
+
+  it("a subsequent non-skipFallback fetchPage call for the same URL still fetches fresh after two web-extract calls (six-lens review, LOW coverage gap c — confirms nothing about web-extract's skipCache change corrupted the shared cache's normal operation for other callers)", async () => {
+    const url = "https://example.com/no-cache-writeback-test";
+
+    fetchMock
+      .mockResolvedValueOnce(new Response(RENDERED_HTML, { status: 200 })) // web-extract call 1
+      .mockResolvedValueOnce(new Response(RENDERED_HTML, { status: 200 })); // web-extract call 2
+
+    await exec()({ url, extract: "headline" });
+    await exec()({ url, extract: "headline" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // A plain (non-skipFallback, default networkidle0) caller for the SAME
+    // url — a different capability's typical call shape, landing in the
+    // "default:networkidle0" namespace web-extract never touches.
+    const FRESH_PLAIN_HTML = `<html><head><title>Fresh Plain Fetch</title></head><body>${"Fresh plain-fetch content, unrelated to web-extract's renders. ".repeat(
+      40,
+    )}</body></html>`;
+    fetchMock.mockResolvedValueOnce(
+      new Response(FRESH_PLAIN_HTML, { status: 200, headers: { "content-type": "text/html" } }),
+    );
+    const third = await fetchRenderedHtml(url);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(third).toContain("Fresh Plain Fetch");
   }, 10000);
 
   it("appends 'Retrying will not help.' to the 403 message for consistency with the other permanent-failure statuses (six-lens review, LOW)", async () => {

--- a/apps/api/src/capabilities/web-extract-resilience.test.ts
+++ b/apps/api/src/capabilities/web-extract-resilience.test.ts
@@ -1,10 +1,11 @@
 /**
  * Regression tests for routing web-extract through the shared web-provider
- * layer (T0.3 investigation, 2026-08-16).
+ * layer (T0.3 investigation, 2026-08-16), plus fixes from the external
+ * (Codex) review of that change (2026-08-16).
  *
- * Before this fix, web-extract called Browserless with a bare `fetch()`:
- * one attempt, no retry, no backoff, no cache — unlike the other 47+
- * Browserless-backed capabilities, which all go through
+ * Before the original fix, web-extract called Browserless with a bare
+ * `fetch()`: one attempt, no retry, no backoff, no cache — unlike the other
+ * 47+ Browserless-backed capabilities, which all go through
  * `lib/web-provider.ts` and get exponential-backoff retry, a 5-minute
  * response cache, and a concurrency limiter for free. Real customer
  * failures in the 14 days before the fix were navigation timeouts and
@@ -13,9 +14,8 @@
  *
  * These tests exercise the real `web-provider.ts` retry/cache machinery
  * (only `@anthropic-ai/sdk` and `url-validator.js` are mocked) so they
- * assert the actual wiring, not a mocked-away stand-in. All three fail
- * against the pre-fix bare-fetch executor and pass against the fix —
- * see the handoff report for the fail-before verification transcript.
+ * assert the actual wiring, not a mocked-away stand-in. See the handoff
+ * report for the fail-before verification transcript for each test.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,8 +34,17 @@ vi.mock("../lib/url-validator.js", () => ({ validateUrl: vi.fn(async () => {}) }
 
 import { getDirectExecutor } from "./index.js";
 import "./web-extract.js";
+import { fetchRenderedHtml } from "./lib/web-provider.js";
 
 const RENDERED_HTML = `<html><head><title>Example Domain</title></head><body>${"Real page content. ".repeat(20)}</body></html>`;
+
+/** Assert a captured global-fetch call was a POST to Browserless's /content endpoint. */
+function expectBrowserlessContentPost(call: unknown[]): void {
+  const [reqUrl, init] = call as [string, RequestInit];
+  expect(String(reqUrl)).toContain("chromium.test");
+  expect(String(reqUrl)).toContain("/content");
+  expect(init?.method).toBe("POST");
+}
 
 describe("web-extract shared resilience", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
@@ -61,7 +70,7 @@ describe("web-extract shared resilience", () => {
 
   const exec = () => getDirectExecutor("web-extract")!;
 
-  it("recovers from a transient 429 via the shared retry layer (bare fetch had exactly one attempt and would have failed here)", async () => {
+  it("recovers from a transient 429 via the shared retry layer, and every retry actually hits Browserless (bare fetch had exactly one attempt and would have failed here)", async () => {
     fetchMock
       .mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
       .mockResolvedValueOnce(new Response(RENDERED_HTML, { status: 200 }));
@@ -72,8 +81,32 @@ describe("web-extract shared resilience", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    // External review finding 5: counting fetch calls alone doesn't prove
+    // the retry hit Browserless — it would also pass if the first call were
+    // misrouted through a fallback tier. Pin every call to the real
+    // Browserless /content POST endpoint.
+    for (const call of fetchMock.mock.calls) {
+      expectBrowserlessContentPost(call);
+    }
     expect(result.output.page_title).toBe("Example Domain");
     expect(result.output.data).toMatchObject({ headline: "hi" });
+  }, 10000);
+
+  it("recovers from a transient 408 (request timeout) via the shared retry layer (external review finding 2: 408 was missing from the transient classification)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response("nav timeout", { status: 408 }))
+      .mockResolvedValueOnce(new Response(RENDERED_HTML, { status: 200 }));
+
+    const result = await exec()({
+      url: "https://example.com/408-retry-test",
+      extract: "headline",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const call of fetchMock.mock.calls) {
+      expectBrowserlessContentPost(call);
+    }
+    expect(result.output.page_title).toBe("Example Domain");
   }, 10000);
 
   it("serves a repeat render of the same URL from the shared TTL cache — one upstream call for two capability calls (bare fetch had no cache and would call Browserless twice)", async () => {
@@ -89,8 +122,65 @@ describe("web-extract shared resilience", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expectBrowserlessContentPost(fetchMock.mock.calls[0]);
     expect(second.output.page_title).toBe(first.output.page_title);
     expect(second.output.page_title).toBe("Example Domain");
+  }, 10000);
+
+  it("keeps the skipFallback cache namespace separate from the fallback-tier namespace — a plain-fetch-warmed entry for the same URL is never read by web-extract (external review finding 1, BLOCKER)", async () => {
+    const url = "https://example.com/shared-cache-test";
+    const PLAIN_FETCH_HTML = `<html><head><title>Plain Fetch Version</title></head><body>${"Plain-fetch content, definitely not what Browserless would render. ".repeat(
+      40,
+    )}</body></html>`;
+
+    // Warm the cache via a NON-skipFallback call — this is served by tier 1
+    // (plain fetch through safeFetch, which also goes through the stubbed
+    // global fetch), not Browserless.
+    fetchMock.mockResolvedValueOnce(
+      new Response(PLAIN_FETCH_HTML, {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    const warmed = await fetchRenderedHtml(url);
+    expect(warmed).toContain("Plain Fetch Version");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // That one call must NOT have been a Browserless render — confirms the
+    // warm-up really went through the fallback tier, not tier 3.
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("/content");
+
+    // web-extract (skipFallback: true) requests the SAME url. Pre-fix, the
+    // single URL-keyed cache would return the plain-fetch HTML above with
+    // zero further fetch calls — silently violating web-extract's "full
+    // JavaScript rendering" contract. Post-fix, the namespaces are disjoint,
+    // so this must make its own Browserless render.
+    fetchMock.mockResolvedValueOnce(new Response(RENDERED_HTML, { status: 200 }));
+    const result = await exec()({ url, extract: "headline" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expectBrowserlessContentPost(fetchMock.mock.calls[1]);
+    expect(result.output.page_title).toBe("Example Domain");
+    expect(result.output.page_title).not.toBe("Plain Fetch Version");
+  }, 10000);
+
+  it("accepts a Browserless render between 50 and 100 bytes — web-extract's pre-existing 50-byte floor is preserved via minHtmlLength, not silently tightened to the shared layer's default of 100 (external review finding 4)", async () => {
+    // 74 bytes: >= web-extract's historical 50-byte floor, < the shared
+    // layer's default 100-byte floor.
+    const shortButValid = `<html><title>Hi</title><body>${"x".repeat(30)}</body></html>`;
+    expect(shortButValid.length).toBeGreaterThanOrEqual(50);
+    expect(shortButValid.length).toBeLessThan(100);
+
+    fetchMock.mockResolvedValueOnce(new Response(shortButValid, { status: 200 }));
+
+    const result = await exec()({
+      url: "https://example.com/short-content-test",
+      extract: "headline",
+    });
+
+    // A single attempt succeeds — the shared default would have rejected
+    // this as "too short", retried once, and thrown.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.output.page_title).toBe("Hi");
   }, 10000);
 
   it("maps a permanent Browserless failure (404) to a structured, human-readable error with no raw response body embedded (bare fetch spliced up to 200 raw chars of the body straight into the thrown message)", async () => {

--- a/apps/api/src/capabilities/web-extract-resilience.test.ts
+++ b/apps/api/src/capabilities/web-extract-resilience.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression tests for routing web-extract through the shared web-provider
+ * layer (T0.3 investigation, 2026-08-16).
+ *
+ * Before this fix, web-extract called Browserless with a bare `fetch()`:
+ * one attempt, no retry, no backoff, no cache — unlike the other 47+
+ * Browserless-backed capabilities, which all go through
+ * `lib/web-provider.ts` and get exponential-backoff retry, a 5-minute
+ * response cache, and a concurrency limiter for free. Real customer
+ * failures in the 14 days before the fix were navigation timeouts and
+ * transient HTTP 429s that a retry would likely have absorbed, each
+ * billed against the customer's error budget.
+ *
+ * These tests exercise the real `web-provider.ts` retry/cache machinery
+ * (only `@anthropic-ai/sdk` and `url-validator.js` are mocked) so they
+ * assert the actual wiring, not a mocked-away stand-in. All three fail
+ * against the pre-fix bare-fetch executor and pass against the fix —
+ * see the handoff report for the fail-before verification transcript.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { messagesCreate } = vi.hoisted(() => ({ messagesCreate: vi.fn() }));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: messagesCreate };
+  },
+}));
+
+// Avoid real DNS lookups in the shared layer's SSRF check (same pattern as
+// screenshot-url.test.ts) — the URLs below are fake test hosts.
+vi.mock("../lib/url-validator.js", () => ({ validateUrl: vi.fn(async () => {}) }));
+
+import { getDirectExecutor } from "./index.js";
+import "./web-extract.js";
+
+const RENDERED_HTML = `<html><head><title>Example Domain</title></head><body>${"Real page content. ".repeat(20)}</body></html>`;
+
+describe("web-extract shared resilience", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env.BROWSERLESS_URL = "https://chromium.test";
+    process.env.BROWSERLESS_API_KEY = "test-token";
+    process.env.ANTHROPIC_API_KEY = "test-key";
+
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    messagesCreate.mockReset();
+    messagesCreate.mockResolvedValue({
+      content: [{ type: "text", text: '{"headline":"hi"}' }],
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  const exec = () => getDirectExecutor("web-extract")!;
+
+  it("recovers from a transient 429 via the shared retry layer (bare fetch had exactly one attempt and would have failed here)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
+      .mockResolvedValueOnce(new Response(RENDERED_HTML, { status: 200 }));
+
+    const result = await exec()({
+      url: "https://example.com/retry-test",
+      extract: "headline",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.output.page_title).toBe("Example Domain");
+    expect(result.output.data).toMatchObject({ headline: "hi" });
+  }, 10000);
+
+  it("serves a repeat render of the same URL from the shared TTL cache — one upstream call for two capability calls (bare fetch had no cache and would call Browserless twice)", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(RENDERED_HTML, { status: 200 }));
+
+    const first = await exec()({
+      url: "https://example.com/cache-test",
+      extract: "headline",
+    });
+    const second = await exec()({
+      url: "https://example.com/cache-test",
+      extract: "headline",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(second.output.page_title).toBe(first.output.page_title);
+    expect(second.output.page_title).toBe("Example Domain");
+  }, 10000);
+
+  it("maps a permanent Browserless failure (404) to a structured, human-readable error with no raw response body embedded (bare fetch spliced up to 200 raw chars of the body straight into the thrown message)", async () => {
+    const rawErrorBody = `<html><body><h1>Not Found</h1><p>${"filler text ".repeat(30)}</p></body></html>`;
+    fetchMock.mockResolvedValueOnce(new Response(rawErrorBody, { status: 404 }));
+
+    let message = "";
+    await exec()({ url: "https://example.com/missing-page", extract: "headline" }).catch(
+      (err: unknown) => {
+        message = err instanceof Error ? err.message : String(err);
+      },
+    );
+
+    expect(message).toBeTruthy();
+    // No raw HTML/markup leaked into the error — this is the exact shape
+    // the pre-fix `errText.slice(0, 200)` splice used to produce.
+    expect(message).not.toMatch(/<html|<body|<h1|<p>|filler text/i);
+    expect(message).toMatch(/404/);
+    // 404 is not a transient status — the shared layer does not retry it.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  }, 10000);
+});

--- a/apps/api/src/capabilities/web-extract-resilience.test.ts
+++ b/apps/api/src/capabilities/web-extract-resilience.test.ts
@@ -254,6 +254,7 @@ describe("web-extract shared resilience", () => {
   it("the generic-status branch never echoes upstream body content into the message — no secrets/tokens/markup can leak (six-lens review, HIGH, round 3: a denylist sanitizer cannot be made secret-safe, so the appended-detail approach was removed entirely)", async () => {
     const bodyWithSecrets =
       `<html><body><script>alert(1)</script>Bearer sk_live_FAKESECRETTOKEN1234 ` +
+      `net::ERR_CERT_FAKE_SECRET_IN_TOKEN ` +
       `signed_url=https://internal.example/secret?token=abc123 ${"padding ".repeat(20)}</body></html>`;
     fetchMock.mockResolvedValueOnce(new Response(bodyWithSecrets, { status: 422 }));
 
@@ -268,6 +269,7 @@ describe("web-extract shared resilience", () => {
     expect(message).toContain("422");
     // Fixed string, status only — none of the upstream body survives.
     expect(message).not.toMatch(/sk_live_FAKESECRETTOKEN1234/);
+    expect(message).not.toMatch(/ERR_CERT_FAKE_SECRET_IN_TOKEN/);
     expect(message).not.toMatch(/internal\.example/);
     expect(message).not.toMatch(/token=abc123/);
     expect(message).not.toMatch(/<script|<html|<body|padding/i);
@@ -344,12 +346,33 @@ describe("web-extract shared resilience", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(message).toMatch(/TLS certificate is invalid/i);
-    expect(message).toMatch(/ERR_CERT_AUTHORITY_INVALID/);
+    // Round-5 review HIGH: the matched ERR_CERT_* token is body-controlled
+    // and must NOT be echoed — the message is a fixed string.
+    expect(message).not.toMatch(/ERR_CERT_AUTHORITY_INVALID/);
     expect(message).toMatch(/retrying will not help/i);
     expect(message).not.toMatch(/usually transient/i);
   }, 10000);
 
-  it("a subsequent non-skipFallback fetchPage call for the same URL still fetches fresh after two web-extract calls (six-lens review, LOW coverage gap c — confirms nothing about web-extract's skipCache change corrupted the shared cache's normal operation for other callers)", async () => {
+  it("a 429 whose body mentions a net-error token still gets its retry — the permanent-failure short-circuit is scoped to 5xx (round-5 review, MEDIUM)", async () => {
+    const RENDERED_HTML = `<html><head><title>Recovered After 429</title></head><body>${"Recovered content after a rate-limited first attempt. ".repeat(30)}</body></html>`;
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response("rate limited — see also net::ERR_NAME_NOT_RESOLVED docs", { status: 429 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(RENDERED_HTML, { status: 200, headers: { "content-type": "text/html" } }),
+      );
+
+    const result = await fetchPage("https://example.com/scoped-shortcircuit-test", {
+      skipFallback: true,
+    });
+
+    // 429 keeps its own retry semantics regardless of body text.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.html).toContain("Recovered After 429");
+  }, 10000);
+
+  it("a cache-enabled call in web-extract's own namespace still fetches fresh after two web-extract calls — proving skipCache suppressed the writes, not just the reads (round-5 review, LOW)", async () => {
     const url = "https://example.com/no-cache-writeback-test";
 
     fetchMock
@@ -360,19 +383,23 @@ describe("web-extract shared resilience", () => {
     await exec()({ url, extract: "headline" });
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
-    // A plain (non-skipFallback, default networkidle0) caller for the SAME
-    // url — a different capability's typical call shape, landing in the
-    // "default:networkidle0" namespace web-extract never touches.
-    const FRESH_PLAIN_HTML = `<html><head><title>Fresh Plain Fetch</title></head><body>${"Fresh plain-fetch content, unrelated to web-extract's renders. ".repeat(
+    // Round-5 review LOW: to prove web-extract WROTE nothing, the probe must
+    // read from the SAME namespace web-extract's calls would have written to
+    // (skipFallback + networkidle0) — a different-namespace probe would fetch
+    // fresh even if web-extract had polluted its own namespace. This is a
+    // cache-enabled direct call in that exact namespace: a cache hit here
+    // would mean web-extract's skipCache leaked a write.
+    const FRESH_RENDER_HTML = `<html><head><title>Fresh Same-Namespace Render</title></head><body>${"Fresh render proving the namespace holds no entry from web-extract. ".repeat(
       40,
     )}</body></html>`;
     fetchMock.mockResolvedValueOnce(
-      new Response(FRESH_PLAIN_HTML, { status: 200, headers: { "content-type": "text/html" } }),
+      new Response(FRESH_RENDER_HTML, { status: 200, headers: { "content-type": "text/html" } }),
     );
-    const third = await fetchRenderedHtml(url);
+    const third = await fetchPage(url, { skipFallback: true, waitUntil: "networkidle0" });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(third).toContain("Fresh Plain Fetch");
+    expect(third.html).toContain("Fresh Same-Namespace Render");
+    expect(third.cached).toBe(false);
   }, 10000);
 
   it("appends 'Retrying will not help.' to the 403 message for consistency with the other permanent-failure statuses (six-lens review, LOW)", async () => {

--- a/apps/api/src/capabilities/web-extract.ts
+++ b/apps/api/src/capabilities/web-extract.ts
@@ -38,15 +38,15 @@ registerCapability("web-extract", async (input: CapabilityInput) => {
   }
 
   // Step 1: Render page via the shared web-provider layer (lib/web-provider.ts)
-  // — retry with exponential backoff, a 5-minute response cache, and a
-  // concurrency limiter on top of Browserless, the same resilience the other
-  // 47+ Browserless-backed capabilities get. web-extract's output contract
-  // promises full JavaScript rendering (manifest: "Handles SPAs, dynamic
-  // content, and pages that require JS to load", data_source: "Headless
-  // browser rendering via Browserless.io"), so skipFallback bypasses
-  // web-provider's plain-fetch and Jina Reader tiers — neither runs the
-  // page's JS, and Jina reformats the document, which would silently change
-  // both the extracted content and the <title> this capability parses out.
+  // — retry with exponential backoff and a concurrency limiter on top of
+  // Browserless, the same resilience the other 47+ Browserless-backed
+  // capabilities get. web-extract's output contract promises full
+  // JavaScript rendering (manifest: "Handles SPAs, dynamic content, and
+  // pages that require JS to load", data_source: "Headless browser
+  // rendering via Browserless.io"), so skipFallback bypasses web-provider's
+  // plain-fetch and Jina Reader tiers — neither runs the page's JS, and
+  // Jina reformats the document, which would silently change both the
+  // extracted content and the <title> this capability parses out.
   // waitUntil/pageTimeout/fetchTimeout reproduce the previous bare-fetch call
   // exactly (networkidle0, 25s nav timeout, 35s outer budget).
   // minHtmlLength: 50 reproduces web-extract's own pre-existing threshold —
@@ -54,12 +54,26 @@ registerCapability("web-extract", async (input: CapabilityInput) => {
   // (external review finding, 2026-08-16). The redundant local length guard
   // right below is kept as a defense-in-depth backstop, not the enforcement
   // point.
+  // skipCache: true — this capability's manifest declares
+  // freshness_category: live-fetch and stamps provenance.fetched_at at
+  // return time unconditionally. A cache hit would return HTML rendered up
+  // to 5 minutes earlier stamped with a fresh timestamp — fabricated
+  // provenance on every repeat call within the TTL (six-lens review,
+  // HIGH, 2026-08-16). The retry/backoff resilience is the value of this
+  // whole change, not the cache, so this capability opts out of caching
+  // entirely rather than reconciling the timestamp with cache age.
+  // maxRetries: 2 (one retry, matching the shared default — see the
+  // "maxRetries" note in the fix report for why this is 2, not 1) bounds
+  // the Browserless leg's worst case at 2 attempts × 35s fetchTimeout +
+  // ~1-1.5s backoff between ≈ 71.5s.
   let html = await fetchRenderedHtml(url, {
     waitUntil: "networkidle0",
     pageTimeout: 25000,
     fetchTimeout: 35000,
     skipFallback: true,
     minHtmlLength: 50,
+    skipCache: true,
+    maxRetries: 2,
   });
 
   if (!html || html.length < 50) {

--- a/apps/api/src/capabilities/web-extract.ts
+++ b/apps/api/src/capabilities/web-extract.ts
@@ -1,8 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { registerCapability, type CapabilityInput } from "./index.js";
-import { validateUrl } from "../lib/url-validator.js";
 import { assertTargetAllowed } from "./lib/tos-blocklist.js";
 import { extractJsonObject } from "./lib/llm-json.js";
+import { fetchRenderedHtml } from "./lib/browserless-extract.js";
 
 registerCapability("web-extract", async (input: CapabilityInput) => {
   const url = input.url as string | undefined;
@@ -14,22 +14,15 @@ registerCapability("web-extract", async (input: CapabilityInput) => {
     );
   }
 
-  // F-0-006: the URL is forwarded to Browserless, which does the fetch
-  // from its own network. Our `safeFetch` dispatcher cannot protect that
-  // outbound call. The only layer we control is THIS validator: if it
-  // rejects the URL we never pass it along. Private IP / carrier-grade
-  // NAT / cloud metadata / non-http schemes are refused here before
-  // Browserless is even contacted.
   // Per-source ToS policy applies to EVERY fetch path, not only the purpose-
   // built extractors. Observed bypass (2026-08-12 activity analysis): a caller
   // refused on Trustpilot via product-reviews-extract re-ran the identical
   // extraction through web-extract with a raw prompt. Same blocklist, same
   // refusal, same compliant-alternative hint — closing the side door
   // commit 87b84db already flagged once for domain-contact-extract.
-  // (Pure string check — runs before the DNS-touching validateUrl.)
+  // (Pure string check — runs before fetchRenderedHtml's DNS-touching
+  // validateUrl, same ordering rationale as every other web-provider caller.)
   assertTargetAllowed(url);
-
-  await validateUrl(url);
 
   const browserlessUrl = process.env.BROWSERLESS_URL;
   const browserlessKey = process.env.BROWSERLESS_API_KEY;
@@ -44,37 +37,24 @@ registerCapability("web-extract", async (input: CapabilityInput) => {
     throw new Error("ANTHROPIC_API_KEY is required for web-extract.");
   }
 
-  // Step 1: Render page with Browserless
-  // buildBrowserlessRequestUrl appends ?launch= per-request — Browserless v2's
-  // LAUNCH_ARGS env var is deprecated/ignored. See lib/browserless-launch.ts.
-  const { buildBrowserlessRequestUrl } = await import("../lib/browserless-launch.js");
-  const contentUrl = buildBrowserlessRequestUrl(browserlessUrl, "/content", browserlessKey);
-
-  // unguarded-fetch-ok: our Browserless endpoint; caller URL gated by assertTargetAllowed above
-  const renderResponse = await fetch(contentUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      url,
-      // 25s matches every other Browserless caller (annual-report-extract,
-      // html-to-pdf, screenshot-url) and web-provider's default pageTimeout.
-      // Was 20s, the odd one out. Note this only helps pages that are slow but
-      // alive — an unreachable host burns the whole budget either way.
-      gotoOptions: { waitUntil: "networkidle0", timeout: 25000 },
-    }),
-    // Outer budget stays 10s above the navigation timeout so Browserless gets
-    // to return its own structured error instead of us aborting the socket.
-    signal: AbortSignal.timeout(35000),
+  // Step 1: Render page via the shared web-provider layer (lib/web-provider.ts)
+  // — retry with exponential backoff, a 5-minute response cache, and a
+  // concurrency limiter on top of Browserless, the same resilience the other
+  // 47+ Browserless-backed capabilities get. web-extract's output contract
+  // promises full JavaScript rendering (manifest: "Handles SPAs, dynamic
+  // content, and pages that require JS to load", data_source: "Headless
+  // browser rendering via Browserless.io"), so skipFallback bypasses
+  // web-provider's plain-fetch and Jina Reader tiers — neither runs the
+  // page's JS, and Jina reformats the document, which would silently change
+  // both the extracted content and the <title> this capability parses out.
+  // waitUntil/pageTimeout/fetchTimeout reproduce the previous bare-fetch call
+  // exactly (networkidle0, 25s nav timeout, 35s outer budget).
+  let html = await fetchRenderedHtml(url, {
+    waitUntil: "networkidle0",
+    pageTimeout: 25000,
+    fetchTimeout: 35000,
+    skipFallback: true,
   });
-
-  if (!renderResponse.ok) {
-    const errText = await renderResponse.text().catch(() => "");
-    throw new Error(
-      `Failed to render page: Browserless returned HTTP ${renderResponse.status}: ${errText.slice(0, 200)}`,
-    );
-  }
-
-  let html = await renderResponse.text();
 
   if (!html || html.length < 50) {
     throw new Error("Page returned empty or too-short content.");

--- a/apps/api/src/capabilities/web-extract.ts
+++ b/apps/api/src/capabilities/web-extract.ts
@@ -49,11 +49,17 @@ registerCapability("web-extract", async (input: CapabilityInput) => {
   // both the extracted content and the <title> this capability parses out.
   // waitUntil/pageTimeout/fetchTimeout reproduce the previous bare-fetch call
   // exactly (networkidle0, 25s nav timeout, 35s outer budget).
+  // minHtmlLength: 50 reproduces web-extract's own pre-existing threshold —
+  // the shared layer's default (100) would otherwise silently tighten it
+  // (external review finding, 2026-08-16). The redundant local length guard
+  // right below is kept as a defense-in-depth backstop, not the enforcement
+  // point.
   let html = await fetchRenderedHtml(url, {
     waitUntil: "networkidle0",
     pageTimeout: 25000,
     fetchTimeout: 35000,
     skipFallback: true,
+    minHtmlLength: 50,
   });
 
   if (!html || html.length < 50) {

--- a/apps/api/src/lib/dependency-manifest.ts
+++ b/apps/api/src/lib/dependency-manifest.ts
@@ -108,7 +108,7 @@ export const PROVIDERS: DependencyProvider[] = [
       "html-to-pdf",             // requires real Chromium PDF rendering
       "landing-page-roast",      // direct Browserless screenshot
       "screenshot-url",          // requires real Chromium screenshots
-      "web-extract",             // direct Browserless call for extraction
+      "web-extract",             // web-provider.ts with skipFallback: true — no plain-fetch/Jina tier, so still requires Browserless
     ],
     tier: "self-hosted",
   },


### PR DESCRIPTION
## Summary
- web-extract's Browserless rendering now goes through the shared web-provider layer (retry with backoff, concurrency limiting) instead of a bare single-attempt fetch — the last 14 days of real customer failures on this capability were transient timeouts/429s a retry would largely have absorbed.
- `skipFallback` (new option, default off) protects its full-JS-rendering contract from plain-fetch/Jina substitution; `skipCache: true` keeps the live-fetch freshness promise honest (`provenance.fetched_at` never describes a cached render).
- Error messages hardened: fixed strings only — no upstream body bytes can reach a customer-facing message; permanent net-errors (DNS/refused/TLS) get "retrying will not help" AND genuinely skip the retry (scoped to 5xx; 408/429 keep their retry semantics).
- Shared-layer fixes that benefit all ~47 callers: cache keys namespaced by rendering tier + waitUntil (blocker: cross-tier cache contamination), 408 classified transient, cache hits revalidated against the caller's minHtmlLength.

## Verification
- Typecheck: clean. Full suite: 1753 passed / 33 skipped; targeted suite 17/17.
- /go gates: capability validation green; smoke test 10/11 (the one "failure" is ALLOW_MATRIX refusing live paid execution from test context — cost protection by design, identical on main); standalone checkReadiness harness reports no-executor for every capability incl. known-good controls (harness artifact — the green suite bootstraps all executors and is the real evidence).
- Fail-before/pass-after evidence per round for every regression test (path-scoped checkouts, no git stash).
- Six-lens review (technical + product) + 5 Codex cross-provider rounds; 1 HIGH (fabricated provenance on cache hits), 1 HIGH (body bytes in cert message) and mediums found and fixed; final verdict "APPROVE — no findings".

## Reviewer findings
- MEDIUM (deferred, documented): concurrency permit held across backoff sleeps — throughput-only, needs test-only introspection to fix safely.
- LOW (deferred): browser-slot queue has no waiter timeout; a hung render can strand queued callers.
- Note (architect): skipFallback + minHtmlLength are single-consumer booleans; if a second caller needs different resilience semantics, consider a renderMode enum instead of a third option.
- Note (product): worst-case render path is ~2×35s + backoff vs the old 35s ceiling; maxRetries pinned at 2 with the bound documented.

## Test plan
- Merge → deploy → next real web-extract traffic should show retries absorbing transient 429/timeouts (transactions error text), zero cached-render provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)