### PR TITLE
test(api): first-ever wallet coverage + /v1/do core paths, mutation-verified (Phase 1)

### DIFF
--- a/apps/api/src/routes/do.core.test.ts
+++ b/apps/api/src/routes/do.core.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Route-level regression tests for POST /v1/do — the core execution
+ * endpoint (Phase 1 / T1.2 of the Codebase Quality Program,
+ * docs/strategy/2026-08-16-codebase-quality-program.md).
+ *
+ * Scope: the authenticated, paid-capability sync path (executeSync).
+ * do.spend-cap.test.ts already covers the in-tx spend-cap re-check at
+ * the unit level (spendCapWouldExceed) — this file does not duplicate
+ * that; every fixture user here has maxSpendPerHourCents: null so the
+ * spend-cap branch is skipped entirely.
+ *
+ * Harness: mounts `doRoute` directly on a bare Hono app (not the full
+ * app.ts) — do.ts's own try/catch blocks build every structured error
+ * response the tests below assert on (apiError(...)), so app.ts's
+ * top-level onError is not in the path being tested. This also avoids
+ * pulling in the rest of app.ts's route graph (mcp.js, admin routes,
+ * etc.), keeping the mock surface to what do.ts itself imports.
+ *
+ * Module boundaries mocked (matching the "mock at module boundaries"
+ * convention used by transactions.test.ts / internal-auth.test.ts):
+ *   - ../db/index.js — getDb(). Outer db.select() is a FIFO queue (each
+ *     test pushes exactly the rows each SELECT in the request path will
+ *     consume, in call order); db.transaction() invokes a hand-built
+ *     mock tx object; db.insert() records every insert for assertion
+ *     (used for the failed_requests no_match logging path).
+ *   - ../lib/matching.js (matchCapability) — fully controlled per test.
+ *   - ../capabilities/index.js (getExecutor) — fully controlled per test.
+ *   - ../capabilities/guarded-executor.js — assertGuardedAllow forced to
+ *     allow (real error classes kept via importOriginal so `instanceof`
+ *     checks in do.ts still work if ever exercised).
+ *   - ../lib/circuit-breaker.js, quality-capture.js, event-triggers.js,
+ *     piggyback-monitor.js, quality-aggregation.js, x402-gateway.js,
+ *     progressive-unlock.js, milestones.js, activation-hook.js — all
+ *     no-op stubs. These are fire-and-forget telemetry/side-channel
+ *     concerns in the paths under test; real implementations touch DB
+ *     tables (capability_health, cost budgets, etc.) this harness does
+ *     not model.
+ *
+ * Left real (pure, no DB, no env-gated throw beyond what
+ * test-env-setup.ts already satisfies): lib/rate-limit.ts (in-memory;
+ * each test uses a fresh random user id so rateLimitByKey's 10 req/sec
+ * bucket never collides across tests), lib/middleware.ts
+ * (optionalAuthMiddleware — exercised for real against the mocked
+ * `users` row), lib/attribution.ts, lib/audit-token.ts,
+ * lib/audit-helpers.ts, lib/sanitize.ts, lib/provenance-builder.ts,
+ * lib/processing-location.ts, lib/trust-grade.ts, lib/errors.ts.
+ *
+ * Uncovered paths (documented per the task's instruction not to fake
+ * coverage): executeAsync / executeInBackground (async execution,
+ * DEC-22 — avgLatencyMs > 10s), the x402 unauthenticated payment path,
+ * free-tier (unauthenticated and authenticated-free-tier) execution,
+ * the postgres 25P03/55P03 timeout-code catch branch, and the
+ * low-balance/zero-balance conversion-email fire-and-forget branch.
+ * Each depends on either a second DB-shaped mock surface (async
+ * background-worker semantics) or triggers not exercised by the core
+ * paths this task scoped in. Flagged for a follow-up pass rather than
+ * asserted on with a mock that would tautologically pass.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { Hono } from "hono";
+
+import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
+import { wallets, transactions, walletTransactions } from "../db/schema.js";
+
+// ─── Hoisted mutable mock state (referenced from vi.mock factories) ───────────
+
+const mocks = vi.hoisted(() => ({
+  outerSelectQueue: [] as unknown[][],
+  outerInserts: [] as Array<{ table: unknown; vals: unknown }>,
+  dbTransactionCalls: 0,
+  // Set per-test before the request; consumed by db.transaction(cb).
+  txRef: { current: null as unknown },
+}));
+
+vi.mock("../db/index.js", () => {
+  function chainableFromQueue() {
+    const rows = (mocks.outerSelectQueue.shift() as unknown[]) ?? [];
+    const p = Promise.resolve(rows) as Promise<unknown[]> & {
+      limit?: (n: number) => Promise<unknown[]>;
+    };
+    (p as any).limit = (n: number) => Promise.resolve(rows.slice(0, n));
+    return p;
+  }
+  return {
+    getDb: () => ({
+      select: () => ({ from: () => ({ where: () => chainableFromQueue() }) }),
+      insert: (table: unknown) => ({
+        values: (vals: unknown) => {
+          mocks.outerInserts.push({ table, vals });
+          return Promise.resolve([]);
+        },
+      }),
+      execute: async () => [],
+      transaction: async (cb: (tx: unknown) => unknown) => {
+        mocks.dbTransactionCalls++;
+        return cb(mocks.txRef.current);
+      },
+    }),
+  };
+});
+
+vi.mock("../lib/matching.js", () => ({ matchCapability: vi.fn() }));
+
+vi.mock("../capabilities/index.js", () => ({
+  getExecutor: vi.fn(),
+  registerCapability: vi.fn(),
+  getDirectExecutor: vi.fn(),
+  getRegisteredCount: vi.fn(() => 0),
+}));
+
+vi.mock("../capabilities/guarded-executor.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, assertGuardedAllow: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock("../lib/circuit-breaker.js", () => ({
+  checkCircuitBreaker: vi.fn().mockResolvedValue({ allowed: true }),
+  recordSuccess: vi.fn().mockResolvedValue(undefined),
+  recordFailure: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../lib/quality-capture.js", () => ({ recordQuality: vi.fn() }));
+vi.mock("../lib/event-triggers.js", () => ({ triggerOnFailure: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../lib/piggyback-monitor.js", () => ({ recordPiggybackResult: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../lib/quality-aggregation.js", () => ({
+  getCapabilityQuality: vi.fn().mockResolvedValue({ p95ResponseTimeMs: null }),
+}));
+vi.mock("../lib/x402-gateway.js", () => ({
+  isX402Configured: vi.fn(() => false),
+  build402Response: vi.fn(),
+  verifyX402PaymentOnly: vi.fn(),
+  settleX402Payment: vi.fn(),
+  extractPaymentHeader: vi.fn(() => null),
+}));
+vi.mock("../lib/progressive-unlock.js", () => ({
+  recordUnlock: vi.fn(() => []),
+  isUnlocked: vi.fn(() => false),
+  getUnlockedSlugs: vi.fn(() => []),
+}));
+vi.mock("../lib/milestones.js", () => ({ checkMilestone: vi.fn() }));
+vi.mock("../lib/activation-hook.js", () => ({ onFirstTransaction: vi.fn().mockResolvedValue(undefined) }));
+
+// ─── Test helpers ──────────────────────────────────────────────────────────
+
+const TEST_API_KEY = "sk_live_" + "b".repeat(56);
+
+function buildUserRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: randomUUID(),
+    email: "do-core-test@example.com",
+    apiKeyHash: hashApiKey(TEST_API_KEY),
+    keyPrefix: getKeyPrefix(TEST_API_KEY),
+    maxSpendPerHourCents: null,
+    ...overrides,
+  };
+}
+
+function authHeaders(extra: Record<string, string> = {}) {
+  return {
+    Authorization: `Bearer ${TEST_API_KEY}`,
+    "content-type": "application/json",
+    ...extra,
+  };
+}
+
+function chainablePromise(rows: unknown[]) {
+  const p = Promise.resolve(rows) as any;
+  p.limit = (n: number) => Promise.resolve(rows.slice(0, n));
+  p.for = () => Promise.resolve(rows);
+  p.orderBy = () => chainablePromise(rows);
+  return p;
+}
+
+/** Builds the tx object handed to db.transaction(cb) inside executeSync. */
+function buildMockTx(opts: { walletRow: Record<string, unknown> | null; transactionId: string }) {
+  const insertCalls: Array<{ table: unknown; vals: unknown }> = [];
+  const updateCalls: Array<{ table: unknown; vals: unknown }> = [];
+  return {
+    __insertCalls: insertCalls,
+    __updateCalls: updateCalls,
+    execute: vi.fn(async () => []),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => chainablePromise(opts.walletRow ? [opts.walletRow] : [])),
+      })),
+    })),
+    insert: vi.fn((table: unknown) => ({
+      values: vi.fn((vals: unknown) => {
+        insertCalls.push({ table, vals });
+        const p = Promise.resolve([]) as any;
+        p.returning = () => Promise.resolve([{ id: opts.transactionId }]);
+        return p;
+      }),
+    })),
+    update: vi.fn((table: unknown) => ({
+      set: vi.fn((vals: unknown) => ({
+        where: vi.fn(() => {
+          updateCalls.push({ table, vals });
+          return Promise.resolve([]);
+        }),
+      })),
+    })),
+  };
+}
+
+const CAPABILITY_FIXTURE = {
+  id: "11111111-1111-1111-1111-111111111111",
+  slug: "test-capability",
+  name: "Test Capability",
+  priceCents: 5,
+  isActive: true,
+  isFreeTier: false,
+  lifecycleState: "active",
+  capabilityType: "deterministic",
+  transparencyTag: "algorithmic",
+  dataSource: "Test Source",
+  dataClassification: null,
+  freshnessCategory: "live-fetch",
+  dataUpdateCycleDays: null,
+  datasetLastUpdated: null,
+  processesPersonalData: false,
+  personalDataCategories: [],
+  avgLatencyMs: 200, // well under ASYNC_THRESHOLD_MS (10_000) — forces executeSync
+  outputSchema: { type: "object", properties: {} },
+  inputSchema: { type: "object", properties: { value: { type: "string" } }, required: [] },
+};
+
+async function flushMicrotasks() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.route("/v1", doRoute);
+  app.onError((_err, c) =>
+    c.json({ error_code: "internal_error", message: "An unexpected error occurred. Please try again." }, 500),
+  );
+  return app;
+}
+
+// Imports after the mocks/helpers above so vi.mock hoisting applies cleanly.
+import { doRoute } from "./do.js";
+import { matchCapability } from "../lib/matching.js";
+import { getExecutor } from "../capabilities/index.js";
+
+const mockMatchCapability = matchCapability as unknown as ReturnType<typeof vi.fn>;
+const mockGetExecutor = getExecutor as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mocks.outerSelectQueue = [];
+  mocks.outerInserts = [];
+  mocks.dbTransactionCalls = 0;
+  mocks.txRef.current = null;
+  mockMatchCapability.mockReset();
+  mockGetExecutor.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /v1/do — happy path (authenticated, paid capability, sync)", () => {
+  it("debits the wallet, executes the capability, and returns {result:{output,...}} with wallet_balance_cents", async () => {
+    const user = buildUserRow();
+    const startingBalance = 10_000; // €100.00 — well above LOW_BALANCE_THRESHOLD after debit
+    mocks.outerSelectQueue.push([user]); // optionalAuthMiddleware lookup
+
+    const executorFn = vi.fn(async (input: Record<string, unknown>) => ({
+      output: { echoed: input.value, ok: true },
+      provenance: { source: "test-source", fetched_at: new Date().toISOString() },
+    }));
+    mockGetExecutor.mockReturnValue(executorFn);
+    mockMatchCapability.mockResolvedValue({ capability: CAPABILITY_FIXTURE });
+
+    const walletId = randomUUID();
+    const txnId = randomUUID();
+    mocks.txRef.current = buildMockTx({
+      walletRow: { id: walletId, userId: user.id, balanceCents: startingBalance },
+      transactionId: txnId,
+    });
+
+    const app = makeApp();
+    const res = await app.request("/v1/do", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        capability_slug: "test-capability",
+        inputs: { value: "hello" },
+        max_price_cents: 100,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.result).toBeDefined();
+    expect(body.result.status).toBe("completed");
+    expect(body.result.capability_used).toBe("test-capability");
+    expect(body.result.price_cents).toBe(CAPABILITY_FIXTURE.priceCents);
+    expect(body.result.wallet_balance_cents).toBe(startingBalance - CAPABILITY_FIXTURE.priceCents);
+    expect(body.result.output).toEqual({ echoed: "hello", ok: true });
+    expect(body.meta.audit).toBeTruthy();
+    // Money is integer cents, not a formatted string (wire-shape rule).
+    expect(typeof body.result.wallet_balance_cents).toBe("number");
+    expect(typeof body.result.price_cents).toBe("number");
+
+    expect(executorFn).toHaveBeenCalledTimes(1);
+    expect(executorFn).toHaveBeenCalledWith({ value: "hello" });
+
+    const tx = mocks.txRef.current as ReturnType<typeof buildMockTx>;
+    // Wallet debited by exactly the capability price.
+    const walletUpdate = tx.__updateCalls.find((c) => c.table === wallets);
+    expect(walletUpdate).toBeTruthy();
+    expect((walletUpdate!.vals as any).balanceCents).toBe(startingBalance - CAPABILITY_FIXTURE.priceCents);
+    // Wallet transaction ledger entry logged.
+    const walletTxInsert = tx.__insertCalls.find((c) => c.table === walletTransactions);
+    expect(walletTxInsert).toBeTruthy();
+    expect((walletTxInsert!.vals as any).amountCents).toBe(-CAPABILITY_FIXTURE.priceCents);
+    // Transaction row marked completed.
+    const txnUpdate = tx.__updateCalls.find((c) => c.table === transactions);
+    expect((txnUpdate!.vals as any).status).toBe("completed");
+  });
+});
+
+describe("POST /v1/do — no matching capability", () => {
+  it("returns a structured no_matching_capability error and logs to failed_requests", async () => {
+    const user = buildUserRow();
+    mocks.outerSelectQueue.push([user]);
+    mockMatchCapability.mockResolvedValue(null);
+
+    const app = makeApp();
+    const res = await app.request("/v1/do", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        task: "do something nobody offers",
+        max_price_cents: 100,
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error_code).toBe("no_matching_capability");
+    expect(typeof body.message).toBe("string");
+    expect(body.details).toMatchObject({ task: "do something nobody offers", max_price_cents: 100 });
+    // Pin the documented failure shape: no top-level `error` key.
+    expect(body.error).toBeUndefined();
+
+    await flushMicrotasks();
+    expect(mocks.outerInserts.length).toBe(1);
+    expect((mocks.outerInserts[0].vals as any).failureType).toBe("no_match");
+    expect((mocks.outerInserts[0].vals as any).userId).toBe(user.id);
+
+    expect(mocks.dbTransactionCalls).toBe(0);
+  });
+});
+
+describe("POST /v1/do — insufficient balance", () => {
+  it("returns 402 insufficient_balance without creating a transaction record or debiting", async () => {
+    const user = buildUserRow();
+    mocks.outerSelectQueue.push([user]);
+    mockMatchCapability.mockResolvedValue({ capability: CAPABILITY_FIXTURE }); // price 5 cents
+    mockGetExecutor.mockReturnValue(vi.fn());
+
+    mocks.txRef.current = buildMockTx({
+      walletRow: { id: randomUUID(), userId: user.id, balanceCents: 2 }, // less than priceCents (5)
+      transactionId: randomUUID(),
+    });
+
+    const app = makeApp();
+    const res = await app.request("/v1/do", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        capability_slug: "test-capability",
+        inputs: { value: "x" },
+        max_price_cents: 100,
+      }),
+    });
+
+    expect(res.status).toBe(402);
+    const body = await res.json();
+    expect(body.error_code).toBe("insufficient_balance");
+    expect(body.details.wallet_balance_cents).toBe(2);
+    expect(body.details.required_cents).toBe(CAPABILITY_FIXTURE.priceCents);
+    expect(body.error).toBeUndefined();
+
+    const tx = mocks.txRef.current as ReturnType<typeof buildMockTx>;
+    expect(tx.__insertCalls.length).toBe(0); // no transaction row created
+    expect(tx.__updateCalls.length).toBe(0); // no debit
+  });
+});
+
+describe("POST /v1/do — idempotency replay", () => {
+  it("returns the stored result for a repeated Idempotency-Key without re-executing or re-matching", async () => {
+    const user = buildUserRow();
+    const existingTxn = {
+      id: randomUUID(),
+      status: "completed",
+      priceCents: CAPABILITY_FIXTURE.priceCents,
+      latencyMs: 42,
+      output: { echoed: "original", ok: true },
+      provenance: { source: "test-source", fetched_at: "2026-08-01T00:00:00Z" },
+      auditTrail: { transaction_id: "stored-audit" },
+    };
+    mocks.outerSelectQueue.push([user]); // auth
+    mocks.outerSelectQueue.push([existingTxn]); // idempotency lookup
+    mocks.outerSelectQueue.push([{ balanceCents: 9_995 }]); // balance for response
+
+    const app = makeApp();
+    const res = await app.request("/v1/do", {
+      method: "POST",
+      headers: authHeaders({ "Idempotency-Key": "replay-key-1" }),
+      body: JSON.stringify({
+        capability_slug: "test-capability",
+        inputs: { value: "hello-again" },
+        max_price_cents: 100,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.transaction_id).toBe(existingTxn.id);
+    expect(body.status).toBe("completed");
+    expect(body.price_cents).toBe(existingTxn.priceCents);
+    expect(body.output).toEqual(existingTxn.output);
+    expect(body.wallet_balance_cents).toBe(9_995);
+    expect(body.meta.idempotency_replay).toBe(true);
+    expect(body.meta.audit).toEqual(existingTxn.auditTrail);
+
+    // No re-execution: matching/execution never ran, no new charge attempted.
+    expect(mockMatchCapability).not.toHaveBeenCalled();
+    expect(mockGetExecutor).not.toHaveBeenCalled();
+    expect(mocks.dbTransactionCalls).toBe(0);
+  });
+});
+
+describe("POST /v1/do — dry_run", () => {
+  it("reports what would execute without charging or invoking the executor", async () => {
+    const user = buildUserRow();
+    mocks.outerSelectQueue.push([user]); // auth
+    mockMatchCapability.mockResolvedValue({ capability: CAPABILITY_FIXTURE });
+    const executorFn = vi.fn();
+    mockGetExecutor.mockReturnValue(executorFn);
+    mocks.outerSelectQueue.push([{ balanceCents: 10_000 }]); // dry-run balance fetch
+
+    const app = makeApp();
+    const res = await app.request("/v1/do", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        capability_slug: "test-capability",
+        inputs: { value: "x" },
+        max_price_cents: 100,
+        dry_run: true,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      dry_run: true,
+      would_execute: "test-capability",
+      price_cents: CAPABILITY_FIXTURE.priceCents,
+      wallet_balance_cents: 10_000,
+      wallet_sufficient: true,
+    });
+
+    expect(executorFn).not.toHaveBeenCalled();
+    expect(mocks.dbTransactionCalls).toBe(0);
+  });
+});
+
+describe("POST /v1/do — execution failure shape + DEC-14 ordering", () => {
+  it("returns execution_failed with details.error (no top-level error key) and leaves the wallet untouched", async () => {
+    const user = buildUserRow();
+    mocks.outerSelectQueue.push([user]);
+    mockMatchCapability.mockResolvedValue({ capability: CAPABILITY_FIXTURE });
+    const executorFn = vi.fn(async () => {
+      throw new Error("mock executor rejected the request");
+    });
+    mockGetExecutor.mockReturnValue(executorFn);
+
+    const startingBalance = 10_000;
+    mocks.txRef.current = buildMockTx({
+      walletRow: { id: randomUUID(), userId: user.id, balanceCents: startingBalance },
+      transactionId: randomUUID(),
+    });
+
+    const app = makeApp();
+    const res = await app.request("/v1/do", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        capability_slug: "test-capability",
+        inputs: { value: "x" },
+        max_price_cents: 100,
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+
+    // Pin the exact documented shape (MEMORY.md: three false alarms on
+    // 2026-08-14 traced to assuming a top-level `error` key on failure).
+    expect(body.error_code).toBe("execution_failed");
+    expect(typeof body.message).toBe("string");
+    expect(body.error).toBeUndefined();
+    expect(body.details.error).toBe("mock executor rejected the request");
+    expect(body.details.wallet_balance_cents).toBe(startingBalance);
+
+    // DEC-14: lock → execute → deduct on success. Execution failed, so no
+    // debit and no wallet_transactions ledger entry.
+    const tx = mocks.txRef.current as ReturnType<typeof buildMockTx>;
+    const walletUpdate = tx.__updateCalls.find((c) => c.table === wallets);
+    expect(walletUpdate).toBeUndefined();
+    const walletTxInsert = tx.__insertCalls.find((c) => c.table === walletTransactions);
+    expect(walletTxInsert).toBeUndefined();
+    // The transaction row is still marked failed for the audit trail.
+    const txnUpdate = tx.__updateCalls.find((c) => c.table === transactions);
+    expect((txnUpdate!.vals as any).status).toBe("failed");
+  });
+});

--- a/apps/api/src/routes/do.core.test.ts
+++ b/apps/api/src/routes/do.core.test.ts
@@ -41,9 +41,16 @@
  *     means a code change that drops `.for("update")` (the DEC-8
  *     double-spend lock) breaks at await-time (destructuring a
  *     non-iterable) rather than silently succeeding against a mock that
- *     is thenable either way; `.for` calls are also recorded on
- *     `tx.__forCalls` and asserted on directly in the happy-path and
- *     DEC-14 tests.
+ *     is thenable either way. The table passed to `.from()` and the real
+ *     Drizzle condition passed to `.where()` are ALSO recorded (on
+ *     `tx.__selectCalls`, alongside the `.for()` mode) — not just the
+ *     lock mode — so the happy-path and DEC-14 tests can assert the
+ *     locked select actually targeted `wallets` with a where-clause
+ *     scoped to the authenticated user's id, the same fidelity the outer
+ *     db mock has. Recording only the mode (an earlier version of this
+ *     file did) left a gap: mutating do.ts's wallet-lock condition from
+ *     `eq(wallets.userId, user.id)` to `eq(wallets.id, user.id)` still
+ *     returned the canned wallet row and every lock-path test passed.
  *   - db.insert() records every insert (table + values) for assertion
  *     (used for the failed_requests no_match logging path).
  *
@@ -212,8 +219,19 @@ function whereReferences(cond: unknown, table: unknown, columnName: string, matc
         const next = chunks[i + 1];
         if (isStringChunk(next) && next.value.join("").toLowerCase().includes("is null")) return true;
       } else {
+        // MEDIUM (residual): verify the chunk BETWEEN the column and the
+        // param is actually the equality operator, not just that a column
+        // ref and a matching param happen to be two slots apart. Without
+        // this, eq(col, v) → ne(col, v) is invisible: ne() emits the exact
+        // same [Column, StringChunk(" <> "), Param] shape at these indices,
+        // just with " <> " instead of " = " — an eq→ne swap leaves the
+        // column ref and the param VALUE both unchanged, only the operator
+        // text differs.
+        const opChunk = chunks[i + 1];
         const paramChunk = chunks[i + 2];
-        if (isParamChunk(paramChunk) && paramChunk.value === match.eq) return true;
+        const opText = isStringChunk(opChunk) ? opChunk.value.join("") : "";
+        const isEqualityOperator = opText.includes("=") && !opText.includes("<>") && !opText.includes("!=");
+        if (isEqualityOperator && isParamChunk(paramChunk) && paramChunk.value === match.eq) return true;
       }
     }
   }
@@ -256,25 +274,37 @@ function authHeaders(extra: Record<string, string> = {}) {
  * plain `{ for }` object (a no-op — non-Promise objects pass through
  * `await` unchanged) and the subsequent `const [wallet] = ...`
  * destructure would throw (plain objects aren't iterable), surfacing as
- * a 500 in the tests below. `.for` calls are also recorded on
- * `__forCalls` so the happy-path/DEC-14 tests can assert
- * `.for("update")` fired exactly once, independent of that crash-based
- * signal.
+ * a 500 in the tests below. The `table`/`cond`/`mode` triple is recorded
+ * on `__selectCalls` at the point `.for()` fires, so the happy-path/
+ * DEC-14 tests can assert both that `.for("update")` fired exactly once
+ * AND that the locked select actually targeted `wallets` with a
+ * where-clause scoped to `wallets.userId = <the authenticated user>` —
+ * independent of the crash-based signal above, which only catches a
+ * *dropped* lock, not a *mistargeted* one.
  */
 function buildMockTx(opts: { walletRow: Record<string, unknown> | null; transactionId: string }) {
   const insertCalls: Array<{ table: unknown; vals: unknown }> = [];
   const updateCalls: Array<{ table: unknown; vals: unknown }> = [];
-  const forCalls: string[] = [];
+  // MAJOR (residual): previously only `.for(mode)` was recorded — the
+  // table passed to `.from()` and the condition passed to `.where()` were
+  // both discarded, so a mutation on do.ts ~1668 that swapped
+  // eq(wallets.userId, user.id) for eq(wallets.id, user.id) still handed
+  // back the canned wallet row and every lock-path test passed. Recorded
+  // exactly like the outer db mock now: table + cond + mode, all captured
+  // at the point `.for()` actually fires (the only call shape the
+  // exercised code path uses — see the file-header note on the FOR-UPDATE
+  // gating this select provides).
+  const selectCalls: Array<{ table: unknown; cond: unknown; mode: string }> = [];
   return {
     __insertCalls: insertCalls,
     __updateCalls: updateCalls,
-    __forCalls: forCalls,
+    __selectCalls: selectCalls,
     execute: vi.fn(async () => []),
     select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn((cond: unknown) => ({
           for: vi.fn((mode: string) => {
-            forCalls.push(mode);
+            selectCalls.push({ table, cond, mode });
             return Promise.resolve(opts.walletRow ? [opts.walletRow] : []);
           }),
         })),
@@ -411,8 +441,13 @@ describe("POST /v1/do — happy path (authenticated, paid capability, sync)", ()
     expect(whereReferences(authSelect.cond, users, "key_prefix", { eq: getKeyPrefix(TEST_API_KEY) })).toBe(true);
 
     const tx = mocks.txRef.current as ReturnType<typeof buildMockTx>;
-    // MAJOR 4 (DEC-8): the wallet row was read under FOR UPDATE, exactly once.
-    expect(tx.__forCalls).toEqual(["update"]);
+    // MAJOR 4 (DEC-8), residual fix: the wallet row was read under FOR
+    // UPDATE, exactly once, AND the lock targeted the `wallets` table
+    // scoped to THIS user's id — not just "some FOR UPDATE call happened".
+    expect(tx.__selectCalls).toHaveLength(1);
+    expect(tx.__selectCalls[0].mode).toBe("update");
+    expect(tx.__selectCalls[0].table).toBe(wallets);
+    expect(whereReferences(tx.__selectCalls[0].cond, wallets, "user_id", { eq: user.id })).toBe(true);
     // Wallet debited by exactly the capability price.
     const walletUpdate = tx.__updateCalls.find((c) => c.table === wallets);
     expect(walletUpdate).toBeTruthy();
@@ -500,7 +535,12 @@ describe("POST /v1/do — insufficient balance", () => {
     expect(executorSpy).not.toHaveBeenCalled();
 
     const tx = mocks.txRef.current as ReturnType<typeof buildMockTx>;
-    expect(tx.__forCalls).toEqual(["update"]); // the lock is still taken to read the balance
+    // The lock is still taken to read the balance, and targets THIS
+    // user's wallet row — not just "a FOR UPDATE call happened".
+    expect(tx.__selectCalls).toHaveLength(1);
+    expect(tx.__selectCalls[0].mode).toBe("update");
+    expect(tx.__selectCalls[0].table).toBe(wallets);
+    expect(whereReferences(tx.__selectCalls[0].cond, wallets, "user_id", { eq: user.id })).toBe(true);
     expect(tx.__insertCalls.length).toBe(0); // no transaction row created
     expect(tx.__updateCalls.length).toBe(0); // no debit
   });
@@ -640,9 +680,12 @@ describe("POST /v1/do — execution failure shape + DEC-14 ordering", () => {
     expect(body.details.wallet_balance_cents).toBe(startingBalance);
 
     // DEC-8: the wallet was still read under FOR UPDATE before anything
-    // else happened.
+    // else happened, scoped to THIS user's wallet row.
     const tx = mocks.txRef.current as ReturnType<typeof buildMockTx>;
-    expect(tx.__forCalls).toEqual(["update"]);
+    expect(tx.__selectCalls).toHaveLength(1);
+    expect(tx.__selectCalls[0].mode).toBe("update");
+    expect(tx.__selectCalls[0].table).toBe(wallets);
+    expect(whereReferences(tx.__selectCalls[0].cond, wallets, "user_id", { eq: user.id })).toBe(true);
 
     // DEC-14: lock → execute → deduct on success. Execution failed, so no
     // debit and no wallet_transactions ledger entry.

--- a/apps/api/src/routes/do.core.test.ts
+++ b/apps/api/src/routes/do.core.test.ts
@@ -1,7 +1,6 @@
 /**
  * Route-level regression tests for POST /v1/do — the core execution
- * endpoint (Phase 1 / T1.2 of the Codebase Quality Program,
- * docs/strategy/2026-08-16-codebase-quality-program.md).
+ * endpoint (Phase 1 / T1.2 of the Codebase Quality Program).
  *
  * Scope: the authenticated, paid-capability sync path (executeSync).
  * do.spend-cap.test.ts already covers the in-tx spend-cap re-check at
@@ -10,40 +9,65 @@
  * spend-cap branch is skipped entirely.
  *
  * Harness: mounts `doRoute` directly on a bare Hono app (not the full
- * app.ts) — do.ts's own try/catch blocks build every structured error
- * response the tests below assert on (apiError(...)), so app.ts's
- * top-level onError is not in the path being tested. This also avoids
- * pulling in the rest of app.ts's route graph (mcp.js, admin routes,
- * etc.), keeping the mock surface to what do.ts itself imports.
+ * app.ts). Only one response in the paths under test is actually a
+ * try/catch product — the execution_failed branch, built from the
+ * executor's thrown error. The rest (no_matching_capability,
+ * insufficient_balance, spend_cap_exceeded, dry_run, the idempotency
+ * replay) are ordinary route branches / early returns built the same
+ * way regardless of which app the route is mounted on, so app.ts's
+ * top-level onError is not load-bearing for what these tests assert;
+ * mounting doRoute directly (instead of the whole app.ts route graph)
+ * keeps the mock surface to what do.ts itself imports.
  *
- * Module boundaries mocked (matching the "mock at module boundaries"
- * convention used by transactions.test.ts / internal-auth.test.ts):
- *   - ../db/index.js — getDb(). Outer db.select() is a FIFO queue (each
- *     test pushes exactly the rows each SELECT in the request path will
- *     consume, in call order); db.transaction() invokes a hand-built
- *     mock tx object; db.insert() records every insert for assertion
+ * DB mock fidelity:
+ *   - Outer db.select() is a FIFO row queue (each test pushes exactly
+ *     the rows each SELECT in the request path will consume, in call
+ *     order) that also RECORDS, per call, the `table` passed to
+ *     `.from()` and the real Drizzle condition object passed to
+ *     `.where()` — `eq`/`and`/`isNull` are the real drizzle-orm
+ *     functions, never mocked. `whereReferences()` below walks the
+ *     condition's `queryChunks` (the shape do.spend-cap.test.ts's
+ *     `findDateChunks` already walks) to answer structurally "does this
+ *     where-clause reference table.column [= value | IS NULL]?" — so a
+ *     mutation that drops a scoping predicate (e.g. the idempotency
+ *     lookup losing its user-id scope, which would replay a DIFFERENT
+ *     user's transaction) is caught instead of silently passing through
+ *     a mock that answers every query with the same fixture regardless
+ *     of what was asked.
+ *   - db.transaction() invokes a hand-built mock tx object whose
+ *     `select().from().where()` is deliberately NOT awaitable on its
+ *     own — it exposes only `.for(mode)`, which is the only shape the
+ *     exercised code path (the wallet-lock read) actually calls. This
+ *     means a code change that drops `.for("update")` (the DEC-8
+ *     double-spend lock) breaks at await-time (destructuring a
+ *     non-iterable) rather than silently succeeding against a mock that
+ *     is thenable either way; `.for` calls are also recorded on
+ *     `tx.__forCalls` and asserted on directly in the happy-path and
+ *     DEC-14 tests.
+ *   - db.insert() records every insert (table + values) for assertion
  *     (used for the failed_requests no_match logging path).
- *   - ../lib/matching.js (matchCapability) — fully controlled per test.
- *   - ../capabilities/index.js (getExecutor) — fully controlled per test.
- *   - ../capabilities/guarded-executor.js — assertGuardedAllow forced to
- *     allow (real error classes kept via importOriginal so `instanceof`
- *     checks in do.ts still work if ever exercised).
- *   - ../lib/circuit-breaker.js, quality-capture.js, event-triggers.js,
- *     piggyback-monitor.js, quality-aggregation.js, x402-gateway.js,
- *     progressive-unlock.js, milestones.js, activation-hook.js — all
- *     no-op stubs. These are fire-and-forget telemetry/side-channel
- *     concerns in the paths under test; real implementations touch DB
- *     tables (capability_health, cost budgets, etc.) this harness does
- *     not model.
  *
- * Left real (pure, no DB, no env-gated throw beyond what
- * test-env-setup.ts already satisfies): lib/rate-limit.ts (in-memory;
- * each test uses a fresh random user id so rateLimitByKey's 10 req/sec
- * bucket never collides across tests), lib/middleware.ts
- * (optionalAuthMiddleware — exercised for real against the mocked
- * `users` row), lib/attribution.ts, lib/audit-token.ts,
- * lib/audit-helpers.ts, lib/sanitize.ts, lib/provenance-builder.ts,
- * lib/processing-location.ts, lib/trust-grade.ts, lib/errors.ts.
+ * Module boundaries mocked: ../lib/matching.js (matchCapability),
+ * ../capabilities/index.js (getExecutor) — fully controlled per test.
+ * ../capabilities/guarded-executor.js — assertGuardedAllow forced to
+ * allow (real error classes kept via importOriginal so `instanceof`
+ * checks in do.ts still work if ever exercised). ../lib/circuit-
+ * breaker.js, quality-capture.js, event-triggers.js, piggyback-
+ * monitor.js, quality-aggregation.js, x402-gateway.js, progressive-
+ * unlock.js, milestones.js, activation-hook.js — all no-op stubs.
+ * These are fire-and-forget telemetry/side-channel concerns in the
+ * paths under test; real implementations touch DB tables (capability_
+ * health, cost budgets, etc.) this harness does not model.
+ *
+ * Left real (pure, no DB, no env-gated throw beyond what test-env-
+ * setup.ts already satisfies): lib/rate-limit.ts (in-memory; each test
+ * uses a fresh random user id so rateLimitByKey's 10 req/sec bucket
+ * never collides across tests), lib/middleware.ts (optionalAuth
+ * Middleware — exercised for real against the mocked `users` row,
+ * scoped-query-checked the same as everything else), lib/attribution.ts,
+ * lib/audit-token.ts, lib/audit-helpers.ts, lib/sanitize.ts, lib/
+ * provenance-builder.ts, lib/processing-location.ts, lib/trust-grade.ts,
+ * lib/errors.ts.
  *
  * Uncovered paths (documented per the task's instruction not to fake
  * coverage): executeAsync / executeInBackground (async execution,
@@ -62,12 +86,13 @@ import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 
 import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
-import { wallets, transactions, walletTransactions } from "../db/schema.js";
+import { users, wallets, transactions, walletTransactions, failedRequests } from "../db/schema.js";
 
 // ─── Hoisted mutable mock state (referenced from vi.mock factories) ───────────
 
 const mocks = vi.hoisted(() => ({
   outerSelectQueue: [] as unknown[][],
+  recordedSelects: [] as Array<{ table: unknown; cond: unknown }>,
   outerInserts: [] as Array<{ table: unknown; vals: unknown }>,
   dbTransactionCalls: 0,
   // Set per-test before the request; consumed by db.transaction(cb).
@@ -75,17 +100,18 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../db/index.js", () => {
-  function chainableFromQueue() {
+  function chainableFromQueue(table: unknown, cond: unknown) {
+    mocks.recordedSelects.push({ table, cond });
     const rows = (mocks.outerSelectQueue.shift() as unknown[]) ?? [];
-    const p = Promise.resolve(rows) as Promise<unknown[]> & {
-      limit?: (n: number) => Promise<unknown[]>;
-    };
-    (p as any).limit = (n: number) => Promise.resolve(rows.slice(0, n));
+    const p = Promise.resolve(rows) as any;
+    p.limit = (n: number) => Promise.resolve(rows.slice(0, n));
     return p;
   }
   return {
     getDb: () => ({
-      select: () => ({ from: () => ({ where: () => chainableFromQueue() }) }),
+      select: () => ({
+        from: (table: unknown) => ({ where: (cond: unknown) => chainableFromQueue(table, cond) }),
+      }),
       insert: (table: unknown) => ({
         values: (vals: unknown) => {
           mocks.outerInserts.push({ table, vals });
@@ -142,6 +168,61 @@ vi.mock("../lib/progressive-unlock.js", () => ({
 vi.mock("../lib/milestones.js", () => ({ checkMilestone: vi.fn() }));
 vi.mock("../lib/activation-hook.js", () => ({ onFirstTransaction: vi.fn().mockResolvedValue(undefined) }));
 
+// ─── Drizzle condition introspection ───────────────────────────────────────
+// Same technique as wallet.test.ts (kept file-local rather than shared, to
+// match the house style of self-contained test files).
+
+function sqlChunksOf(node: unknown): unknown[] | null {
+  if (!node || typeof node !== "object") return null;
+  const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+  return Array.isArray(chunks) ? chunks : null;
+}
+
+function isColumnChunk(c: unknown): c is { name: string; table: unknown } {
+  return (
+    !!c &&
+    typeof c === "object" &&
+    typeof (c as any).name === "string" &&
+    "table" in (c as any) &&
+    (c as any).table !== undefined
+  );
+}
+
+function isParamChunk(c: unknown): c is { value: unknown } {
+  return !!c && typeof c === "object" && (c as any).constructor?.name === "Param";
+}
+
+function isStringChunk(c: unknown): c is { value: string[] } {
+  return !!c && typeof c === "object" && (c as any).constructor?.name === "StringChunk";
+}
+
+/**
+ * True if the Drizzle condition tree `cond` contains `table.columnName = value`
+ * (pass `{ eq: value }`) or `table.columnName IS NULL` (pass `"is_null"`).
+ * `table` must be the actual imported schema table object — Column chunks
+ * carry a direct reference to it, so the check is by identity.
+ */
+function whereReferences(cond: unknown, table: unknown, columnName: string, match: { eq: unknown } | "is_null"): boolean {
+  const chunks = sqlChunksOf(cond);
+  if (!chunks) return false;
+  for (let i = 0; i < chunks.length; i++) {
+    const c = chunks[i];
+    if (isColumnChunk(c) && c.table === table && c.name === columnName) {
+      if (match === "is_null") {
+        const next = chunks[i + 1];
+        if (isStringChunk(next) && next.value.join("").toLowerCase().includes("is null")) return true;
+      } else {
+        const paramChunk = chunks[i + 2];
+        if (isParamChunk(paramChunk) && paramChunk.value === match.eq) return true;
+      }
+    }
+  }
+  for (const c of chunks) {
+    if (whereReferences(c, table, columnName, match)) return true;
+  }
+  return false;
+}
+
 // ─── Test helpers ──────────────────────────────────────────────────────────
 
 const TEST_API_KEY = "sk_live_" + "b".repeat(56);
@@ -165,25 +246,38 @@ function authHeaders(extra: Record<string, string> = {}) {
   };
 }
 
-function chainablePromise(rows: unknown[]) {
-  const p = Promise.resolve(rows) as any;
-  p.limit = (n: number) => Promise.resolve(rows.slice(0, n));
-  p.for = () => Promise.resolve(rows);
-  p.orderBy = () => chainablePromise(rows);
-  return p;
-}
-
-/** Builds the tx object handed to db.transaction(cb) inside executeSync. */
+/**
+ * Builds the tx object handed to db.transaction(cb) inside executeSync.
+ *
+ * The wallet-lock select is deliberately shaped so `.where()` alone is
+ * NOT awaitable — only `.for(mode)` resolves to rows. Production code
+ * always calls `.for("update")` immediately after `.where()`; if that
+ * call were ever dropped, `await tx.select()...where(...)` would await a
+ * plain `{ for }` object (a no-op — non-Promise objects pass through
+ * `await` unchanged) and the subsequent `const [wallet] = ...`
+ * destructure would throw (plain objects aren't iterable), surfacing as
+ * a 500 in the tests below. `.for` calls are also recorded on
+ * `__forCalls` so the happy-path/DEC-14 tests can assert
+ * `.for("update")` fired exactly once, independent of that crash-based
+ * signal.
+ */
 function buildMockTx(opts: { walletRow: Record<string, unknown> | null; transactionId: string }) {
   const insertCalls: Array<{ table: unknown; vals: unknown }> = [];
   const updateCalls: Array<{ table: unknown; vals: unknown }> = [];
+  const forCalls: string[] = [];
   return {
     __insertCalls: insertCalls,
     __updateCalls: updateCalls,
+    __forCalls: forCalls,
     execute: vi.fn(async () => []),
     select: vi.fn(() => ({
       from: vi.fn(() => ({
-        where: vi.fn(() => chainablePromise(opts.walletRow ? [opts.walletRow] : [])),
+        where: vi.fn(() => ({
+          for: vi.fn((mode: string) => {
+            forCalls.push(mode);
+            return Promise.resolve(opts.walletRow ? [opts.walletRow] : []);
+          }),
+        })),
       })),
     })),
     insert: vi.fn((table: unknown) => ({
@@ -250,6 +344,7 @@ const mockGetExecutor = getExecutor as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   mocks.outerSelectQueue = [];
+  mocks.recordedSelects = [];
   mocks.outerInserts = [];
   mocks.dbTransactionCalls = 0;
   mocks.txRef.current = null;
@@ -309,7 +404,15 @@ describe("POST /v1/do — happy path (authenticated, paid capability, sync)", ()
     expect(executorFn).toHaveBeenCalledTimes(1);
     expect(executorFn).toHaveBeenCalledWith({ value: "hello" });
 
+    // MAJOR 2/3: the auth lookup itself is scoped by key_prefix — not
+    // "the mock answers with whichever user row it's holding".
+    const authSelect = mocks.recordedSelects[0];
+    expect(authSelect.table).toBe(users);
+    expect(whereReferences(authSelect.cond, users, "key_prefix", { eq: getKeyPrefix(TEST_API_KEY) })).toBe(true);
+
     const tx = mocks.txRef.current as ReturnType<typeof buildMockTx>;
+    // MAJOR 4 (DEC-8): the wallet row was read under FOR UPDATE, exactly once.
+    expect(tx.__forCalls).toEqual(["update"]);
     // Wallet debited by exactly the capability price.
     const walletUpdate = tx.__updateCalls.find((c) => c.table === wallets);
     expect(walletUpdate).toBeTruthy();
@@ -350,6 +453,9 @@ describe("POST /v1/do — no matching capability", () => {
 
     await flushMicrotasks();
     expect(mocks.outerInserts.length).toBe(1);
+    // MINOR 6: the insert actually targets failed_requests, not just "some
+    // insert with the right-looking values".
+    expect(mocks.outerInserts[0].table).toBe(failedRequests);
     expect((mocks.outerInserts[0].vals as any).failureType).toBe("no_match");
     expect((mocks.outerInserts[0].vals as any).userId).toBe(user.id);
 
@@ -358,11 +464,15 @@ describe("POST /v1/do — no matching capability", () => {
 });
 
 describe("POST /v1/do — insufficient balance", () => {
-  it("returns 402 insufficient_balance without creating a transaction record or debiting", async () => {
+  it("returns 402 insufficient_balance without ever invoking the executor, creating a transaction record, or debiting", async () => {
     const user = buildUserRow();
     mocks.outerSelectQueue.push([user]);
     mockMatchCapability.mockResolvedValue({ capability: CAPABILITY_FIXTURE }); // price 5 cents
-    mockGetExecutor.mockReturnValue(vi.fn());
+    // MAJOR 5: capture the spy so we can assert it. Codex's scenario: the
+    // executor running before the balance check gives away a free external
+    // call even though the customer gets a 402.
+    const executorSpy = vi.fn(async () => ({ output: {}, provenance: { source: "x", fetched_at: "now" } }));
+    mockGetExecutor.mockReturnValue(executorSpy);
 
     mocks.txRef.current = buildMockTx({
       walletRow: { id: randomUUID(), userId: user.id, balanceCents: 2 }, // less than priceCents (5)
@@ -387,14 +497,17 @@ describe("POST /v1/do — insufficient balance", () => {
     expect(body.details.required_cents).toBe(CAPABILITY_FIXTURE.priceCents);
     expect(body.error).toBeUndefined();
 
+    expect(executorSpy).not.toHaveBeenCalled();
+
     const tx = mocks.txRef.current as ReturnType<typeof buildMockTx>;
+    expect(tx.__forCalls).toEqual(["update"]); // the lock is still taken to read the balance
     expect(tx.__insertCalls.length).toBe(0); // no transaction row created
     expect(tx.__updateCalls.length).toBe(0); // no debit
   });
 });
 
 describe("POST /v1/do — idempotency replay", () => {
-  it("returns the stored result for a repeated Idempotency-Key without re-executing or re-matching", async () => {
+  it("returns the stored result for a repeated Idempotency-Key without re-executing or re-matching, scoped to the requesting user", async () => {
     const user = buildUserRow();
     const existingTxn = {
       id: randomUUID(),
@@ -434,6 +547,17 @@ describe("POST /v1/do — idempotency replay", () => {
     expect(mockMatchCapability).not.toHaveBeenCalled();
     expect(mockGetExecutor).not.toHaveBeenCalled();
     expect(mocks.dbTransactionCalls).toBe(0);
+
+    // MAJOR 2/3: the idempotency lookup's where-clause must scope by BOTH
+    // the idempotency key AND the requesting user's id, AND exclude
+    // soft-deleted rows. Codex's scenario: a lookup that drops the
+    // user-id scope would replay a DIFFERENT user's transaction for
+    // anyone who guesses/reuses their Idempotency-Key value.
+    const idempotencySelect = mocks.recordedSelects[1];
+    expect(idempotencySelect.table).toBe(transactions);
+    expect(whereReferences(idempotencySelect.cond, transactions, "idempotency_key", { eq: "replay-key-1" })).toBe(true);
+    expect(whereReferences(idempotencySelect.cond, transactions, "user_id", { eq: user.id })).toBe(true);
+    expect(whereReferences(idempotencySelect.cond, transactions, "deleted_at", "is_null")).toBe(true);
   });
 });
 
@@ -470,6 +594,10 @@ describe("POST /v1/do — dry_run", () => {
 
     expect(executorFn).not.toHaveBeenCalled();
     expect(mocks.dbTransactionCalls).toBe(0);
+
+    const balanceSelect = mocks.recordedSelects[1];
+    expect(balanceSelect.table).toBe(wallets);
+    expect(whereReferences(balanceSelect.cond, wallets, "user_id", { eq: user.id })).toBe(true);
   });
 });
 
@@ -511,9 +639,13 @@ describe("POST /v1/do — execution failure shape + DEC-14 ordering", () => {
     expect(body.details.error).toBe("mock executor rejected the request");
     expect(body.details.wallet_balance_cents).toBe(startingBalance);
 
+    // DEC-8: the wallet was still read under FOR UPDATE before anything
+    // else happened.
+    const tx = mocks.txRef.current as ReturnType<typeof buildMockTx>;
+    expect(tx.__forCalls).toEqual(["update"]);
+
     // DEC-14: lock → execute → deduct on success. Execution failed, so no
     // debit and no wallet_transactions ledger entry.
-    const tx = mocks.txRef.current as ReturnType<typeof buildMockTx>;
     const walletUpdate = tx.__updateCalls.find((c) => c.table === wallets);
     expect(walletUpdate).toBeUndefined();
     const walletTxInsert = tx.__insertCalls.find((c) => c.table === walletTransactions);

--- a/apps/api/src/routes/wallet.test.ts
+++ b/apps/api/src/routes/wallet.test.ts
@@ -1,29 +1,44 @@
 /**
  * Route-level regression tests for /v1/wallet/* (Phase 1 / T1.1 of the
- * Codebase Quality Program, docs/strategy/2026-08-16-codebase-quality-
- * program.md). wallet.ts had zero test coverage before this file.
+ * Codebase Quality Program). wallet.ts had zero test coverage before this
+ * file.
  *
  * Covers: POST /topup (Stripe Checkout session creation — amount,
- * currency, user linkage, success/cancel URLs), invalid-amount 400s,
- * unauthenticated 401, a Stripe API failure surfacing as a structured
- * error rather than a raw exception; GET /balance (integer-cents wire
- * shape, missing-wallet fallback); GET /transactions (shape, LIMIT 100
- * pagination, missing-wallet fallback).
+ * currency, user linkage, exact success/cancel URLs), invalid-amount
+ * 400s, unauthenticated 401, a Stripe API failure surfacing through
+ * app.ts's real onError handler as a structured error rather than a raw
+ * exception; GET /balance (integer-cents wire shape, missing-wallet
+ * fallback, query scoped to the authenticated user); GET /transactions
+ * (shape, LIMIT-100 result-size cap, missing-wallet fallback that
+ * verifiably skips the wallet_transactions query, query scoped to the
+ * authenticated user).
  *
- * Harness: mounts `walletRoute` directly on a bare Hono app plus a
- * minimal onError mirroring app.ts's structured 500 response (wallet.ts
- * has no try/catch of its own around the Stripe call — the "structured
- * error, not raw exception" contract lives in app.ts's app.onError, so
- * the test harness reproduces exactly that handler rather than the
- * whole app.ts import graph).
+ * Harness: most tests mount `walletRoute` directly on a bare Hono app
+ * (plus the real `requestContext()` middleware — wallet.ts calls
+ * `c.get("log").info(...)` unguarded, so the request-scoped child logger
+ * must exist). One test (the Stripe-failure structured-error case) loads
+ * the real `app` from app.ts instead, per external review: wallet.ts has
+ * no try/catch of its own around the Stripe call, so "structured error,
+ * not raw exception" is a claim about app.ts's app.onError (app.ts:114),
+ * not about wallet.ts — pinning it against a hand-copied onError would
+ * silently stop catching a drift between the two. `./mcp.js` is mocked
+ * for that one import because it pulls in the `strale-mcp/tools`
+ * workspace package (same pattern as transactions.test.ts /
+ * internal-auth.test.ts); nothing in this file exercises `/mcp`.
  *
- * Module boundaries mocked: ../db/index.js (getDb — FIFO row queue
- * matching each SELECT's call order: auth lookup first, then whatever
- * the handler itself queries) and ../lib/stripe.js (getStripe —
- * checkout.sessions.create is a vi.fn asserted on directly). Auth runs
- * for real (authMiddleware, hashApiKey/getKeyPrefix) against the mocked
- * `users` row returned by the queue, exercising the real API-key
- * hashing/matching logic rather than stubbing auth out.
+ * DB mock fidelity: ../db/index.js's getDb() is a FIFO row queue keyed to
+ * call order (auth lookup first, then whatever the handler itself
+ * queries), but it also RECORDS, per select call, the `table` passed to
+ * `.from()` and the real Drizzle condition object passed to `.where()`
+ * (not a stub — `eq`/`and`/`isNull` are the real drizzle-orm functions).
+ * `whereReferences()` below walks the condition's `queryChunks` (the same
+ * shape do.spend-cap.test.ts's `findDateChunks` walks) to answer
+ * structurally "does this where-clause reference table.column [= value |
+ * IS NULL]?" — so a mutation that drops a scoping predicate (e.g. a
+ * lookup that stops filtering by the authenticated user's id) is caught
+ * by an assertion instead of silently passing through a mock that
+ * ignores the condition entirely and answers every query with the same
+ * canned fixture.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -31,39 +46,109 @@ import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 
 import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
+import { users, wallets, walletTransactions } from "../db/schema.js";
 
 // ─── Hoisted mutable mock state ────────────────────────────────────────────
 
 const mocks = vi.hoisted(() => ({
   selectQueue: [] as unknown[][],
+  recordedSelects: [] as Array<{ table: unknown; cond: unknown }>,
   stripeCreate: vi.fn(),
 }));
 
-vi.mock("../db/index.js", () => {
-  function chainableFromQueue() {
-    const rows = (mocks.selectQueue.shift() as unknown[]) ?? [];
-    const p = Promise.resolve(rows) as any;
-    p.limit = (n: number) => Promise.resolve(rows.slice(0, n));
-    p.orderBy = () => {
-      const inner = Promise.resolve(rows) as any;
-      inner.limit = (n: number) => Promise.resolve(rows.slice(0, n));
-      return inner;
-    };
-    return p;
-  }
-  return {
-    getDb: () => ({
-      select: () => ({ from: () => ({ where: () => chainableFromQueue() }) }),
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({
+    select: () => ({
+      from: (table: unknown) => ({
+        where: (cond: unknown) => {
+          mocks.recordedSelects.push({ table, cond });
+          const rows = (mocks.selectQueue.shift() as unknown[]) ?? [];
+          const p = Promise.resolve(rows) as any;
+          p.limit = (n: number) => Promise.resolve(rows.slice(0, n));
+          p.orderBy = () => {
+            const inner = Promise.resolve(rows) as any;
+            inner.limit = (n: number) => Promise.resolve(rows.slice(0, n));
+            return inner;
+          };
+          return p;
+        },
+      }),
     }),
-  };
-});
+  }),
+}));
 
 vi.mock("../lib/stripe.js", () => ({
   getStripe: () => ({ checkout: { sessions: { create: mocks.stripeCreate } } }),
 }));
 
+// Only needed for the one test that loads the real app.ts (MAJOR 1 fix
+// below) — app.ts imports mcp.js, which pulls in the strale-mcp/tools
+// workspace package. Same stub as transactions.test.ts / internal-auth.
+// test.ts. No test in this file exercises /mcp.
+vi.mock("./mcp.js", () => {
+  const { Hono: HonoCtor } = require("hono");
+  return { mcpRoute: new HonoCtor() };
+});
+
 import { walletRoute } from "./wallet.js";
 import { requestContext } from "../middleware/request-context.js";
+
+// ─── Drizzle condition introspection ───────────────────────────────────────
+// `eq`/`and`/`isNull` used by wallet.ts (and by any test data built here)
+// are the real drizzle-orm functions — never mocked — so the `cond` object
+// captured above is a genuine Drizzle SQL condition tree, not a string.
+
+function sqlChunksOf(node: unknown): unknown[] | null {
+  if (!node || typeof node !== "object") return null;
+  const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+  return Array.isArray(chunks) ? chunks : null;
+}
+
+function isColumnChunk(c: unknown): c is { name: string; table: unknown } {
+  return (
+    !!c &&
+    typeof c === "object" &&
+    typeof (c as any).name === "string" &&
+    "table" in (c as any) &&
+    (c as any).table !== undefined
+  );
+}
+
+function isParamChunk(c: unknown): c is { value: unknown } {
+  return !!c && typeof c === "object" && (c as any).constructor?.name === "Param";
+}
+
+function isStringChunk(c: unknown): c is { value: string[] } {
+  return !!c && typeof c === "object" && (c as any).constructor?.name === "StringChunk";
+}
+
+/**
+ * True if the Drizzle condition tree `cond` contains `table.columnName = value`
+ * (pass `{ eq: value }`) or `table.columnName IS NULL` (pass `"is_null"`).
+ * `table` must be the actual imported schema table object — Column chunks
+ * carry a direct reference to it, so the check is by identity, exactly how
+ * Drizzle itself resolves columns.
+ */
+function whereReferences(cond: unknown, table: unknown, columnName: string, match: { eq: unknown } | "is_null"): boolean {
+  const chunks = sqlChunksOf(cond);
+  if (!chunks) return false;
+  for (let i = 0; i < chunks.length; i++) {
+    const c = chunks[i];
+    if (isColumnChunk(c) && c.table === table && c.name === columnName) {
+      if (match === "is_null") {
+        const next = chunks[i + 1];
+        if (isStringChunk(next) && next.value.join("").toLowerCase().includes("is null")) return true;
+      } else {
+        const paramChunk = chunks[i + 2];
+        if (isParamChunk(paramChunk) && paramChunk.value === match.eq) return true;
+      }
+    }
+  }
+  for (const c of chunks) {
+    if (whereReferences(c, table, columnName, match)) return true;
+  }
+  return false;
+}
 
 // ─── Test helpers ──────────────────────────────────────────────────────────
 
@@ -95,17 +180,17 @@ function makeApp() {
   // must be mounted or that throws. Real, pure, no DB — safe to use as-is.
   app.use("*", requestContext());
   app.route("/v1/wallet", walletRoute);
-  // Mirrors app.ts's app.onError exactly (see file header) — wallet.ts's
-  // own topup handler has no try/catch around stripe.checkout.sessions.create,
-  // so the "structured error, not raw exception" contract is enforced here.
-  app.onError((_err, c) =>
-    c.json({ error_code: "internal_error", message: "An unexpected error occurred. Please try again." }, 500),
-  );
+  return app;
+}
+
+async function loadRealApp() {
+  const { app } = await import("../app.js");
   return app;
 }
 
 beforeEach(() => {
   mocks.selectQueue = [];
+  mocks.recordedSelects = [];
   mocks.stripeCreate.mockReset();
 });
 
@@ -114,7 +199,7 @@ afterEach(() => {
 });
 
 describe("POST /v1/wallet/topup", () => {
-  it("creates a Stripe Checkout session with correct amount, currency, user linkage, and redirect URLs", async () => {
+  it("creates a Stripe Checkout session with correct amount, currency, user linkage, and exact redirect URLs", async () => {
     const user = buildUserRow();
     mocks.selectQueue.push([user]); // auth lookup
     mocks.stripeCreate.mockResolvedValue({
@@ -146,10 +231,14 @@ describe("POST /v1/wallet/topup", () => {
     expect(callArg.line_items[0].quantity).toBe(1);
     expect(callArg.metadata.user_id).toBe(user.id);
     expect(callArg.metadata.amount_cents).toBe("2500");
-    expect(callArg.success_url).toContain(process.env.FRONTEND_URL);
-    expect(callArg.success_url).toContain("status=success");
-    expect(callArg.cancel_url).toContain(process.env.FRONTEND_URL);
-    expect(callArg.cancel_url).toContain("status=cancelled");
+    // Pin the FULL URL (including the literal {CHECKOUT_SESSION_ID}
+    // Stripe template token), not a substring — a substring match would
+    // survive a mutation that mangles the query string around a matching
+    // fragment.
+    expect(callArg.success_url).toBe(
+      `${process.env.FRONTEND_URL}/topup?status=success&session_id={CHECKOUT_SESSION_ID}`,
+    );
+    expect(callArg.cancel_url).toBe(`${process.env.FRONTEND_URL}/topup?status=cancelled`);
   });
 
   it("rejects a missing amount_cents with a structured 400", async () => {
@@ -235,13 +324,15 @@ describe("POST /v1/wallet/topup", () => {
     expect(body.error_code).toBe("unauthorized");
     expect(mocks.stripeCreate).not.toHaveBeenCalled();
   });
+});
 
-  it("surfaces a Stripe API failure as a structured error, not a raw exception", async () => {
+describe("POST /v1/wallet/topup — via the real app.ts pipeline (MAJOR 1)", () => {
+  it("a Stripe API failure surfaces via app.ts's real onError as a structured error, not a raw exception", async () => {
     const user = buildUserRow();
     mocks.selectQueue.push([user]);
     mocks.stripeCreate.mockRejectedValue(new Error("stripe unavailable — do not leak this"));
 
-    const app = makeApp();
+    const app = await loadRealApp();
     const res = await app.request("/v1/wallet/topup", {
       method: "POST",
       headers: authHeaders(),
@@ -250,15 +341,17 @@ describe("POST /v1/wallet/topup", () => {
 
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(typeof body.error_code).toBe("string");
-    expect(typeof body.message).toBe("string");
-    // The raw Stripe error text must not reach the client.
+    // Pins app.ts's actual app.onError contract (app.ts:114), not a
+    // hand-copied stand-in — this is the production handler, reached via
+    // the real app.ts route graph.
+    expect(body.error_code).toBe("internal_error");
+    expect(body.message).toBe("An unexpected error occurred. Please try again.");
     expect(JSON.stringify(body)).not.toContain("stripe unavailable");
   });
 });
 
 describe("GET /v1/wallet/balance", () => {
-  it("returns balance_cents as an integer (wire-shape rule), not a formatted string", async () => {
+  it("returns balance_cents as an integer (wire-shape rule), scoped to the authenticated user", async () => {
     const user = buildUserRow();
     mocks.selectQueue.push([user], [{ balanceCents: 4321 }]);
 
@@ -271,6 +364,18 @@ describe("GET /v1/wallet/balance", () => {
     expect(typeof body.balance_cents).toBe("number");
     expect(res.headers.get("X-Credits-Remaining")).toBe("4321");
     expect(res.headers.get("X-Credits-Currency")).toBe("EUR");
+
+    // MAJOR 2/3: the auth lookup itself is scoped by key_prefix, and the
+    // balance lookup is a real Drizzle where-clause query against
+    // `wallets`, scoped to THIS user's id — not just "some row from a
+    // fixture the mock hands back regardless of the query".
+    const authSelect = mocks.recordedSelects[0];
+    expect(authSelect.table).toBe(users);
+    expect(whereReferences(authSelect.cond, users, "key_prefix", { eq: getKeyPrefix(TEST_API_KEY) })).toBe(true);
+
+    const balanceSelect = mocks.recordedSelects[1];
+    expect(balanceSelect.table).toBe(wallets);
+    expect(whereReferences(balanceSelect.cond, wallets, "user_id", { eq: user.id })).toBe(true);
   });
 
   it("returns balance_cents 0 when no wallet row exists yet", async () => {
@@ -293,8 +398,9 @@ describe("GET /v1/wallet/balance", () => {
 });
 
 describe("GET /v1/wallet/transactions", () => {
-  it("returns the transaction list with integer-cents shape", async () => {
+  it("returns the transaction list with integer-cents shape, scoped to the authenticated user's wallet", async () => {
     const user = buildUserRow();
+    const walletId = randomUUID();
     const rows = [
       {
         id: "t1",
@@ -311,7 +417,7 @@ describe("GET /v1/wallet/transactions", () => {
         created_at: new Date("2026-07-01T00:00:00Z"),
       },
     ];
-    mocks.selectQueue.push([user], [{ id: "wallet-1" }], rows);
+    mocks.selectQueue.push([user], [{ id: walletId }], rows);
 
     const app = makeApp();
     const res = await app.request("/v1/wallet/transactions", { headers: authHeaders() });
@@ -322,6 +428,17 @@ describe("GET /v1/wallet/transactions", () => {
     expect(body.transactions[0]).toMatchObject({ id: "t1", amount_cents: -5, type: "purchase" });
     expect(typeof body.transactions[0].amount_cents).toBe("number");
     expect(typeof body.transactions[1].amount_cents).toBe("number");
+
+    // MAJOR 2/3: the wallet-id lookup is scoped to this user; the
+    // transaction-list lookup is scoped to that specific wallet id —
+    // not "any wallet_transactions row the mock happens to be holding".
+    const walletLookup = mocks.recordedSelects[1];
+    expect(walletLookup.table).toBe(wallets);
+    expect(whereReferences(walletLookup.cond, wallets, "user_id", { eq: user.id })).toBe(true);
+
+    const txListLookup = mocks.recordedSelects[2];
+    expect(txListLookup.table).toBe(walletTransactions);
+    expect(whereReferences(txListLookup.cond, walletTransactions, "wallet_id", { eq: walletId })).toBe(true);
   });
 
   it("caps the result at 100 rows (regression: .limit(100) in the query)", async () => {
@@ -344,7 +461,7 @@ describe("GET /v1/wallet/transactions", () => {
     expect(body.transactions).toHaveLength(100);
   });
 
-  it("returns an empty list when no wallet row exists yet, without querying wallet_transactions", async () => {
+  it("returns an empty list when no wallet row exists yet, and does not issue a second query for wallet_transactions", async () => {
     const user = buildUserRow();
     mocks.selectQueue.push([user], []);
 
@@ -354,6 +471,12 @@ describe("GET /v1/wallet/transactions", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ transactions: [] });
+
+    // Exactly 2 selects: the auth lookup and the wallet-id lookup. If the
+    // handler still queried wallet_transactions after finding no wallet,
+    // a 3rd entry would show up here.
+    expect(mocks.recordedSelects).toHaveLength(2);
+    expect(mocks.recordedSelects.some((s) => s.table === walletTransactions)).toBe(false);
   });
 
   it("returns 401 without an Authorization header", async () => {

--- a/apps/api/src/routes/wallet.test.ts
+++ b/apps/api/src/routes/wallet.test.ts
@@ -139,8 +139,19 @@ function whereReferences(cond: unknown, table: unknown, columnName: string, matc
         const next = chunks[i + 1];
         if (isStringChunk(next) && next.value.join("").toLowerCase().includes("is null")) return true;
       } else {
+        // MEDIUM (residual): verify the chunk BETWEEN the column and the
+        // param is actually the equality operator, not just that a column
+        // ref and a matching param happen to be two slots apart. Without
+        // this, eq(col, v) → ne(col, v) is invisible: ne() emits the exact
+        // same [Column, StringChunk(" <> "), Param] shape at these indices,
+        // just with " <> " instead of " = " — an eq→ne swap leaves the
+        // column ref and the param VALUE both unchanged, only the operator
+        // text differs.
+        const opChunk = chunks[i + 1];
         const paramChunk = chunks[i + 2];
-        if (isParamChunk(paramChunk) && paramChunk.value === match.eq) return true;
+        const opText = isStringChunk(opChunk) ? opChunk.value.join("") : "";
+        const isEqualityOperator = opText.includes("=") && !opText.includes("<>") && !opText.includes("!=");
+        if (isEqualityOperator && isParamChunk(paramChunk) && paramChunk.value === match.eq) return true;
       }
     }
   }

--- a/apps/api/src/routes/wallet.test.ts
+++ b/apps/api/src/routes/wallet.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Route-level regression tests for /v1/wallet/* (Phase 1 / T1.1 of the
+ * Codebase Quality Program, docs/strategy/2026-08-16-codebase-quality-
+ * program.md). wallet.ts had zero test coverage before this file.
+ *
+ * Covers: POST /topup (Stripe Checkout session creation — amount,
+ * currency, user linkage, success/cancel URLs), invalid-amount 400s,
+ * unauthenticated 401, a Stripe API failure surfacing as a structured
+ * error rather than a raw exception; GET /balance (integer-cents wire
+ * shape, missing-wallet fallback); GET /transactions (shape, LIMIT 100
+ * pagination, missing-wallet fallback).
+ *
+ * Harness: mounts `walletRoute` directly on a bare Hono app plus a
+ * minimal onError mirroring app.ts's structured 500 response (wallet.ts
+ * has no try/catch of its own around the Stripe call — the "structured
+ * error, not raw exception" contract lives in app.ts's app.onError, so
+ * the test harness reproduces exactly that handler rather than the
+ * whole app.ts import graph).
+ *
+ * Module boundaries mocked: ../db/index.js (getDb — FIFO row queue
+ * matching each SELECT's call order: auth lookup first, then whatever
+ * the handler itself queries) and ../lib/stripe.js (getStripe —
+ * checkout.sessions.create is a vi.fn asserted on directly). Auth runs
+ * for real (authMiddleware, hashApiKey/getKeyPrefix) against the mocked
+ * `users` row returned by the queue, exercising the real API-key
+ * hashing/matching logic rather than stubbing auth out.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { Hono } from "hono";
+
+import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
+
+// ─── Hoisted mutable mock state ────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  selectQueue: [] as unknown[][],
+  stripeCreate: vi.fn(),
+}));
+
+vi.mock("../db/index.js", () => {
+  function chainableFromQueue() {
+    const rows = (mocks.selectQueue.shift() as unknown[]) ?? [];
+    const p = Promise.resolve(rows) as any;
+    p.limit = (n: number) => Promise.resolve(rows.slice(0, n));
+    p.orderBy = () => {
+      const inner = Promise.resolve(rows) as any;
+      inner.limit = (n: number) => Promise.resolve(rows.slice(0, n));
+      return inner;
+    };
+    return p;
+  }
+  return {
+    getDb: () => ({
+      select: () => ({ from: () => ({ where: () => chainableFromQueue() }) }),
+    }),
+  };
+});
+
+vi.mock("../lib/stripe.js", () => ({
+  getStripe: () => ({ checkout: { sessions: { create: mocks.stripeCreate } } }),
+}));
+
+import { walletRoute } from "./wallet.js";
+import { requestContext } from "../middleware/request-context.js";
+
+// ─── Test helpers ──────────────────────────────────────────────────────────
+
+const TEST_API_KEY = "sk_live_" + "c".repeat(56);
+
+function buildUserRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: randomUUID(),
+    email: "wallet-test@example.com",
+    apiKeyHash: hashApiKey(TEST_API_KEY),
+    keyPrefix: getKeyPrefix(TEST_API_KEY),
+    maxSpendPerHourCents: null,
+    ...overrides,
+  };
+}
+
+function authHeaders(extra: Record<string, string> = {}) {
+  return {
+    Authorization: `Bearer ${TEST_API_KEY}`,
+    "content-type": "application/json",
+    ...extra,
+  };
+}
+
+function makeApp() {
+  const app = new Hono();
+  // wallet.ts calls c.get("log").info(...) directly (unguarded) — the real
+  // request-scoped child logger from app.ts's requestContext() middleware
+  // must be mounted or that throws. Real, pure, no DB — safe to use as-is.
+  app.use("*", requestContext());
+  app.route("/v1/wallet", walletRoute);
+  // Mirrors app.ts's app.onError exactly (see file header) — wallet.ts's
+  // own topup handler has no try/catch around stripe.checkout.sessions.create,
+  // so the "structured error, not raw exception" contract is enforced here.
+  app.onError((_err, c) =>
+    c.json({ error_code: "internal_error", message: "An unexpected error occurred. Please try again." }, 500),
+  );
+  return app;
+}
+
+beforeEach(() => {
+  mocks.selectQueue = [];
+  mocks.stripeCreate.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /v1/wallet/topup", () => {
+  it("creates a Stripe Checkout session with correct amount, currency, user linkage, and redirect URLs", async () => {
+    const user = buildUserRow();
+    mocks.selectQueue.push([user]); // auth lookup
+    mocks.stripeCreate.mockResolvedValue({
+      id: "cs_test_123",
+      url: "https://checkout.stripe.com/pay/cs_test_123",
+    });
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/topup", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ amount_cents: 2500 }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      checkout_url: "https://checkout.stripe.com/pay/cs_test_123",
+      session_id: "cs_test_123",
+      amount_cents: 2500,
+    });
+
+    expect(mocks.stripeCreate).toHaveBeenCalledTimes(1);
+    const callArg = mocks.stripeCreate.mock.calls[0][0];
+    expect(callArg.mode).toBe("payment");
+    expect(callArg.line_items).toHaveLength(1);
+    expect(callArg.line_items[0].price_data.currency).toBe("eur");
+    expect(callArg.line_items[0].price_data.unit_amount).toBe(2500);
+    expect(callArg.line_items[0].quantity).toBe(1);
+    expect(callArg.metadata.user_id).toBe(user.id);
+    expect(callArg.metadata.amount_cents).toBe("2500");
+    expect(callArg.success_url).toContain(process.env.FRONTEND_URL);
+    expect(callArg.success_url).toContain("status=success");
+    expect(callArg.cancel_url).toContain(process.env.FRONTEND_URL);
+    expect(callArg.cancel_url).toContain("status=cancelled");
+  });
+
+  it("rejects a missing amount_cents with a structured 400", async () => {
+    const user = buildUserRow();
+    mocks.selectQueue.push([user]);
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/topup", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_code).toBe("invalid_request");
+    expect(body.details.min_amount_cents).toBe(1000);
+    expect(body.details.max_amount_cents).toBe(1_000_000);
+    expect(mocks.stripeCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects an amount below the €10 minimum with a structured 400", async () => {
+    const user = buildUserRow();
+    mocks.selectQueue.push([user]);
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/topup", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ amount_cents: 500 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_code).toBe("invalid_request");
+    expect(mocks.stripeCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects an amount above the €10,000 maximum with a structured 400", async () => {
+    const user = buildUserRow();
+    mocks.selectQueue.push([user]);
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/topup", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ amount_cents: 2_000_000 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_code).toBe("invalid_request");
+    expect(mocks.stripeCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-integer amount_cents with a structured 400", async () => {
+    const user = buildUserRow();
+    mocks.selectQueue.push([user]);
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/topup", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ amount_cents: 2500.5 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_code).toBe("invalid_request");
+    expect(mocks.stripeCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a request with no Authorization header, without calling Stripe", async () => {
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/topup", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount_cents: 2500 }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error_code).toBe("unauthorized");
+    expect(mocks.stripeCreate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a Stripe API failure as a structured error, not a raw exception", async () => {
+    const user = buildUserRow();
+    mocks.selectQueue.push([user]);
+    mocks.stripeCreate.mockRejectedValue(new Error("stripe unavailable — do not leak this"));
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/topup", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ amount_cents: 2500 }),
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(typeof body.error_code).toBe("string");
+    expect(typeof body.message).toBe("string");
+    // The raw Stripe error text must not reach the client.
+    expect(JSON.stringify(body)).not.toContain("stripe unavailable");
+  });
+});
+
+describe("GET /v1/wallet/balance", () => {
+  it("returns balance_cents as an integer (wire-shape rule), not a formatted string", async () => {
+    const user = buildUserRow();
+    mocks.selectQueue.push([user], [{ balanceCents: 4321 }]);
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/balance", { headers: authHeaders() });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ balance_cents: 4321, currency: "EUR" });
+    expect(typeof body.balance_cents).toBe("number");
+    expect(res.headers.get("X-Credits-Remaining")).toBe("4321");
+    expect(res.headers.get("X-Credits-Currency")).toBe("EUR");
+  });
+
+  it("returns balance_cents 0 when no wallet row exists yet", async () => {
+    const user = buildUserRow();
+    mocks.selectQueue.push([user], []);
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/balance", { headers: authHeaders() });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ balance_cents: 0, currency: "EUR" });
+  });
+
+  it("returns 401 without an Authorization header", async () => {
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/balance");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /v1/wallet/transactions", () => {
+  it("returns the transaction list with integer-cents shape", async () => {
+    const user = buildUserRow();
+    const rows = [
+      {
+        id: "t1",
+        amount_cents: -5,
+        type: "purchase",
+        description: "Capability: test-capability",
+        created_at: new Date("2026-08-01T00:00:00Z"),
+      },
+      {
+        id: "t2",
+        amount_cents: 1000,
+        type: "top_up",
+        description: null,
+        created_at: new Date("2026-07-01T00:00:00Z"),
+      },
+    ];
+    mocks.selectQueue.push([user], [{ id: "wallet-1" }], rows);
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/transactions", { headers: authHeaders() });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.transactions).toHaveLength(2);
+    expect(body.transactions[0]).toMatchObject({ id: "t1", amount_cents: -5, type: "purchase" });
+    expect(typeof body.transactions[0].amount_cents).toBe("number");
+    expect(typeof body.transactions[1].amount_cents).toBe("number");
+  });
+
+  it("caps the result at 100 rows (regression: .limit(100) in the query)", async () => {
+    const user = buildUserRow();
+    const walletId = "wallet-1";
+    const manyRows = Array.from({ length: 150 }, (_, i) => ({
+      id: `t${i}`,
+      amount_cents: -1,
+      type: "purchase",
+      description: null,
+      created_at: new Date(),
+    }));
+    mocks.selectQueue.push([user], [{ id: walletId }], manyRows);
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/transactions", { headers: authHeaders() });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.transactions).toHaveLength(100);
+  });
+
+  it("returns an empty list when no wallet row exists yet, without querying wallet_transactions", async () => {
+    const user = buildUserRow();
+    mocks.selectQueue.push([user], []);
+
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/transactions", { headers: authHeaders() });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ transactions: [] });
+  });
+
+  it("returns 401 without an Authorization header", async () => {
+    const app = makeApp();
+    const res = await app.request("/v1/wallet/transactions");
+    expect(res.status).toBe(401);
+  });
+});

--- a/docs/strategy/2026-08-16-codebase-quality-program.md
+++ b/docs/strategy/2026-08-16-codebase-quality-program.md
@@ -1,0 +1,101 @@
+# Codebase Quality Program — 2026-08-16
+
+**Intent:** Make the Strale codebase fit for purpose, evenly guarded, and unbloated.
+Triggered by the 2026-08-16 triage: no widespread capability breakage, but uneven
+quality gates (money path untested, frontend/SDKs/scripts never typechecked),
+a failure taxonomy that punishes correct refusals under an armed quality floor,
+and ~⅓ of `apps/api/scripts/` being dead one-off tooling.
+
+**Operating model:** Fable (Opus-class session) orchestrates and verifies.
+Implementation is done by cheaper-model subagents (Sonnet) in isolated git
+worktrees (Shared-Checkout Rule). Every diff gets cross-provider review via
+model-os dispatch (Codex reviews Claude-authored code) before merge. No phase
+is "done" until its exit criteria are verified by measurement, not assertion.
+
+**Standing protocols that bind every phase:** Audit-Follow-up Test Coverage
+(regression tests must fail-before/pass-after), Deploy Mechanism Verification
+(CI/startup changes verified by reading the actual mechanism + post-deploy prod
+query), Bulk-Operation Deploy (backlog audit before re-enabling silent bulk
+ops), code-review gate (`/go` before session end).
+
+---
+
+## Phase 0 — Stop the self-harm (urgent)
+
+**Goal:** The platform can no longer delist healthy capabilities for correct
+behavior, and the one real customer-facing outage cause (scraper rate limiting)
+is diagnosed.
+
+| # | Target | Verified by |
+|---|--------|-------------|
+| T0.1 | Failure classification distinguishes **correct refusals** (policy refusals e.g. Trustpilot ToS, input-validation rejections, ambiguous-match refusals, coverage refusals) from **genuine failures** (upstream 5xx, timeouts, parse bugs). Refusals are excluded from quality-floor success-rate math. | Unit tests: each refusal class + each genuine-failure class asserted; tests fail against pre-fix code. Re-run of the 7-day failure query shows e.g. product-reviews-extract no longer "88% failure". |
+| T0.2 | 30-day audit of quality-floor actions: every quarantine/deactivation listed and classified right/wrong. Wrongly delisted capabilities reinstated (platform-acts-alone per DEC-20260812-A). | Written audit table in the PR; DB state after reinstatement. |
+| T0.3 | Browserless 429 root cause known: quota exhaustion vs burst vs target-site limits, with a costed recommendation. | Investigation report. Spend/plan decision escalated to Petter (escalation contract — vendor spend is human-decided). |
+
+**Exit criteria:** T0.1 merged + deployed with green tests; T0.2 table produced and reinstatements applied; T0.3 report delivered.
+
+## Phase 1 — Guard the money and the heart
+
+**Goal:** The two most critical untested surfaces — wallet/Stripe and the
+`/v1/do` execution path — have real regression tests.
+
+| # | Target | Verified by |
+|---|--------|-------------|
+| T1.1 | `routes/wallet.ts` covered: top-up session creation (Stripe mocked), balance read, transaction list, error paths. | New test file(s) green in `npm test`; deliberate mutation of wallet code makes them fail. |
+| T1.2 | `routes/do.ts` core paths covered: happy path, no-match, insufficient balance, idempotency replay, dry_run, structured error shape (both documented response shapes). | Same standard: green, and mutation-tested by spot check. |
+| T1.3 | Any real bug found while writing tests is fixed in its own commit with fail-before/pass-after evidence. | Commit-by-commit review. |
+
+**Exit criteria:** suite green; wallet.ts and do.ts no longer test-free; Codex review passed.
+
+## Phase 2 — Close the gates
+
+**Goal:** Nothing that can break ships without an inspector at the door.
+
+| # | Target | Verified by |
+|---|--------|-------------|
+| T2.1 | `npm run typecheck` (and CI) covers: `apps/api/src`, `apps/api/scripts`, `apps/api/test`, and all published TS packages (`sdk-typescript`, `mcp-server`, `langchain`, `semantic-kernel-strale`). Pre-existing type errors surfaced by the wider net are fixed or explicitly triaged in the PR. | CI run on the PR shows the wider scope executing and green. |
+| T2.2 | Zero orphaned guard scripts: each of the 11 unwired `check-*` scripts is either wired into CI/package.json or moved to `scripts/archive/` with a one-line reason. | Grep proves no `check-*` script exists that is referenced by nothing. |
+| T2.3 | Warn-only and weekly-only gates re-tiered deliberately: tier-coverage promoted to blocking or its Phase-2 deferral documented; cross-repo shape contract (`AuditRecord`) checked on PRs that touch `routes/audit.ts`, not only Mondays. | CI config diff + a deliberately-broken test PR demonstrating the block. |
+| T2.4 | CI changes obey Deploy Mechanism Verification: each new gate proven to actually execute (workflow run link), not assumed. | Links in PR body. |
+
+**Exit criteria:** a type error, a broken shape, or an unwired guard can no longer reach `main` silently.
+
+## Phase 3 — Debloat
+
+**Goal:** The repo matches its own documented structure; dead weight is archived.
+
+| # | Target | Verified by |
+|---|--------|-------------|
+| T3.1 | The ~60 dead one-off scripts (`diag-*`, `fix-*`, `backfill-*`, date-stamped, etc.) moved to `apps/api/scripts/archive/` after grepping for references. Top-level scripts dir contains only live tooling. | Reference-grep output in PR; CI green after moves. |
+| T3.2 | `audit/`, `audit-output/`, `audit-reports/` contents routed to `archive/sessions/` per the Report Filing Convention; repo root matches the documented structure list. | Directory listing diff. |
+| T3.3 | Loose handoff notes committed; `AGENTS.md` / `.claude/model-os/` / `.agents/` resolved as tracked-or-gitignored (Petter's call). | git status clean of stray categories. |
+| T3.4 | `test/` vs `tests/` naming confusion resolved (one canonical location or a README pointer). | Path check. |
+
+**Exit criteria:** `git status` noise gone; nothing valuable deleted (archive, not rm, for anything with doubt); CI green.
+
+## Phase 4 — Capability truth pass
+
+**Goal:** Harness health reflects reality, and the weak tail is root-caused.
+
+| # | Target | Verified by |
+|---|--------|-------------|
+| T4.1 | The uniform ~83–84% cluster (name-parse, npm-package-info, iso-country-lookup, etc. — identical rates, ~500 runs) root-caused as a shared harness issue or disproven; fixed at the shared cause. | Pass rates for the cluster >95% over the following 7 days of runs. |
+| T4.2 | Weak registries (danish 38%, page-exists 38%, french 50%, polish 57%, us-company-data 60%, uk-gazette 59%, us-court-search 66%…) each root-caused: fixed, or quarantined with a written reason. | Per-capability disposition table. |
+| T4.3 | ≤5 capabilities under 90% harness pass rate (7-day window), refusal-classification corrections from Phase 0 already applied. | Re-run of the harness health query. |
+
+**Exit criteria:** the harness dashboard is trustworthy enough that "a large chunk is broken" can be answered with one query, confidently.
+
+---
+
+## Iteration loop (every phase)
+
+1. Sonnet implementer in an isolated worktree (npm install inside it; removed via `git worktree remove`).
+2. Fable verifies against the phase's targets: runs the tests, runs the measurement queries, checks fail-before/pass-after.
+3. Codex external review via model-os dispatch. Findings fixed and re-verified.
+4. PR opened (draft PRs are platform-acts-alone), merged only when green + reviewed.
+5. Post-deploy: prod queried for the expected effect (not just clean logs).
+6. Loop until exit criteria measured true; then next phase.
+
+**Sequencing:** 0 → 1 → 2 → 3 → 4, with 1‖2 parallelizable in separate worktrees if review bandwidth allows. Phase 3 deliberately after 2 (moving scripts is safer once typecheck covers them).
+
+**Petter-owned decisions surfaced by this program:** Browserless spend/plan (T0.3); tracked-vs-ignored for model-os/AGENTS.md (T3.3); any deactivation of revenue-earning capabilities (always, per DEC-20260812-A).


### PR DESCRIPTION
## Summary
- `routes/wallet.ts` (Stripe top-ups, balance, transactions — the money path) gets its first tests ever: 14 covering session creation, integer-cents shapes, auth, error paths through the REAL production error handler.
- `routes/do.ts` core paths: 6 tests covering happy path, no-match + failed_requests logging, insufficient balance, idempotency replay (proving no re-execution), dry_run, exact failure shape (`details.error`, no top-level `error` key — pinning the documented footgun), and DEC-14 no-debit-before-success ordering.
- Mock fidelity engineered so the dangerous mutations fail: deleting the `SELECT ... FOR UPDATE` lock (DEC-8), dropping user-scoping from the locked wallet query or the idempotency lookup (cross-user exposure), `eq→ne` operator swaps, and execute-before-balance-check all break tests — each proven RED→GREEN.
- Also lands `docs/strategy/2026-08-16-codebase-quality-program.md`, the plan these tests execute against.

## Verification
- 15 documented mutation proofs across 3 review rounds; production `do.ts`/`wallet.ts` byte-identical (test-only change, verified by empty diff).
- Full suite: 1798 passed / 33 skipped, reproduced twice; typecheck clean.
- Cross-provider review (Codex): 2 rejection rounds (mock-fidelity majors — the FIFO mock originally couldn't see a deleted row lock), final verdict "APPROVE — no findings."

## Reviewer findings
- Documented uncovered do.ts paths (honest gaps, not faked): async execution path (DEC-22), x402 unauthenticated path, free-tier branches, postgres timeout-code catch, conversion-email fire-and-forget. Each needs a differently-shaped harness; queued as Phase 1 follow-up.

## Test plan
- CI green is the test plan — these ARE the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)