### PR TITLE
fix(invariant): correctness floor stops blaming capabilities for the world

### DIFF
--- a/apps/api/src/jobs/invariant-checker.correctness.test.ts
+++ b/apps/api/src/jobs/invariant-checker.correctness.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression tests for the algorithmic-correctness floor's denominator.
+ *
+ * Measured against production 2026-08-17: ten capabilities were emitting
+ * "ALGORITHMIC CORRECTNESS VIOLATION … correctness 0%" every ~36 minutes for
+ * over 24 hours, while answering correctly when called directly on prod. The
+ * failures being counted were a test-budget guard, an expired vendor token, and
+ * upstream 5xx/429s — none of which is evidence about the capability's logic.
+ *
+ * Every case below uses a real failure_reason string copied from
+ * `test_results.failure_reason` in production, so these tests pin behaviour
+ * against what the system actually produces rather than against invented text.
+ *
+ * Discrimination: against the un-fixed code (which counted every failing row,
+ * i.e. `rate = passed / rows.length` and quoted all failures), the environmental
+ * cases below compute 0% and would fire — each `expect` here inverts that.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  scoreCorrectness,
+  isEnvironmentalFailure,
+  ENVIRONMENTAL_FAILURE_CLASSES,
+  type CorrectnessTestRow,
+} from "./invariant-checker.js";
+
+/** Verbatim from production `test_results.failure_reason`, 2026-08-17. */
+const PROD_REASONS = {
+  quotaExhausted:
+    "Execution error: Capability 'swedish-company-data' has exhausted its daily test budget (free_quota, quota_cap=1000). Customer traffic is unaffected; Strale's own tests are throttled.",
+  tokenRejected:
+    "Execution error: CourtListener rejected the token (HTTP 403). Verify COURTLISTENER_API_TOKEN.",
+  upstream500: "Execution error: The Gazette API returned HTTP 500.",
+  upstream429:
+    "Execution error: GDELT API returned HTTP 429. The news search service may be temporarily unavailable. Please try again.",
+  timeout: "Execution error: The operation was aborted due to timeout",
+  // Capability-attributable: the fixture or the contract is ours either way.
+  missingField: "guaranteed_field_missing:best_match",
+  allNull:
+    "high_null_ratio: 100% of declared fields returned null (6/6). Null fields: name, region, alpha_2, alpha_3, schengen, eu_member",
+  wrongValue: "is_reachable: expected 'true', got 'false'",
+} as const;
+
+const fail = (reason: string, name = "t"): CorrectnessTestRow => ({
+  test_name: name,
+  passed: false,
+  failure_reason: reason,
+});
+const pass = (name = "t"): CorrectnessTestRow => ({
+  test_name: name,
+  passed: true,
+  failure_reason: null,
+});
+
+describe("isEnvironmentalFailure — production failure strings", () => {
+  it.each([
+    ["test-budget exhaustion", PROD_REASONS.quotaExhausted],
+    ["rejected vendor token", PROD_REASONS.tokenRejected],
+    ["upstream 500", PROD_REASONS.upstream500],
+    ["upstream 429", PROD_REASONS.upstream429],
+    ["timeout", PROD_REASONS.timeout],
+  ])("treats %s as environmental", (_label, reason) => {
+    expect(isEnvironmentalFailure(reason)).toBe(true);
+  });
+
+  it.each([
+    ["a missing guaranteed field", PROD_REASONS.missingField],
+    ["an all-null response", PROD_REASONS.allNull],
+    ["a wrong value", PROD_REASONS.wrongValue],
+  ])("keeps %s attributable to the capability", (_label, reason) => {
+    expect(isEnvironmentalFailure(reason)).toBe(false);
+  });
+
+  it("treats a missing reason as attributable, not as a free pass", () => {
+    // An unexplained failure must never be excused. Defaulting the other way
+    // would let any unclassified error silence the floor.
+    expect(isEnvironmentalFailure(null)).toBe(false);
+    expect(isEnvironmentalFailure(undefined)).toBe(false);
+    expect(isEnvironmentalFailure("")).toBe(false);
+  });
+
+  it("excludes caller_input and tos_policy from the environmental set", () => {
+    // A known-answer fixture is OUR input. "The caller sent something bad"
+    // means we wrote a bad fixture, which is ours to fix.
+    expect(ENVIRONMENTAL_FAILURE_CLASSES.has("caller_input")).toBe(false);
+    expect(ENVIRONMENTAL_FAILURE_CLASSES.has("tos_policy")).toBe(false);
+    expect(ENVIRONMENTAL_FAILURE_CLASSES.has("internal")).toBe(false);
+  });
+});
+
+describe("scoreCorrectness", () => {
+  it("does not fire when every failure is a throttled test budget", () => {
+    // swedish-company-data, 2026-08-16/17: 37 such failures, reported as 5%.
+    const rows = [...Array(19)].map(() => fail(PROD_REASONS.quotaExhausted));
+    const r = scoreCorrectness([pass(), ...rows]);
+
+    expect(r.environmentalFailures).toHaveLength(19);
+    expect(r.attributableFailures).toHaveLength(0);
+    // Un-fixed code: 1/20 = 5%, well under the 85% floor → Tier-1 alert.
+    expect(r.correctnessRate).toBe(100);
+    expect(r.correctnessRate).toBeGreaterThanOrEqual(85);
+  });
+
+  it("does not fire when every failure is an expired vendor token", () => {
+    // us-court-search: 26 failures in 48h, reported as 0%.
+    const rows = [...Array(20)].map(() => fail(PROD_REASONS.tokenRejected));
+    const r = scoreCorrectness(rows);
+
+    expect(r.attributableFailures).toHaveLength(0);
+    expect(r.passed).toBe(0);
+    // Nothing judgeable: denominator 0. The caller reports this at Tier 2
+    // rather than as a code defect.
+    expect(r.passed + r.attributableFailures.length).toBe(0);
+  });
+
+  it("still fires when the capability's own contract is broken", () => {
+    // iso-country-lookup's shape: every declared field null, 24 times.
+    const rows = [...Array(20)].map(() => fail(PROD_REASONS.allNull));
+    const r = scoreCorrectness(rows);
+
+    expect(r.attributableFailures).toHaveLength(20);
+    expect(r.environmentalFailures).toHaveLength(0);
+    expect(r.correctnessRate).toBe(0);
+    expect(r.correctnessRate).toBeLessThan(85);
+  });
+
+  it("judges a real defect on the surviving rows, not on the padded total", () => {
+    // The case the fix must not get wrong: a capability that is genuinely
+    // broken WHILE its upstream is also flaky. Excluding environmental rows
+    // from the denominator (rather than scoring them as passes) is what keeps
+    // this visible.
+    const rows = [
+      pass(),
+      fail(PROD_REASONS.missingField),
+      fail(PROD_REASONS.missingField),
+      fail(PROD_REASONS.missingField),
+      ...[...Array(10)].map(() => fail(PROD_REASONS.upstream500)),
+    ];
+    const r = scoreCorrectness(rows);
+
+    expect(r.environmentalFailures).toHaveLength(10);
+    // 1 pass / (1 pass + 3 real failures) = 25%.
+    expect(r.correctnessRate).toBe(25);
+    expect(r.correctnessRate).toBeLessThan(85);
+    // Had environmental rows been counted as passes, this would read 11/14 =
+    // 79%, and had they stayed in the denominator as failures, 1/14 = 7%.
+    // Both are wrong about a capability with a 3-in-4 real failure rate.
+    expect(r.correctnessRate).not.toBe(79);
+    expect(r.correctnessRate).not.toBe(7);
+  });
+
+  it("quotes only capability-attributable failures back to the operator", () => {
+    const rows = [
+      fail(PROD_REASONS.upstream429, "news-known-answer"),
+      fail(PROD_REASONS.missingField, "id-known-answer"),
+    ];
+    const r = scoreCorrectness(rows);
+
+    expect(r.attributableFailures.map((x) => x.test_name)).toEqual(["id-known-answer"]);
+    expect(r.environmentalFailures.map((x) => x.test_name)).toEqual(["news-known-answer"]);
+  });
+
+  it("is unchanged for a healthy capability", () => {
+    const r = scoreCorrectness([...Array(20)].map(() => pass()));
+    expect(r.correctnessRate).toBe(100);
+    expect(r.attributableFailures).toHaveLength(0);
+    expect(r.environmentalFailures).toHaveLength(0);
+  });
+});

--- a/apps/api/src/jobs/invariant-checker.ts
+++ b/apps/api/src/jobs/invariant-checker.ts
@@ -20,6 +20,10 @@ import { sendAlert } from "../lib/alerting.js";
 import { randomUUID } from "node:crypto";
 import { log, logError, logWarn } from "../lib/log.js";
 import { isShuttingDown } from "../lib/shutdown.js";
+import {
+  classifyTransactionFailure,
+  type TransactionFailureClass,
+} from "../lib/transaction-failure-taxonomy.js";
 
 const CHECK_INTERVAL_MS = 2 * 60 * 60 * 1000; // 2 hours
 const STARTUP_DELAY_MS = 60_000; // 60 seconds
@@ -292,8 +296,134 @@ async function checkOrphanedSolutionSteps(): Promise<{ alerts: number; checked: 
 }
 
 // ─── CHECK 5: Algorithmic correctness floor (Tier 1 — CRITICAL ALERT) ───────
-// Pure algorithmic capabilities have zero environmental variability.
-// Correctness below 85% is definitionally a code defect, not a transient issue.
+// A capability's known-answer suite failing is a code defect — but only when
+// the failures are the capability's own doing.
+//
+// The original premise here was "pure algorithmic capabilities have zero
+// environmental variability, so correctness below 85% is definitionally a code
+// defect". That is false, and 2026-08-17 measured the cost: ten capabilities
+// were reported at "correctness 0%" every ~36 minutes for over 24 hours —
+// roughly 400 Tier-1 alerts a day — while every one of them answered correctly
+// in production when called directly. `transparency_tag = 'algorithmic'`
+// describes how an answer is DERIVED (deterministically, not by an LLM); it
+// says nothing about whether the capability makes a network call.
+// `swedish-company-data` is algorithmic and calls a Swedish registry;
+// `us-court-search` is algorithmic and calls CourtListener.
+//
+// So the failures being counted included: a test-budget guard whose own
+// message says "Customer traffic is unaffected", an expired vendor token
+// (HTTP 403), upstream 5xx from the Gazette and PageSpeed APIs, GDELT 429s,
+// and plain timeouts. None of those is a correctness signal, and burying the
+// real ones under 400 daily false alarms is how a genuine break goes unseen.
+//
+// The fix: environmental failures leave the denominator entirely, and are
+// reported separately (Tier 2) rather than silently dropped — the signal moves,
+// it does not disappear. Failures that ARE the capability's own — a missing
+// guaranteed field, an all-null response, a wrong value — still count in full,
+// which is why this change silences six capabilities and keeps seven.
+//
+// Classification reuses lib/transaction-failure-taxonomy.ts rather than growing
+// a third parallel list of error strings. That module is pure string
+// classification with no transaction coupling, and it answers exactly the
+// question asked here: is this failure ours, or the world's?
+
+/** One known-answer result, as the correctness check reads it. */
+export interface CorrectnessTestRow {
+  test_name: string;
+  passed: boolean;
+  failure_reason: string | null;
+}
+
+/**
+ * Failure classes that are the world's doing, not the capability's, and so
+ * cannot be evidence about its correctness.
+ *
+ * - `upstream` — vendor 5xx/429, and the test-budget guard, whose message says
+ *   in as many words that customer traffic is unaffected.
+ * - `config`   — a credential of ours is missing or rejected. Real, and a
+ *   different problem with a different owner; the dependency-health check is
+ *   where it belongs.
+ * - `timeout`  — a deadline, not a wrong answer.
+ *
+ * `caller_input` and `tos_policy` are deliberately absent: a known-answer
+ * fixture is our own input, so "the caller sent something bad" means we wrote
+ * a bad fixture. That is ours to fix and it keeps counting.
+ */
+export const ENVIRONMENTAL_FAILURE_CLASSES: ReadonlySet<TransactionFailureClass> = new Set<
+  TransactionFailureClass
+>(["upstream", "config", "timeout"]);
+
+export function isEnvironmentalFailure(reason: string | null | undefined): boolean {
+  return ENVIRONMENTAL_FAILURE_CLASSES.has(classifyTransactionFailure(reason));
+}
+
+/**
+ * Split a window of known-answer results into what it says about the
+ * capability and what it says about the world.
+ *
+ * The rate's denominator is `passed + attributable` — environmental results
+ * leave entirely rather than counting as passes. Counting them as passes would
+ * be worse than the bug being fixed: a capability that is genuinely broken
+ * while its upstream is also flaky would be flattered into looking fine.
+ */
+export function scoreCorrectness(rows: readonly CorrectnessTestRow[]): {
+  passed: number;
+  attributableFailures: CorrectnessTestRow[];
+  environmentalFailures: CorrectnessTestRow[];
+  /** 0–100, or null when nothing in the window was judgeable. */
+  correctnessRate: number;
+} {
+  const passed = rows.filter((r) => r.passed).length;
+  const failures = rows.filter((r) => !r.passed);
+  const environmentalFailures = failures.filter((r) => isEnvironmentalFailure(r.failure_reason));
+  const attributableFailures = failures.filter((r) => !isEnvironmentalFailure(r.failure_reason));
+  const denominator = passed + attributableFailures.length;
+  return {
+    passed,
+    attributableFailures,
+    environmentalFailures,
+    correctnessRate: denominator === 0 ? 100 : Math.round((passed / denominator) * 100),
+  };
+}
+
+function describeFailures(rows: readonly CorrectnessTestRow[], limit = 5): string[] {
+  return rows
+    .map((r) => `"${r.test_name}": ${r.failure_reason ?? "no reason recorded"}`)
+    .slice(0, limit);
+}
+
+/**
+ * Every failure in the window was environmental. Report it at Tier 2 so the
+ * signal moves rather than disappearing — a capability whose upstream has been
+ * down for twelve hours is still something an operator should see, just not
+ * under a heading that says its code is wrong.
+ */
+async function reportEnvironmentalOnly(
+  cap: { slug: string; name: string },
+  environmentalFailures: readonly CorrectnessTestRow[],
+  windowHours: number,
+): Promise<void> {
+  if (environmentalFailures.length === 0) return;
+  logWarn(
+    "invariant-check-5-environmental-only",
+    `All known-answer failures for ${cap.slug} in the last ${windowHours}h were environmental; no correctness evidence`,
+    { capability_slug: cap.slug, excluded_count: environmentalFailures.length },
+  );
+  await logHealthEvent({
+    eventType: "invariant_alert",
+    capabilitySlug: cap.slug,
+    tier: 2,
+    actionTaken: `${cap.slug}: all ${environmentalFailures.length} known-answer failure(s) in the last ${windowHours}h were environmental (upstream, credential, or timeout) — no correctness evidence either way`,
+    details: {
+      check: "algorithmic_correctness_environmental_only",
+      capability_slug: cap.slug,
+      capability_name: cap.name,
+      excluded_count: environmentalFailures.length,
+      excluded_examples: describeFailures(environmentalFailures, 3),
+      window_hours: windowHours,
+    },
+  });
+}
 
 async function checkAlgorithmicCorrectnessFloor(
   unhealthyCapabilities: Set<string>,
@@ -344,8 +474,16 @@ async function checkAlgorithmicCorrectnessFloor(
 
     if (rows.length === 0) continue;
 
-    const passed = rows.filter((r) => r.passed).length;
-    const correctnessRate = Math.round((passed / rows.length) * 100);
+    const { passed, attributableFailures, environmentalFailures, correctnessRate } =
+      scoreCorrectness(rows);
+
+    // Every failure in the window was the world's fault, not ours. There is no
+    // correctness evidence to judge — say so at Tier 2 and move on, rather than
+    // either crying code-bug or going quiet.
+    if (passed + attributableFailures.length === 0) {
+      await reportEnvironmentalOnly(cap, environmentalFailures, ROLLING_WINDOW_HOURS);
+      continue;
+    }
 
     if (correctnessRate < CORRECTNESS_FLOOR) {
       // Check if failures are explained by a known provider outage
@@ -406,10 +544,10 @@ async function checkAlgorithmicCorrectnessFloor(
         continue; // Skip CODE BUG alert for this capability
       }
 
-      const failingTests = rows
-        .filter((r) => !r.passed)
-        .map((r) => `"${r.test_name}": ${r.failure_reason ?? "no reason recorded"}`)
-        .slice(0, 5);
+      // Only capability-attributable failures are quoted. Listing an upstream
+      // 500 under "ALGORITHMIC CORRECTNESS VIOLATION" is what sent three
+      // separate sessions looking for a bug in working code.
+      const failingTests = describeFailures(attributableFailures);
 
       logError(
         "invariant-algorithmic-correctness-violation",
@@ -418,9 +556,10 @@ async function checkAlgorithmicCorrectnessFloor(
           capability_slug: cap.slug,
           correctness_rate_pct: correctnessRate,
           floor_pct: CORRECTNESS_FLOOR,
-          tests_checked: rows.length,
+          tests_checked: passed + attributableFailures.length,
           tests_passed: passed,
-          tests_failed: rows.length - passed,
+          tests_failed: attributableFailures.length,
+          tests_excluded_environmental: environmentalFailures.length,
           failing_tests: failingTests,
         },
       );
@@ -438,6 +577,12 @@ async function checkAlgorithmicCorrectnessFloor(
           correctness_rate: correctnessRate,
           floor: CORRECTNESS_FLOOR,
           failing_tests: failingTests,
+          // Denominator provenance: whoever reads this event can see how many
+          // results were judged and how many were set aside as the world's
+          // fault, without re-querying.
+          tests_judged: passed + attributableFailures.length,
+          tests_excluded_environmental: environmentalFailures.length,
+          excluded_examples: describeFailures(environmentalFailures, 3),
           window_hours: ROLLING_WINDOW_HOURS,
           provider_health: "verified_healthy",
         },

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1230,6 +1230,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0086_srcBasis",
       "runMigration0087_unhideRedactedRows",
       "runMigration0088_solutionGateCondition",
+      "runMigration0089_deactivateUsCourtSearch",
     ]);
   });
 });
@@ -1541,5 +1542,65 @@ describe("startup-migrations — failure-aborts-boot semantics (orchestrator)", 
     await expect(runStartupMigrations()).rejects.toThrow(
       /0062_paid_vendor_costs post-condition failed/,
     );
+  });
+});
+
+describe("startup-migrations — block 0089 (deactivate us-court-search)", () => {
+  it("takes the capability off every surface, not just x402", async () => {
+    // The defect this executes against: DQ-4 recorded us-court-search as
+    // switched off on 2026-08-15, but only x402_enabled was cleared. Verified
+    // on production 2026-08-17 — still is_active, still visible, still on
+    // /v1/capabilities at EUR 0.15, returning HTTP 500 to every caller because
+    // CourtListener rejects the token with 403.
+    const { runMigration0089_deactivateUsCourtSearch } = await import("./startup-migrations.js");
+    const stub = makeStub({ queue: [{ count: 1 }] });
+    const result = await runMigration0089_deactivateUsCourtSearch(stub);
+
+    const rendered = stub.renderedSql[0].toLowerCase();
+    expect(rendered).toContain("update capabilities");
+    expect(rendered).toContain("is_active = false");
+    expect(rendered).toContain("visible = false");
+    expect(rendered).toContain("x402_enabled = false");
+    expect(rendered).toContain("us-court-search");
+    expect(result.rows_affected).toBe(1);
+    expect(result.block).toBe("0089_deactivateUsCourtSearch");
+  });
+
+  it("is idempotent — the WHERE clause makes a re-run a no-op", async () => {
+    const { runMigration0089_deactivateUsCourtSearch } = await import("./startup-migrations.js");
+    const stub = makeStub({ queue: [{ count: 0 }] });
+    const result = await runMigration0089_deactivateUsCourtSearch(stub);
+
+    // Guards both re-running on an already-deactivated row AND re-deactivating
+    // a capability an operator has since deliberately switched back on.
+    expect(stub.renderedSql[0].toLowerCase()).toContain("is_active = true");
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toContain("no change");
+  });
+
+  it("records a reversible reason naming the credential to restore", async () => {
+    const { runMigration0089_deactivateUsCourtSearch, US_COURT_SEARCH_DEACTIVATION_REASON } =
+      await import("./startup-migrations.js");
+    const stub = makeStub({ queue: [{ count: 1 }] });
+    await runMigration0089_deactivateUsCourtSearch(stub);
+
+    // The reason is bound as a parameter, so it is in the query's params, not
+    // in the rendered SQL text — assert on the bound value, not on the string.
+    expect(US_COURT_SEARCH_DEACTIVATION_REASON).toContain("COURTLISTENER_API_TOKEN");
+    expect(US_COURT_SEARCH_DEACTIVATION_REASON).toContain("DQ-4");
+    expect(dialect.sqlToQuery(stub.captured[0]).params).toContain(
+      US_COURT_SEARCH_DEACTIVATION_REASON,
+    );
+  });
+
+  it("no captured statement binds a Date instance (DEC-20260504-A bind-encoder shape)", async () => {
+    const { runMigration0089_deactivateUsCourtSearch } = await import("./startup-migrations.js");
+    const stub = makeStub({ queue: [{ count: 1 }] });
+    await runMigration0089_deactivateUsCourtSearch(stub);
+    for (const query of stub.captured) {
+      const chunks = (query as unknown as { queryChunks?: unknown[] }).queryChunks ?? [];
+      const badChunks = chunks.filter((c) => c instanceof Date || Buffer.isBuffer(c));
+      expect(badChunks, "no Date/Buffer chunk reaches the SQL bind layer").toEqual([]);
+    }
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1551,6 +1551,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0086_srcBasis,
   runMigration0087_unhideRedactedRows,
   runMigration0088_solutionGateCondition,
+  runMigration0089_deactivateUsCourtSearch,
 ];
 
 /**
@@ -2124,4 +2125,54 @@ export async function runMigration0088_solutionGateCondition(
   const startedAt = Date.now();
   await tx.execute(sql`ALTER TABLE solution_steps ADD COLUMN IF NOT EXISTS gate_condition JSONB`);
   return { block: "0088_solutionGateCondition", outcome: "applied", duration_ms: Date.now() - startedAt };
+}
+
+/**
+ * Block 0089 — take `us-court-search` off the shelf.
+ *
+ * DQ-4 (2026-08-15) recorded the decision to switch this capability off: its
+ * CourtListener token had expired and it was returning errors to every caller.
+ * Only the x402 flag was ever cleared, so the capability stayed `is_active`
+ * and `visible` — on the public `/v1/capabilities` catalogue, priced at €0.15,
+ * returning HTTP 500 to anyone who called it. Verified against production
+ * 2026-08-17: `CourtListener rejected the token (HTTP 403)`, and the harness
+ * has been failing its known-answer suite continuously for at least 48 hours.
+ *
+ * This block is the decision actually executing. Reversal is a fresh
+ * COURTLISTENER_API_TOKEN plus flipping the flags back; the row, its suites
+ * and its history are all left intact so that is a one-step change.
+ *
+ * Idempotent via `WHERE is_active = true` — a re-run on a healthy DB is a
+ * no-op, and it deliberately does NOT re-deactivate a capability an operator
+ * has since switched back on, because it only matches rows still carrying the
+ * broken state.
+ */
+export const US_COURT_SEARCH_DEACTIVATION_REASON =
+  "CourtListener API token rejected (HTTP 403) — deactivated per DQ-4; reversible by restoring COURTLISTENER_API_TOKEN";
+
+export async function runMigration0089_deactivateUsCourtSearch(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const res = await tx.execute(sql`
+    UPDATE capabilities
+    SET is_active = false,
+        visible = false,
+        x402_enabled = false,
+        deactivation_reason = ${US_COURT_SEARCH_DEACTIVATION_REASON}
+    WHERE slug = 'us-court-search'
+      AND is_active = true
+  `);
+  const affected = (res as { count?: number }).count ?? 0;
+
+  return {
+    block: "0089_deactivateUsCourtSearch",
+    outcome:
+      affected === 0
+        ? "no change (us-court-search already inactive)"
+        : "us-court-search deactivated — was serving HTTP 500 on an expired CourtListener token",
+    rows_affected: affected,
+    duration_ms: Date.now() - startedAt,
+  };
 }


### PR DESCRIPTION
## What this fixes

Two defects with one root: a signal that named the wrong culprit, and a decision that never executed. Both found during the 2026-08-17 morning check-in.

### 1. The algorithmic-correctness invariant counted environmental failures as code defects

Its premise — *"pure algorithmic capabilities have zero environmental variability, so correctness below 85% is definitionally a code defect"* — is false. `transparency_tag = 'algorithmic'` describes how an answer is **derived** (deterministically, not by an LLM); it says nothing about whether the capability makes a network call. `swedish-company-data` is algorithmic and calls a Swedish registry; `us-court-search` is algorithmic and calls CourtListener.

**Measured against production:** ten capabilities emitting `ALGORITHMIC CORRECTNESS VIOLATION … correctness 0%` every ~36 minutes for over 24 hours — roughly **400 Tier-1 alerts per day**. All ten answered correctly when called directly on prod. What was being counted:

| capability | actual failure reason | truth |
|---|---|---|
| `swedish-company-data` | test budget exhausted, *"Customer traffic is unaffected"* | our own throttle |
| `us-court-search` | `CourtListener rejected the token (HTTP 403)` | expired credential |
| `uk-gazette-notice-search` | `The Gazette API returned HTTP 500` | upstream |
| `company-news` | `GDELT API returned HTTP 429` | upstream |
| `page-speed-test` | `PageSpeed Insights returned HTTP 500` | upstream |
| `redirect-trace` | `operation was aborted due to timeout` | timeout |

Burying real signal under 400 daily false alarms is how a genuine break goes unseen.

**The fix:** environmental failures (`upstream`, `config`, `timeout`) leave the denominator entirely and are reported at Tier 2 instead — the signal moves, it does not disappear. They are deliberately *not* scored as passes, which would flatter a capability that is genuinely broken while its upstream is also flaky. `caller_input` and `tos_policy` stay attributable: a known-answer fixture is *our* input, so a bad one is ours to fix.

Classification reuses `lib/transaction-failure-taxonomy.ts` rather than growing a third parallel list of error strings.

**Effect:** silences six capabilities' false alarms; keeps the seven whose known-answer suites genuinely fail on their own contract (`iso-country-lookup`, `skill-extract`, `company-id-detect`, `incoterms-explain`, `dangerous-goods-classify`, `beneficial-ownership-lookup`, `name-parse` — all `guaranteed_field_missing` / `high_null_ratio`, tracked separately as fixture-shape bugs).

### 2. Block 0089 — `us-court-search` actually comes off the shelf

DQ-4 (2026-08-15) recorded the decision to switch it off after its CourtListener token expired. Only `x402_enabled` was ever cleared. Verified on production 2026-08-17: still `is_active`, still `visible`, still on the public `/v1/capabilities` catalogue at €0.15, **returning HTTP 500 to every caller**.

Idempotent via `WHERE is_active = true` — a re-run is a no-op, and it will not re-deactivate a capability an operator has since deliberately switched back on. Reversal is a fresh `COURTLISTENER_API_TOKEN` plus flipping the flags; the row, suites and history are untouched.

## Tests — DEC-20260504-A

20 new tests. Every failure string is copied verbatim from production `test_results.failure_reason`, so they pin behaviour against what the system actually emits rather than invented text.

**Discrimination proven in both directions:**
- Stubbing `isEnvironmentalFailure` to `false` (the pre-fix state) → **9 of 16** correctness tests fail.
- Reducing block 0089's `UPDATE` to `x402_enabled` only (the *actual* pre-fix production state) → the "off every surface" test fails.

Full suite: 1833 passed, 33 skipped. `tsc --noEmit` clean. Shape-contract and platform-facts drift sweeps clean.

## Deploy-mechanism verification — DEC-20260504-C

Block 0089 is registered in `BLOCKS`, which `runStartupMigrations()` executes from `index.ts` before the API listens. A registry test asserts 0089 is present and ordered. Post-merge verification queries the capability row and the served `/v1/capabilities`, not the log line.

DEC-20260504-B does not apply: single-row UPDATE, no accumulated backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)