### PR TITLE
fix(test-runner): a fixture baseline older than its suite is not evidence

### DIFF
--- a/apps/api/src/lib/test-runner.stale-baseline.test.ts
+++ b/apps/api/src/lib/test-runner.stale-baseline.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression tests for stale fixture baselines.
+ *
+ * Measured against production 2026-08-17. Six capabilities had been failing
+ * their known-answer suite continuously since 2026-03-20 without a single live
+ * execution, because:
+ *
+ *   1. `test_mode = 'fixture'` replays `baseline_output` instead of calling the
+ *      executor, and
+ *   2. `captureBaseline` returned early whenever a baseline already existed.
+ *
+ * Together those make a wrong baseline permanent. `iso-country-lookup`'s
+ * known-answer suite stores `{"query":"Sweden"}`; its baseline was captured
+ * 2026-03-13 from a different suite's input (`"land"`), the suite's input was
+ * changed 2026-03-20, and all 81 recorded runs over the following week echoed
+ * `"land"`. The verdict could never change, because nothing re-ran.
+ *
+ * 81 fixture-mode suites carry a baseline older than their last edit; 6 were
+ * failing and 75 pass only by luck. These tests pin the staleness predicate
+ * and the capture/refresh rule.
+ *
+ * Discrimination: against the un-fixed code `isBaselineStale` did not exist and
+ * `captureBaseline` early-returned unconditionally; the "refreshes" and
+ * "predates" cases below fail when the predicate is stubbed to `false`.
+ */
+import { describe, it, expect } from "vitest";
+import { isBaselineStale } from "./test-runner.js";
+
+const at = (iso: string) => new Date(iso);
+
+describe("isBaselineStale", () => {
+  it("flags the production case: baseline captured before the input changed", () => {
+    // iso-country-lookup known_answer, verbatim from test_suites.
+    expect(
+      isBaselineStale({
+        baselineOutput: { query: "land", matches: [], total_matches: 0 },
+        baselineCapturedAt: at("2026-03-13T07:30:37.740Z"),
+        updatedAt: at("2026-03-20T21:10:50.738Z"),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not flag a baseline captured at or after the last edit", () => {
+    expect(
+      isBaselineStale({
+        baselineOutput: { ok: true },
+        baselineCapturedAt: at("2026-03-20T21:10:50.738Z"),
+        updatedAt: at("2026-03-20T21:10:50.738Z"),
+      }),
+    ).toBe(false);
+    expect(
+      isBaselineStale({
+        baselineOutput: { ok: true },
+        baselineCapturedAt: at("2026-08-17T09:00:00.000Z"),
+        updatedAt: at("2026-03-20T21:10:50.738Z"),
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a one-millisecond gap as stale — the predicate is strict", () => {
+    // This is why captureBaseline must write ONE timestamp to both columns.
+    // Two `new Date()` calls a millisecond apart would make every freshly
+    // captured baseline stale on arrival, and the suite would never use
+    // fixture mode again.
+    expect(
+      isBaselineStale({
+        baselineOutput: { ok: true },
+        baselineCapturedAt: at("2026-08-17T09:00:00.000Z"),
+        updatedAt: at("2026-08-17T09:00:00.001Z"),
+      }),
+    ).toBe(true);
+  });
+
+  it("is not stale when there is no baseline at all", () => {
+    // Never captured is not the same as captured-and-rotten; the live path
+    // handles it and would otherwise be told to 'refresh' nothing.
+    expect(isBaselineStale({ baselineOutput: null, baselineCapturedAt: null, updatedAt: at("2026-08-17T09:00:00.000Z") })).toBe(false);
+    expect(isBaselineStale({ baselineOutput: undefined, baselineCapturedAt: at("2026-01-01T00:00:00.000Z"), updatedAt: at("2026-08-17T09:00:00.000Z") })).toBe(false);
+  });
+
+  it("treats an undateable baseline as stale rather than trusting it", () => {
+    expect(
+      isBaselineStale({
+        baselineOutput: { ok: true },
+        baselineCapturedAt: null,
+        updatedAt: at("2026-08-17T09:00:00.000Z"),
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a baseline whose suite has no recorded edit time", () => {
+    expect(
+      isBaselineStale({
+        baselineOutput: { ok: true },
+        baselineCapturedAt: at("2026-03-13T07:30:37.740Z"),
+        updatedAt: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("the fixture-mode branch conditions", () => {
+  // The runner's guard is
+  //   testMode === 'fixture' && baselineOutput && !isBaselineStale(suite)
+  // and the paid fallback is
+  //   testMode === 'fixture' && baselineOutput && externalCostCents > 0
+  // These assert the decision table those two lines encode, which is the part
+  // that determines whether an executor is called at all.
+  const decide = (s: {
+    testMode: string;
+    baselineOutput: unknown;
+    baselineCapturedAt: Date | null;
+    updatedAt: Date | null;
+    externalCostCents: number;
+  }): "replay" | "stale-paid" | "live" => {
+    if (s.testMode === "fixture" && s.baselineOutput && !isBaselineStale(s)) return "replay";
+    if (s.testMode === "fixture" && s.baselineOutput && s.externalCostCents > 0) return "stale-paid";
+    return "live";
+  };
+
+  const FRESH = { baselineCapturedAt: at("2026-08-17T09:00:00Z"), updatedAt: at("2026-08-17T09:00:00Z") };
+  const STALE = { baselineCapturedAt: at("2026-03-13T07:30:00Z"), updatedAt: at("2026-03-20T21:10:50Z") };
+
+  it("replays a current baseline — fixture mode still costs nothing", () => {
+    expect(decide({ testMode: "fixture", baselineOutput: { a: 1 }, ...FRESH, externalCostCents: 0 })).toBe("replay");
+  });
+
+  it("re-executes a stale baseline when the capability is free to run", () => {
+    // All six production casualties were external_cost_cents = 0, so this is
+    // the path that actually repairs them.
+    expect(decide({ testMode: "fixture", baselineOutput: { a: 1 }, ...STALE, externalCostCents: 0 })).toBe("live");
+  });
+
+  it("does not spend money to refresh — it reports the instrument instead", () => {
+    expect(decide({ testMode: "fixture", baselineOutput: { a: 1 }, ...STALE, externalCostCents: 1 })).toBe("stale-paid");
+  });
+
+  it("leaves live-mode suites alone entirely", () => {
+    expect(decide({ testMode: "live", baselineOutput: { a: 1 }, ...STALE, externalCostCents: 0 })).toBe("live");
+    expect(decide({ testMode: "live", baselineOutput: { a: 1 }, ...FRESH, externalCostCents: 5 })).toBe("live");
+  });
+});

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -474,8 +474,26 @@ async function runSingleTest(
   // ── Fixture mode: validate stored baseline without calling the executor ────
   // For deterministic capabilities where the output never changes.
   // Zero cost — just validates baseline_output against validation_rules.
-  if (suite.testMode === "fixture" && suite.baselineOutput) {
+  //
+  // A baseline captured BEFORE the suite was last edited describes an input
+  // that is no longer the one under test, so replaying it answers a question
+  // nobody asked. Because `captureBaseline` refuses to overwrite an existing
+  // baseline, that state is permanent: the executor is never called again and
+  // the verdict never changes. Measured 2026-08-17 — six capabilities had been
+  // failing continuously since 2026-03-20 on baselines captured 2026-03-13/19
+  // with a different suite's input, 81 runs each without one live execution.
+  // `iso-country-lookup`'s known-answer suite stores `{"query":"Sweden"}` and
+  // every recorded result echoed `"land"`.
+  if (suite.testMode === "fixture" && suite.baselineOutput && !isBaselineStale(suite)) {
     return runFixtureTest(suite, fieldReliabilityMap, outputSchemaMap);
+  }
+
+  // Stale baseline on a suite we cannot re-run for free: do not guess. Report
+  // it as an instrument problem under its own name rather than manufacturing a
+  // pass or a failure about the capability — the same rule the correctness
+  // invariant learned on 2026-08-17.
+  if (suite.testMode === "fixture" && suite.baselineOutput && (suite.externalCostCents ?? 0) > 0) {
+    return recordStaleFixture(suite);
   }
 
   // ── Real execution for other test types (negative, edge_case, known_answer)
@@ -1040,19 +1058,92 @@ function extractKeyStructure(obj: unknown, prefix = ""): string[] {
   return keys;
 }
 
-/** Capture baseline output on first successful real execution. */
+/**
+ * Is this suite's stored baseline older than the suite itself?
+ *
+ * `updated_at` moves on any edit to the suite — including the input change
+ * that makes a baseline meaningless. Using it is deliberately conservative:
+ * the worst case for a false positive is one live execution followed by a
+ * fresh capture, which for a zero-cost capability costs nothing. The worst
+ * case for a false negative is what shipped — a permanently wrong verdict
+ * that no amount of re-running can correct.
+ *
+ * A suite with no baseline is not stale; it has simply never been captured,
+ * and the live path handles it.
+ */
+export function isBaselineStale(suite: {
+  baselineOutput?: unknown;
+  baselineCapturedAt?: Date | null;
+  updatedAt?: Date | null;
+}): boolean {
+  if (!suite.baselineOutput) return false;
+  if (!suite.baselineCapturedAt) return true; // a baseline we cannot date is not one we can trust
+  if (!suite.updatedAt) return false;
+  return suite.baselineCapturedAt.getTime() < suite.updatedAt.getTime();
+}
+
+/**
+ * Record a stale fixture on a suite that costs money to re-run.
+ *
+ * Deliberately `passed: false` with a reason naming the instrument, not the
+ * capability. `transaction-failure-taxonomy` classifies this as `config`
+ * (ours to fix, not the capability's logic), so the correctness invariant
+ * excludes it from the denominator rather than reporting a code defect.
+ */
+async function recordStaleFixture(
+  suite: typeof testSuites.$inferSelect,
+): Promise<SingleTestResult> {
+  const db = getDb();
+  const failureReason =
+    `fixture_refresh_required: baseline captured ${suite.baselineCapturedAt?.toISOString() ?? "at an unknown time"} ` +
+    `predates the suite's last edit ${suite.updatedAt?.toISOString() ?? ""} and the suite is not free to re-run ` +
+    `(external_cost_cents=${suite.externalCostCents ?? 0}). Not evidence about the capability.`;
+
+  await db.insert(testResults).values({
+    testSuiteId: suite.id,
+    capabilitySlug: suite.capabilitySlug,
+    passed: false,
+    failureReason,
+    responseTimeMs: 0,
+    failureClassification: "stale_input",
+  });
+
+  return {
+    testName: suite.testName,
+    testType: suite.testType,
+    capabilitySlug: suite.capabilitySlug,
+    passed: false,
+    failureReason,
+    responseTimeMs: 0,
+  };
+}
+
+/**
+ * Capture baseline output on first successful real execution — or refresh one
+ * that has gone stale.
+ *
+ * The early return used to be unconditional, which is what made a stale
+ * baseline permanent: the fixture path replayed it forever and the capture
+ * path declined to replace it.
+ */
 async function captureBaseline(
   suite: typeof testSuites.$inferSelect,
   output: Record<string, unknown>,
 ): Promise<void> {
-  if (suite.baselineOutput) return; // already captured
+  if (suite.baselineOutput && !isBaselineStale(suite)) return; // already captured and still current
   const db = getDb();
+  const capturedAt = new Date();
   await db
     .update(testSuites)
     .set({
       baselineOutput: output,
-      baselineCapturedAt: new Date(),
-      updatedAt: new Date(),
+      // ONE timestamp for both columns. Two `new Date()` calls can differ by a
+      // millisecond, and `capturedAt < updatedAt` by a millisecond is exactly
+      // the staleness predicate — every freshly captured baseline would be born
+      // stale, and the suite would re-execute live forever instead of ever
+      // using fixture mode again.
+      baselineCapturedAt: capturedAt,
+      updatedAt: capturedAt,
     })
     .where(eq(testSuites.id, suite.id));
 }


### PR DESCRIPTION
## The bug

Six capabilities had been failing their known-answer suite **continuously since 2026-03-20 without a single live execution**. Two behaviours combine to make that permanent:

1. `test_mode = 'fixture'` replays `baseline_output` instead of calling the executor (`runFixtureTest` even records the baseline as `actual_output`).
2. `captureBaseline` returned early whenever a baseline already existed.

So a baseline captured against the wrong input can never be corrected — the executor is never called again, and the verdict never changes.

## The evidence

`iso-country-lookup`'s known-answer suite stores `{"query":"Sweden"}`. Its baseline was captured **2026-03-13** from a different suite's input (`"land"`); the suite's input was changed **2026-03-20**; the baseline was never re-captured.

| suite | stored input | what its results echoed (7d) |
|---|---|---|
| known_answer | `{"query":"Sweden"}` | **`"land"` — 81 runs, 0 passes** |
| dependency_health | `{"query":"land"}` | `"land"` ✓ |
| edge_case | `{"query":";"}` | `";"` ✓ |
| known_bad | `{"query":"INVALID_TEST_VALUE_12345"}` | `INVALID_TEST_VALUE_12345` ✓ |
| piggyback (real traffic) | — | `"Sweden"` |

Every other suite echoes its own input exactly. Only the fixture-mode one is frozen.

## Scope

**81 active fixture-mode suites carry a baseline older than their last edit.** Six are currently failing (`iso-country-lookup`, `name-parse`, `skill-extract`, `company-id-detect`, `incoterms-explain`, `dangerous-goods-classify`); the other 75 pass only because their stale baselines happen to still satisfy the rules. This is a latent trap across all of them, not six unlucky capabilities.

## The fix

- **`isBaselineStale`** — a baseline captured before the suite's last edit is not replayed. `updated_at` is deliberately coarse: a false positive costs one live execution on a zero-cost capability; a false negative is a permanently wrong verdict that no amount of re-running corrects.
- **`captureBaseline` refreshes** a stale baseline instead of declining.
- **One `Date` for both timestamp columns.** Two `new Date()` calls can differ by a millisecond, and `capturedAt < updatedAt` by a millisecond *is* the staleness predicate — every freshly captured baseline would be born stale and fixture mode would never be used again. This is pinned by its own test.
- **A stale baseline on a suite that costs money** is reported as `fixture_refresh_required` (classified `config`), not as a capability failure — the same rule the correctness invariant learned in #305: never blame the capability for an instrument problem. All six current casualties are `external_cost_cents = 0`, so they repair themselves by re-executing.

## Tests

10 new, pinned to the actual production timestamps. **Discrimination proven:** 5 fail when `isBaselineStale` is stubbed to `false` (the pre-fix behaviour). Full suite 1843 passed, `tsc --noEmit` clean.

## Follow-up (not in this PR)

Re-executing is necessary but not sufficient for all seven. `iso-country-lookup`, `incoterms-explain`, `dangerous-goods-classify`, `company-id-detect` and `beneficial-ownership-lookup` also carry genuine **manifest drift** — `output_schema.properties` still lists a flat field set the executors stopped returning. That correction ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)