### PR TITLE
fix(capabilities): realign seven declared output contracts with reality

### DIFF
--- a/apps/api/src/lib/capability-output-contracts.test.ts
+++ b/apps/api/src/lib/capability-output-contracts.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Contract tests for the seven realigned capabilities.
+ *
+ * These assert three things:
+ *   1. Every contract reproduces the shape production actually returns, using
+ *      responses captured 2026-08-17 by calling /v1/do directly.
+ *   2. Under those contracts the harness's two gates PASS, and — the part that
+ *      matters — they still FAIL for a genuinely broken executor. A correction
+ *      that silences the alarm by removing all coverage is not a fix.
+ *   3. The manifests on disk agree with the module the migration writes from,
+ *      so the two cannot drift apart again. That drift is the whole defect:
+ *      every one of these manifests already carried a correct
+ *      `output_schema.example` alongside a stale `properties`.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import yaml from "js-yaml";
+import {
+  CAPABILITY_OUTPUT_CONTRACTS,
+  CORRECTED_SLUGS,
+  type OutputContract,
+} from "./capability-output-contracts.js";
+import { calculateNullFieldRatio } from "./null-field-ratio.js";
+import { checkGuaranteedFieldsPresent } from "./guaranteed-fields-sentinel.js";
+
+const REPO = resolve(import.meta.dirname, "../../../..");
+
+/**
+ * Verbatim production responses, captured 2026-08-17 by POSTing each
+ * capability's own known-answer input to /v1/do. Trimmed only where a nested
+ * object's contents are irrelevant to the gates, which walk top-level keys.
+ */
+const PROD: Record<string, Record<string, unknown>> = {
+  "iso-country-lookup": { query: "Sweden", match: { name: "Sweden", alpha_2: "SE" } },
+  "incoterms-explain": {
+    incoterm: { code: "FOB", full_name: "Free On Board" },
+    version: "Incoterms 2020",
+    published_by: "International Chamber of Commerce",
+  },
+  "dangerous-goods-classify": {
+    query: "acid",
+    matches: [{ un_number: "UN3149", class: "5" }],
+    total_matches: 2,
+  },
+  "company-id-detect": {
+    input: "559395-7979",
+    detected: true,
+    best_match: { country: "Sweden", id_type: "org_number" },
+    all_matches: [{ country: "Sweden" }],
+  },
+  "name-parse": {
+    full_name: "Dr. John Robert Smith Jr.",
+    first_name: "John",
+    middle_name: "Robert",
+    last_name: "Smith",
+    prefix: "Dr.",
+    suffix: "Jr.",
+    nickname: null,
+  },
+  "skill-extract": {
+    technical_skills: ["Python", "TypeScript", "AWS", "Kubernetes"],
+    soft_skills: ["communication", "mentoring"],
+    tools: ["Docker", "Git", "Terraform"],
+    certifications: ["AWS Certified"],
+    languages: ["Swedish", "English"],
+    experience_levels_mentioned: ["6+ years"],
+    seniority_signals: ["senior"],
+    total_skills_found: 12,
+  },
+  "beneficial-ownership-lookup": {
+    company_name: "TESCO PLC",
+    company_number: "00445790",
+    jurisdiction: "gb",
+    company_status: "active",
+    beneficial_owners: [],
+    total_beneficial_owners: 0,
+    has_psc_data: true,
+    data_source: "UK Companies House PSC Register",
+  },
+};
+
+/** The two gates the test runner applies, in the order it applies them. */
+function gates(output: Record<string, unknown>, c: OutputContract) {
+  const sentinel = checkGuaranteedFieldsPresent(output, c.reliability);
+  const ratio = calculateNullFieldRatio(output, { properties: c.properties }, c.reliability);
+  return { sentinel, ratio, passes: sentinel.passed && !ratio.wouldFail };
+}
+
+describe("capability output contracts — production shapes pass both gates", () => {
+  it.each(CORRECTED_SLUGS)("%s", (slug) => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS[slug]!;
+    const { sentinel, ratio, passes } = gates(PROD[slug]!, c);
+    expect(sentinel.failureReason ?? null).toBeNull();
+    expect(ratio.wouldFail).toBe(false);
+    expect(passes).toBe(true);
+  });
+
+  it.each(CORRECTED_SLUGS)("%s declares every key production returned", (slug) => {
+    const declared = new Set(Object.keys(CAPABILITY_OUTPUT_CONTRACTS[slug]!.properties));
+    for (const key of Object.keys(PROD[slug]!)) {
+      expect(declared, `${slug}.${key} is returned but not declared`).toContain(key);
+    }
+  });
+
+  it.each(CORRECTED_SLUGS)("%s annotates reliability for exactly its declared fields", (slug) => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS[slug]!;
+    expect(Object.keys(c.reliability).sort()).toEqual(Object.keys(c.properties).sort());
+  });
+});
+
+describe("the corrections still catch a broken executor", () => {
+  // The failure mode a lenient "fix" would introduce: silence the alarm by
+  // declaring everything optional. Each case below is a plausible breakage that
+  // must still be caught.
+
+  it("iso-country-lookup: an empty envelope still fails the sentinel", () => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS["iso-country-lookup"]!;
+    expect(gates({ match: { name: "Sweden" } }, c).sentinel.passed).toBe(false);
+  });
+
+  it("dangerous-goods-classify: losing `matches` entirely still fails", () => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS["dangerous-goods-classify"]!;
+    // Keys dropped by a parser regression → sentinel catches it.
+    expect(gates({ query: "acid" }, c).sentinel.passed).toBe(false);
+    // Keys present but the search silently returns nothing for every query →
+    // null-ratio catches it (2 of 3 guaranteed fields empty).
+    const empty = gates({ query: "acid", matches: [], total_matches: 0 }, c);
+    expect(empty.sentinel.passed).toBe(true);
+    expect(empty.ratio.wouldFail).toBe(false); // total_matches: 0 is a real answer, not an empty one
+    // ...but an all-empty envelope is not:
+    expect(gates({ query: "", matches: [], total_matches: null }, c).ratio.wouldFail).toBe(true);
+  });
+
+  it("incoterms-explain: a hollowed-out response still fails on null ratio", () => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS["incoterms-explain"]!;
+    const r = gates({ incoterm: null, version: null, published_by: null }, c);
+    expect(r.ratio.wouldFail).toBe(true);
+    expect(r.ratio.nullCount).toBe(3);
+  });
+
+  it("name-parse: losing the actual name parts still fails", () => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS["name-parse"]!;
+    const r = gates(
+      { full_name: "", first_name: null, last_name: null, middle_name: null, prefix: null, suffix: null, nickname: null },
+      c,
+    );
+    expect(r.ratio.wouldFail).toBe(true);
+  });
+
+  it("name-parse: an ordinary name with no prefix or nickname PASSES", () => {
+    // The regression this correction exists to stop — 'John Smith' scored 67%
+    // null and was reported as an algorithmic-correctness violation.
+    const c = CAPABILITY_OUTPUT_CONTRACTS["name-parse"]!;
+    const r = gates(
+      { full_name: "John Smith", first_name: "John", last_name: "Smith", middle_name: null, prefix: null, suffix: null, nickname: null },
+      c,
+    );
+    expect(r.passes).toBe(true);
+  });
+
+  it("skill-extract: extracting nothing from a real résumé still fails", () => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS["skill-extract"]!;
+    const r = gates(
+      { technical_skills: [], soft_skills: [], tools: [], certifications: [], languages: [], experience_levels_mentioned: [], seniority_signals: [], total_skills_found: 0 },
+      c,
+    );
+    // 2 of 3 guaranteed categories empty (total_skills_found: 0 is not empty).
+    expect(r.ratio.wouldFail).toBe(true);
+  });
+
+  it("beneficial-ownership-lookup: dropping the identity fields still fails", () => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS["beneficial-ownership-lookup"]!;
+    expect(gates({ beneficial_owners: [], total_beneficial_owners: 0 }, c).sentinel.passed).toBe(false);
+  });
+
+  it("company-id-detect: dropping the echo or the verdict still fails", () => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS["company-id-detect"]!;
+    expect(gates({ detected: true, best_match: {} }, c).sentinel.passed).toBe(false);
+    expect(gates({ input: "x", best_match: {} }, c).sentinel.passed).toBe(false);
+  });
+
+  it("company-id-detect: the not-detected branch is legitimate and passes", () => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS["company-id-detect"]!;
+    const r = gates(
+      { input: "test_value", detected: false, matches: [], message: "Could not identify the format of this company ID." },
+      c,
+    );
+    expect(r.passes).toBe(true);
+  });
+});
+
+describe("manifests agree with the contract module", () => {
+  it.each(CORRECTED_SLUGS)("manifests/%s.yaml matches", (slug) => {
+    const c = CAPABILITY_OUTPUT_CONTRACTS[slug]!;
+    const m = yaml.load(readFileSync(resolve(REPO, `manifests/${slug}.yaml`), "utf8")) as Record<string, any>;
+    expect(m.output_schema?.properties).toEqual(c.properties);
+    expect(m.output_field_reliability).toEqual(c.reliability);
+    if (c.knownAnswerInput) {
+      expect(m.test_fixtures?.known_answer?.input).toEqual(c.knownAnswerInput);
+    }
+  });
+
+  it("no manifest still carries a placeholder known-answer input", () => {
+    // 'test_value' and the generic testing sentence are what made two of these
+    // suites ask the capability to find nothing and then fail it for complying.
+    for (const slug of CORRECTED_SLUGS) {
+      const m = yaml.load(readFileSync(resolve(REPO, `manifests/${slug}.yaml`), "utf8")) as Record<string, any>;
+      const input = JSON.stringify(m.test_fixtures?.known_answer?.input ?? {});
+      expect(input, `${slug} known_answer input`).not.toContain("test_value");
+      expect(input, `${slug} known_answer input`).not.toContain("This is a test input for automated");
+    }
+  });
+});

--- a/apps/api/src/lib/capability-output-contracts.ts
+++ b/apps/api/src/lib/capability-output-contracts.ts
@@ -1,0 +1,263 @@
+/**
+ * Corrected output contracts for capabilities whose declared schema drifted
+ * away from what their executor actually returns.
+ *
+ * Why this module exists. `capabilities.output_schema.properties` and
+ * `capabilities.output_field_reliability` are what the test harness measures a
+ * capability against — Gate 2 (null-field ratio) walks the declared properties
+ * and treats an absent one as null, and Gate 3 (the guaranteed-fields sentinel)
+ * fails on a missing guaranteed key. When an executor is reshaped and the
+ * declaration is not, the harness reports a healthy capability as broken,
+ * forever.
+ *
+ * That is what happened here. Measured against production 2026-08-17: seven
+ * capabilities were failing their known-answer suite while returning correct,
+ * fully-populated answers to real calls. Each manifest's `output_schema.example`
+ * had been regenerated at some point and already showed the real shape, while
+ * `properties` still listed a flat field set the executor had stopped
+ * returning. `iso-country-lookup` is the clearest case: it declares
+ * `name, region, alpha_2, alpha_3, schengen, eu_member` at the top level and
+ * returns them nested under `match`, so Gate 2 scored it "100% of declared
+ * fields returned null (6/6)".
+ *
+ * Every shape below was captured by calling production directly with the
+ * capability's own fixture input — not read off the executor source, and not
+ * inferred from the manifest.
+ *
+ * Reliability levels are chosen to be TRUE, not to be quiet:
+ *   - `guaranteed` — present and non-empty on every successful call.
+ *   - `common`     — the key is always present but may be empty, or the field
+ *                    belongs to one of two mutually exclusive response shapes.
+ *   - `rare`       — only on an error/unsupported branch.
+ * Downgrading a field that is genuinely conditional is a correction, not a
+ * weakening; declaring a conditional field `guaranteed` is what produced the
+ * false alarms. Where a downgrade does cost real coverage, it is called out in
+ * the entry's `note`.
+ */
+
+export type Reliability = "guaranteed" | "common" | "rare";
+
+export interface OutputContract {
+  /** JSON-schema `properties` for the capability's output. */
+  properties: Record<string, { type: string }>;
+  /** Per-field reliability, keyed by the same names. */
+  reliability: Record<string, Reliability>;
+  /**
+   * Replacement known-answer fixture input, when the stored one is a
+   * placeholder that exercises the empty path instead of the correct one.
+   */
+  knownAnswerInput?: Record<string, unknown>;
+  /** Why this capability drifted, and what the correction costs. */
+  note: string;
+}
+
+export const CAPABILITY_OUTPUT_CONTRACTS: Record<string, OutputContract> = {
+  // {"query":"Sweden"} -> {query, match}
+  // {"query":"land"}   -> {query, matches, total_matches}
+  // no match           -> {query, matches, total_matches, error}
+  "iso-country-lookup": {
+    properties: {
+      query: { type: "string" },
+      match: { type: "object" },
+      matches: { type: "array" },
+      total_matches: { type: "integer" },
+      error: { type: "string" },
+    },
+    reliability: {
+      query: "guaranteed",
+      match: "common",
+      matches: "common",
+      total_matches: "common",
+      error: "rare",
+    },
+    note:
+      "Two mutually exclusive shapes: an exact hit returns `match`, a fuzzy hit returns " +
+      "`matches`/`total_matches`. Neither can be guaranteed, so only `query` is. That leaves " +
+      "one guaranteed field, below Gate 2's three-field minimum, so the null-ratio rule no " +
+      "longer applies to this capability — the explicit not_null checks in its suite's " +
+      "validation_rules remain the assertion that would catch a regression.",
+  },
+
+  // {"incoterm":"FOB"} -> {incoterm, version, published_by}
+  // unknown code       -> {error, available_codes, available_terms}
+  "incoterms-explain": {
+    properties: {
+      incoterm: { type: "object" },
+      version: { type: "string" },
+      published_by: { type: "string" },
+      error: { type: "string" },
+      available_codes: { type: "array" },
+      available_terms: { type: "array" },
+    },
+    reliability: {
+      incoterm: "guaranteed",
+      version: "guaranteed",
+      published_by: "guaranteed",
+      error: "rare",
+      available_codes: "rare",
+      available_terms: "rare",
+    },
+    note:
+      "The four declared fields (full_name, buyer_obligations, seller_obligations, " +
+      "risk_transfer_point) moved inside the `incoterm` object. Three guaranteed fields " +
+      "remain, so Gate 2 still applies at full strength.",
+  },
+
+  // {"substance":"acid"} -> {query, matches, total_matches}
+  // no match             -> {query, matches, total_matches, error}
+  "dangerous-goods-classify": {
+    properties: {
+      query: { type: "string" },
+      matches: { type: "array" },
+      total_matches: { type: "integer" },
+      error: { type: "string" },
+    },
+    reliability: {
+      query: "guaranteed",
+      matches: "guaranteed",
+      total_matches: "guaranteed",
+      error: "rare",
+    },
+    note:
+      "class/un_number/packing_group/marine_pollutant/proper_shipping_name are per-result " +
+      "fields inside `matches[]`, never top-level. The three envelope fields are always " +
+      "present, so all three stay guaranteed and Gate 2 keeps full strength. `total_matches: 0` " +
+      "is not an empty value, so a genuine no-match still passes; an executor that stopped " +
+      "returning `matches` entirely would still fail.",
+  },
+
+  // {"id":"559395-7979"} -> {input, detected, best_match, all_matches}
+  // {"id":"test_value"}  -> {input, detected, matches, message}
+  "company-id-detect": {
+    properties: {
+      input: { type: "string" },
+      detected: { type: "boolean" },
+      best_match: { type: "object" },
+      all_matches: { type: "array" },
+      matches: { type: "array" },
+      message: { type: "string" },
+    },
+    reliability: {
+      input: "guaranteed",
+      detected: "guaranteed",
+      best_match: "common",
+      all_matches: "common",
+      matches: "common",
+      message: "common",
+    },
+    knownAnswerInput: { id: "559395-7979" },
+    note:
+      "The stored fixture input was the literal placeholder `test_value`, which exercises the " +
+      "not-detected branch — so `best_match` was legitimately absent and the sentinel failed on " +
+      "it every run. A correctness fixture must use a real identifier; this is Moonlighter AB's " +
+      "Swedish org number. best_match/all_matches are genuinely conditional on `detected`.",
+  },
+
+  // {"full_name":"Dr. John Robert Smith Jr."} -> all seven keys, nickname null
+  "name-parse": {
+    properties: {
+      full_name: { type: "string" },
+      first_name: { type: "string" },
+      last_name: { type: "string" },
+      middle_name: { type: "string" },
+      prefix: { type: "string" },
+      suffix: { type: "string" },
+      nickname: { type: "string" },
+    },
+    reliability: {
+      full_name: "guaranteed",
+      first_name: "guaranteed",
+      last_name: "guaranteed",
+      middle_name: "common",
+      prefix: "common",
+      suffix: "common",
+      nickname: "common",
+    },
+    note:
+      "Most names have no prefix, suffix, middle name or nickname. Declaring all six parts " +
+      "guaranteed meant a plain 'John Smith' scored 67% null — the capability was being " +
+      "marked broken for parsing an ordinary name correctly. Three guaranteed fields remain.",
+  },
+
+  // Real shape has eight keys; every one is always present, arrays may be empty.
+  "skill-extract": {
+    properties: {
+      technical_skills: { type: "array" },
+      soft_skills: { type: "array" },
+      tools: { type: "array" },
+      certifications: { type: "array" },
+      languages: { type: "array" },
+      experience_levels_mentioned: { type: "array" },
+      seniority_signals: { type: "array" },
+      total_skills_found: { type: "integer" },
+    },
+    reliability: {
+      technical_skills: "guaranteed",
+      languages: "guaranteed",
+      total_skills_found: "guaranteed",
+      soft_skills: "common",
+      tools: "common",
+      certifications: "common",
+      experience_levels_mentioned: "common",
+      seniority_signals: "common",
+    },
+    knownAnswerInput: {
+      text:
+        "Senior backend engineer with 6 years building Python and TypeScript services on AWS " +
+        "and Kubernetes. Day-to-day tools are Docker, Git and Terraform. AWS Certified " +
+        "Solutions Architect. Known for clear written communication and mentoring juniors. " +
+        "Fluent in Swedish and English.",
+    },
+    note:
+      "The stored fixture text was 'This is a test input for automated capability testing.' — " +
+      "prose containing no skills, so every category came back empty and Gate 2 scored it " +
+      "100% null. The capability was correct; the fixture asked it to find nothing. Replaced " +
+      "with a résumé fragment that genuinely contains skills, tools, a certification and " +
+      "languages, so the three guaranteed categories are non-empty and Gate 2 keeps its bite.",
+  },
+
+  // {company_name:"Tesco PLC", jurisdiction:"GB"} ->
+  //   {company_name, company_number, jurisdiction, company_status,
+  //    beneficial_owners, total_beneficial_owners, has_psc_data, data_source}
+  // unsupported jurisdiction ->
+  //   {company_name, company_number, jurisdiction, supported_jurisdiction,
+  //    message, supported_jurisdictions}
+  "beneficial-ownership-lookup": {
+    properties: {
+      company_name: { type: "string" },
+      company_number: { type: "string" },
+      jurisdiction: { type: "string" },
+      company_status: { type: "string" },
+      beneficial_owners: { type: "array" },
+      total_beneficial_owners: { type: "integer" },
+      has_psc_data: { type: "boolean" },
+      data_source: { type: "string" },
+      supported_jurisdiction: { type: "boolean" },
+      message: { type: "string" },
+      supported_jurisdictions: { type: "array" },
+    },
+    reliability: {
+      company_name: "guaranteed",
+      jurisdiction: "guaranteed",
+      company_number: "common",
+      company_status: "common",
+      beneficial_owners: "common",
+      total_beneficial_owners: "common",
+      has_psc_data: "common",
+      data_source: "common",
+      supported_jurisdiction: "rare",
+      message: "rare",
+      supported_jurisdictions: "rare",
+    },
+    note:
+      "Declared query/lookup_date/total_owners/company_match; the executor returns none of " +
+      "those names, which is why the sentinel failed on `query` every run. UK-only coverage " +
+      "means the unsupported-jurisdiction branch is a real second shape. `beneficial_owners` " +
+      "stays common because a company with no PSC entries correctly returns [] — Tesco PLC " +
+      "does. Two guaranteed fields leaves this below Gate 2's three-field minimum; the " +
+      "sentinel still enforces both keys.",
+  },
+};
+
+/** Slugs this module corrects, in a stable order for logging and tests. */
+export const CORRECTED_SLUGS = Object.keys(CAPABILITY_OUTPUT_CONTRACTS).sort();

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1231,6 +1231,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0087_unhideRedactedRows",
       "runMigration0088_solutionGateCondition",
       "runMigration0089_deactivateUsCourtSearch",
+      "runMigration0090_capabilityOutputContracts",
     ]);
   });
 });
@@ -1597,6 +1598,59 @@ describe("startup-migrations — block 0089 (deactivate us-court-search)", () =>
     const { runMigration0089_deactivateUsCourtSearch } = await import("./startup-migrations.js");
     const stub = makeStub({ queue: [{ count: 1 }] });
     await runMigration0089_deactivateUsCourtSearch(stub);
+    for (const query of stub.captured) {
+      const chunks = (query as unknown as { queryChunks?: unknown[] }).queryChunks ?? [];
+      const badChunks = chunks.filter((c) => c instanceof Date || Buffer.isBuffer(c));
+      expect(badChunks, "no Date/Buffer chunk reaches the SQL bind layer").toEqual([]);
+    }
+  });
+});
+
+describe("startup-migrations — block 0090 (capability output contracts)", () => {
+  it("writes properties, reliability and the two replacement fixtures", async () => {
+    const { runMigration0090_capabilityOutputContracts } = await import("./startup-migrations.js");
+    const { CORRECTED_SLUGS, CAPABILITY_OUTPUT_CONTRACTS } = await import(
+      "./capability-output-contracts.js"
+    );
+    const withFixture = CORRECTED_SLUGS.filter(
+      (s) => CAPABILITY_OUTPUT_CONTRACTS[s]!.knownAnswerInput,
+    );
+    // 2 statements per slug, plus one more for each replacement fixture.
+    const expected = CORRECTED_SLUGS.length * 2 + withFixture.length;
+    const stub = makeStub({ default: { count: 1 } });
+    const result = await runMigration0090_capabilityOutputContracts(stub);
+
+    expect(stub.captured).toHaveLength(expected);
+    expect(result.rows_affected).toBe(expected);
+
+    // Slugs are bound parameters, not SQL text — assert on the binds.
+    const boundParams = stub.captured.flatMap((c) => dialect.sqlToQuery(c).params);
+    for (const slug of CORRECTED_SLUGS) expect(boundParams).toContain(slug);
+
+    const all = stub.renderedSql.join(" ").toLowerCase();
+    // Only `properties` is replaced, so a hand-written `example` survives.
+    expect(all).toContain("jsonb_set");
+    expect(all).toContain("'{properties}'");
+    expect(all).toContain("update test_suites");
+    expect(all).toContain("test_type = 'known_answer'");
+  });
+
+  it("is idempotent — every statement is guarded by IS DISTINCT FROM", async () => {
+    const { runMigration0090_capabilityOutputContracts } = await import("./startup-migrations.js");
+    const stub = makeStub({ default: { count: 0 } });
+    const result = await runMigration0090_capabilityOutputContracts(stub);
+
+    for (const rendered of stub.renderedSql) {
+      expect(rendered.toLowerCase()).toContain("is distinct from");
+    }
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toContain("no change");
+  });
+
+  it("no captured statement binds a Date instance (DEC-20260504-A bind-encoder shape)", async () => {
+    const { runMigration0090_capabilityOutputContracts } = await import("./startup-migrations.js");
+    const stub = makeStub({ default: { count: 1 } });
+    await runMigration0090_capabilityOutputContracts(stub);
     for (const query of stub.captured) {
       const chunks = (query as unknown as { queryChunks?: unknown[] }).queryChunks ?? [];
       const badChunks = chunks.filter((c) => c instanceof Date || Buffer.isBuffer(c));

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -46,6 +46,10 @@ import {
   deriveQuotaCapFromRateLimit,
   type ManifestKnownRateLimit,
 } from "./capability-manifest-types.js";
+import {
+  CAPABILITY_OUTPUT_CONTRACTS,
+  CORRECTED_SLUGS,
+} from "./capability-output-contracts.js";
 
 /**
  * Minimal executor surface — matches what `getDb().execute()` returns
@@ -1552,6 +1556,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0087_unhideRedactedRows,
   runMigration0088_solutionGateCondition,
   runMigration0089_deactivateUsCourtSearch,
+  runMigration0090_capabilityOutputContracts,
 ];
 
 /**
@@ -2173,6 +2178,89 @@ export async function runMigration0089_deactivateUsCourtSearch(
         ? "no change (us-court-search already inactive)"
         : "us-court-search deactivated — was serving HTTP 500 on an expired CourtListener token",
     rows_affected: affected,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+/**
+ * Block 0090 — realign seven capabilities' declared output contract with what
+ * their executors actually return.
+ *
+ * The harness measures a capability against `output_schema.properties` (Gate 2,
+ * null-field ratio) and `output_field_reliability` (Gate 3, guaranteed-fields
+ * sentinel). Seven capabilities had declarations describing a shape their
+ * executors stopped returning, so the harness reported them broken while
+ * production answered every call correctly. See
+ * lib/capability-output-contracts.ts for each shape and how it was captured.
+ *
+ * Two capabilities also carry a replacement known-answer fixture input: their
+ * stored inputs were placeholders (`test_value`, "This is a test input for
+ * automated capability testing.") that exercise the empty branch, so the suite
+ * asked the capability to find nothing and then failed it for finding nothing.
+ *
+ * Idempotent: each UPDATE is guarded by `IS DISTINCT FROM` on the value being
+ * written, so a re-run on a corrected row affects zero rows. Changing a suite's
+ * input bumps `updated_at`, which invalidates its now-wrong fixture baseline
+ * under the staleness rule added in the same release — the suite re-executes
+ * live and re-captures. That interaction is deliberate.
+ */
+export async function runMigration0090_capabilityOutputContracts(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  let schemaRows = 0;
+  let reliabilityRows = 0;
+  let fixtureRows = 0;
+
+  for (const slug of CORRECTED_SLUGS) {
+    const contract = CAPABILITY_OUTPUT_CONTRACTS[slug]!;
+
+    // jsonb_set on `properties` alone, so a hand-written `example`, `type` or
+    // `required` elsewhere in the schema survives.
+    const schemaRes = await tx.execute(sql`
+      UPDATE capabilities
+      SET output_schema = jsonb_set(
+            COALESCE(output_schema, '{"type":"object"}'::jsonb),
+            '{properties}',
+            ${JSON.stringify(contract.properties)}::jsonb,
+            true
+          )
+      WHERE slug = ${slug}
+        AND COALESCE(output_schema->'properties', 'null'::jsonb)
+            IS DISTINCT FROM ${JSON.stringify(contract.properties)}::jsonb
+    `);
+    schemaRows += (schemaRes as { count?: number }).count ?? 0;
+
+    const relRes = await tx.execute(sql`
+      UPDATE capabilities
+      SET output_field_reliability = ${JSON.stringify(contract.reliability)}::jsonb
+      WHERE slug = ${slug}
+        AND COALESCE(output_field_reliability, 'null'::jsonb)
+            IS DISTINCT FROM ${JSON.stringify(contract.reliability)}::jsonb
+    `);
+    reliabilityRows += (relRes as { count?: number }).count ?? 0;
+
+    if (contract.knownAnswerInput) {
+      const fixRes = await tx.execute(sql`
+        UPDATE test_suites
+        SET input = ${JSON.stringify(contract.knownAnswerInput)}::jsonb,
+            updated_at = now()
+        WHERE capability_slug = ${slug}
+          AND test_type = 'known_answer'
+          AND input IS DISTINCT FROM ${JSON.stringify(contract.knownAnswerInput)}::jsonb
+      `);
+      fixtureRows += (fixRes as { count?: number }).count ?? 0;
+    }
+  }
+
+  const total = schemaRows + reliabilityRows + fixtureRows;
+  return {
+    block: "0090_capabilityOutputContracts",
+    outcome:
+      total === 0
+        ? "no change (all seven contracts already match the executors)"
+        : `${schemaRows} schema, ${reliabilityRows} reliability, ${fixtureRows} fixture input(s) realigned`,
+    rows_affected: total,
     duration_ms: Date.now() - startedAt,
   };
 }

--- a/manifests/beneficial-ownership-lookup.yaml
+++ b/manifests/beneficial-ownership-lookup.yaml
@@ -1,10 +1,9 @@
 slug: beneficial-ownership-lookup
 name: Beneficial Ownership Lookup (UK)
 description: >-
-  Look up UK beneficial ownership (UBO / PSC) information for a company. Returns individuals
-  who ultimately own or control the entity, their ownership percentage, and the ownership
-  chain. Uses Companies House Persons of Significant Control. UK-only — non-GB inputs
-  return a clear coverage notice rather than a fabricated result.
+  Look up UK beneficial ownership (UBO / PSC) information for a company. Returns individuals who ultimately own or
+  control the entity, their ownership percentage, and the ownership chain. Uses Companies House Persons of Significant
+  Control. UK-only — non-GB inputs return a clear coverage notice rather than a fabricated result.
 category: compliance
 cost_class: free_quota
 quota_window: daily
@@ -32,50 +31,44 @@ input_schema:
 output_schema:
   type: object
   properties:
-    query:
+    company_name:
+      type: string
+    company_number:
+      type: string
+    jurisdiction:
+      type: string
+    company_status:
       type: string
     beneficial_owners:
-      type:
-        - array
-        - "null"
-      description: >-
-        Array of resolved PSCs on the success path. Absent entirely on the
-        `supported_jurisdiction: false` envelope (non-UK jurisdictions —
-        discriminated runtime shape, check the discriminator before reading).
-    total_owners:
+      type: array
+    total_beneficial_owners:
       type: integer
-    company_match:
-      type: object
+    has_psc_data:
+      type: boolean
     data_source:
-      type: string
-    lookup_date:
       type: string
     supported_jurisdiction:
       type: boolean
-      description: >-
-        Present on the non-UK path. `false` indicates the executor does not
-        currently cover this jurisdiction; data fields are absent.
+    message:
+      type: string
+    supported_jurisdictions:
+      type: array
 data_source: Companies House Persons of Significant Control (UK)
 data_source_type: api
 transparency_tag: algorithmic
 freshness_category: live-fetch
 maintenance_class: commercial-stable-api
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
 processes_personal_data: true
 personal_data_categories:
   - name
   - address
   - sensitive_special
-# Cert-audit RED-4: was 'global' in the manifest while the executor only
-# calls Companies House for jurisdiction='gb'. Corrected to UK-only.
-# Adding non-UK coverage requires either a real UBO API integration
-# (OpenOwnership / aggregator) or a vendor wrap per DEC-20260428-A.
 geography: uk
 test_fixtures:
   known_answer:
     input:
-      company_name: "Tesco PLC"
-      jurisdiction: "GB"
+      company_name: Tesco PLC
+      jurisdiction: GB
     expected_fields:
       - field: query
         operator: not_null
@@ -90,22 +83,26 @@ test_fixtures:
         operator: not_null
         reliability: guaranteed
   health_check_input:
-    company_name: "Tesco PLC"
-    jurisdiction: "GB"
+    company_name: Tesco PLC
+    jurisdiction: GB
 output_field_reliability:
-  query: guaranteed
-  beneficial_owners: common
-  total_owners: guaranteed
-  company_match: common
-  data_source: guaranteed
-  lookup_date: guaranteed
-  jurisdiction: common
+  company_name: guaranteed
+  jurisdiction: guaranteed
   company_number: common
-  coverage_note: common
+  company_status: common
+  beneficial_owners: common
+  total_beneficial_owners: common
+  has_psc_data: common
+  data_source: common
   supported_jurisdiction: rare
+  message: rare
+  supported_jurisdictions: rare
 limitations:
   - title: UK only — non-GB inputs return a coverage notice
-    text: This capability calls Companies House Persons of Significant Control. Non-GB jurisdictions return a structured coverage notice rather than a result. Adding non-UK coverage requires a separate real UBO source (OpenOwnership integration or aggregator wrap per DEC-20260428-A).
+    text: >-
+      This capability calls Companies House Persons of Significant Control. Non-GB jurisdictions return a structured
+      coverage notice rather than a result. Adding non-UK coverage requires a separate real UBO source (OpenOwnership
+      integration or aggregator wrap per DEC-20260428-A).
     category: coverage
     severity: warning
   - title: PSC data may lag real ownership changes
@@ -113,6 +110,8 @@ limitations:
     category: freshness
     severity: info
   - title: Complex ownership chains may not be fully resolved
-    text: Cross-border ownership chains where intermediate entities are non-UK companies cannot be traced from this dataset alone.
+    text: >-
+      Cross-border ownership chains where intermediate entities are non-UK companies cannot be traced from this dataset
+      alone.
     category: accuracy
     severity: info

--- a/manifests/company-id-detect.yaml
+++ b/manifests/company-id-detect.yaml
@@ -1,6 +1,3 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
-
 slug: company-id-detect
 name: Company ID Detection
 description: >-
@@ -27,24 +24,29 @@ output_schema:
     message: Could not identify the format of this company ID.
     detected: false
   properties:
+    input:
+      type: string
     detected:
       type: boolean
     best_match:
       type: object
     all_matches:
       type: array
+    matches:
+      type: array
+    message:
+      type: string
 data_source: Algorithmic (pattern matching for org number formats across 20+ countries)
 data_source_type: computed
 transparency_tag: algorithmic
 freshness_category: computed
 maintenance_class: pure-computation
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
 processes_personal_data: false
 geography: global
 test_fixtures:
   known_answer:
     input:
-      id: 556703-7485
+      id: 559395-7979
     expected_fields:
       - field: detected
         operator: not_null
@@ -68,11 +70,14 @@ test_fixtures:
         reliability: guaranteed
         value: array
   health_check_input:
-    id: 556703-7485
+    id: 559395-7979
 output_field_reliability:
+  input: guaranteed
   detected: guaranteed
-  best_match: guaranteed
-  all_matches: guaranteed
+  best_match: common
+  all_matches: common
+  matches: common
+  message: common
 limitations:
   - title: Ambiguous IDs matching multiple country formats may return multiple candidates requiring manual disambiguation
     text: >-

--- a/manifests/dangerous-goods-classify.yaml
+++ b/manifests/dangerous-goods-classify.yaml
@@ -1,6 +1,3 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
-
 slug: dangerous-goods-classify
 name: Dangerous Goods Classify
 description: >-
@@ -29,22 +26,19 @@ output_schema:
     matches: []
     total_matches: 0
   properties:
-    class:
+    query:
       type: string
-    un_number:
-      type: string
-    packing_group:
-      type: string
-    marine_pollutant:
-      type: boolean
-    proper_shipping_name:
+    matches:
+      type: array
+    total_matches:
+      type: integer
+    error:
       type: string
 data_source: Algorithmic (UN dangerous goods classification, ADR/IMDG/IATA rules)
 data_source_type: computed
 transparency_tag: algorithmic
 freshness_category: computed
 maintenance_class: pure-computation
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
 processes_personal_data: false
 geography: global
 test_fixtures:
@@ -64,11 +58,10 @@ test_fixtures:
   health_check_input:
     substance: acid
 output_field_reliability:
-  class: guaranteed
-  un_number: guaranteed
-  packing_group: guaranteed
-  marine_pollutant: guaranteed
-  proper_shipping_name: guaranteed
+  query: guaranteed
+  matches: guaranteed
+  total_matches: guaranteed
+  error: rare
 limitations:
   - title: >-
       AI-based dangerous goods classification is a preliminary screen only — certified testing and documentation are

--- a/manifests/incoterms-explain.yaml
+++ b/manifests/incoterms-explain.yaml
@@ -1,6 +1,3 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
-
 slug: incoterms-explain
 name: Incoterms Explain
 description: Explain any Incoterms 2020 rule. Returns seller/buyer obligations, risk/cost transfer points, suitability.
@@ -20,7 +17,7 @@ input_schema:
 output_schema:
   type: object
   example:
-    error: "Unknown Incoterm: \"test\". Must be one of the 11 Incoterms 2020 rules."
+    error: 'Unknown Incoterm: "test". Must be one of the 11 Incoterms 2020 rules.'
     available_codes:
       - EXW
       - FCA
@@ -68,20 +65,23 @@ output_schema:
         full_name: Cost, Insurance and Freight
         suitable_for: sea_and_inland_waterway_only
   properties:
-    full_name:
+    incoterm:
+      type: object
+    version:
       type: string
-    buyer_obligations:
-      type: array
-    seller_obligations:
-      type: array
-    risk_transfer_point:
+    published_by:
       type: string
+    error:
+      type: string
+    available_codes:
+      type: array
+    available_terms:
+      type: array
 data_source: Algorithmic (ICC Incoterms 2020 rule database)
 data_source_type: computed
 transparency_tag: algorithmic
 freshness_category: computed
 maintenance_class: pure-computation
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
 processes_personal_data: false
 geography: global
 test_fixtures:
@@ -98,10 +98,12 @@ test_fixtures:
   health_check_input:
     incoterm: EXW
 output_field_reliability:
-  full_name: guaranteed
-  buyer_obligations: guaranteed
-  seller_obligations: guaranteed
-  risk_transfer_point: guaranteed
+  incoterm: guaranteed
+  version: guaranteed
+  published_by: guaranteed
+  error: rare
+  available_codes: rare
+  available_terms: rare
 limitations:
   - title: Incoterms 2020 explanation does not account for contractual modifications or local trade customs
     text: AI-generated explanation of Incoterms 2020 — does not account for contractual modifications or local trade customs

--- a/manifests/iso-country-lookup.yaml
+++ b/manifests/iso-country-lookup.yaml
@@ -1,6 +1,3 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
-
 slug: iso-country-lookup
 name: ISO Country Lookup
 description: >-
@@ -27,24 +24,21 @@ output_schema:
     matches: []
     total_matches: 0
   properties:
-    name:
+    query:
       type: string
-    region:
+    match:
+      type: object
+    matches:
+      type: array
+    total_matches:
+      type: integer
+    error:
       type: string
-    alpha_2:
-      type: string
-    alpha_3:
-      type: string
-    schengen:
-      type: boolean
-    eu_member:
-      type: boolean
 data_source: Algorithmic (ISO 3166-1 country code database)
 data_source_type: computed
 transparency_tag: algorithmic
 freshness_category: computed
 maintenance_class: pure-computation
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
 processes_personal_data: false
 personal_data_categories: []
 geography: global
@@ -64,16 +58,12 @@ test_fixtures:
         reliability: common
   health_check_input:
     query: land
-# Top-level response fields only. `name`, `alpha_2`, `region` etc. are NOT
-# top-level — the executor nests them inside `match` (single hit) or inside
-# each element of `matches` (zero or several hits). Declaring them here made
-# the smoke test assert not-null on fields that never appear at the top level,
-# so step 3 failed on every run.
 output_field_reliability:
   query: guaranteed
   match: common
   matches: common
   total_matches: common
+  error: rare
 limitations:
   - title: Country data is based on ISO 3166-1 — newly created or renamed countries may not yet be reflected
     text: Country data based on ISO 3166-1 standard — newly created or renamed countries may take time to be reflected

--- a/manifests/name-parse.yaml
+++ b/manifests/name-parse.yaml
@@ -1,6 +1,3 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
-
 slug: name-parse
 name: Name Parse
 description: >-
@@ -30,24 +27,25 @@ output_schema:
     first_name: test
     middle_name: null
   properties:
+    full_name:
+      type: string
+    first_name:
+      type: string
+    last_name:
+      type: string
+    middle_name:
+      type: string
     prefix:
       type: string
     suffix:
       type: string
     nickname:
       type: string
-    last_name:
-      type: string
-    first_name:
-      type: string
-    middle_name:
-      type: string
 data_source: Algorithmic (name component extraction, no external data)
 data_source_type: computed
 transparency_tag: algorithmic
 freshness_category: computed
 maintenance_class: pure-computation
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
 processes_personal_data: true
 personal_data_categories:
   - name
@@ -81,12 +79,13 @@ test_fixtures:
   health_check_input:
     full_name: test
 output_field_reliability:
-  prefix: guaranteed
-  suffix: guaranteed
-  nickname: guaranteed
-  last_name: guaranteed
+  full_name: guaranteed
   first_name: guaranteed
-  middle_name: guaranteed
+  last_name: guaranteed
+  middle_name: common
+  prefix: common
+  suffix: common
+  nickname: common
 limitations:
   - title: Compound surnames, non-Western naming conventions, and honorifics may be split incorrectly
     text: AI-powered name parsing — compound surnames, cultural naming conventions, and honorifics may be split incorrectly

--- a/manifests/skill-extract.yaml
+++ b/manifests/skill-extract.yaml
@@ -1,6 +1,3 @@
-# Auto-generated from database on 2026-03-17
-# Review and adjust before using as onboarding template
-
 slug: skill-extract
 name: Skill Extract
 description: >-
@@ -31,22 +28,27 @@ output_schema:
     total_skills_found: 0
     experience_levels_mentioned: []
   properties:
-    tools:
-      type: array
-    languages:
+    technical_skills:
       type: array
     soft_skills:
       type: array
+    tools:
+      type: array
     certifications:
       type: array
-    technical_skills:
+    languages:
       type: array
+    experience_levels_mentioned:
+      type: array
+    seniority_signals:
+      type: array
+    total_skills_found:
+      type: integer
 data_source: Algorithmic (skill taxonomy matching from text, no external data)
 data_source_type: computed
 transparency_tag: algorithmic
 freshness_category: computed
 maintenance_class: commercial-stable-api
-# SA.2b: per-capability PII classification (F-A-003, F-A-009)
 processes_personal_data: true
 personal_data_categories:
   - professional
@@ -54,7 +56,10 @@ geography: global
 test_fixtures:
   known_answer:
     input:
-      text: This is a test input for automated capability testing.
+      text: >-
+        Senior backend engineer with 6 years building Python and TypeScript services on AWS and Kubernetes. Day-to-day
+        tools are Docker, Git and Terraform. AWS Certified Solutions Architect. Known for clear written communication
+        and mentoring juniors. Fluent in Swedish and English.
     expected_fields:
       - field: tools
         operator: not_null
@@ -85,13 +90,19 @@ test_fixtures:
         reliability: guaranteed
         value: array
   health_check_input:
-    text: test
+    text: >-
+      Senior backend engineer with 6 years building Python and TypeScript services on AWS and Kubernetes. Day-to-day
+      tools are Docker, Git and Terraform. AWS Certified Solutions Architect. Known for clear written communication and
+      mentoring juniors. Fluent in Swedish and English.
 output_field_reliability:
-  tools: guaranteed
-  languages: guaranteed
-  soft_skills: guaranteed
-  certifications: guaranteed
   technical_skills: guaranteed
+  languages: guaranteed
+  total_skills_found: guaranteed
+  soft_skills: common
+  tools: common
+  certifications: common
+  experience_levels_mentioned: common
+  seniority_signals: common
 limitations:
   - title: AI skill extraction may categorize competencies differently than industry taxonomies like ESCO or O*NET
     text: >-


### PR DESCRIPTION
Follow-up to #305 (the correctness invariant) and #308 (stale fixture baselines). Those two stopped the harness blaming capabilities for the world and for its own frozen fixtures. This one fixes the last cause: **declarations that describe a shape the executors stopped returning.**

## What was wrong

The harness measures a capability against `output_schema.properties` (Gate 2, null-field ratio) and `output_field_reliability` (Gate 3, guaranteed-fields sentinel). When an executor is reshaped and the declaration is not, a healthy capability is reported broken — permanently.

Every one of these manifests already carried a **regenerated `output_schema.example` showing the real shape, right next to a stale `properties`**. The example was maintained; the contract was not.

| capability | declared | actually returns |
|---|---|---|
| `iso-country-lookup` | 6 flat fields (`name`, `alpha_2`, …) | `{query, match}` or `{query, matches, total_matches}` |
| `incoterms-explain` | `full_name`, `buyer_obligations`, … | those moved inside `incoterm` |
| `dangerous-goods-classify` | `class`, `un_number`, … | per-result fields inside `matches[]` |
| `beneficial-ownership-lookup` | `query`, `lookup_date`, `total_owners`, `company_match` | none of those names exist |
| `name-parse` | all six name parts **guaranteed** | most names have no prefix/suffix/middle/nickname |
| `company-id-detect` | fixture input `test_value` | a placeholder that exercises the *not-detected* branch |
| `skill-extract` | fixture text with no skills in it | correctly extracted nothing, scored 100% null |

The last two are worth stating plainly: those suites asked the capability to find nothing, and then failed it for complying.

Every shape above was captured by **calling production with the capability's own fixture input** — not read off the executor source, not inferred from the manifest.

## Honesty about coverage

Reliability levels are set to be *true*, not quiet. A field that is genuinely conditional becomes `common`; declaring it `guaranteed` is what produced the false alarms in the first place.

Where that costs real coverage, the entry's `note` says so out loud: `iso-country-lookup` and `beneficial-ownership-lookup` drop below Gate 2's three-field minimum, so the null-ratio rule no longer applies to them and their suites' explicit `not_null` checks become the assertion that would catch a regression. `dangerous-goods-classify`, `incoterms-explain`, `name-parse` and `skill-extract` keep three or more guaranteed fields and full Gate 2 strength.

## One source of truth

`lib/capability-output-contracts.ts`. Migration 0090 writes it to the DB using `jsonb_set` on `properties` alone, so hand-written `example` blocks survive. The manifests are generated from the same module and **a test asserts they agree**, so the two cannot drift apart again — which is exactly how this happened.

Changing a suite's input bumps `updated_at`, which invalidates its now-wrong fixture baseline under #308's staleness rule; the suite re-executes live and re-captures. That interaction is deliberate.

## Tests

41 new. Beyond the happy path, **each capability has a case proving a genuinely broken executor is still caught** — a correction that silences the alarm by deleting coverage is not a fix:

- `name-parse`: "John Smith" now passes, but a response with the name parts emptied still fails.
- `dangerous-goods-classify`: `total_matches: 0` is a real answer and passes; an all-empty envelope fails; dropping `matches` entirely fails.
- `company-id-detect`: the not-detected branch passes; dropping the echo or the verdict fails.
- `skill-extract`: extracting nothing from a real résumé still fails.

**Discrimination proven:** 10 tests fail against the pre-fix declarations; the idempotency test fails when a guard is removed. Full suite 1884 passed, `tsc --noEmit` clean, shape-contract / platform-facts / manifest-consistency sweeps clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)