### PR TITLE
fix(tests): stop asserting fields beneficial-ownership-lookup does not return

### DIFF
--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1232,6 +1232,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0088_solutionGateCondition",
       "runMigration0089_deactivateUsCourtSearch",
       "runMigration0090_capabilityOutputContracts",
+      "runMigration0091_bolStaleValidationRules",
     ]);
   });
 });
@@ -1655,6 +1656,66 @@ describe("startup-migrations — block 0090 (capability output contracts)", () =
       const chunks = (query as unknown as { queryChunks?: unknown[] }).queryChunks ?? [];
       const badChunks = chunks.filter((c) => c instanceof Date || Buffer.isBuffer(c));
       expect(badChunks, "no Date/Buffer chunk reaches the SQL bind layer").toEqual([]);
+    }
+  });
+});
+
+describe("startup-migrations — block 0091 (stale beneficial-ownership assertions)", () => {
+  it("asserts only fields the executor actually returns", async () => {
+    const { BOL_DEPENDENCY_HEALTH_CHECKS, BOL_SCHEMA_CHECK_CHECKS } = await import(
+      "./startup-migrations.js"
+    );
+    // Verbatim from production 2026-08-17, input {company_name:"Tesco PLC", jurisdiction:"GB"}.
+    const PROD_KEYS = [
+      "company_name", "company_number", "jurisdiction", "company_status",
+      "beneficial_owners", "total_beneficial_owners", "has_psc_data", "data_source",
+    ];
+    for (const rules of [BOL_DEPENDENCY_HEALTH_CHECKS, BOL_SCHEMA_CHECK_CHECKS]) {
+      for (const c of rules.checks) {
+        expect(PROD_KEYS, `asserts a field production does not return: ${c.field}`).toContain(c.field);
+      }
+    }
+    // The four dead names must be gone from both.
+    const all = JSON.stringify([BOL_DEPENDENCY_HEALTH_CHECKS, BOL_SCHEMA_CHECK_CHECKS]);
+    for (const dead of ["coverage_note", "total_owners", "lookup_date"]) {
+      expect(all).not.toContain(dead);
+    }
+    // ...and the replacements must still assert something real, not nothing.
+    expect(BOL_DEPENDENCY_HEALTH_CHECKS.checks.length).toBeGreaterThanOrEqual(3);
+    expect(BOL_SCHEMA_CHECK_CHECKS.checks.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("targets only the schema_check suite carrying the dead names", async () => {
+    const { runMigration0091_bolStaleValidationRules } = await import("./startup-migrations.js");
+    const stub = makeStub({ default: { count: 1 } });
+    await runMigration0091_bolStaleValidationRules(stub);
+    const [depSql, schemaSql] = stub.renderedSql.map((x) => x.toLowerCase());
+    expect(depSql).toContain("test_type = 'dependency_health'");
+    expect(schemaSql).toContain("test_type = 'schema_check'");
+    // Without this predicate the migration would overwrite the three sibling
+    // schema_check suites that assert real fields.
+    expect(schemaSql).toContain("coverage_note");
+    expect(schemaSql).toContain("like");
+  });
+
+  it("is idempotent — both statements guard on IS DISTINCT FROM", async () => {
+    const { runMigration0091_bolStaleValidationRules } = await import("./startup-migrations.js");
+    const stub = makeStub({ default: { count: 0 } });
+    const result = await runMigration0091_bolStaleValidationRules(stub);
+    for (const rendered of stub.renderedSql) {
+      expect(rendered.toLowerCase()).toContain("is distinct from");
+    }
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toContain("no change");
+  });
+
+  it("no captured statement binds a Date instance (DEC-20260504-A bind-encoder shape)", async () => {
+    const { runMigration0091_bolStaleValidationRules } = await import("./startup-migrations.js");
+    const stub = makeStub({ default: { count: 1 } });
+    await runMigration0091_bolStaleValidationRules(stub);
+    for (const query of stub.captured) {
+      const chunks = (query as unknown as { queryChunks?: unknown[] }).queryChunks ?? [];
+      expect(chunks.filter((c) => c instanceof Date || Buffer.isBuffer(c))).toEqual([]);
     }
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1557,6 +1557,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0088_solutionGateCondition,
   runMigration0089_deactivateUsCourtSearch,
   runMigration0090_capabilityOutputContracts,
+  runMigration0091_bolStaleValidationRules,
 ];
 
 /**
@@ -2260,6 +2261,87 @@ export async function runMigration0090_capabilityOutputContracts(
       total === 0
         ? "no change (all seven contracts already match the executors)"
         : `${schemaRows} schema, ${reliabilityRows} reliability, ${fixtureRows} fixture input(s) realigned`,
+    rows_affected: total,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+/**
+ * Block 0091 — drop assertions on fields `beneficial-ownership-lookup` does
+ * not return.
+ *
+ * Two of its suites still assert the pre-rewrite field names — `coverage_note`,
+ * `query`, `total_owners`, `lookup_date`. The executor returns none of them in
+ * either of its two response shapes; the same drift that block 0090 fixed in
+ * the declared schema also reached the suites' validation_rules.
+ *
+ * Until 0090 these checks were masked: `output_field_reliability` carried
+ * `coverage_note: common`, and Gate 1 excuses a failing check on a
+ * common/rare field. Removing the dead names from the reliability map — correct
+ * in itself, since they are not fields — made Gate 1 treat them as unannotated
+ * and therefore enforced. The honest repair is to stop asserting fields that do
+ * not exist, not to re-add fictional entries to the reliability map so the
+ * assertions stay excused.
+ *
+ * The known_answer suite already lost its `coverage_note` check to
+ * auto-remediation at 2026-08-17T07:41:03Z; this covers the two it did not
+ * reach. Replacement checks name only fields observed in production.
+ *
+ * Idempotent via `IS DISTINCT FROM` on the value being written.
+ */
+export const BOL_DEPENDENCY_HEALTH_CHECKS = {
+  checks: [
+    { field: "jurisdiction", operator: "not_null" },
+    { field: "beneficial_owners", operator: "not_null" },
+    { field: "data_source", operator: "not_null" },
+  ],
+};
+
+export const BOL_SCHEMA_CHECK_CHECKS = {
+  checks: [
+    { field: "company_name", operator: "not_null" },
+    { field: "jurisdiction", operator: "not_null" },
+    { field: "beneficial_owners", operator: "not_null" },
+    { field: "data_source", operator: "not_null" },
+    { field: "total_beneficial_owners", operator: "not_null" },
+    { field: "has_psc_data", operator: "not_null" },
+  ],
+};
+
+export async function runMigration0091_bolStaleValidationRules(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const dep = await tx.execute(sql`
+    UPDATE test_suites
+    SET validation_rules = ${JSON.stringify(BOL_DEPENDENCY_HEALTH_CHECKS)}::jsonb,
+        updated_at = now()
+    WHERE capability_slug = 'beneficial-ownership-lookup'
+      AND test_type = 'dependency_health'
+      AND validation_rules IS DISTINCT FROM ${JSON.stringify(BOL_DEPENDENCY_HEALTH_CHECKS)}::jsonb
+  `);
+
+  // Only the one schema_check suite that carries the dead names. The other
+  // three assert real fields and are left alone.
+  const schema = await tx.execute(sql`
+    UPDATE test_suites
+    SET validation_rules = ${JSON.stringify(BOL_SCHEMA_CHECK_CHECKS)}::jsonb,
+        updated_at = now()
+    WHERE capability_slug = 'beneficial-ownership-lookup'
+      AND test_type = 'schema_check'
+      AND validation_rules::text LIKE '%coverage_note%'
+      AND validation_rules IS DISTINCT FROM ${JSON.stringify(BOL_SCHEMA_CHECK_CHECKS)}::jsonb
+  `);
+
+  const total =
+    ((dep as { count?: number }).count ?? 0) + ((schema as { count?: number }).count ?? 0);
+  return {
+    block: "0091_bolStaleValidationRules",
+    outcome:
+      total === 0
+        ? "no change (no suite still asserts the removed field names)"
+        : `${total} suite(s) stopped asserting fields the executor does not return`,
     rows_affected: total,
     duration_ms: Date.now() - startedAt,
   };


### PR DESCRIPTION
Tail of the #308 / #309 work. Found by waiting for the real scheduler tick rather than trusting the in-process check.

## What happened

`beneficial-ownership-lookup` failed once at 07:41:03Z on `coverage_note: expected non-null` — a **new** reason, and this one was mine.

Two of its suites still assert the pre-rewrite field names: `coverage_note`, `query`, `total_owners`, `lookup_date`. The executor returns none of them in either of its two response shapes — the same drift #309 fixed in the declared schema had also reached the suites' `validation_rules`.

Until #309 these checks were **masked**: `output_field_reliability` carried `coverage_note: common`, and Gate 1 excuses a failing check on a `common`/`rare` field. Removing the dead names from the reliability map — correct in itself, since they are not fields — made Gate 1 treat them as unannotated, and an unannotated field is enforced. So assertions that had been silently excused for months became live.

Auto-remediation repaired the `known_answer` suite four seconds later (`Downgraded 'coverage_note' from guaranteed to common`). It did not reach the other two.

## The fix

Stop asserting fields that do not exist — rather than re-adding fictional entries to the reliability map so the assertions stay excused. Replacement checks name only fields observed in production (`company_name`, `jurisdiction`, `beneficial_owners`, `data_source`, `total_beneficial_owners`, `has_psc_data`), and both suites keep at least three real assertions.

The `schema_check` UPDATE is scoped by `LIKE '%coverage_note%'` so it touches only the one drifted suite and leaves its three siblings — which assert real fields — alone. A test pins that predicate, because without it the migration would flatten all four.

## Tests

4 new. **Discrimination proven:** the field-existence test fails when `coverage_note` is put back into the replacement checks. Idempotency guarded by `IS DISTINCT FROM` on both statements, with a test that fails when a guard is removed.

Full local suite is noisy on this machine (29 stray node processes competing for ports); pristine `origin/main` fails the same way with a *different* file set each run, so the flakes are environmental. CI is the authority.

## Context: the seven

Six of seven now pass their known-answer suite against production, including `iso-country-lookup` echoing `"Sweden"` for the first time since March with a freshly captured baseline. `beneficial-ownership-lookup` is the seventh and re-runs about every two hours.

Note the alerts lag the fix: the correctness invariant reads a 12-hour window of the last 20 known-answer results, so each capability's window still holds 4–6 old failures and will keep firing until it turns over — expected to go quiet around 19:41Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)