### PR TITLE
fix(web-extract, product-reviews-extract): stop LLM output truncation from reading as capability failure

### DIFF
--- a/apps/api/src/capabilities/product-reviews-extract-truncation.test.ts
+++ b/apps/api/src/capabilities/product-reviews-extract-truncation.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression tests for the 2026-08-17 LLM output-truncation bug — the
+ * product-reviews-extract half of the fix.
+ *
+ * See web-extract-truncation.test.ts for the production incident this class
+ * of bug caused on web-extract. product-reviews-extract had the same latent
+ * bug (fixed max_tokens, no stop_reason check) plus a second, independent
+ * defect: it parsed with the greedy regex `/\{[\s\S]*\}/`, which is exactly
+ * the over-capture bug lib/llm-json.ts's docstring warns about — the regex
+ * runs to the LAST `}` in the string, so trailing prose containing a brace
+ * silently pulls unrelated text into the "parsed" object instead of failing.
+ *
+ * Mocking pattern matches the existing product-reviews-extract.test.ts file
+ * (mock ./lib/browserless-extract.js and @anthropic-ai/sdk directly).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { fetchRenderedHtml, messagesCreate } = vi.hoisted(() => ({
+  fetchRenderedHtml: vi.fn(),
+  messagesCreate: vi.fn(),
+}));
+
+vi.mock("./lib/browserless-extract.js", () => ({
+  fetchRenderedHtml,
+  htmlToText: (h: string) => h,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: messagesCreate };
+  },
+}));
+
+import { getDirectExecutor } from "./index.js";
+import "./product-reviews-extract.js";
+import { CapabilityRefusalError } from "../lib/capability-refusal.js";
+import { classifyTransactionFailure, CALLER_ATTRIBUTABLE } from "../lib/transaction-failure-taxonomy.js";
+
+describe("product-reviews-extract output-truncation handling", () => {
+  beforeEach(() => {
+    fetchRenderedHtml.mockReset();
+    messagesCreate.mockReset();
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    fetchRenderedHtml.mockResolvedValue("<html>lots of reviews</html>");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const exec = () => getDirectExecutor("product-reviews-extract")!;
+
+  it("requests an 8000 max_tokens budget (raised from 2000)", async () => {
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: '{"average_rating":4.2}' }],
+    });
+
+    await exec()({ url: "https://www.consumerlab.com/example/" });
+
+    expect(messagesCreate).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ max_tokens: 8000 }),
+    );
+  });
+
+  it("throws the truncation refusal (not a parse error) when stop_reason is max_tokens — the bug case", async () => {
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "max_tokens",
+      content: [{ type: "text", text: '{"recent_reviews": [{"rating": 5, "text": "great product but the box was' }],
+    });
+
+    let error: unknown;
+    try {
+      await exec()({ url: "https://www.consumerlab.com/example/" });
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(CapabilityRefusalError);
+    expect((error as Error).message).toMatch(/too large for one call/);
+    expect((error as Error).message).toMatch(/fewer reviews/i);
+    expect((error as Error).message).not.toMatch(/Failed to extract product review data/);
+  });
+
+  it("the truncation refusal classifies as caller_input under the quality floor", async () => {
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "max_tokens",
+      content: [{ type: "text", text: "{" }],
+    });
+
+    let message = "";
+    try {
+      await exec()({ url: "https://www.consumerlab.com/example/" });
+    } catch (e) {
+      message = (e as Error).message;
+    }
+
+    const cls = classifyTransactionFailure(message);
+    expect(cls).toBe("caller_input");
+    expect(CALLER_ATTRIBUTABLE.has(cls)).toBe(true);
+  });
+
+  it("still throws the ordinary parse-failure error for genuinely malformed, non-truncation output (must not regress)", async () => {
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "Sorry, I could not read this page." }],
+    });
+
+    let error: unknown;
+    try {
+      await exec()({ url: "https://www.consumerlab.com/example/" });
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).not.toBeInstanceOf(CapabilityRefusalError);
+    expect((error as Error).message).toMatch(/Failed to extract product review data/);
+  });
+
+  it("now parses via extractJsonObject — does not over-capture trailing prose the old greedy regex would have grabbed", async () => {
+    // The exact shape lib/llm-json.ts's docstring warns about: a well-formed
+    // object followed by prose containing a brace. The old
+    // `/\{[\s\S]*\}/` regex runs to the LAST `}` in the string, which is the
+    // one in "{missing}" below — pulling the trailing sentence's brace into
+    // the "parsed" span and making JSON.parse throw (or worse, silently
+    // succeed on a mangled object) instead of returning the real result.
+    const raw =
+      '{"product_name":"Widget","average_rating":4.5,"review_count":10,' +
+      '"recent_reviews":[{"rating":5,"title":"Great","text":"Loved it","date":"2024-01-15","verified":true}],' +
+      '"common_pros":["Durable"],"common_cons":[],"sentiment_summary":"Positive"}\n\n' +
+      "Note: some fields were left as {missing} because the page truncated the review list.";
+
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: raw }],
+    });
+
+    const result = await exec()({ url: "https://www.consumerlab.com/widget/" });
+
+    expect(result.output).toMatchObject({
+      product_name: "Widget",
+      average_rating: 4.5,
+      review_count: 10,
+      sentiment_summary: "Positive",
+    });
+    expect(result.output.url).toBe("https://www.consumerlab.com/widget/");
+  });
+
+  it("still succeeds normally when the response completes within budget (no over-triggering)", async () => {
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: '{"average_rating":4.1,"review_count":5}' }],
+    });
+
+    const result = await exec()({ url: "https://www.consumerlab.com/example/" });
+
+    expect(result.output).toMatchObject({ average_rating: 4.1, review_count: 5 });
+  });
+});

--- a/apps/api/src/capabilities/product-reviews-extract.ts
+++ b/apps/api/src/capabilities/product-reviews-extract.ts
@@ -1,6 +1,8 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import { fetchRenderedHtml, htmlToText } from "./lib/browserless-extract.js";
 import { assertTargetAllowed } from "./lib/tos-blocklist.js";
+import { extractJsonObject } from "./lib/llm-json.js";
+import { CapabilityRefusalError } from "../lib/capability-refusal.js";
 import Anthropic from "@anthropic-ai/sdk";
 
 // Product review extraction from review and product pages via Browserless + Claude.
@@ -39,7 +41,7 @@ registerCapability("product-reviews-extract", async (input: CapabilityInput) => 
   const client = new Anthropic({ apiKey });
   const r = await client.messages.create({
     model: "claude-haiku-4-5-20251001",
-    max_tokens: 2000,
+    max_tokens: 8000,
     messages: [
       {
         role: "user",
@@ -82,11 +84,34 @@ Extract up to 10 recent reviews. Use null for any fields you cannot determine. S
     ],
   });
 
-  const responseText = r.content[0].type === "text" ? r.content[0].text.trim() : "";
-  const jsonMatch = responseText.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) throw new Error("Failed to extract product review data.");
+  // Check BEFORE attempting to parse — same reasoning as web-extract.ts.
+  // A response cut off at max_tokens is truncated mid-JSON; the old greedy
+  // regex below would have matched to the LAST `}` in whatever partial text
+  // came back (which may not even close the object), and the follow-on
+  // JSON.parse would throw a generic error that transaction-failure-taxonomy.ts
+  // classifies as `internal` (INTERNAL_RE matches "failed to parse") — our
+  // fault, not the caller's, feeding the armed quality floor (DEC-20260812-A).
+  // Budget raised 2000 -> 8000 so this should be rare in practice; when it
+  // still happens the caller gets guidance instead of a raw parse error.
+  if (r.stop_reason === "max_tokens") {
+    throw new CapabilityRefusalError(
+      "Extraction result too large for one call: the output exceeded the per-call budget before completing. " +
+        "Try a page with fewer reviews — this capability extracts up to ~10 recent reviews per call.",
+    );
+  }
 
-  const output = JSON.parse(jsonMatch[0]);
+  const responseText = r.content[0].type === "text" ? r.content[0].text.trim() : "";
+
+  // extractJsonObject does real brace-matching rather than the greedy
+  // /\{[\s\S]*\}/ regex this replaces — the exact over-capture bug
+  // lib/llm-json.ts's docstring warns about: the greedy regex runs to the
+  // LAST `}` in the string, so trailing prose containing a brace (e.g. "use
+  // {} for missing fields") would silently pull unrelated text into the
+  // parsed object instead of failing loudly.
+  const parsed = extractJsonObject(responseText);
+  if (!parsed) throw new Error("Failed to extract product review data.");
+
+  const output = parsed;
   output.url = fullUrl;
 
   // Refuse to bill for an empty extraction.

--- a/apps/api/src/capabilities/product-reviews-extract.ts
+++ b/apps/api/src/capabilities/product-reviews-extract.ts
@@ -100,7 +100,7 @@ Extract up to 10 recent reviews. Use null for any fields you cannot determine. S
     );
   }
 
-  const responseText = r.content[0].type === "text" ? r.content[0].text.trim() : "";
+  const responseText = r.content[0]?.type === "text" ? r.content[0].text.trim() : "";
 
   // extractJsonObject does real brace-matching rather than the greedy
   // /\{[\s\S]*\}/ regex this replaces — the exact over-capture bug

--- a/apps/api/src/capabilities/web-extract-truncation.test.ts
+++ b/apps/api/src/capabilities/web-extract-truncation.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Regression tests for the 2026-08-17 LLM output-truncation bug.
+ *
+ * web-extract called Claude Haiku with a fixed max_tokens and never checked
+ * stop_reason. A paying x402 customer requested extraction of a ~100-name
+ * roster page from ipt.org; the model's output hit the 4000-token cap,
+ * truncated mid-JSON, extractJsonObject() correctly returned null
+ * (unbalanced braces), and the capability threw a generic
+ * "Failed to parse extraction result as JSON" error. That message contains
+ * "failed to parse", which transaction-failure-taxonomy.ts's INTERNAL_RE
+ * classifies as `internal` — our fault — so the armed quality floor
+ * (DEC-20260812-A) counted six such failures in 5 minutes and quarantined a
+ * revenue-earning capability over its own truncation bug.
+ *
+ * The fix raises the token budget (4000 -> 16000) and, when the model still
+ * hits the cap, throws a distinct CapabilityRefusalError BEFORE attempting to
+ * parse — instead of falling through to the generic parse-failure error.
+ *
+ * Mocking pattern follows product-reviews-extract.test.ts: mock
+ * ./lib/browserless-extract.js (web-extract.ts's actual import) and
+ * @anthropic-ai/sdk directly, rather than exercising the full web-provider
+ * retry/cache machinery (that's covered separately by
+ * web-extract-resilience.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { fetchRenderedHtml, messagesCreate } = vi.hoisted(() => ({
+  fetchRenderedHtml: vi.fn(),
+  messagesCreate: vi.fn(),
+}));
+
+vi.mock("./lib/browserless-extract.js", () => ({
+  fetchRenderedHtml,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: messagesCreate };
+  },
+}));
+
+import { getDirectExecutor } from "./index.js";
+import "./web-extract.js";
+import { CapabilityRefusalError } from "../lib/capability-refusal.js";
+import { classifyTransactionFailure, CALLER_ATTRIBUTABLE } from "../lib/transaction-failure-taxonomy.js";
+
+describe("web-extract output-truncation handling", () => {
+  beforeEach(() => {
+    fetchRenderedHtml.mockReset();
+    messagesCreate.mockReset();
+    process.env.BROWSERLESS_URL = "https://chromium.test";
+    process.env.BROWSERLESS_API_KEY = "test-token";
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    fetchRenderedHtml.mockResolvedValue(
+      `<html><head><title>Roster</title></head><body>${"Member name. ".repeat(200)}</body></html>`,
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const exec = () => getDirectExecutor("web-extract")!;
+
+  it("requests a 16000 max_tokens budget (raised from 4000)", async () => {
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: '{"headline":"hi"}' }],
+    });
+
+    await exec()({ url: "https://example.com/roster", extract: "every member name" });
+
+    expect(messagesCreate).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ max_tokens: 16000 }),
+    );
+  });
+
+  it("throws the truncation refusal (not a parse error) when stop_reason is max_tokens — the bug case", async () => {
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "max_tokens",
+      // Deliberately truncated mid-object — extractJsonObject would return
+      // null for this, and the old code fell through to the generic parse
+      // error. The fix must never reach extractJsonObject at all here.
+      content: [{ type: "text", text: '{"members": [{"name": "Alice"}, {"name": "Bob' }],
+    });
+
+    let error: unknown;
+    try {
+      await exec()({ url: "https://example.com/roster", extract: "every member name and title" });
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(CapabilityRefusalError);
+    expect((error as Error).message).toMatch(/too large for one call/);
+    expect((error as Error).message).toMatch(/narrow your 'extract' instruction/i);
+    // Must NOT be the old generic parse-failure wording.
+    expect((error as Error).message).not.toMatch(/Failed to parse extraction result as JSON/);
+  });
+
+  it("the truncation refusal classifies as caller_input under the quality floor (the actual production fix)", async () => {
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "max_tokens",
+      content: [{ type: "text", text: "{" }],
+    });
+
+    let message = "";
+    try {
+      await exec()({ url: "https://example.com/roster", extract: "every member" });
+    } catch (e) {
+      message = (e as Error).message;
+    }
+
+    const cls = classifyTransactionFailure(message);
+    expect(cls).toBe("caller_input");
+    expect(CALLER_ATTRIBUTABLE.has(cls)).toBe(true);
+  });
+
+  it("still throws the ordinary parse-failure error for genuinely malformed, non-truncation output (must not regress)", async () => {
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "The page had no extractable data, sorry!" }],
+    });
+
+    let error: unknown;
+    try {
+      await exec()({ url: "https://example.com/empty", extract: "headline" });
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).not.toBeInstanceOf(CapabilityRefusalError);
+    expect((error as Error).message).toMatch(/Failed to parse extraction result as JSON/);
+    // This one is still ours — the floor must keep counting it.
+    const cls = classifyTransactionFailure((error as Error).message);
+    expect(cls).toBe("internal");
+  });
+
+  it("still succeeds normally when the response completes within budget (no over-triggering)", async () => {
+    messagesCreate.mockResolvedValueOnce({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: '{"headline":"Example roster","count":3}' }],
+    });
+
+    const result = await exec()({ url: "https://example.com/roster", extract: "headline and count" });
+
+    expect(result.output.data).toMatchObject({ headline: "Example roster", count: 3 });
+  });
+});

--- a/apps/api/src/capabilities/web-extract.ts
+++ b/apps/api/src/capabilities/web-extract.ts
@@ -3,6 +3,7 @@ import { registerCapability, type CapabilityInput } from "./index.js";
 import { assertTargetAllowed } from "./lib/tos-blocklist.js";
 import { extractJsonObject } from "./lib/llm-json.js";
 import { fetchRenderedHtml } from "./lib/browserless-extract.js";
+import { CapabilityRefusalError } from "../lib/capability-refusal.js";
 
 registerCapability("web-extract", async (input: CapabilityInput) => {
   const url = input.url as string | undefined;
@@ -123,7 +124,7 @@ registerCapability("web-extract", async (input: CapabilityInput) => {
 
   const response = await client.messages.create({
     model: "claude-haiku-4-5-20251001",
-    max_tokens: 4000,
+    max_tokens: 16000,
     messages: [
       {
         role: "user",
@@ -141,11 +142,37 @@ Return ONLY valid JSON. No markdown, no explanation, no code fences. Just the JS
     ],
   });
 
+  // Check BEFORE attempting to parse. A response cut off at max_tokens is
+  // truncated mid-JSON, so extractJsonObject correctly returns null (the
+  // object never closes — unbalanced braces), and the old code fell through
+  // to the generic parse-failure error below. That error text contains
+  // "failed to parse", which transaction-failure-taxonomy.ts's INTERNAL_RE
+  // classifies as `internal` — our fault — so the quality floor (DEC-20260812-A)
+  // counted these as capability failures and quarantined web-extract in
+  // production on 2026-08-17 after six paid x402 calls hit this in 5 minutes,
+  // all six were a ~100-name roster page that legitimately needed more than
+  // 4000 output tokens. The fix is two-part: raise the budget (4000 -> 16000)
+  // so most legitimate extractions fit, AND refuse distinctly when the model
+  // still runs out, so the caller gets actionable guidance instead of a raw
+  // parse error, and the failure is attributed to the request's scope (caller
+  // input) rather than to us.
+  if (response.stop_reason === "max_tokens") {
+    throw new CapabilityRefusalError(
+      "Extraction result too large for one call: the output exceeded the per-call budget before completing. " +
+        "Narrow your 'extract' instruction or split the request (e.g. one page or one section at a time).",
+    );
+  }
+
   const responseText =
     response.content[0].type === "text" ? response.content[0].text : "";
 
   const parsed = extractJsonObject(responseText);
   if (!parsed) {
+    // Genuinely malformed (non-truncation) output — the model returned
+    // something that isn't recoverable JSON even though it had room to
+    // finish. This stays a plain Error: it's our parsing/prompting problem,
+    // not the caller's request being too large, so it must keep classifying
+    // as `internal` in the taxonomy.
     throw new Error(
       `Failed to parse extraction result as JSON. Raw response: ${responseText.slice(0, 300)}`,
     );

--- a/apps/api/src/capabilities/web-extract.ts
+++ b/apps/api/src/capabilities/web-extract.ts
@@ -164,7 +164,7 @@ Return ONLY valid JSON. No markdown, no explanation, no code fences. Just the JS
   }
 
   const responseText =
-    response.content[0].type === "text" ? response.content[0].text : "";
+    response.content[0]?.type === "text" ? response.content[0].text : "";
 
   const parsed = extractJsonObject(responseText);
   if (!parsed) {

--- a/apps/api/src/lib/capability-refusal.ts
+++ b/apps/api/src/lib/capability-refusal.ts
@@ -74,6 +74,21 @@ export const REFUSAL_MESSAGE_PATTERNS = [
   "Ambiguous ", // pickByName: several equally-good registry matches
   "No confident ", // pickByName / assertSingleResultMatch: nothing matched well enough
   "Could not identify a specific ", // extractCompanyName: input names no company
+  // web-extract / product-reviews-extract: the LLM extraction call hit its
+  // per-call output-token budget before finishing. The page rendered fine
+  // and the model understood the request well enough to start answering it —
+  // the request just needs to be narrower or split, which is the same "the
+  // capability worked, the ask has to change" shape as the entries above.
+  // 2026-08-17: this exact failure (undetected truncation -> unbalanced-brace
+  // parse failure -> classified `internal` by INTERNAL_RE's "failed to parse"
+  // match) quarantined web-extract in production after six paid x402 calls
+  // hit it in 5 minutes. Registering the phrase here — rather than only in
+  // transaction-failure-taxonomy.ts's CALLER_INPUT_RE — additionally keeps
+  // the circuit breaker (circuit-breaker.ts spreads REFUSAL_MESSAGE_PATTERNS
+  // into USER_INPUT_ERROR_PATTERNS) and quality-capture.ts's categorizeError
+  // (via isCapabilityRefusal) aligned with the taxonomy, the same three-consumer
+  // guarantee this list already gives the registry-refusal patterns above.
+  "Extraction result too large for one call",
 ] as const;
 
 /** Does this error — object or bare message — represent a refusal? */

--- a/apps/api/src/lib/transaction-failure-taxonomy.test.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.test.ts
@@ -230,3 +230,73 @@ describe("the incident this fixes", () => {
     expect(excused("SEC EDGAR search returned HTTP 500")).toBe(false);
   });
 });
+
+describe("LLM output-truncation refusal (2026-08-17 web-extract quarantine incident)", () => {
+  // web-extract calls Claude Haiku with a fixed max_tokens and never checked
+  // stop_reason. A ~100-name roster page hit the cap, the response came back
+  // truncated mid-JSON, extractJsonObject correctly returned null (unbalanced
+  // braces), and the capability threw "Failed to parse extraction result as
+  // JSON. Raw response: ...". INTERNAL_RE's "failed to parse" match classified
+  // that as `internal` — our fault — and the armed quality floor
+  // (DEC-20260812-A) quarantined a revenue-earning capability over its own
+  // truncation bug. web-extract.ts and product-reviews-extract.ts now detect
+  // `stop_reason === "max_tokens"` and throw a distinct, actionable refusal
+  // BEFORE attempting to parse, instead of letting it fall through to the
+  // generic parse-failure error.
+
+  const WEB_EXTRACT_TRUNCATION_REFUSAL =
+    "Extraction result too large for one call: the output exceeded the per-call budget before completing. " +
+    "Narrow your 'extract' instruction or split the request (e.g. one page or one section at a time).";
+
+  const PRODUCT_REVIEWS_TRUNCATION_REFUSAL =
+    "Extraction result too large for one call: the output exceeded the per-call budget before completing. " +
+    "Try a page with fewer reviews — this capability extracts up to ~10 recent reviews per call.";
+
+  it("classifies the new truncation refusal as caller_input, not internal — the whole point of the fix", () => {
+    expect(classOf(WEB_EXTRACT_TRUNCATION_REFUSAL)).toBe("caller_input");
+    expect(excused(WEB_EXTRACT_TRUNCATION_REFUSAL)).toBe(true);
+    expect(classOf(PRODUCT_REVIEWS_TRUNCATION_REFUSAL)).toBe("caller_input");
+    expect(excused(PRODUCT_REVIEWS_TRUNCATION_REFUSAL)).toBe(true);
+  });
+
+  it("the legacy generic parse-failure message — genuinely malformed, non-truncation output — still classifies as internal (must not regress)", () => {
+    // This is the exact message shape that caused the 2026-08-17 quarantine.
+    // It must keep classifying as `internal`: web-extract.ts only throws it
+    // now for non-truncation parse failures, which really are our defect
+    // (bad prompt, model went off-script) and must keep counting against the
+    // capability so the floor retains its teeth for a genuine regression.
+    const legacyMessage =
+      'Failed to parse extraction result as JSON. Raw response: {"data": {"headline": "broken';
+    expect(classOf(legacyMessage)).toBe("internal");
+    expect(excused(legacyMessage)).toBe(false);
+  });
+
+  it("does not misfire on INTERNAL_RE's own patterns — the new phrase shares no vocabulary with 'failed to parse' or 'response parse failed'", () => {
+    // Guards the ordering requirement directly: INTERNAL_RE runs before
+    // CALLER_INPUT_RE, so if the new refusal text ever drifted to contain
+    // "parse" it would silently flip back to `internal`.
+    expect(WEB_EXTRACT_TRUNCATION_REFUSAL).not.toMatch(/failed to parse|response parse failed|in JSON at position|unterminated string/i);
+    expect(PRODUCT_REVIEWS_TRUNCATION_REFUSAL).not.toMatch(/failed to parse|response parse failed|in JSON at position|unterminated string/i);
+  });
+
+  it("is recognised through the shared CapabilityRefusalError machinery, not a bespoke taxonomy-only pattern", async () => {
+    // The pattern is registered once, in capability-refusal.ts's
+    // REFUSAL_MESSAGE_PATTERNS, and taxonomy.ts's CALLER_INPUT_RE spreads it
+    // in — the same three-consumer arrangement (breaker / taxonomy /
+    // quality-capture) the registry-refusal patterns already use.
+    const { isRefusalMessage, isCapabilityRefusal, CapabilityRefusalError } = await import(
+      "./capability-refusal.js"
+    );
+    const { isUserInputError } = await import("./circuit-breaker.js");
+    const { categorizeError } = await import("./quality-capture.js");
+
+    expect(isRefusalMessage(WEB_EXTRACT_TRUNCATION_REFUSAL)).toBe(true);
+    expect(isCapabilityRefusal(WEB_EXTRACT_TRUNCATION_REFUSAL)).toBe(true);
+    expect(isUserInputError(WEB_EXTRACT_TRUNCATION_REFUSAL)).toBe(true);
+    expect(categorizeError(WEB_EXTRACT_TRUNCATION_REFUSAL)).toBe("capability_refusal");
+
+    const err = new CapabilityRefusalError(WEB_EXTRACT_TRUNCATION_REFUSAL);
+    expect(isCapabilityRefusal(err)).toBe(true);
+    expect(categorizeError(err)).toBe("capability_refusal");
+  });
+});

--- a/manifests/product-reviews-extract.yaml
+++ b/manifests/product-reviews-extract.yaml
@@ -125,3 +125,11 @@ limitations:
     category: coverage
     severity: info
     workaround: Request the direct product review page URL rather than the main product page for more complete review coverage
+  - title: Output size cap per call
+    text: >-
+      Extractions whose structured output would exceed the per-call budget (~8k output tokens) are refused rather
+      than returned truncated — for example a page with an unusually large number of long reviews. Retrying the
+      identical request will not help.
+    category: coverage
+    severity: info
+    workaround: Try a page with fewer reviews — this capability extracts up to ~10 recent reviews per call

--- a/manifests/web-extract.yaml
+++ b/manifests/web-extract.yaml
@@ -96,3 +96,11 @@ limitations:
     category: accuracy
     severity: info
     workaround: Use structured-scrape with CSS selectors for precise extraction when you know the page structure
+  - title: Output size cap per call
+    text: >-
+      Extractions whose structured output would exceed the per-call budget (~16k output tokens) are refused
+      rather than returned truncated — for example a page listing 100+ items when 'extract' asks for every one
+      of them in detail. Retrying the identical request will not help.
+    category: coverage
+    severity: info
+    workaround: Narrow the 'extract' instruction, or split the request into multiple calls (e.g. one page or one section at a time)


### PR DESCRIPTION
## What happened (prod, 2026-08-17)

A paying x402 customer ran large roster extractions through web-extract. The executor's `max_tokens: 4000` truncated the model output mid-JSON, the parse failed with a message the transaction-failure taxonomy classifies as `internal`, and after six such paid failures in 5 minutes the armed quality floor (DEC-20260812-A) correctly quarantined web-extract at 07:37 UTC — pulling a revenue earner off the x402 rail because of its own truncation bug. Event: health_monitor_events `quality_floor` / `quarantined`, completion 21% on 14 eligible calls/30d.

## The fix
- **web-extract**: `max_tokens` 4000→16000; when `stop_reason === "max_tokens"` still fires, throw `CapabilityRefusalError` ("Extraction result too large for one call…") with caller guidance — a correct refusal, not a fault.
- **product-reviews-extract**: same guard (2000→8000), plus the greedy `/\{[\s\S]*\}/` parse replaced with `extractJsonObject` (the exact over-capture bug `llm-json.ts` documents).
- **capability-refusal.ts**: refusal phrase registered once in `REFUSAL_MESSAGE_PATTERNS` → aligns all three consumers (taxonomy `caller_input`, circuit breaker, quality-capture).
- **Both executors**: `content[0]` optional-chained (empty content on an Anthropic `refusal` stop reason no longer TypeErrors into `internal`).
- **Manifests**: "Output size cap per call" limitation added to both.

## Verification
- New tests: truncation → refusal (both executors); taxonomy classifies the new refusal `caller_input` and the legacy parse-failure message still `internal` (both directions pinned).
- Fail-before/pass-after verified twice independently (author agent + reviewer): 3 tests fail against the origin/main executors, all pass with the fix.
- `tsc --noEmit` clean; touched suites + consumers (92 tests) green; `validate-capability.ts` passes for both slugs.
- DEC-20260504-A discipline applied though not a numbered cert-audit finding (money-path classification touched).
- DEC-20260504-C: no deploy-pipeline dependency — executors are on the auto-register import graph; post-deploy replay of the failing extraction shape is planned (see follow-up: manifest limitations also need an explicit manifest→DB sync, which `onboard --backfill` does not perform).

## Follow-ups (not in this PR)
- Restore web-extract to the x402 rail with an enforce-mode promotion event (separate op, this session).
- Generalize the truncation guard across the other ~20 LLM-backed executors (tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)