### PR TITLE
fix(phase4): the capability tail — redirect-trace, budget-aware scheduling, honest metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       # script header for why identifier-format + checksum was chosen over
       # a name-shaped heuristic for the wider scope.
       - run: node apps/api/scripts/check-pii.mjs --strict
-      # Phase 1 tier-coverage gate (WARN-ONLY). For each manifest with a
+      # Tier-coverage gate (STRICT since 2026-08-17 — zero unallowlisted findings). For each manifest with a
       # captured response fixture at apps/api/test/fixtures/tier-coverage/
       # <slug>.json, compares empirical wire-shape against manifest
       # declarations: guaranteed-reliability fields must be populated;
@@ -125,7 +125,7 @@ jobs:
       # Phase 2 promotion (separate PR) flips --strict to exit 1 after
       # the WARN findings are reviewed and the allowlist is established.
       # See script header for findings classification + extension notes.
-      - run: node apps/api/scripts/check-tier-coverage.mjs
+      - run: node apps/api/scripts/check-tier-coverage.mjs --strict
       # DEC-20260513-D Phase 3 Harden gate (a): canonical-input sentinel for
       # Identity capabilities. Catches the GR-PR-#116 class of bad-shape
       # fixture (branch entity asserted, dissolved status equals-asserted,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,10 +120,12 @@ jobs:
       # <slug>.json, compares empirical wire-shape against manifest
       # declarations: guaranteed-reliability fields must be populated;
       # populated fields must be declared in both output_field_reliability
-      # and output_schema.properties. Phase 1 exits 0 regardless of
-      # findings — surfacing the WARN signal in CI logs is the value.
-      # Phase 2 promotion (separate PR) flips --strict to exit 1 after
-      # the WARN findings are reviewed and the allowlist is established.
+      # and output_schema.properties. --strict now ENFORCES: any finding
+      # not listed in scripts/tier-coverage-allowlist.txt fails this step.
+      # Grandfathered findings stay in that allowlist until their manifest
+      # is fixed (recapture, or declare the missing fields directly — see
+      # the allowlist file's own header for when each applies). New slugs
+      # with new findings fail CI on first appearance, by design.
       # See script header for findings classification + extension notes.
       - run: node apps/api/scripts/check-tier-coverage.mjs --strict
       # DEC-20260513-D Phase 3 Harden gate (a): canonical-input sentinel for

--- a/apps/api/scripts/capture-tier-fixtures.ts
+++ b/apps/api/scripts/capture-tier-fixtures.ts
@@ -92,6 +92,14 @@ const PII_ARRAY_FIELDS = new Set([
   "managers",
   "officers",
   "legal_representatives",
+  // Phase-4 tail fix (2026-08-17): spanish-company-data's BORME activity
+  // log. Each element's free-text `registral_reference` embeds appointee /
+  // officer names inline (e.g. "Apo.Sol.: ROTETA ZUGAZAGASTI MIKEL;ORTIZ
+  // DE ZARATE SANTAMARIA LAURA;..."), unlike the structured person-record
+  // arrays above — caught live during the 2026-08-17 spanish-company-data
+  // recapture, same incident class as the 2026-08-14 italian-company-
+  // stakeholders exposure this scrub exists to prevent.
+  "recent_borme_acts",
 ]);
 
 // Fields whose value is a live wall-clock timestamp from the capture run.

--- a/apps/api/scripts/capture-tier-fixtures.ts
+++ b/apps/api/scripts/capture-tier-fixtures.ts
@@ -93,12 +93,17 @@ const PII_ARRAY_FIELDS = new Set([
   "officers",
   "legal_representatives",
   // Phase-4 tail fix (2026-08-17): spanish-company-data's BORME activity
-  // log. Each element's free-text `registral_reference` embeds appointee /
-  // officer names inline (e.g. "Apo.Sol.: ROTETA ZUGAZAGASTI MIKEL;ORTIZ
-  // DE ZARATE SANTAMARIA LAURA;..."), unlike the structured person-record
-  // arrays above — caught live during the 2026-08-17 spanish-company-data
-  // recapture, same incident class as the 2026-08-14 italian-company-
-  // stakeholders exposure this scrub exists to prevent.
+  // log. Each element's free-text `registral_reference` field embeds real
+  // officer/appointee full names inline as unstructured prose (BORME's
+  // "Apo.Sol.: <name>;<name>;..." appointment-notice format), unlike the
+  // structured person-record arrays above — caught live during the
+  // 2026-08-17 spanish-company-data recapture (see commit history for
+  // apps/api/test/fixtures/tier-coverage/spanish-company-data.json), same
+  // incident class as the 2026-08-14 italian-company-stakeholders exposure
+  // this scrub exists to prevent. Never paste the raw officer names this
+  // finding surfaced into a comment, commit message, or doc — describing
+  // the shape (a name-bearing free-text field) is all a future reader
+  // needs.
   "recent_borme_acts",
 ]);
 

--- a/apps/api/scripts/check-tier-coverage.mjs
+++ b/apps/api/scripts/check-tier-coverage.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Tier-coverage structural gate (Phase 1: WARN-ONLY).
+ * Tier-coverage structural gate (STRICT in CI as of 2026-08-17).
  *
  * Fourth structural CI gate alongside:
  *   - check-output-schema.ts               (output_schema isn't char-indexed)
@@ -17,7 +17,7 @@
  *       A guaranteed field absent from the wire is the worst class of drift:
  *       customers assert on it, downstream callers .field access it without
  *       a null-guard, and the SQS engine (gone) used to mark capabilities
- *       degraded on first miss. Phase 1 reports it; Phase 2 fails CI on it.
+ *       degraded on first miss. Strict mode fails CI on it.
  *
  *   (b) UNDECLARED_POPULATED — every populated key in the fixture must be
  *       declared in BOTH (i) `output_field_reliability` and (ii)
@@ -33,11 +33,10 @@
  * the guaranteed-emptiness check nor the undeclared-populated check fires
  * on them. They're allowed to be present or absent.
  *
- * Phase 1 — WARN-ONLY:
- *   Default and --strict both exit 0; --strict still groups & formats
- *   findings the same way Phase 2 will. Phase 2 promotion (separate PR)
- *   flips --strict to exit 1 after the WARN findings are reviewed and
- *   the allowlist is established.
+ * Enforcement (promoted 2026-08-17, the day findings-not-in-allowlist hit
+ * zero): --strict exits 1 on any finding not in
+ * scripts/tier-coverage-allowlist.txt; the bare invocation stays warn-only
+ * for local exploration. CI runs --strict.
  *
  * The fixture set is the EU30 registry capabilities (output of
  *   npx tsx apps/api/scripts/capture-tier-fixtures.ts --company-data
@@ -48,10 +47,8 @@
  * Pattern mirrors check-manifest-guaranteed-consistency.mjs.
  *
  * Usage (run from repo root or apps/api):
- *   node apps/api/scripts/check-tier-coverage.mjs
- *   node apps/api/scripts/check-tier-coverage.mjs --strict   # still exits 0 in Phase 1
- *
- * Exits 0 in Phase 1 regardless of findings.
+ *   node apps/api/scripts/check-tier-coverage.mjs            # warn-only
+ *   node apps/api/scripts/check-tier-coverage.mjs --strict   # CI mode, enforcing
  */
 
 import { readFileSync, readdirSync, existsSync } from "node:fs";
@@ -65,8 +62,6 @@ const manifestsDir = resolve(repoRoot, "manifests");
 const fixturesDir = resolve(repoRoot, "apps", "api", "test", "fixtures", "tier-coverage");
 const allowlistPath = resolve(__dirname, "tier-coverage-allowlist.txt");
 const strict = process.argv.includes("--strict");
-
-const PHASE = 1; // WARN-only. Phase 2 promotion changes this to 2.
 
 function isPopulated(v) {
   if (v === null || v === undefined) return false;
@@ -198,7 +193,7 @@ const allowed = loadAllowlist();
 const newFindings = findings.filter((f) => !allowed.has(f.slug));
 
 console.log(
-  `tier-coverage [phase ${PHASE} / WARN-ONLY]: ${scanned} manifests scanned, ` +
+  `tier-coverage [${strict ? "strict" : "warn-only"}]: ${scanned} manifests scanned, ` +
     `${withFixture} with fixtures, ${findings.length} findings (${newFindings.length} not in allowlist)`,
 );
 
@@ -216,15 +211,19 @@ if (findings.length > 0) {
     }
   }
   console.log(
-    "\nPhase 1 is WARN-ONLY — exiting 0 regardless. Phase 2 promotion (separate PR) " +
-      "will change the final exit to fail on findings NOT in scripts/tier-coverage-allowlist.txt. " +
-      "Re-capture a fixture after fixing its manifest with: " +
-      "npx tsx apps/api/scripts/capture-tier-fixtures.ts --slug <slug>",
+    strict
+      ? "\nSTRICT: findings not in scripts/tier-coverage-allowlist.txt fail this gate. " +
+          "Re-capture a fixture after fixing its manifest with: " +
+          "npx tsx apps/api/scripts/capture-tier-fixtures.ts --slug <slug>"
+      : "\nWarn-only invocation — exiting 0. CI runs this gate with --strict. " +
+          "Re-capture a fixture after fixing its manifest with: " +
+          "npx tsx apps/api/scripts/capture-tier-fixtures.ts --slug <slug>",
   );
 }
 
-// Phase 1: always exit 0. The `strict` flag is accepted (for parity with the
-// sibling gates' invocation surface) but not enforced. Phase 2 promotion
-// replaces the next line with:
-//   if (strict && newFindings.length > 0) process.exit(1);
+// Phase 2 promotion (2026-08-17): --strict now enforces. Promoted the same
+// day the finding count reached zero-not-in-allowlist (spanish recaptured
+// after its 2026-08-13 vendor swap; cypriot allowlisted pending the
+// OPENAPI_ENABLED legal gate, case 151296).
+if (strict && newFindings.length > 0) process.exit(1);
 process.exit(0);

--- a/apps/api/scripts/tier-coverage-allowlist.txt
+++ b/apps/api/scripts/tier-coverage-allowlist.txt
@@ -24,3 +24,8 @@ swedish-company-data
 us-company-data
 # uk: tier fixture capture requires COMPANIES_HOUSE_API_KEY (prod-only); recapture in a keyed environment
 uk-company-data
+# cyprus: tier fixture capture requires OPENAPI_ENABLED=true, which is legally gated —
+# unsigned resale addendum, case 151296 (per CLAUDE.md capabilities notes, 2026-08-17).
+# Do not flip OPENAPI_ENABLED to recapture this fixture without Petter's sign-off on
+# the addendum; remove this line once that's resolved and a clean recapture lands.
+cypriot-company-data

--- a/apps/api/scripts/tier-coverage-allowlist.txt
+++ b/apps/api/scripts/tier-coverage-allowlist.txt
@@ -1,15 +1,17 @@
-# tier-coverage gate — Phase 1 grandfathered findings.
+# tier-coverage gate — grandfathered findings.
 #
 # Each slug below has at least one finding in the 2026-05-17 capture pass.
-# Phase 1 (current) is WARN-ONLY and surfaces all findings; this allowlist
-# is consulted only for the per-finding "[allowlisted]" tag in the output.
-#
-# When the gate is promoted to Phase 2 (--strict exits 1 on new findings),
-# slugs in this allowlist are grandfathered and won't fail CI. New slugs
-# that appear in future captures will fail. Remove a slug from this list
-# AFTER its manifest is fixed (re-capture with `npx tsx
-# apps/api/scripts/capture-tier-fixtures.ts --slug <slug>` and confirm
-# the gate reports zero findings for it).
+# The gate was promoted to Phase 2 / STRICT on 2026-08-17 (--strict now
+# exits 1 on any finding not in this allowlist; see check-tier-coverage.mjs
+# and .github/workflows/ci.yml). Slugs listed here are grandfathered and
+# won't fail CI. New slugs that appear in future captures WILL fail. Remove
+# a slug from this list AFTER its manifest is fixed (re-capture with `npx
+# tsx apps/api/scripts/capture-tier-fixtures.ts --slug <slug>` and confirm
+# the gate reports zero findings for it) — or, per the 2026-08-17 review,
+# after declaring the missing fields directly in the manifest when no
+# recapture is actually needed (cypriot-company-data's case: the 3
+# undeclared fields were known, stable canonical aliases, not a data-shape
+# question the vendor answers).
 #
 # Format: one slug per line, # comments allowed, blank lines ignored.
 
@@ -24,8 +26,9 @@ swedish-company-data
 us-company-data
 # uk: tier fixture capture requires COMPANIES_HOUSE_API_KEY (prod-only); recapture in a keyed environment
 uk-company-data
-# cyprus: tier fixture capture requires OPENAPI_ENABLED=true, which is legally gated —
-# unsigned resale addendum, case 151296 (per CLAUDE.md capabilities notes, 2026-08-17).
-# Do not flip OPENAPI_ENABLED to recapture this fixture without Petter's sign-off on
-# the addendum; remove this line once that's resolved and a clean recapture lands.
-cypriot-company-data
+# cyprus: NOT allowlisted (2026-08-17 review, MEDIUM-4) — its 3 undeclared
+# fields (legal_name, primary_registration_id, date_incorporated) are
+# DEC-20260518-A canonical aliases the executor sets unconditionally; no
+# live recapture was needed (that would have required flipping the
+# legally-gated OPENAPI_ENABLED flag, case 151296). Declared directly in
+# manifests/cypriot-company-data.yaml instead.

--- a/apps/api/src/capabilities/company-news.test.ts
+++ b/apps/api/src/capabilities/company-news.test.ts
@@ -1,38 +1,58 @@
 /**
- * Regression tests for company-news's GDELT 429 backoff (Phase-4 tail fix,
- * 2026-08-17). GDELT rate-limits under normal traffic; before this fix any
- * HTTP 429 response surfaced straight through as a capability failure with
- * no retry. Same idiom as us-company-data.ts's `fetchSec`: delegate to the
- * shared `withRetry` primitive (its default retryable set already covers
- * `/HTTP 429/i`), single retry with backoff+jitter.
+ * Regression tests for company-news's GDELT 429 handling (Phase-4 tail fix,
+ * 2026-08-17; revised same day per review MEDIUM-3).
+ *
+ * History: GDELT rate-limits under normal traffic. The original fix added
+ * an executor-level `withRetry` (single retry, ~1s backoff) around the
+ * fetch. Review caught that this stacked with the TWO outer retry layers
+ * that already wrap the whole executor call — do.ts's executeWithRetry
+ * (customer /v1/do path) and test-runner.ts's runSingleTest (scheduler
+ * path), both maxRetries: 1 — so one logical call could fire up to
+ * 2 (outer) x 2 (this layer) = 4 requests against an API already asking
+ * for backoff.
+ *
+ * Fixed shape: fetchGdelt has NO internal retry. A 429 cancels the
+ * unconsumed response body (so the stream doesn't pin the connection open
+ * until GC — same fix shape as safe-fetch.ts's redirect-cap cancellation)
+ * and throws; the outer layers' own retry re-invokes the WHOLE executor,
+ * which re-runs this fetch from scratch, giving exactly one retry per
+ * logical call end-to-end instead of up to four.
  */
 
 import { describe, it, expect, vi } from "vitest";
 import { fetchGdelt } from "./company-news.js";
 
 function resp(status: number): Response {
-  return new Response(status === 200 ? "{}" : "", { status });
+  return new Response(status === 200 ? "{}" : "some body", { status });
 }
 
 describe("fetchGdelt", () => {
-  it("retries a 429 and returns the eventual 200 (the bug case)", async () => {
-    const fetchImpl = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(resp(429))
-      .mockResolvedValueOnce(resp(200));
-
-    const r = await fetchGdelt("https://x", fetchImpl);
-
-    expect(r.status).toBe(200);
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-  });
-
-  it("throws after the single retry on persistent 429", async () => {
+  it("throws immediately on 429 — no internal retry (outer layers own retry now)", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(resp(429));
 
     await expect(fetchGdelt("https://x", fetchImpl)).rejects.toThrow(/HTTP 429/);
-    // maxRetries:1 → 2 total attempts.
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    // Exactly ONE call — the amplification bug (this layer retrying on top
+    // of do.ts / test-runner.ts's own retry) is exactly what this pins.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the response body before throwing on 429 (no pinned stream)", async () => {
+    const response = resp(429);
+    const cancelSpy = vi.spyOn(response.body!, "cancel");
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(response);
+
+    await expect(fetchGdelt("https://x", fetchImpl)).rejects.toThrow(/HTTP 429/);
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw if the body has no readable stream (cancel is optional-chained)", async () => {
+    // A Response constructed with a null body has no ReadableStream at all —
+    // `response.body` is null. The cancel call must be optional-chained, not
+    // assumed present.
+    const response = new Response(null, { status: 429 });
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(response);
+
+    await expect(fetchGdelt("https://x", fetchImpl)).rejects.toThrow(/HTTP 429/);
   });
 
   it("does NOT retry a non-429 error status — passes it straight through unchanged", async () => {

--- a/apps/api/src/capabilities/company-news.test.ts
+++ b/apps/api/src/capabilities/company-news.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression tests for company-news's GDELT 429 backoff (Phase-4 tail fix,
+ * 2026-08-17). GDELT rate-limits under normal traffic; before this fix any
+ * HTTP 429 response surfaced straight through as a capability failure with
+ * no retry. Same idiom as us-company-data.ts's `fetchSec`: delegate to the
+ * shared `withRetry` primitive (its default retryable set already covers
+ * `/HTTP 429/i`), single retry with backoff+jitter.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { fetchGdelt } from "./company-news.js";
+
+function resp(status: number): Response {
+  return new Response(status === 200 ? "{}" : "", { status });
+}
+
+describe("fetchGdelt", () => {
+  it("retries a 429 and returns the eventual 200 (the bug case)", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(resp(429))
+      .mockResolvedValueOnce(resp(200));
+
+    const r = await fetchGdelt("https://x", fetchImpl);
+
+    expect(r.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after the single retry on persistent 429", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(resp(429));
+
+    await expect(fetchGdelt("https://x", fetchImpl)).rejects.toThrow(/HTTP 429/);
+    // maxRetries:1 → 2 total attempts.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry a non-429 error status — passes it straight through unchanged", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(resp(500));
+
+    const r = await fetchGdelt("https://x", fetchImpl);
+    expect(r.status).toBe(500);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes a 200 straight through with a single call", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(resp(200));
+
+    const r = await fetchGdelt("https://x", fetchImpl);
+    expect(r.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/capabilities/company-news.ts
+++ b/apps/api/src/capabilities/company-news.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { withRetry } from "../lib/retry.js";
 
 /**
  * Company News — real-time news monitoring via GDELT.
@@ -12,6 +13,30 @@ import { registerCapability, type CapabilityInput } from "./index.js";
  */
 
 const GDELT_API = "https://api.gdeltproject.org/api/v2/doc/doc";
+
+/**
+ * Phase-4 tail fix (2026-08-17): GDELT rate-limits (HTTP 429) under normal
+ * traffic and this executor previously surfaced that straight through as a
+ * capability failure with no retry. Same idiom as us-company-data.ts's
+ * `fetchSec` — delegate to the shared `withRetry` primitive, whose default
+ * retryable-pattern set already covers `/HTTP 429/i`, so a single retry
+ * with backoff+jitter (~1s) is enough without widening the shared default
+ * or introducing new retry machinery. Only 429 is retried here; any other
+ * non-ok status (4xx/5xx) passes straight through to the existing
+ * `!resp.ok` handling below, unchanged.
+ */
+export function fetchGdelt(url: string, fetchImpl: typeof fetch = fetch): Promise<Response> {
+  return withRetry(
+    async () => {
+      const response = await fetchImpl(url, { signal: AbortSignal.timeout(25000) });
+      if (response.status === 429) {
+        throw new Error(`GDELT API returned HTTP 429`);
+      }
+      return response;
+    },
+    { maxRetries: 1, baseDelayMs: 1000, slug: "company-news" },
+  );
+}
 
 const VALID_TIMESPANS = ["1d", "3d", "7d", "14d", "30d"];
 
@@ -43,9 +68,7 @@ registerCapability("company-news", async (input: CapabilityInput) => {
   });
 
   const url = `${GDELT_API}?${params}`;
-  const resp = await fetch(url, {
-    signal: AbortSignal.timeout(25000),
-  });
+  const resp = await fetchGdelt(url);
 
   if (!resp.ok) {
     throw new Error(`GDELT API returned HTTP ${resp.status}. The news search service may be temporarily unavailable. Please try again.`);

--- a/apps/api/src/capabilities/company-news.ts
+++ b/apps/api/src/capabilities/company-news.ts
@@ -1,5 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
-import { withRetry } from "../lib/retry.js";
+import { logWarn } from "../lib/log.js";
 
 /**
  * Company News — real-time news monitoring via GDELT.
@@ -15,27 +15,42 @@ import { withRetry } from "../lib/retry.js";
 const GDELT_API = "https://api.gdeltproject.org/api/v2/doc/doc";
 
 /**
- * Phase-4 tail fix (2026-08-17): GDELT rate-limits (HTTP 429) under normal
- * traffic and this executor previously surfaced that straight through as a
- * capability failure with no retry. Same idiom as us-company-data.ts's
- * `fetchSec` — delegate to the shared `withRetry` primitive, whose default
- * retryable-pattern set already covers `/HTTP 429/i`, so a single retry
- * with backoff+jitter (~1s) is enough without widening the shared default
- * or introducing new retry machinery. Only 429 is retried here; any other
+ * Phase-4 tail fix (2026-08-17, revised same day per review MEDIUM-3):
+ * GDELT rate-limits (HTTP 429) under normal traffic. This executor used
+ * to surface that straight through with no retry at all; a same-day fix
+ * added an executor-level withRetry (single retry, ~1s backoff). Review
+ * caught the amplification that created: do.ts's executeWithRetry (the
+ * customer /v1/do path) and test-runner.ts's runSingleTest (the scheduler
+ * path) BOTH already wrap the whole executor call in their own withRetry
+ * (maxRetries: 1 each) for non-deterministic capabilities. Stacking a
+ * THIRD retry layer here meant one logical call could fire up to 2 (outer)
+ * x 2 (this layer) = 4 requests against an API that was already telling
+ * us to slow down — the opposite of what a 429 backoff should do.
+ *
+ * Fixed by removing this layer entirely: a 429 just throws (still matches
+ * failure-classifier's UPSTREAM_TRANSIENT_PATTERNS `/HTTP 429/i` and
+ * lib/retry.ts's own default retryable set), and the outer layer's retry
+ * re-invokes the WHOLE executor — which re-runs this fetch from scratch —
+ * giving exactly one retry per logical call, not up to four. Any other
  * non-ok status (4xx/5xx) passes straight through to the existing
  * `!resp.ok` handling below, unchanged.
+ *
+ * The 429 branch still cancels the unconsumed response body before
+ * throwing — otherwise the stream pins the connection open until GC
+ * (same failure mode + same fix shape as safe-fetch.ts's redirect-cap
+ * cancellation).
  */
-export function fetchGdelt(url: string, fetchImpl: typeof fetch = fetch): Promise<Response> {
-  return withRetry(
-    async () => {
-      const response = await fetchImpl(url, { signal: AbortSignal.timeout(25000) });
-      if (response.status === 429) {
-        throw new Error(`GDELT API returned HTTP 429`);
-      }
-      return response;
-    },
-    { maxRetries: 1, baseDelayMs: 1000, slug: "company-news" },
-  );
+export async function fetchGdelt(url: string, fetchImpl: typeof fetch = fetch): Promise<Response> {
+  const response = await fetchImpl(url, { signal: AbortSignal.timeout(25000) });
+  if (response.status === 429) {
+    await response.body?.cancel().catch((err) =>
+      logWarn("gdelt-429-body-cancel-failed", "429 body cancel failed (connection may pin until GC)", {
+        err: String(err),
+      }),
+    );
+    throw new Error(`GDELT API returned HTTP 429`);
+  }
+  return response;
 }
 
 const VALID_TIMESPANS = ["1d", "3d", "7d", "14d", "30d"];

--- a/apps/api/src/capabilities/guarded-executor.test.ts
+++ b/apps/api/src/capabilities/guarded-executor.test.ts
@@ -312,6 +312,71 @@ describe("computeWindowStart", () => {
   });
 });
 
+// ─── isBudgetExhausted peek (Phase-4 tail fix, 2026-08-17) ──────────────────
+//
+// Regression coverage for the scheduler's mid-batch budget skip. Confirmed
+// live against prod (read-only): danish-company-data had 4 duplicate
+// known_answer test suites whose per-suite stagger hash collided on the
+// same minute, so findOverdueSuites()'s once-per-cycle SQL exclusion saw
+// "budget available" and returned all of them in one batch — the
+// scheduler's sequential loop then spent the budget on the first couple
+// and ran the rest straight into BudgetExhaustedError (15 of 17 attempts
+// in 24h). isBudgetExhausted() lets the scheduler re-check per suite.
+describe("isBudgetExhausted (Phase-4 tail fix)", () => {
+  it("returns false for a cost_class that doesn't budget-track (no counter query issued)", async () => {
+    stubMeta({ slug: "x", cost_class: "free_unlimited" });
+    const { isBudgetExhausted } = await import("./guarded-executor.js");
+    await expect(isBudgetExhausted("x")).resolves.toBe(false);
+    // Only the cost-meta SELECT — short-circuits before any counter query.
+    expect(mockDbExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false for paid_prepaid (never budget-tracked)", async () => {
+    stubMeta({ slug: "x", cost_class: "paid_prepaid" });
+    const { isBudgetExhausted } = await import("./guarded-executor.js");
+    await expect(isBudgetExhausted("x")).resolves.toBe(false);
+  });
+
+  it("returns false when no counter row exists yet this window (nothing spent)", async () => {
+    stubMeta({ slug: "x", cost_class: "free_quota", quota_window: "daily", quota_cap: 20 });
+    mockDbExecute.mockResolvedValueOnce([]); // counter SELECT — no row yet
+    const { isBudgetExhausted } = await import("./guarded-executor.js");
+    await expect(isBudgetExhausted("x")).resolves.toBe(false);
+  });
+
+  it("returns false when test_count is under budget_cap", async () => {
+    stubMeta({ slug: "danish-company-data", cost_class: "free_quota", quota_window: "daily", quota_cap: 20 });
+    mockDbExecute.mockResolvedValueOnce([{ test_count: 1, budget_cap: 2 }]);
+    const { isBudgetExhausted } = await import("./guarded-executor.js");
+    await expect(isBudgetExhausted("danish-company-data")).resolves.toBe(false);
+  });
+
+  it("returns true when test_count has reached budget_cap (the exact prod shape: 2/2)", async () => {
+    stubMeta({ slug: "danish-company-data", cost_class: "free_quota", quota_window: "daily", quota_cap: 20 });
+    mockDbExecute.mockResolvedValueOnce([{ test_count: 2, budget_cap: 2 }]);
+    const { isBudgetExhausted } = await import("./guarded-executor.js");
+    await expect(isBudgetExhausted("danish-company-data")).resolves.toBe(true);
+  });
+
+  it("returns true when test_count has overshot budget_cap (burst overshoot)", async () => {
+    stubMeta({ slug: "x", cost_class: "paid_with_free_tier", quota_window: "daily", quota_cap: 100 });
+    mockDbExecute.mockResolvedValueOnce([{ test_count: 6, budget_cap: 5 }]);
+    const { isBudgetExhausted } = await import("./guarded-executor.js");
+    await expect(isBudgetExhausted("x")).resolves.toBe(true);
+  });
+
+  it("never writes — only SELECT statements reach the DB", async () => {
+    stubMeta({ slug: "x", cost_class: "free_quota", quota_window: "daily", quota_cap: 20 });
+    mockDbExecute.mockResolvedValueOnce([{ test_count: 2, budget_cap: 2 }]);
+    const { isBudgetExhausted } = await import("./guarded-executor.js");
+    await isBudgetExhausted("x");
+    for (const call of mockDbExecute.mock.calls) {
+      const queryText = String(call[0]);
+      expect(queryText).not.toMatch(/INSERT|UPDATE|DELETE/i);
+    }
+  });
+});
+
 // ─── Budget race (concurrent burst) ─────────────────────────────────────────
 
 describe("budget race", () => {

--- a/apps/api/src/capabilities/guarded-executor.ts
+++ b/apps/api/src/capabilities/guarded-executor.ts
@@ -441,6 +441,67 @@ export async function assertBudgetAvailable(
   );
 }
 
+/**
+ * Read-only peek at whether `slug`'s current budget window is already
+ * spent — no write, no side effect, safe to call speculatively.
+ *
+ * Phase-4 tail fix (2026-08-17): `test-scheduler.ts`'s `findOverdueSuites()`
+ * already excludes budget-exhausted capabilities from its SELECT, but that
+ * exclusion is a snapshot taken ONCE per poll cycle. When a capability has
+ * several suites whose per-suite stagger hash collides on the same minute
+ * (verified live for danish-company-data: 4 duplicate `known_answer` test
+ * suites all hash `slug + ':known_answer'` to the identical minute), the
+ * SQL pre-check sees the capability as "not yet exhausted" at query time,
+ * returns all of its suites in one batch, and the scheduler's sequential
+ * for-loop then burns through them one by one — the first couple succeed
+ * and spend the budget, every suite after that in the SAME batch hits
+ * `assertBudgetAvailable` mid-loop and fails with `BudgetExhaustedError`,
+ * writing a FAILED `test_results` row for every one. Confirmed against
+ * prod (read-only): danish-company-data logged 17 attempts in 24h, 15 of
+ * them budget-exhaustion failures, all 9 seconds apart in a single burst.
+ *
+ * This function lets the scheduler re-check remaining budget PER SUITE,
+ * immediately before each `runTests()` call, so a mid-batch exhaustion
+ * skips the remaining suites in that same batch instead of running them
+ * to a guaranteed, metrics-poisoning failure. It intentionally does NOT
+ * reserve a slot (no INSERT) — `assertBudgetAvailable` inside the executor
+ * path remains the sole place that increments the counter, so a race
+ * between the peek and the real call still fails safe (the real call's
+ * atomic increment is what actually enforces the cap).
+ */
+export async function isBudgetExhausted(slug: string): Promise<boolean> {
+  const meta = await getCapabilityCostMeta(slug);
+  if (meta.cost_class !== "free_quota" && meta.cost_class !== "paid_with_free_tier") {
+    // Doesn't budget-track (free_unlimited, paid_prepaid, paid_subscription,
+    // unclassified) — never "exhausted" in this sense.
+    return false;
+  }
+  if (meta.quota_window === null || meta.quota_window === "none") return false;
+
+  // ISO string, never a Date instance — see the bind-encoder note on
+  // assertBudgetAvailable (DEC-20260504-A / PR #43 bug class).
+  const windowStart = computeWindowStart(meta.quota_window, meta.quota_reset_dom).toISOString();
+  const windowKind = meta.quota_window;
+
+  const db = getDb();
+  const result = await db.execute(sql`
+    SELECT test_count, budget_cap
+      FROM capability_budget_counters
+     WHERE capability_slug = ${slug}
+       AND window_start = ${windowStart}
+       AND window_kind = ${windowKind}
+  `);
+  const rows = Array.isArray(result) ? result : (result as { rows?: unknown[] })?.rows ?? [];
+  const row = rows[0] as { test_count: number; budget_cap: number } | undefined;
+  if (!row) return false; // No counter row yet this window — nothing spent.
+
+  // Compare against the ROW's own budget_cap (what assertBudgetAvailable's
+  // RETURNING clause checked, and what actually got written), not a fresh
+  // computeBudgetCap(meta) recomputation — a manifest change mid-window
+  // can't then produce a peek/assert disagreement.
+  return row.test_count >= row.budget_cap;
+}
+
 async function maybeFireThresholdAlerts(
   row: BudgetRow,
   slug: string,

--- a/apps/api/src/capabilities/redirect-trace.test.ts
+++ b/apps/api/src/capabilities/redirect-trace.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression tests for redirect-trace's core bug (Phase-4 tail fix,
+ * 2026-08-17).
+ *
+ * redirect-trace calls `safeFetch(url, {maxRedirects: 0})` expecting the
+ * first 3xx response back so it can walk the redirect chain itself. But
+ * `safe-fetch.ts`'s `followRedirects` increments `hop` to 1 on the first
+ * redirect and throws "Too many redirects (>0)" whenever `hop >
+ * maxRedirects` — with `maxRedirects: 0` that was ALWAYS true on the first
+ * redirect. Introduced in commit 1f0d480 (2026-04-17) swapping raw
+ * `fetch(url, {redirect:'manual'})` for safeFetch under a wrong equivalence
+ * assumption. Any URL with >=1 real redirect failed; the harness "passed"
+ * only when httpbin.org 503s (not a redirect — skips the broken branch),
+ * which is why it went undetected.
+ *
+ * Fix: safeFetch grows a `returnOnRedirectCap` option that returns the 3xx
+ * response at the cap instead of throwing, used only by redirect-trace. SSRF
+ * validation per hop is unchanged — each hop's URL is still validated
+ * BEFORE any request, including inside redirect-trace's own manual
+ * next-hop loop (test 2 below asserts the blocked hop is never fetched).
+ *
+ * `validateUrl` is mocked to reject literal loopback IPs (mirroring the
+ * real implementation's `net.isIP` fast path, which needs no DNS) and
+ * accept everything else — this keeps the suite deterministic and
+ * network-free while still exercising the real "block before fetch" shape
+ * for the SSRF test. The general validateUrl/isBlockedIp behavior has its
+ * own direct coverage in url-validator.test.ts; this file exists to prove
+ * redirect-trace's hop loop actually calls it at the right time.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/url-validator.js", () => ({
+  validateUrl: vi.fn(async (u: string) => {
+    if (/127\.0\.0\.1|::1|localhost/.test(String(u))) {
+      throw new Error("This URL targets a restricted address.");
+    }
+  }),
+}));
+
+import { getDirectExecutor } from "./index.js";
+import "./redirect-trace.js";
+
+describe("redirect-trace", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("traces a 2-hop redirect chain correctly (the core bug case)", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      const u = String(url);
+      if (u === "https://example.test/start") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "/middle", server: "test-srv" },
+        });
+      }
+      if (u === "https://example.test/middle") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "/end" },
+        });
+      }
+      if (u === "https://example.test/end") {
+        return new Response(null, { status: 200 });
+      }
+      throw new Error(`unexpected fetch to ${u}`);
+    });
+
+    const exec = getDirectExecutor("redirect-trace")!;
+    const result = await exec({ url: "https://example.test/start" });
+    const output = result.output as Record<string, unknown>;
+
+    // Pre-fix this threw "Too many redirects (>0)" on the very first hop.
+    expect(output.chain).toHaveLength(3);
+    expect(output.redirect_count).toBe(2);
+    expect(output.final_url).toBe("https://example.test/end");
+    expect(output.final_status_code).toBe(200);
+    expect(output.original_url).toBe("https://example.test/start");
+    expect(output.uses_https).toBe(true);
+    expect(output.same_domain).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("blocks a redirect to a private IP at hop N — the blocked hop is never fetched", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      const u = String(url);
+      if (u === "https://example.test/start") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "http://127.0.0.1:1/" },
+        });
+      }
+      // If we ever get here, the SSRF guard failed to stop the hop
+      // BEFORE the request — the whole point of the per-hop validation.
+      throw new Error(`SSRF guard failed to block fetch to ${u}`);
+    });
+
+    const exec = getDirectExecutor("redirect-trace")!;
+    await expect(exec({ url: "https://example.test/start" })).rejects.toThrow(
+      /restricted/,
+    );
+    // Only the first (allowed) hop was ever fetched.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects the maxRedirects cap on the trace's own hop count", async () => {
+    // Every hop redirects to the next — an effectively infinite chain if
+    // uncapped. Confirms redirect-trace's own step-count cap (independent
+    // of safeFetch's per-call maxRedirects: 0), which is what actually
+    // bounds the chain length here.
+    fetchMock.mockImplementation(async (url: string) => {
+      const u = new URL(String(url));
+      const n = parseInt(u.pathname.slice(1) || "0", 10);
+      return new Response(null, {
+        status: 302,
+        headers: { location: `/${n + 1}` },
+      });
+    });
+
+    const exec = getDirectExecutor("redirect-trace")!;
+    const result = await exec({
+      url: "https://example.test/0",
+      max_redirects: 2,
+    });
+    const output = result.output as Record<string, unknown>;
+
+    expect(output.chain).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/capabilities/redirect-trace.test.ts
+++ b/apps/api/src/capabilities/redirect-trace.test.ts
@@ -136,4 +136,39 @@ describe("redirect-trace", () => {
     expect(output.chain).toHaveLength(2);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it("cancels every hop's response body — none are read (MEDIUM-6, 2026-08-17 review)", async () => {
+    // `new Response(null, ...)` has no ReadableStream body at all (`.body`
+    // is `null`), which would make a body-leak test vacuously pass. Give
+    // every hop a real, non-null body so `.body` is a genuine
+    // ReadableStream we can spy `.cancel()` on.
+    const responses: Response[] = [];
+    const makeResponse = (init: ResponseInit) => {
+      const r = new Response("some response bytes", init);
+      responses.push(r);
+      return r;
+    };
+
+    fetchMock.mockImplementation(async (url: string) => {
+      const u = String(url);
+      if (u === "https://example.test/start") {
+        return makeResponse({ status: 302, headers: { location: "/end" } });
+      }
+      if (u === "https://example.test/end") {
+        return makeResponse({ status: 200 });
+      }
+      throw new Error(`unexpected fetch to ${u}`);
+    });
+
+    const exec = getDirectExecutor("redirect-trace")!;
+    await exec({ url: "https://example.test/start" });
+
+    // Both hops (the redirect AND the final 200) got a real body, and
+    // this loop never calls .text()/.json() on either — only .cancel()
+    // should have consumed them.
+    expect(responses).toHaveLength(2);
+    for (const r of responses) {
+      expect(r.bodyUsed).toBe(true);
+    }
+  });
 });

--- a/apps/api/src/capabilities/redirect-trace.ts
+++ b/apps/api/src/capabilities/redirect-trace.ts
@@ -2,6 +2,7 @@ import { registerCapability, type CapabilityInput } from "./index.js";
 import { validateUrl } from "../lib/url-validator.js";
 import { safeFetch } from "../lib/safe-fetch.js";
 import { TOS_REFUSAL_MARKER } from "../lib/tos-blocklist.js";
+import { logWarn } from "../lib/log.js";
 
 /**
  * F-0-006 special case: redirect-trace exists to FOLLOW and REPORT ON
@@ -68,6 +69,20 @@ registerCapability("redirect-trace", async (input: CapabilityInput) => {
     const latency = Date.now() - start;
     const location = response.headers.get("location");
     const server = response.headers.get("server");
+
+    // Phase-4 tail fix (MEDIUM-6, 2026-08-17 review): this loop never
+    // reads the body of ANY hop's response (only headers/status) — up to
+    // `maxRedirects` (default 20, cap 30) unconsumed streams per trace,
+    // each pinning its connection open until GC. Cancel it here, whether
+    // the hop is a redirect we're about to follow or the final response
+    // where the loop is about to break. Mirrors safe-fetch.ts's own
+    // maxRedirects-cap cancellation (same failure mode, same fix shape).
+    await response.body?.cancel().catch((err) =>
+      logWarn("redirect-trace-body-cancel-failed", "hop body cancel failed (connection may pin until GC)", {
+        step,
+        err: String(err),
+      }),
+    );
 
     chain.push({
       step,

--- a/apps/api/src/capabilities/redirect-trace.ts
+++ b/apps/api/src/capabilities/redirect-trace.ts
@@ -7,10 +7,19 @@ import { TOS_REFUSAL_MARKER } from "../lib/tos-blocklist.js";
  * F-0-006 special case: redirect-trace exists to FOLLOW and REPORT ON
  * redirects, which means the Bucket-A recipe (auto-follow via safeFetch)
  * would destroy the feature. Instead we call safeFetch with
- * maxRedirects: 0 — we still get validateUrl + the undici dispatcher's
- * DNS-rebinding refusal, but the 3xx response is returned to us so we
+ * maxRedirects: 0 and returnOnRedirectCap: true — we still get
+ * validateUrl + the undici dispatcher's DNS-rebinding refusal, but the
+ * 3xx response is returned to us (instead of safeFetch throwing) so we
  * can record the hop and advance the chain ourselves. validateUrl is
- * also called on every next-hop URL before we fetch it.
+ * also called on every next-hop URL before we fetch it (each hop is a
+ * fresh safeFetch call, and safeFetch always validates before fetching).
+ *
+ * Phase-4 tail fix: before `returnOnRedirectCap` existed, `maxRedirects:
+ * 0` alone made safeFetch throw "Too many redirects (>0)" on the FIRST
+ * redirect (followRedirects increments hop to 1 before the hop >
+ * maxRedirects check, so 1 > 0 is always true) — every URL with a real
+ * redirect failed here. See safe-fetch.ts's SafeFetchOptions doc for the
+ * full history.
  */
 registerCapability("redirect-trace", async (input: CapabilityInput) => {
   let url = ((input.url as string) ?? (input.task as string) ?? "").trim();
@@ -34,6 +43,7 @@ registerCapability("redirect-trace", async (input: CapabilityInput) => {
       response = await safeFetch(currentUrl, {
         method: "GET",
         maxRedirects: 0,
+        returnOnRedirectCap: true,
         signal: AbortSignal.timeout(10000),
       });
     } catch (err) {

--- a/apps/api/src/capabilities/url-health-check.test.ts
+++ b/apps/api/src/capabilities/url-health-check.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression tests for url-health-check's redirect-following bug (Phase-4
+ * tail fix, MEDIUM-5, 2026-08-17 review).
+ *
+ * Same bug class as redirect-trace.ts before its own fix: this executor's
+ * comment claimed "safeFetch with maxRedirects: 0 returns the 3xx so we can
+ * walk the chain ourselves" — but without `returnOnRedirectCap: true`,
+ * safeFetch's `followRedirects` increments hop to 1 on the first redirect
+ * and throws "Too many redirects (>0)" whenever hop > maxRedirects, which
+ * with maxRedirects: 0 is ALWAYS true on the first redirect. Any URL with a
+ * real redirect failed this whole capability instead of reporting the
+ * redirect chain (follow_redirects: true) or the bare 3xx status
+ * (follow_redirects: false).
+ *
+ * `validateUrl` is mocked to reject literal loopback IPs (mirroring the
+ * real implementation's `net.isIP` fast path, no DNS needed) and accept
+ * everything else — deterministic and network-free, same pattern as
+ * redirect-trace.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/url-validator.js", () => ({
+  validateUrl: vi.fn(async (u: string) => {
+    if (/127\.0\.0\.1|::1|localhost/.test(String(u))) {
+      throw new Error("This URL targets a restricted address.");
+    }
+  }),
+}));
+
+import { getDirectExecutor } from "./index.js";
+import "./url-health-check.js";
+
+describe("url-health-check", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("follows a redirect chain to the final 200 (the core bug case, follow_redirects: true)", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      const u = String(url);
+      if (u === "https://example.test/start") {
+        return new Response(null, {
+          status: 301,
+          headers: { location: "https://example.test/end", server: "test-srv" },
+        });
+      }
+      if (u === "https://example.test/end") {
+        return new Response(null, { status: 200, headers: { "content-type": "text/html" } });
+      }
+      throw new Error(`unexpected fetch to ${u}`);
+    });
+
+    const exec = getDirectExecutor("url-health-check")!;
+    const result = await exec({ url: "https://example.test/start" });
+    const output = result.output as Record<string, unknown>;
+
+    // Pre-fix this threw "Too many redirects (>0)" on the very first hop.
+    expect(output.status_code).toBe(200);
+    expect(output.final_url).toBe("https://example.test/end");
+    expect(output.is_up).toBe(true);
+    expect(output.redirect_chain).toEqual([
+      { url: "https://example.test/start", status: 301 },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the bare 3xx status when follow_redirects is false, instead of throwing", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://example.test/end" },
+      }),
+    );
+
+    const exec = getDirectExecutor("url-health-check")!;
+    const result = await exec({ url: "https://example.test/start", follow_redirects: false });
+    const output = result.output as Record<string, unknown>;
+
+    expect(output.status_code).toBe(302);
+    expect(output.final_url).toBe("https://example.test/start");
+    // is_up's window is [200,400) — a bare 3xx (unfollowed) still counts as
+    // "up" (the server responded); it just isn't the ultimate destination.
+    expect(output.is_up).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a non-redirecting 200 directly with no redirect chain", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+
+    const exec = getDirectExecutor("url-health-check")!;
+    const result = await exec({ url: "https://example.test/ok" });
+    const output = result.output as Record<string, unknown>;
+
+    expect(output.status_code).toBe(200);
+    expect(output.redirect_chain).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/capabilities/url-health-check.ts
+++ b/apps/api/src/capabilities/url-health-check.ts
@@ -26,12 +26,22 @@ registerCapability("url-health-check", async (input: CapabilityInput) => {
     // Manual redirect following to capture chain
     let maxRedirects = 10;
     while (maxRedirects > 0) {
-      // F-0-006: re-validate every hop. safeFetch with maxRedirects: 0
-      // returns the 3xx so we can walk the chain ourselves.
+      // F-0-006: re-validate every hop. safeFetch with maxRedirects: 0 +
+      // returnOnRedirectCap: true returns the 3xx instead of throwing, so
+      // we can walk the chain ourselves. Phase-4 tail fix (MEDIUM-5,
+      // 2026-08-17 review): this call was missing returnOnRedirectCap —
+      // same bug class as redirect-trace.ts before its fix. Without the
+      // flag, maxRedirects: 0 alone makes safeFetch throw "Too many
+      // redirects (>0)" on the FIRST redirect (followRedirects increments
+      // hop to 1 before the hop > maxRedirects check, so 1 > 0 is always
+      // true) — any URL with a real redirect failed this whole capability
+      // outright instead of reporting the redirect chain. See
+      // safe-fetch.ts's SafeFetchOptions doc for the full history.
       await validateUrl(currentUrl);
       const response = await safeFetch(currentUrl, {
         method: "HEAD",
         maxRedirects: 0,
+        returnOnRedirectCap: true,
         signal: AbortSignal.timeout(timeout),
         headers: { "User-Agent": "Strale/1.0 (health-check; admin@strale.io)" },
       });
@@ -58,9 +68,14 @@ registerCapability("url-health-check", async (input: CapabilityInput) => {
     }
     responseTimeMs = Date.now() - start;
   } else {
+    // follow_redirects: false — caller wants to see whether the URL
+    // redirects at all, not follow it. Same returnOnRedirectCap need as
+    // above: without it, a redirecting URL threw instead of reporting
+    // its 3xx status_code.
     const response = await safeFetch(fullUrl, {
       method: "HEAD",
       maxRedirects: 0,
+      returnOnRedirectCap: true,
       signal: AbortSignal.timeout(timeout),
       headers: { "User-Agent": "Strale/1.0 (health-check; admin@strale.io)" },
     });

--- a/apps/api/src/jobs/test-scheduler.test.ts
+++ b/apps/api/src/jobs/test-scheduler.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression tests for the scheduler's mid-batch budget skip (Phase-4 tail
+ * fix, 2026-08-17).
+ *
+ * `findOverdueSuites()`'s SQL exclusion (in this same file) already keeps
+ * budget-exhausted capabilities out of a poll cycle's batch — but only as a
+ * snapshot taken once at the start of the cycle. Confirmed live against
+ * prod (read-only query): danish-company-data has 4 duplicate
+ * `known_answer` test suites whose per-suite stagger hash
+ * (`hashtext(slug || ':' || test_type)`) collides on the identical minute
+ * (same slug, same test_type string). The snapshot query said "budget
+ * available" and returned all of that capability's suites in one batch; the
+ * scheduler's sequential for-loop then spent the daily budget_cap=2 on the
+ * first couple of suites and ran the rest straight into
+ * `assertBudgetAvailable`'s `BudgetExhaustedError` — 15 of 17 attempts in
+ * 24h, all 9 seconds apart in a single burst, each one a FAILED
+ * `test_results` row poisoning pass-rate metrics.
+ *
+ * `shouldSkipForBudget()` is the fix: a per-suite re-check, called
+ * immediately before the `runTests()` call that would otherwise run to a
+ * guaranteed failure. These tests pin its two outcomes (skip vs proceed)
+ * and its fail-open behavior when the peek itself errors — a peek failure
+ * must never block real testing.
+ *
+ * No DB harness exists for test-scheduler.ts's pollCycle (raw postgres
+ * client for the advisory lock, live HTTP calls per capability, 5-10 minute
+ * cycles) — test-harness exemption, DEC-20260504-A. `shouldSkipForBudget`
+ * is extracted specifically so the new code path is unit-testable without
+ * that machinery; the wiring point (this function called inside pollCycle's
+ * for-loop, `continue`-ing before any `runTests()` call — i.e. no
+ * `test_results` row) is verified by reading test-scheduler.ts directly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockIsBudgetExhausted = vi.fn();
+vi.mock("../capabilities/guarded-executor.js", () => ({
+  isBudgetExhausted: (slug: string) => mockIsBudgetExhausted(slug),
+}));
+
+import { shouldSkipForBudget } from "./test-scheduler.js";
+
+beforeEach(() => {
+  mockIsBudgetExhausted.mockReset();
+});
+
+describe("shouldSkipForBudget (Phase-4 tail fix)", () => {
+  it("skips (returns true) when the capability's budget is exhausted", async () => {
+    mockIsBudgetExhausted.mockResolvedValueOnce(true);
+    await expect(shouldSkipForBudget("danish-company-data")).resolves.toBe(true);
+    expect(mockIsBudgetExhausted).toHaveBeenCalledWith("danish-company-data");
+  });
+
+  it("does not skip (returns false) when budget is available", async () => {
+    mockIsBudgetExhausted.mockResolvedValueOnce(false);
+    await expect(shouldSkipForBudget("danish-company-data")).resolves.toBe(false);
+  });
+
+  it("fails open (returns false, does not throw) when the peek itself errors", async () => {
+    mockIsBudgetExhausted.mockRejectedValueOnce(new Error("DB unavailable"));
+    await expect(shouldSkipForBudget("danish-company-data")).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/jobs/test-scheduler.test.ts
+++ b/apps/api/src/jobs/test-scheduler.test.ts
@@ -61,3 +61,23 @@ describe("shouldSkipForBudget (Phase-4 tail fix)", () => {
     await expect(shouldSkipForBudget("danish-company-data")).resolves.toBe(false);
   });
 });
+
+describe("suitesTestedFromResults (closing review round — heartbeat accounting)", () => {
+  it("derives 'tested' from executed results, not batch arithmetic — the reviewer's exact trace", async () => {
+    const { suitesTestedFromResults } = await import("./test-scheduler.js");
+    // 4 duplicate suites, budget for 2: two execute (say both pass), the
+    // runner internally skips two, the scheduler skips 3 later batch
+    // entries. The OLD formula (batch 4 − outer skips 3) reported 1.
+    // The truth is the number of results that exist: 2.
+    expect(suitesTestedFromResults(2, 0)).toBe(2);
+    expect(suitesTestedFromResults(1, 1)).toBe(2);
+    expect(suitesTestedFromResults(0, 0)).toBe(0);
+  });
+
+  it("pollCycle's summary uses the results-derived helper, never batch subtraction", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL("./test-scheduler.ts", import.meta.url), "utf8");
+    expect(src).toContain("suitesTestedFromResults(totalPassed, totalFailed)");
+    expect(src).not.toMatch(/runnableSuites\.length\s*-\s*skippedBudgetExhausted/);
+  });
+});

--- a/apps/api/src/jobs/test-scheduler.ts
+++ b/apps/api/src/jobs/test-scheduler.ts
@@ -418,6 +418,20 @@ export async function shouldSkipForBudget(slug: string): Promise<boolean> {
   }
 }
 
+/**
+ * The heartbeat's "suites tested" figure, derived from executed results
+ * only. Deliberately NOT batch arithmetic (`runnableSuites.length -
+ * outerSkips`): the runner can also skip suites internally via its own
+ * per-suite budget re-check, which the scheduler cannot observe, so any
+ * batch-based subtraction misreports in both directions (closing review
+ * round, 2026-08-17: 4-duplicate-suite batch with budget 2 → old formula
+ * said 1 tested; 2 results actually existed). Exported for the regression
+ * test that pins this shape.
+ */
+export function suitesTestedFromResults(totalPassed: number, totalFailed: number): number {
+  return totalPassed + totalFailed;
+}
+
 // ─── Auxiliary tasks ────────────────────────────────────────────────────────
 
 async function runAuxiliaryTasks(): Promise<void> {
@@ -776,13 +790,17 @@ async function pollCycle(): Promise<void> {
         await delay(DELAY_BETWEEN_CAPABILITIES_MS);
       }
 
-      // Phase-4 tail fix (2026-08-17 review, LOW-8): runnableSuites is the
-      // BATCH size (everything the scheduler decided to attempt this
-      // cycle) — it is NOT the same as "suites actually tested" once
-      // shouldSkipForBudget can skip suites mid-batch. Reporting it as
-      // suites_tested silently counted skips as tests. Subtract the
-      // skipped ones so the summary/heartbeat reflect what actually ran.
-      const suitesActuallyTested = runnableSuites.length - skippedBudgetExhausted;
+      // Phase-4 tail fix (2026-08-17 review, LOW-8; corrected in the closing
+      // review round): "suites tested" must be DERIVED FROM EXECUTED RESULTS,
+      // never from batch arithmetic. runnableSuites counts scheduler batch
+      // entries; skippedBudgetExhausted counts only the batches skipped at
+      // THIS level — but runTests() can also skip suites internally (the
+      // per-suite budget re-check), so `batch - outerSkips` over-counts in
+      // one direction and under-counts in the other (Codex's trace: 4
+      // duplicate suites, budget 2 → formula said 1 tested/3 skipped;
+      // reality was 2 executed, 2 internally skipped). totalPassed +
+      // totalFailed is the count of results that actually exist.
+      const suitesActuallyTested = suitesTestedFromResults(totalPassed, totalFailed);
 
       jobLog.info(
         {

--- a/apps/api/src/jobs/test-scheduler.ts
+++ b/apps/api/src/jobs/test-scheduler.ts
@@ -776,10 +776,18 @@ async function pollCycle(): Promise<void> {
         await delay(DELAY_BETWEEN_CAPABILITIES_MS);
       }
 
+      // Phase-4 tail fix (2026-08-17 review, LOW-8): runnableSuites is the
+      // BATCH size (everything the scheduler decided to attempt this
+      // cycle) — it is NOT the same as "suites actually tested" once
+      // shouldSkipForBudget can skip suites mid-batch. Reporting it as
+      // suites_tested silently counted skips as tests. Subtract the
+      // skipped ones so the summary/heartbeat reflect what actually ran.
+      const suitesActuallyTested = runnableSuites.length - skippedBudgetExhausted;
+
       jobLog.info(
         {
           label: "test-scheduler-poll-complete",
-          suites_tested: runnableSuites.length,
+          suites_tested: suitesActuallyTested,
           capabilities_touched: slugsTested.size,
           passed: totalPassed,
           failed: totalFailed,
@@ -797,9 +805,10 @@ async function pollCycle(): Promise<void> {
           logHealthEvent({
             eventType: "scheduler_heartbeat",
             tier: 1,
-            actionTaken: `DB-driven poll: ${runnableSuites.length} suites tested across ${slugsTested.size} capabilities`,
+            actionTaken: `DB-driven poll: ${suitesActuallyTested} suites tested across ${slugsTested.size} capabilities` +
+              (skippedBudgetExhausted > 0 ? ` (${skippedBudgetExhausted} skipped, budget exhausted)` : ""),
             details: {
-              suites_tested: runnableSuites.length,
+              suites_tested: suitesActuallyTested,
               capabilities_touched: slugsTested.size,
               passed: totalPassed,
               failed: totalFailed,

--- a/apps/api/src/jobs/test-scheduler.ts
+++ b/apps/api/src/jobs/test-scheduler.ts
@@ -388,6 +388,36 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// ─── Mid-batch budget re-check (Phase-4 tail fix, 2026-08-17) ───────────────
+//
+// findOverdueSuites()'s budget exclusion above is a snapshot taken once at
+// the START of a poll cycle. When several of a capability's suites collide
+// on the same minute's stagger (confirmed live for danish-company-data: 4
+// duplicate `known_answer` test suites all hash `slug + ':known_answer'` to
+// the identical minute), the batch can contain more of that capability's
+// suites than its remaining budget covers — the snapshot said "budget
+// available", but the scheduler's sequential loop spends it as it goes. The
+// first couple of suites in the batch succeed and exhaust the counter;
+// every suite after that in the SAME batch used to run straight into
+// `assertBudgetAvailable`'s `BudgetExhaustedError`, writing a failed
+// `test_results` row (confirmed live: danish-company-data logged 15
+// budget-exhaustion failures out of 17 attempts in 24h).
+//
+// Exported so the skip decision — including its fail-open behavior — is
+// unit-testable without the DB/advisory-lock machinery the rest of this
+// module needs (test-harness exemption, DEC-20260504-A).
+export async function shouldSkipForBudget(slug: string): Promise<boolean> {
+  try {
+    const { isBudgetExhausted } = await import("../capabilities/guarded-executor.js");
+    return await isBudgetExhausted(slug);
+  } catch (err) {
+    // A peek failure must never block real testing — fail open, same
+    // posture as the health-check peek a few lines up in pollCycle().
+    logError("test-scheduler-budget-peek-failed", err, { capability_slug: slug });
+    return false;
+  }
+}
+
 // ─── Auxiliary tasks ────────────────────────────────────────────────────────
 
 async function runAuxiliaryTasks(): Promise<void> {
@@ -646,11 +676,34 @@ async function pollCycle(): Promise<void> {
 
       let totalPassed = 0;
       let totalFailed = 0;
+      let skippedBudgetExhausted = 0;
       const slugsTested = new Set<string>();
 
       for (const suite of runnableSuites) {
         const agoMs = suite.lastRunAt ? Date.now() - suite.lastRunAt.getTime() : null;
         const agoLabel = agoMs != null ? `${Math.round(agoMs / 60_000)}m ago` : "never tested";
+
+        // Re-check budget per suite, immediately before the call that would
+        // otherwise run-to-fail and write a budget-exhaustion test_results
+        // row. See shouldSkipForBudget's doc comment for why the once-per-
+        // cycle SQL exclusion in findOverdueSuites() isn't sufficient on
+        // its own. No DB write here — assertBudgetAvailable inside
+        // runTests() remains the sole place that reserves a slot, so this
+        // can never let a call through the real check would refuse; it
+        // only ever turns a guaranteed failure into a skip.
+        if (await shouldSkipForBudget(suite.slug)) {
+          skippedBudgetExhausted++;
+          jobLog.info(
+            {
+              label: "test-scheduler-skip-budget-exhausted",
+              capability_slug: suite.slug,
+              test_type: suite.testType,
+            },
+            "test-scheduler-skip-budget-exhausted",
+          );
+          await delay(DELAY_BETWEEN_CAPABILITIES_MS);
+          continue;
+        }
 
         try {
           jobLog.info(
@@ -731,6 +784,7 @@ async function pollCycle(): Promise<void> {
           passed: totalPassed,
           failed: totalFailed,
           skipped_unhealthy: skippedUnhealthy,
+          skipped_budget_exhausted: skippedBudgetExhausted,
           paid_skipped: paidSkipped,
           queue_depth: queueDepth,
         },
@@ -750,6 +804,7 @@ async function pollCycle(): Promise<void> {
               passed: totalPassed,
               failed: totalFailed,
               skipped_unhealthy: skippedUnhealthy,
+              skipped_budget_exhausted: skippedBudgetExhausted,
               paid_skipped: paidSkipped,
               queue_depth: queueDepth,
             },

--- a/apps/api/src/lib/failure-classifier.test.ts
+++ b/apps/api/src/lib/failure-classifier.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for two failure-classifier.ts pattern gaps (Phase-4 tail
+ * fix, 2026-08-17). Both real-message fixtures fell through every pattern
+ * set to `unknown` before this fix, poisoning failure-taxonomy signal for
+ * two different reasons:
+ *
+ *   1. Scheduler-side budget exhaustion (`BudgetExhaustedError` from
+ *      `guarded-executor.ts`) is the PLATFORM declining to run a test — not
+ *      a capability or upstream signal. It belongs in `test_infrastructure`
+ *      alongside the other INFRA_* patterns, not `unknown`.
+ *
+ *   2. polish-company-data's deliberate compliance refusal (no KRS number
+ *      given, so it refuses name-based search rather than hit a
+ *      non-compliant source) is a correct refusal, not a fault — same
+ *      `test_design` class as INPUT_REJECTION_PATTERNS, just without the
+ *      "required"/"invalid input"/"must provide" phrasing those patterns
+ *      look for.
+ *
+ * Fixtures below are copied verbatim from the real throw sites (not
+ * paraphrased) so the regex match is proven against production message
+ * shape, not an idealized one.
+ */
+
+import { describe, expect, it } from "vitest";
+import { classifyFailure } from "./failure-classifier.js";
+
+// Verbatim from guarded-executor.ts's BudgetExhaustedError constructor:
+//   `Capability '${slug}' has exhausted its ${meta.quota_window} test budget ` +
+//   `(${meta.cost_class}, quota_cap=${meta.quota_cap}). Customer traffic is ` +
+//   `unaffected; Strale's own test/CI usage must wait for the next window.`
+const BUDGET_EXHAUSTION_MESSAGE =
+  "Capability 'danish-company-data' has exhausted its daily test budget " +
+  "(free_quota, quota_cap=2). Customer traffic is unaffected; Strale's own " +
+  "test/CI usage must wait for the next window.";
+
+// Verbatim from polish-company-data.ts:150-157.
+const POLISH_COMPLIANCE_REFUSAL_MESSAGE =
+  "Polish company name search is unavailable: the only compliant data path is the KRS API by registration number. " +
+  "Provide a 10-digit KRS number (e.g. '0000028860' for ORLEN S.A.). " +
+  "Look up KRS numbers at https://wyszukiwarka-krs.ms.gov.pl/.";
+
+describe("classifyFailure — budget exhaustion (Phase-4 tail fix)", () => {
+  it("classifies the real BudgetExhaustedError message as test_infrastructure, not unknown", () => {
+    const result = classifyFailure(
+      BUDGET_EXHAUSTION_MESSAGE,
+      /* executionSucceeded */ false,
+      /* validationFailed */ false,
+      "dependency_health",
+      {},
+    );
+    expect(result.verdict).toBe("test_infrastructure");
+    expect(result.confidence).toBe("high");
+  });
+
+  it("also matches the shorter '(N of N calls)' budget-exhaustion phrasing", () => {
+    const result = classifyFailure(
+      "Capability 'greek-company-data' has exhausted its daily test budget (40 of 40 calls).",
+      false,
+      false,
+      "known_answer",
+      {},
+    );
+    expect(result.verdict).toBe("test_infrastructure");
+  });
+});
+
+describe("classifyFailure — compliance refusal (Phase-4 tail fix)", () => {
+  it("classifies polish-company-data's real compliance-refusal message as test_design, not unknown", () => {
+    const result = classifyFailure(
+      POLISH_COMPLIANCE_REFUSAL_MESSAGE,
+      /* executionSucceeded */ false,
+      /* validationFailed */ false,
+      "negative",
+      {},
+    );
+    expect(result.verdict).toBe("test_design");
+    expect(result.confidence).toBe("high");
+  });
+});

--- a/apps/api/src/lib/failure-classifier.test.ts
+++ b/apps/api/src/lib/failure-classifier.test.ts
@@ -1,8 +1,8 @@
 /**
  * Regression tests for two failure-classifier.ts pattern gaps (Phase-4 tail
- * fix, 2026-08-17). Both real-message fixtures fell through every pattern
- * set to `unknown` before this fix, poisoning failure-taxonomy signal for
- * two different reasons:
+ * fix, 2026-08-17; patterns tightened same day per review LOW-7). Both
+ * real-message fixtures fell through every pattern set to `unknown` before
+ * this fix, poisoning failure-taxonomy signal for two different reasons:
  *
  *   1. Scheduler-side budget exhaustion (`BudgetExhaustedError` from
  *      `guarded-executor.ts`) is the PLATFORM declining to run a test — not
@@ -19,6 +19,14 @@
  * Fixtures below are copied verbatim from the real throw sites (not
  * paraphrased) so the regex match is proven against production message
  * shape, not an idealized one.
+ *
+ * The patterns are anchored on the FULL real message shape, not a bare
+ * substring — the original (looser) versions risked matching an unrelated
+ * message that happened to share a fragment (e.g. "only compliant data
+ * path returned HTTP 500", a genuine upstream failure) and misclassifying
+ * it with high confidence. The negative tests below pin that these
+ * look-alikes correctly fall through to a lower-confidence/different
+ * verdict instead.
  */
 
 import { describe, expect, it } from "vitest";
@@ -52,7 +60,14 @@ describe("classifyFailure — budget exhaustion (Phase-4 tail fix)", () => {
     expect(result.confidence).toBe("high");
   });
 
-  it("also matches the shorter '(N of N calls)' budget-exhaustion phrasing", () => {
+  it("LOW-7: does NOT match a look-alike message missing the real message's full shape", () => {
+    // "(40 of 40 calls)" is an older/different phrasing than the current
+    // BudgetExhaustedError constructor's "(cost_class, quota_cap=N).
+    // Customer traffic is unaffected" — not a real classifyFailure
+    // producer today. Pinning that the tightened pattern does NOT
+    // high-confidence-classify this as test_infrastructure just because it
+    // contains "has exhausted its ... test budget" is the whole point of
+    // the LOW-7 tightening.
     const result = classifyFailure(
       "Capability 'greek-company-data' has exhausted its daily test budget (40 of 40 calls).",
       false,
@@ -60,7 +75,7 @@ describe("classifyFailure — budget exhaustion (Phase-4 tail fix)", () => {
       "known_answer",
       {},
     );
-    expect(result.verdict).toBe("test_infrastructure");
+    expect(result.verdict).not.toBe("test_infrastructure");
   });
 });
 
@@ -75,5 +90,20 @@ describe("classifyFailure — compliance refusal (Phase-4 tail fix)", () => {
     );
     expect(result.verdict).toBe("test_design");
     expect(result.confidence).toBe("high");
+  });
+
+  it("LOW-7: does NOT misclassify an unrelated failure that merely shares the fragment 'only compliant data path'", () => {
+    // The reviewer's exact false-positive case: a genuine upstream failure
+    // whose message happens to contain the bare fragment the original
+    // (looser) pattern matched on, without any of the real refusal
+    // message's surrounding structure.
+    const result = classifyFailure(
+      "only compliant data path returned HTTP 500",
+      /* executionSucceeded */ false,
+      /* validationFailed */ false,
+      "known_answer",
+      {},
+    );
+    expect(result.verdict).not.toBe("test_design");
   });
 });

--- a/apps/api/src/lib/failure-classifier.ts
+++ b/apps/api/src/lib/failure-classifier.ts
@@ -68,6 +68,20 @@ const INFRA_GEO_PATTERNS = [
   /ECB.*restrict/i,
 ];
 
+// Phase-4 tail fix (2026-08-17): scheduler-side budget exhaustion
+// (guarded-executor.ts's BudgetExhaustedError, e.g. "Capability
+// 'danish-company-data' has exhausted its daily test budget (free_quota,
+// quota_cap=2). Customer traffic is unaffected; Strale's own test/CI usage
+// must wait for the next window.") was falling through every pattern set to
+// `unknown` — it isn't a missing key, a quota/billing message, or a
+// geo-restriction; it's the platform's OWN scheduler declining to run the
+// test because the capability's daily test-budget counter is spent. That's
+// test infrastructure, not a capability signal, so it belongs in the same
+// bucket as the other INFRA_* patterns above.
+const INFRA_BUDGET_PATTERNS = [
+  /has exhausted its.*test budget/i,
+];
+
 // Browserless billing/quota (our infrastructure) — NOT target site failures.
 // Browserless 500 and navigation timeouts go to upstream_transient below.
 const INFRA_BROWSERLESS_PATTERNS = [
@@ -136,6 +150,22 @@ const INPUT_REJECTION_PATTERNS = [
   /is required/i,
   /expected.*string.*got/i,
   /expected.*number.*got/i,
+];
+
+// Phase-4 tail fix (2026-08-17): executor-thrown COMPLIANCE refusals — the
+// executor deliberately declines an input shape because no compliant data
+// path exists for it (e.g. polish-company-data.ts:150-157 refusing
+// name-based search: "Polish company name search is unavailable: the only
+// compliant data path is the KRS API by registration number. ..."). This is
+// the same test_design class as INPUT_REJECTION_PATTERNS above — the test
+// sent an unsupported input and the executor correctly refused it — but the
+// phrasing doesn't contain "required"/"invalid input"/"must provide", so it
+// needs its own pattern set. Not a capability bug and not an upstream
+// failure: a correct refusal per DEC-20260428-A must not trip breakers or
+// count against quality signal (feedback_refusal_is_not_a_fault.md).
+const COMPLIANCE_REFUSAL_PATTERNS = [
+  /only compliant data path/i,
+  /search is unavailable:.*compliant/i,
 ];
 
 // Upstream returned empty/HTML instead of expected data — transient
@@ -210,6 +240,14 @@ export function classifyFailure(
     };
   }
 
+  if (matchesAny(reason, INFRA_BUDGET_PATTERNS)) {
+    return {
+      verdict: "test_infrastructure",
+      confidence: "high",
+      reason: `Scheduler skipped/failed due to exhausted test budget: ${truncate(reason, 120)}`,
+    };
+  }
+
   if (matchesAny(reason, INFRA_BROWSERLESS_PATTERNS)) {
     return {
       verdict: "test_infrastructure",
@@ -262,6 +300,18 @@ export function classifyFailure(
       verdict: "test_design",
       confidence: "high",
       reason: `Executor rejected input (expected for negative/edge_case tests): ${truncate(reason, 120)}`,
+    };
+  }
+
+  // ── 5b. COMPLIANCE REFUSAL (test_design) ───────────────────────────────
+  // Executor correctly refused an input shape with no compliant data path
+  // (e.g. polish-company-data refusing name-based search). Same class as
+  // input rejection above: a correct refusal, not a fault.
+  if (!executionSucceeded && matchesAny(reason, COMPLIANCE_REFUSAL_PATTERNS)) {
+    return {
+      verdict: "test_design",
+      confidence: "high",
+      reason: `Executor refused a non-compliant input shape (deliberate compliance refusal, not a bug): ${truncate(reason, 120)}`,
     };
   }
 

--- a/apps/api/src/lib/failure-classifier.ts
+++ b/apps/api/src/lib/failure-classifier.ts
@@ -78,8 +78,16 @@ const INFRA_GEO_PATTERNS = [
 // test because the capability's daily test-budget counter is spent. That's
 // test infrastructure, not a capability signal, so it belongs in the same
 // bucket as the other INFRA_* patterns above.
+// Phase-4 tail fix (2026-08-17 review, LOW-7): anchored on the FULL real
+// message shape ("has exhausted its <window> test budget (<...>). Customer
+// traffic is unaffected") rather than the bare "has exhausted its .* test
+// budget" substring. The looser form risked matching any future message
+// that happened to contain that phrase without actually being a
+// BudgetExhaustedError (e.g. a capability echoing vendor-quota language in
+// an unrelated error) and misclassifying a real upstream/capability signal
+// as test_infrastructure.
 const INFRA_BUDGET_PATTERNS = [
-  /has exhausted its.*test budget/i,
+  /has exhausted its .+ test budget \(.+\)\.\s*Customer traffic is\s*unaffected/i,
 ];
 
 // Browserless billing/quota (our infrastructure) — NOT target site failures.
@@ -163,9 +171,17 @@ const INPUT_REJECTION_PATTERNS = [
 // needs its own pattern set. Not a capability bug and not an upstream
 // failure: a correct refusal per DEC-20260428-A must not trip breakers or
 // count against quality signal (feedback_refusal_is_not_a_fault.md).
+//
+// Phase-4 tail fix (2026-08-17 review, LOW-7): anchored on the fuller real
+// prefix ("<X> search is unavailable: the only compliant data path is")
+// instead of the bare substring "only compliant data path". The looser
+// form would have matched an unrelated message like "only compliant data
+// path returned HTTP 500" (a genuine upstream failure that happens to
+// share that fragment) and misclassified it as a high-confidence
+// test_design refusal instead of the real upstream_transient/
+// capability_bug verdict.
 const COMPLIANCE_REFUSAL_PATTERNS = [
-  /only compliant data path/i,
-  /search is unavailable:.*compliant/i,
+  /search is unavailable: the only compliant data path is/i,
 ];
 
 // Upstream returned empty/HTML instead of expected data — transient

--- a/apps/api/src/lib/safe-fetch.test.ts
+++ b/apps/api/src/lib/safe-fetch.test.ts
@@ -170,3 +170,95 @@ describe("followRedirects — loop mechanics (F-0-006)", () => {
     expect(response.status).toBe(302);
   });
 });
+
+// ── Suite 4: returnOnCap (Phase-4 tail fix, redirect-trace's core bug) ────────
+//
+// Before this flag existed, `maxRedirects: 0` made safeFetch ALWAYS throw on
+// the first redirect: `followRedirects` increments `hop` to 1 before the
+// `hop > maxRedirects` check, so `1 > 0` is true on every redirect,
+// including the very first one. redirect-trace's own comment said it
+// expected "the first 3xx response returned" — that was never true until
+// this flag. See safe-fetch.ts's SafeFetchOptions doc + redirect-trace.ts.
+describe("followRedirects — returnOnCap (Phase-4 tail fix)", () => {
+  it("returns the 3xx response at the cap instead of throwing when returnOnCap is true", async () => {
+    const base = await startServer((req, res) => {
+      if (req.url === "/start") {
+        res.statusCode = 302;
+        res.setHeader("location", "/end");
+        res.end();
+      } else {
+        res.statusCode = 200;
+        res.end("final");
+      }
+    });
+    const response = await followRedirects(
+      `${base}/start`,
+      {},
+      0, // maxRedirects: 0 — the exact redirect-trace call shape.
+      async () => {},
+      true, // returnOnCap
+    );
+    // Pre-fix this threw "Too many redirects (>0)". Post-fix it returns
+    // the first hop's 302 so the caller can walk the chain itself.
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/end");
+  });
+
+  it("still throws past the cap when returnOnCap is false (default) — existing callers unaffected", async () => {
+    const base = await startServer((req, res) => {
+      if (req.url === "/start") {
+        res.statusCode = 302;
+        res.setHeader("location", "/end");
+        res.end();
+      } else {
+        res.statusCode = 200;
+        res.end("final");
+      }
+    });
+    await expect(
+      followRedirects(`${base}/start`, {}, 0, async () => {}),
+    ).rejects.toThrow(/Too many redirects \(>0\)/);
+  });
+
+  it("does not return early when the response at the cap boundary is not a redirect", async () => {
+    const base = await startServer((_req, res) => {
+      res.statusCode = 200;
+      res.end("no redirect here");
+    });
+    const response = await followRedirects(
+      `${base}/`,
+      {},
+      0,
+      async () => {},
+      true,
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it("validates every hop's URL before fetching it, even in returnOnCap mode", async () => {
+    const validated: string[] = [];
+    const base = await startServer((req, res) => {
+      if (req.url === "/start") {
+        res.statusCode = 302;
+        res.setHeader("location", "/end");
+        res.end();
+      } else {
+        res.statusCode = 200;
+        res.end("final");
+      }
+    });
+    await followRedirects(
+      `${base}/start`,
+      {},
+      0,
+      async (u) => {
+        validated.push(u);
+      },
+      true,
+    );
+    // With maxRedirects: 0 + returnOnCap, only the starting URL is fetched
+    // (the 302 is returned to the caller rather than followed) — but that
+    // one hop must still have gone through validation first.
+    expect(validated).toEqual([`${base}/start`]);
+  });
+});

--- a/apps/api/src/lib/safe-fetch.ts
+++ b/apps/api/src/lib/safe-fetch.ts
@@ -117,6 +117,29 @@ export interface SafeFetchOptions extends Omit<RequestInit, "redirect"> {
    * cases, never for normal capability fetches).
    */
   timeoutMs?: number;
+  /**
+   * Phase-4 tail fix: when the hop count exceeds `maxRedirects`, RETURN the
+   * 3xx response at the cap instead of throwing. Default false, so every
+   * existing caller keeps the "throw past the cap" behaviour unchanged.
+   *
+   * Exists for redirect-trace, which calls `safeFetch(url, {maxRedirects:
+   * 0})` expecting the first 3xx response back so it can walk the chain
+   * itself. Without this flag `maxRedirects: 0` always throws on the first
+   * redirect — `followRedirects` increments `hop` to 1 before the
+   * `hop > maxRedirects` check, so `1 > 0` is true on every redirect,
+   * including the very first one (introduced in commit 1f0d480,
+   * 2026-04-17, swapping raw `fetch(url, {redirect:'manual'})` for
+   * safeFetch under a wrong equivalence assumption — raw fetch with
+   * `redirect: 'manual'` returns the 3xx; `safeFetch` with `maxRedirects:
+   * 0` throws instead).
+   *
+   * SSRF guarantee preserved: the URL at the cap has already been
+   * `validate()`-d (it's the URL we just fetched, validated at the top of
+   * this same loop iteration, same as every other hop). This flag changes
+   * only what happens to the response once the cap is hit — it does not
+   * skip or reorder any validation.
+   */
+  returnOnRedirectCap?: boolean;
 }
 
 const DEFAULT_MAX_REDIRECTS = 3;
@@ -140,7 +163,7 @@ export async function safeFetch(
   url: string | URL,
   opts: SafeFetchOptions = {},
 ): Promise<Response> {
-  const { maxRedirects = DEFAULT_MAX_REDIRECTS, timeoutMs, ...init } = opts;
+  const { maxRedirects = DEFAULT_MAX_REDIRECTS, timeoutMs, returnOnRedirectCap, ...init } = opts;
 
   // Per-source ToS policy is enforced at the fetch layer, not only in the
   // capabilities that remember to call it (P2, 2026-08-12 — three separate
@@ -163,6 +186,7 @@ export async function safeFetch(
     init,
     maxRedirects,
     validateUrl,
+    returnOnRedirectCap ?? false,
   );
 }
 
@@ -181,6 +205,7 @@ export async function followRedirects(
   init: Omit<RequestInit, "redirect">,
   maxRedirects: number,
   validate: (u: string) => Promise<void>,
+  returnOnCap = false,
 ): Promise<Response> {
   let current = url;
   let hop = 0;
@@ -208,6 +233,13 @@ export async function followRedirects(
 
     hop++;
     if (hop > maxRedirects) {
+      if (returnOnCap) {
+        // The URL that produced this response was validated at the top of
+        // this same loop iteration (same as every other hop) — returning
+        // it instead of throwing changes nothing about the SSRF guarantee,
+        // only who's responsible for deciding whether to follow further.
+        return response;
+      }
       logWarn("ssrf-too-many-redirects", "Exceeded maxRedirects", {
         start: url,
         hops: hop,

--- a/apps/api/src/lib/test-runner.test.ts
+++ b/apps/api/src/lib/test-runner.test.ts
@@ -1,7 +1,162 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── HIGH-1 fix (2026-08-17 review): per-suite budget re-check ─────────────
+//
+// findOverdueSuites() / shouldSkipForBudget() (test-scheduler.ts) only guard
+// the scheduler's call INTO runTests() — a single runTests({capabilitySlug,
+// testType}) call reloads ALL test_suites rows matching that pair. danish-
+// company-data has 4 duplicate known_answer suites; one runTests() call ran
+// all 4, so the scheduler's once-per-batch pre-check couldn't stop suites 3
+// and 4 from running straight into BudgetExhaustedError after suites 1 and 2
+// spent the budget. This suite proves the fix at the layer that actually
+// matters: runSingleTest() (private, exercised here via the public runTests()
+// entry point) re-checks isBudgetExhausted() immediately before each suite
+// that would reach the executor, and skips silently (no test_results row,
+// no push into the run's results) once the counter reports exhausted.
+//
+// The DB layer is mocked; assertGuardedAllow/isBudgetExhausted are mocked
+// (their own correctness has direct unit coverage in
+// capabilities/guarded-executor.test.ts) so this suite is free to assert
+// purely on the wiring: does runTests() call isBudgetExhausted() before each
+// of the 4 duplicate suites, and does it write a test_results row only for
+// the ones where it returned false?
+
+const mockIsBudgetExhausted = vi.fn();
+const mockAssertGuardedAllow = vi.fn();
+vi.mock("../capabilities/guarded-executor.js", () => ({
+  assertGuardedAllow: (...args: unknown[]) => mockAssertGuardedAllow(...args),
+  isBudgetExhausted: (...args: unknown[]) => mockIsBudgetExhausted(...args),
+  CapabilityInvocationRefusedError: class extends Error {},
+  CapabilityNotClassifiedError: class extends Error {},
+  BudgetExhaustedError: class extends Error {},
+}));
+
+const mockExecutor = vi.fn();
+vi.mock("../capabilities/index.js", () => ({
+  getExecutor: () => mockExecutor,
+}));
+
+const insertResultsCalls: unknown[] = [];
+let suiteRows: unknown[] = [];
+const mockDb = {
+  select: () => ({
+    from: () => ({
+      innerJoin: () => ({
+        where: () => Promise.resolve(suiteRows),
+      }),
+    }),
+  }),
+  insert: (table: unknown) => ({
+    values: (vals: unknown) => {
+      if (table === testResultsTable) insertResultsCalls.push(vals);
+      return Promise.resolve(undefined);
+    },
+  }),
+  update: () => ({
+    set: () => ({
+      where: () => Promise.resolve(undefined),
+    }),
+  }),
+};
+vi.mock("../db/index.js", () => ({ getDb: () => mockDb }));
+
+import { testResults as testResultsTable } from "../db/schema.js";
 import {
   shouldRecordTestEvidence,
+  runTests,
 } from "./test-runner.js";
+
+function fakeSuiteRow(id: string) {
+  return {
+    suite: {
+      id,
+      capabilitySlug: "budget-test-cap",
+      testType: "negative",
+      testName: `duplicate-known-answer-${id}`,
+      testMode: "live",
+      input: {},
+      validationRules: { checks: [] },
+      baselineOutput: null,
+      externalCostCents: 0,
+      estimatedCostCents: 0,
+      active: true,
+      lastClassification: null,
+    },
+    fieldReliability: null,
+    // "deterministic" avoids withRetry's real backoff delays — this test
+    // is about the budget-skip wiring, not retry timing.
+    capabilityType: "deterministic",
+    outputSchema: null,
+  };
+}
+
+describe("runTests — per-suite budget re-check (HIGH-1, 2026-08-17 review)", () => {
+  beforeEach(() => {
+    mockIsBudgetExhausted.mockReset();
+    mockAssertGuardedAllow.mockReset().mockResolvedValue(undefined);
+    mockExecutor.mockReset().mockRejectedValue(new Error("simulated executor error"));
+    insertResultsCalls.length = 0;
+    suiteRows = [
+      fakeSuiteRow("suite-1"),
+      fakeSuiteRow("suite-2"),
+      fakeSuiteRow("suite-3"),
+      fakeSuiteRow("suite-4"),
+    ];
+  });
+
+  it("4 duplicate suites, budget for 2 → exactly 2 test_results rows, 2 silent skips, 0 BudgetExhausted rows", async () => {
+    // isBudgetExhausted mirrors what the REAL counter would report after
+    // the first two suites' assertGuardedAllow calls (mocked here, but in
+    // production that's assertBudgetAvailable's atomic increment) spend
+    // the daily budget_cap=2: available for suite 1 and 2, exhausted for
+    // suite 3 and 4 — all within this ONE runTests() call.
+    mockIsBudgetExhausted
+      .mockResolvedValueOnce(false) // suite-1: budget available
+      .mockResolvedValueOnce(false) // suite-2: budget available
+      .mockResolvedValueOnce(true)  // suite-3: exhausted — must skip
+      .mockResolvedValueOnce(true); // suite-4: exhausted — must skip
+
+    const summary = await runTests({ capabilitySlug: "budget-test-cap", testType: "negative" });
+
+    // isBudgetExhausted was consulted once per suite — the actual fix.
+    expect(mockIsBudgetExhausted).toHaveBeenCalledTimes(4);
+
+    // Only the first 2 suites ever reached the executor.
+    expect(mockExecutor).toHaveBeenCalledTimes(2);
+
+    // Only 2 test_results rows were written — the 2 skipped suites wrote
+    // NOTHING (no row at all, not even a failed/BudgetExhausted one).
+    expect(insertResultsCalls).toHaveLength(2);
+
+    // None of the 2 written rows carry a BudgetExhausted failure —
+    // negative-test-type + thrown executor error is a PASS by design
+    // (validateResult's early return), proving the 2 that ran did so
+    // via the real executor path, not a swallowed budget refusal.
+    for (const row of insertResultsCalls as Array<{ passed: boolean; failureReason: string | null }>) {
+      expect(row.passed).toBe(true);
+      expect(row.failureReason).toBeNull();
+    }
+
+    // The run summary only counts the 2 that actually ran — the 2 skips
+    // are invisible to the summary, matching "no test_results row,
+    // log-only" (same shape as the pre-existing unconfigured/unhealthy
+    // skip categories a few lines above this check in test-runner.ts).
+    expect(summary.total).toBe(2);
+    expect(summary.passed).toBe(2);
+    expect(summary.failed).toBe(0);
+  });
+
+  it("budget available for all 4 → all 4 run, isBudgetExhausted still consulted per suite", async () => {
+    mockIsBudgetExhausted.mockResolvedValue(false);
+
+    const summary = await runTests({ capabilitySlug: "budget-test-cap", testType: "negative" });
+
+    expect(mockIsBudgetExhausted).toHaveBeenCalledTimes(4);
+    expect(mockExecutor).toHaveBeenCalledTimes(4);
+    expect(insertResultsCalls).toHaveLength(4);
+    expect(summary.total).toBe(4);
+  });
+});
 
 // Phase 3 Harden Fix A regression tests. The Phase 2 incident
 // (memo: docs/research/2026-05-07-dk-phase2-understand.md on branch

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -14,6 +14,7 @@ import {
   CapabilityInvocationRefusedError,
   CapabilityNotClassifiedError,
   BudgetExhaustedError,
+  isBudgetExhausted,
 } from "../capabilities/guarded-executor.js";
 import type { CapabilityResult } from "../capabilities/index.js";
 import { computeHealthState, HEALTH_STATE_FREQUENCY_HOURS } from "./health-state.js";
@@ -244,6 +245,13 @@ export async function runTests(
       outputSchemaMap,
     );
 
+    // Phase-4 tail fix (HIGH-1, 2026-08-17 review): runSingleTest returns
+    // null when it hit a per-suite budget-exhaustion skip (see its own
+    // comment for why the once-per-batch scheduler check isn't enough —
+    // this call can carry several suites for the same capability). No
+    // test_results row was written; nothing to push, no self-heal to run.
+    if (result === null) continue;
+
     // ── Self-healing: attempt remediation on failures ──────────────────
     if (!result.passed && result.failureReason) {
       try {
@@ -455,7 +463,7 @@ async function runSingleTest(
   fieldReliabilityMap?: Map<string, Record<string, string>>,
   capabilityTypeMap?: Map<string, string>,
   outputSchemaMap?: Map<string, Record<string, unknown>>,
-): Promise<SingleTestResult> {
+): Promise<SingleTestResult | null> {
   const db = getDb();
   const startTime = Date.now();
 
@@ -526,6 +534,36 @@ async function runSingleTest(
       failureReason,
       responseTimeMs: 0,
     };
+  }
+
+  // Phase-4 tail fix (HIGH-1, 2026-08-17 review): re-check the live budget
+  // counter per suite, immediately before the call that would otherwise
+  // run straight into assertBudgetAvailable's BudgetExhaustedError.
+  //
+  // test-scheduler.ts's shouldSkipForBudget is a once-per-BATCH pre-check
+  // (before calling runTests()) — not enough on its own, because a single
+  // runTests({capabilitySlug, testType}) call reloads ALL suites matching
+  // that (slug, testType) pair, and this per-suite loop then runs them
+  // sequentially. danish-company-data has 4 duplicate known_answer test
+  // suites; a single runTests() call for it ran all 4 in one pass — the
+  // scheduler's outer check saw "budget available" once, the first 2
+  // suites here spent it, and the other 2 used to run straight into
+  // BudgetExhaustedError anyway, each writing a FAILED test_results row.
+  // This is the check that actually closes the gap; the scheduler's
+  // pre-check stays as a cheap early-out that avoids the runTests() call
+  // (and its DB query + per-suite loop startup) entirely when the whole
+  // batch is already known to be spent.
+  if (await isBudgetExhausted(suite.capabilitySlug)) {
+    log.info(
+      {
+        label: "test-runner-skip-budget-exhausted",
+        capability_slug: suite.capabilitySlug,
+        test_suite_id: suite.id,
+        test_type: suite.testType,
+      },
+      "test-runner-skip-budget-exhausted",
+    );
+    return null;
   }
 
   let capResult: CapabilityResult | null = null;

--- a/apps/api/test/fixtures/tier-coverage/spanish-company-data.json
+++ b/apps/api/test/fixtures/tier-coverage/spanish-company-data.json
@@ -1,22 +1,27 @@
 {
-  "company_name": "Telefonica, SA",
-  "native_company_name": null,
-  "registration_number": "A28015865",
-  "vat_number": "ESA28015865",
-  "country_code": "ES",
-  "legal_form": null,
+  "company_name": "CONSTRUCCIONES AMENABAR SA",
+  "nif": "A20072302",
+  "vat_number": "ESA20072302",
+  "company_type": "S.A.",
   "status": "active",
-  "is_active": true,
-  "registered_date": "1924-04-19",
-  "registered_address": "Calle Gran Via, 28 5 28, 28013, Madrid, ES",
-  "lei_code": "549300EEJH4FEPDBBR25",
-  "nace_codes": [
-    {
-      "code": "6190",
-      "description": "Other telecommunications activities"
-    }
-  ],
-  "company_size": null,
-  "source_as_of": "[CAPTURE_TIMESTAMP]",
-  "last_filing_date": "2024-12-31"
+  "status_raw": "Activa",
+  "address": null,
+  "province": "Gipuzkoa",
+  "registration_date": null,
+  "first_borme_activity": "2009-04-16",
+  "last_borme_activity": "2026-01-15",
+  "borme_acts_count": 79,
+  "legal_representatives": "[REDACTED]",
+  "total_legal_representatives": 22,
+  "recent_borme_acts": "[REDACTED]",
+  "jurisdiction": "ES",
+  "legal_name": "CONSTRUCCIONES AMENABAR SA",
+  "primary_registration_id": "A20072302",
+  "legal_form": "S.A.",
+  "registered_address": null,
+  "date_incorporated": null,
+  "tier_2_available": true,
+  "tier_2_available_reason": "current officers (cargos vigentes) from BORME appointment/cessation acts via OpenMercantil.es",
+  "ubo_availability": "unavailable_no_registry",
+  "ubo_availability_reason": "Spain's RETIR/beneficial-ownership registry is not publicly accessible; BORME does not carry ownership"
 }

--- a/manifests/cypriot-company-data.yaml
+++ b/manifests/cypriot-company-data.yaml
@@ -71,6 +71,15 @@ output_schema:
       description: UBO availability flag. CY is unavailable_no_registry — Cyprus UBO Register closed to public access since 2023-01-03 (CJEU C-37/20).
     ubo_availability_reason:
       type: string
+    legal_name:
+      type: string
+      description: Evidence Tier 1 canonical alias (DEC-20260518-A) for company_name. Set unconditionally by the executor — same reliability as company_name.
+    primary_registration_id:
+      type: string
+      description: Evidence Tier 1 canonical alias (DEC-20260518-A) for registration_number. Set unconditionally by the executor — same reliability as registration_number.
+    date_incorporated:
+      type: ["string", "null"]
+      description: Evidence Tier 1 canonical alias (DEC-20260518-A) for registered_date. Set unconditionally by the executor — same reliability as registered_date.
 data_source: Openapi.com WW-Top (Tier-3) + data.gov.cy DRCOR open-data CSV (Tier-2 legal_representatives via C-prefix lookup)
 data_source_type: api
 transparency_tag: algorithmic
@@ -117,6 +126,15 @@ output_field_reliability:
   tier_2_available_reason: guaranteed
   ubo_availability: guaranteed
   ubo_availability_reason: guaranteed
+  # Evidence Tier 1 canonical aliases (DEC-20260518-A) — executor sets these
+  # unconditionally from company_name / registration_number / registered_date
+  # (src/capabilities/cypriot-company-data.ts), so reliability mirrors the
+  # source field exactly. MEDIUM-4, 2026-08-17 review: declared here instead
+  # of allowlisting the slug — these are known, stable fields, not a legal
+  # gate like the recapture itself.
+  legal_name: guaranteed
+  primary_registration_id: guaranteed
+  date_incorporated: common
 limitations:
   - title: Gated behind OPENAPI_ENABLED flag pending resale addendum countersignature
     text: >-

--- a/manifests/redirect-trace.yaml
+++ b/manifests/redirect-trace.yaml
@@ -22,34 +22,34 @@ output_schema:
   type: object
   example:
     chain:
-      - url: https://httpbin.org/redirect/2
+      - url: http://microsoft.com/
         step: 1
-        server: gunicorn/19.9.0
-        location: /relative-redirect/1
-        latency_ms: 3
-        status_code: 302
-        status_text: FOUND
-      - url: https://httpbin.org/relative-redirect/1
+        server: null
+        location: https://microsoft.com/
+        latency_ms: 60
+        status_code: 307
+        status_text: Temporary Redirect
+      - url: https://microsoft.com/
         step: 2
-        server: gunicorn/19.9.0
-        location: /get
-        latency_ms: 4
-        status_code: 302
-        status_text: FOUND
-      - url: https://httpbin.org/get
+        server: null
+        location: https://www.microsoft.com/
+        latency_ms: 55
+        status_code: 301
+        status_text: Moved Permanently
+      - url: https://www.microsoft.com/
         step: 3
-        server: gunicorn/19.9.0
+        server: null
         location: null
-        latency_ms: 5
+        latency_ms: 70
         status_code: 200
         status_text: OK
     issues: []
-    final_url: https://httpbin.org/get
+    final_url: https://www.microsoft.com/
     uses_https: true
-    same_domain: true
-    original_url: https://httpbin.org/redirect/2
+    same_domain: false
+    original_url: http://microsoft.com/
     redirect_count: 2
-    total_latency_ms: 12
+    total_latency_ms: 185
     final_status_code: 200
   properties:
     chain:
@@ -73,7 +73,14 @@ geography: global
 test_fixtures:
   known_answer:
     input:
-      url: https://httpbin.org/redirect/2
+      # Swapped off httpbin.org (2026-08-17, Phase-4 tail fix) — httpbin's
+      # /redirect/N endpoint 503s often enough that the known_answer test
+      # was silently skipping the redirect branch (a 503 isn't a redirect,
+      # so the test "passed" without ever exercising the chain-walk logic —
+      # exactly how the safeFetch maxRedirects:0 regression went
+      # undetected). http://microsoft.com is a real, stable 2-hop chain
+      # (307 http->https, then 301 apex->www) verified live.
+      url: http://microsoft.com
     expected_fields:
       - field: chain
         operator: not_null
@@ -104,7 +111,7 @@ test_fixtures:
         reliability: guaranteed
         value: string
   health_check_input:
-    url: https://httpbin.org/redirect/1
+    url: http://microsoft.com
 output_field_reliability:
   chain: guaranteed
   issues: guaranteed


### PR DESCRIPTION
## Summary
- **redirect-trace worked for the first time in ~4 months**: `safeFetch(maxRedirects:0)` always threw on the first redirect (commit 1f0d480, Apr 17), so every actually-redirecting URL failed and the harness "passes" were httpbin 503 false positives. New opt-in `returnOnRedirectCap` returns the 3xx with SSRF validation intact per hop; per-hop response bodies cancelled; same fix applied to the same-bug sibling `url-health-check`.
- **Test budgets stop poisoning metrics**: the scheduler and the runner (per-suite) now skip silently when a capability's daily budget is exhausted instead of running-to-fail — danish-company-data's "6% pass rate" was ~90% self-inflicted budget failures. Failure classifier gains `test_infrastructure` (budget) and `test_design` (compliance-refusal) patterns, producer-anchored, with the reviewer's false-positive case negative-tested.
- **tier-coverage gate promoted to strict** (completes Phase 2's deferred T2.3): spanish fixture recaptured post-vendor-swap (with a real PII leak caught and scrubbed during capture — officer names in BORME free text), cypriot's canonical-alias fields declared in its manifest instead of slug-allowlisting.
- GDELT (company-news) executor-level retry removed — it stacked with the runner's and do.ts's retries into 4× amplification against an already-throttling API.
- Heartbeat accounting derives `suites_tested` from executed results, never batch arithmetic.

## Verification
- 5 review rounds with Codex (2 HIGH + 6 findings in round 1, all closed; closing pass confirmed 8/8 including a full-branch grep proving zero officer-name occurrences in files and commit messages — one commit message rewritten pre-push for exactly that).
- Fail-before/pass-after evidence per fix; 87+ tests across 9 touched/new test files; full typecheck (6 surfaces), mjs syntax, dispatcher lint, SSRF inventory, PII strict, tier-coverage strict all green.
- DEC-20260504-C: scheduler path proven via index.ts:140→startTestScheduler→pollCycle wiring; post-deploy verification = danish/swedish budget-exhaustion failures cease in test_results (queryable within a day).

## Reviewer findings (accepted, documented)
- check-pii detects checksummed identifiers, not bare names in prose — residual gap, flagged not fixed here.
- Slug-level tier-coverage allowlisting masks future drift for grandfathered slugs — structural improvement deferred.

## Test plan
- CI green; then watch test_results for danish (budget skips instead of failures) and redirect-trace (real 2-hop chain passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)