### PR TITLE
fix(test-infra): suite-scoped scheduling ends quadratic re-testing; Swedish coverage restored honestly

### DIFF
--- a/apps/api/scripts/restore-swedish-known-answers.ts
+++ b/apps/api/scripts/restore-swedish-known-answers.ts
@@ -32,52 +32,97 @@
  * Budget arithmetic (Block 0084, swedish-company-data cost_class=free_quota,
  * quota_cap=1000/day, test budget = min(1, floor(1000*0.10)) = 100/day):
  *
- *   Per-suite daily attempt counts are NOT uniform across test_type — this
- *   was checked directly against test_results for the 5 most recent clean
- *   days (2026-08-13 through 2026-08-17), per suite id:
- *     known_answer (Spotify AB, the one suite untouched by the Phase 4
- *       dedup) ................................ steady 18/day for 5/5 days
- *     dependency_health ........................ steady ~2.2/day
- *     edge_case ................................. steady ~2.8/day
- *     known_bad .................................. steady ~2.2/day
- *     negative .................................... steady ~2.6/day
- *     schema_check ................................ steady ~3.0/day
- *       (post-2026-08-13; was ~12/day on 08-10/08-11, before whatever
- *       changed then — not relevant to this projection)
+ * REVISED 2026-08-18 (Codex review). The original version of this comment
+ * projected ~18/day per known_answer suite, taken from 5 days of observed
+ * test_results for "Spotify AB — known company" (the one suite the Phase 4
+ * dedup left alone). That number was WRONG — not a measurement error, a
+ * measurement of a different bug. test-scheduler.ts's per-suite stagger
+ * hashes `slug + ':' + test_type`, identical for every suite sharing a
+ * test_type — so, pre-fix, ALL of swedish-company-data's known_answer
+ * suites (Spotify plus the 5 duplicates, before today's dedup) became
+ * "overdue" in the same poll-cycle batch. findOverdueSuites() emitted one
+ * row per due SUITE, but the scheduler's loop called
+ * `runTests({capabilitySlug, testType})` per row *without* narrowing to
+ * that row's specific suite — and runTests() with only (slug, testType)
+ * reloads and re-executes EVERY active suite matching that pair. So a
+ * batch of N due same-type suites produced N x N executions, not N: with
+ * 6 known_answer suites, that's up to 36 executions from ONE batch. Every
+ * one of those executions writes a real test_results row against the real
+ * suite it ran (including Spotify's), which is exactly why Spotify's own
+ * suite — never itself duplicated — still measured a contaminated ~18/day:
+ * it was one of the N x N executions fired by its siblings being overdue
+ * in the same cycle, not its own organic hourly cadence. This also
+ * retroactively explains capability_budget_counters showing the pre-dedup
+ * 11-suite configuration hit the full 100/100 hard cap every one of the
+ * 5 days before this fix (2026-08-13 through 2026-08-17), each by
+ * ~04:30-05:40 UTC — 11 suites at a genuinely linear ~2-3/day each would
+ * never have come close to 100.
  *
- *   Current post-Phase-4 active set (6 suites, 1 known_answer + 5 others):
- *     ~2.2 + 2.8 + 18 + 2.2 + 2.6 + 3.0 = ~30.8/day
+ * This session's fix (test-runner.ts's TestRunOptions.suiteId +
+ * test-scheduler.ts passing `suiteId: suite.suiteId` per batch entry, see
+ * the sibling commit) makes execution linear: one batch entry now runs
+ * exactly the one suite it represents, regardless of how many siblings
+ * share its (slug, testType). With the fix landed, the N x N amplifier is
+ * gone, and there is no structural reason for a known_answer suite to cost
+ * more per day than any other suite type on this capability.
  *
- *   Each RESTORED known_answer suite is the same test_type, same shape,
- *   same debounce/stagger mechanics as Spotify's — so ~18/day each is the
- *   best available same-shape estimate (not a generic average; it is the
- *   observed, sustained, 5-day-stable rate for this exact suite type on
- *   this exact capability):
- *     30.8 + 3 suites x 18/day = 30.8 + 54 = ~84.8/day  ≈ 85/day
+ * Per-suite daily attempt counts for the suite TYPES that were never
+ * duplicated (so their historical rate was never contaminated by the N x N
+ * bug — these are the honest baseline), checked against test_results for
+ * 2026-08-13 through 2026-08-17:
+ *   dependency_health ........... steady ~2.2/day
+ *   edge_case .................... steady ~2.8/day
+ *   known_bad ..................... steady ~2.2/day
+ *   negative ....................... steady ~2.6/day
+ *   schema_check ................... steady ~3.0/day
+ *   (unweighted average ~2.56/day — used below as the honest per-suite
+ *   estimate for a LINEAR-scheduled suite of any test_type, including
+ *   known_answer, now that the scheduler fix removes the reason
+ *   known_answer was ever different)
  *
- *   That is under the "~95 of 100" ceiling this task set, with ~10/day of
- *   margin to 95 and ~15/day to the hard 100 cap. Restoring a 4th
- *   (Volvo, if the label question above gets resolved) would land at
- *   ~102.8/day — OVER the 100 hard cap — so 3 is the actual ceiling here,
- *   not merely the instructed range's upper bound.
+ * Post-fix, post-restore projected state (6 pre-existing suites + 3
+ * restored known_answer suites = 9 suites total, all linear):
+ *   9 suites x ~2.56/day/suite = ~23/day
  *
- *   NOTE ON THE TASK'S STATED "~85 attempts/day" BASELINE: that number
- *   describes almost exactly what this script projects for the
- *   POST-RESTORE state (~84.8), not the pre-restore state. The real
- *   pre-restore (current, 6-suite) baseline is ~31/day — confirmed against
- *   capability_budget_counters, which additionally shows the *old*
- *   11-suite configuration hitting the full 100/100 hard cap on every one
- *   of the last 5 days (2026-08-13 through 2026-08-17), each time by
- *   ~04:30-05:40 UTC. That's the concrete cost the Phase 4 dedup fixed;
- *   this script spends about half of what it recovered.
+ * That is far under the "~95 of 100" ceiling this task set — ~72/day of
+ * margin to 95, ~77/day to the hard 100 cap. The tight-margin projection
+ * in the prior version of this file (~84.8/day, "10/day of margin") was an
+ * artifact of extrapolating from a quadratically-inflated measurement; it
+ * is superseded, not merely re-estimated. Restoring a 4th suite (Volvo,
+ * pending the label decision noted above) would add ~2.56/day more —
+ * trivially within budget now — but is out of scope for this session
+ * (not requested by the review; the 3 already live in prod stay as-is).
  *
  * Usage:
  *   npx tsx --env-file=<path to .env> scripts/restore-swedish-known-answers.ts
  *   npx tsx --env-file=<path to .env> scripts/restore-swedish-known-answers.ts --apply
+ *   npx tsx --env-file=<path to .env> scripts/restore-swedish-known-answers.ts --apply --upgrade-rules
  *
- * Dry-run (no --apply) is the default and only prints the diff. --apply is
- * required to write. This script is READ-ONLY against prod unless --apply
- * is passed explicitly by an operator after review.
+ * Dry-run (no --apply) is the default and only prints the diff; the whole
+ * operation — preflight read included — runs inside a transaction that is
+ * always rolled back on this path, so it is genuinely read-only against
+ * prod. --apply is required to write, and commits only if every targeted
+ * row classifies cleanly (see "Row classification" below); a sanity
+ * failure on any one row rolls back the whole transaction, so a run never
+ * leaves a partial restore.
+ *
+ * Idempotent by design (Codex review HIGH-2): a rerun recognizes a row
+ * already in its target state (active, corrected input, no quarantine) as
+ * an OK-skip, not a refusal — this script is now safe to run again after
+ * the orchestrator has already applied it, which is exactly the situation
+ * this review landed in.
+ *
+ * --upgrade-rules is a separate, explicit opt-in for touching an
+ * already-restored row a second time: the version of this script that
+ * first ran against prod wrote `company_name: not_null` validation_rules
+ * (MEDIUM finding — not_null proves nothing about identity, since the
+ * executor echoes org_number/derives vat_number from the request
+ * regardless of which company it resolved). Without --upgrade-rules,
+ * already-restored rows with the old rules are reported (STALE RULES) but
+ * left alone. With it, their validation_rules (and baseline_output) are
+ * upgraded to the current equals-assertion shape via a compare-and-set
+ * scoped to their current (already-restored) state — active/input/
+ * quarantine_reason are untouched.
  */
 import { config } from "dotenv";
 import { resolve } from "node:path";
@@ -110,7 +155,12 @@ const RESTORE_PLANS: RestorePlan[] = [
     newInput: { org_number: "556737-0431" },
     validationRules: {
       checks: [
-        { field: "company_name", operator: "not_null" },
+        // MEDIUM (Codex review): not_null proved nothing about identity —
+        // the executor echoes org_number back from the request and derives
+        // vat_number from it, so any org_number would pass a not_null
+        // company_name check even against the wrong company. equals against
+        // the exact live-verified legal name is the actual identity check.
+        { field: "company_name", value: "Klarna Bank AB", operator: "equals" },
         { field: "org_number", value: "556737-0431", operator: "equals" },
         { field: "vat_number", value: "SE556737043101", operator: "equals" },
         { field: "country_code", value: "SE", operator: "equals" },
@@ -178,7 +228,7 @@ const RESTORE_PLANS: RestorePlan[] = [
     newInput: { org_number: "556042-7220" },
     validationRules: {
       checks: [
-        { field: "company_name", operator: "not_null" },
+        { field: "company_name", value: "H & M Hennes & Mauritz AB", operator: "equals" },
         { field: "org_number", value: "556042-7220", operator: "equals" },
         { field: "vat_number", value: "SE556042722001", operator: "equals" },
         { field: "country_code", value: "SE", operator: "equals" },
@@ -240,7 +290,7 @@ const RESTORE_PLANS: RestorePlan[] = [
     newInput: { org_number: "556074-7551" },
     validationRules: {
       checks: [
-        { field: "company_name", operator: "not_null" },
+        { field: "company_name", value: "IKEA of Sweden AB", operator: "equals" },
         { field: "org_number", value: "556074-7551", operator: "equals" },
         { field: "vat_number", value: "SE556074755101", operator: "equals" },
         { field: "country_code", value: "SE", operator: "equals" },
@@ -299,123 +349,345 @@ const RESTORE_PLANS: RestorePlan[] = [
   },
 ];
 
+// Honest per-suite daily rate: the average of the 5 suite types that were
+// NEVER duplicated, so their historical test_results rate was never
+// contaminated by the scheduler's pre-fix N x N same-test-type amplifier
+// (see the file header for the full incident). Now that runTests() accepts
+// suiteId and the scheduler passes it per batch entry, execution is linear
+// in suite count — a known_answer suite costs the same as any other suite
+// type, because the mechanism that used to make it different is gone.
+const NEVER_DUPLICATED_SUITE_RATES = {
+  dependency_health: 2.2,
+  edge_case: 2.8,
+  known_bad: 2.2,
+  negative: 2.6,
+  schema_check: 3.0,
+} as const;
+const HONEST_PER_SUITE_RATE =
+  Object.values(NEVER_DUPLICATED_SUITE_RATES).reduce((a, b) => a + b, 0) /
+  Object.keys(NEVER_DUPLICATED_SUITE_RATES).length;
+
 function printBudgetArithmetic(): void {
   console.log("Budget arithmetic (Block 0084, swedish-company-data, cap=100/day):");
-  console.log("  Current active-suite baseline (post Phase-4, empirically observed):");
-  console.log("    dependency_health  ~2.2/day");
-  console.log("    edge_case          ~2.8/day");
-  console.log("    known_bad          ~2.2/day");
-  console.log("    negative           ~2.6/day");
-  console.log("    schema_check       ~3.0/day");
-  console.log("    known_answer (Spotify, unchanged)  18.0/day");
-  console.log("    ---------------------------------------");
-  console.log("    baseline total     ~30.8/day");
-  console.log(`  + ${RESTORE_PLANS.length} restored known_answer suites x ~18.0/day each = ${(RESTORE_PLANS.length * 18).toFixed(1)}/day`);
-  const projected = 30.8 + RESTORE_PLANS.length * 18;
+  console.log(
+    "  REVISED (Codex review, 2026-08-18): the scheduler's pre-fix N x N same-\n" +
+      "  test-type amplifier (test-scheduler.ts + test-runner.ts, fixed in the\n" +
+      "  sibling commit of this change) meant a known_answer suite's historical\n" +
+      "  rate was contaminated by however many duplicate known_answer siblings\n" +
+      "  were also overdue in the same poll-cycle batch. Now that execution is\n" +
+      "  linear (runTests() takes an optional suiteId; the scheduler passes the\n" +
+      "  specific overdue suite's id per batch entry), there is no structural\n" +
+      "  reason for known_answer to cost more per day than any other suite type.\n" +
+      "  The honest per-suite estimate below is the average of the 5 suite types\n" +
+      "  that were NEVER duplicated, so their historical rate was never inflated\n" +
+      "  by the bug.",
+  );
+  console.log("  Never-duplicated suite types (honest baseline, /day):");
+  for (const [type, rate] of Object.entries(NEVER_DUPLICATED_SUITE_RATES)) {
+    console.log(`    ${type.padEnd(18)} ${rate.toFixed(1)}`);
+  }
+  console.log(`    average per suite  ${HONEST_PER_SUITE_RATE.toFixed(2)}/day`);
+  console.log();
+
+  const preExistingSuiteCount = Object.keys(NEVER_DUPLICATED_SUITE_RATES).length + 1; // + Spotify's known_answer suite
+  const totalSuiteCount = preExistingSuiteCount + RESTORE_PLANS.length;
+  const projected = totalSuiteCount * HONEST_PER_SUITE_RATE;
+
+  console.log(
+    `  Post-fix, post-restore: ${preExistingSuiteCount} pre-existing suites (5 never-duplicated ` +
+      `types + Spotify's known_answer, now linear like the rest) + ${RESTORE_PLANS.length} ` +
+      `restored known_answer suites = ${totalSuiteCount} suites total, all linear.`,
+  );
+  console.log(
+    `    ${totalSuiteCount} suites x ${HONEST_PER_SUITE_RATE.toFixed(2)}/day/suite = ~${projected.toFixed(1)}/day`,
+  );
   console.log(`  = projected total ~${projected.toFixed(1)}/day  (ceiling requested: ~95/day; hard cap: 100/day)`);
   if (projected > 100) {
     console.log("  *** OVER THE 100/DAY HARD CAP — DO NOT APPLY ***");
   } else if (projected > 95) {
     console.log("  *** OVER THE ~95/DAY REQUESTED CEILING — reconsider suite count ***");
   } else {
-    console.log(`  OK — ${(95 - projected).toFixed(1)}/day of margin to the ~95 ceiling, ${(100 - projected).toFixed(1)}/day to the hard cap.`);
+    console.log(
+      `  OK — ~${(95 - projected).toFixed(1)}/day of margin to the ~95 ceiling, ` +
+        `~${(100 - projected).toFixed(1)}/day to the hard cap. Far more headroom than the ` +
+        "pre-review (quadratically-contaminated) estimate showed — the scheduler fix, not just\n" +
+        "  the dedup, is what actually recovered the budget.",
+    );
   }
   console.log();
 }
 
+// ─── Row classification (idempotency + atomicity, Codex review HIGH-2) ─────
+//
+// A rerun of this script — dry-run OR --apply — must be safe against a row
+// already being in the state a PRIOR run left it in. The original version
+// only recognized one "good" state (inactive, stale Spotify-cloned input)
+// and SANITY-FAILED on anything else, including the row's own POST-restore
+// state — so a rerun after a successful --apply refused every row instead
+// of reporting "already done". That's the exact shape this task's own
+// escalation-contract text ran into: the orchestrator applied this script
+// to prod between when it was written and when this review landed, so any
+// naive rerun today would hit that refusal on all 3 rows.
+type RowClassification =
+  | { kind: "needs_restore" }
+  | { kind: "already_restored"; rulesUpToDate: boolean }
+  | { kind: "sanity_fail"; reason: string };
+
+function classifyRow(
+  plan: RestorePlan,
+  row:
+    | {
+        input: Record<string, unknown>;
+        active: boolean;
+        quarantine_reason: string | null;
+        capability_slug: string;
+        validation_rules: unknown;
+      }
+    | undefined,
+): RowClassification {
+  if (!row) return { kind: "sanity_fail", reason: "suite not found" };
+  if (row.capability_slug !== CAPABILITY_SLUG) {
+    return { kind: "sanity_fail", reason: `belongs to '${row.capability_slug}', not '${CAPABILITY_SLUG}'` };
+  }
+
+  const inputMatchesOld = JSON.stringify(row.input) === JSON.stringify(plan.oldInput);
+  const inputMatchesNew = JSON.stringify(row.input) === JSON.stringify(plan.newInput);
+
+  // Target state: this is what a successful --apply of THIS plan leaves
+  // behind. Recognizing it (rather than only the pre-restore state) is
+  // what makes a rerun idempotent instead of a refusal.
+  if (row.active === true && inputMatchesNew && row.quarantine_reason === null) {
+    // MEDIUM (Codex review): the version of this script that already ran
+    // against prod wrote not_null-only company_name checks. rulesUpToDate
+    // distinguishes "restored with the current (equals-assertion)
+    // validation_rules" from "restored, but with the older weaker rules" —
+    // the latter needs --upgrade-rules, not a fresh restore (the row is
+    // already active/correct otherwise; only the rules are stale).
+    const rulesUpToDate = JSON.stringify(row.validation_rules) === JSON.stringify(plan.validationRules);
+    return { kind: "already_restored", rulesUpToDate };
+  }
+
+  // Pre-restore state: the stale, Spotify-cloned, quarantined row Phase 4
+  // left behind. This is the only state this script is willing to write.
+  if (row.active === false && inputMatchesOld) {
+    return { kind: "needs_restore" };
+  }
+
+  return {
+    kind: "sanity_fail",
+    reason:
+      `unrecognized state — active=${row.active}, input=${JSON.stringify(row.input)}, ` +
+      `quarantine_reason=${row.quarantine_reason ? "(set)" : "(null)"}. Neither the pre-restore ` +
+      "nor the post-restore shape this plan recognizes. Someone touched this row in an " +
+      "unexpected way — refusing to guess.",
+  };
+}
+
+// Sentinel used to unwind db.transaction() on the dry-run path without
+// treating "dry run completed cleanly" as an error — db.transaction()
+// commits unless the callback throws, and dry-run must never commit.
+class DryRunRollback extends Error {}
+
 async function main() {
   const apply = process.argv.includes("--apply");
+  const upgradeRules = process.argv.includes("--upgrade-rules");
   const db = getDb();
 
   printBudgetArithmetic();
 
-  console.log(`Mode: ${apply ? "APPLY (writing to prod)" : "DRY RUN (no writes)"}\n`);
+  console.log(`Mode: ${apply ? "APPLY (writing to prod)" : "DRY RUN (no writes, transaction always rolled back)"}`);
+  console.log(
+    `Rule upgrade: ${upgradeRules ? "ON (--upgrade-rules — will upgrade stale not_null company_name checks to equals)" : "OFF (pass --upgrade-rules to also fix already-restored rows with the older weaker rules)"}\n`,
+  );
 
-  // Sanity check: confirm each target suite is currently inactive with the
-  // expected quarantine reason and the expected stale (Spotify-cloned) input,
-  // so this script can never accidentally "restore" something else.
-  const ids = RESTORE_PLANS.map((p) => p.suiteId);
-  const current = await db.execute(sql`
-    SELECT id::text AS id, test_name, input, active, quarantine_reason, capability_slug
-      FROM test_suites
-     WHERE id IN (${sql.join(ids.map((id) => sql`${id}::uuid`), sql`, `)})
-  `);
-  const rows = (Array.isArray(current) ? current : (current as { rows?: unknown[] }).rows ?? []) as Array<{
-    id: string;
-    test_name: string;
-    input: Record<string, unknown>;
-    active: boolean;
-    quarantine_reason: string | null;
-    capability_slug: string;
-  }>;
-  const byId = new Map(rows.map((r) => [r.id, r]));
+  // Single transaction for the whole operation (Codex review HIGH-2): the
+  // preflight SELECT and the writes now share one transaction and one set
+  // of row locks, so a mid-run failure can never leave a partial restore —
+  // Postgres rolls back everything on any thrown error, and dry-run rolls
+  // back unconditionally regardless of outcome (no COMMIT is ever reached
+  // on that path). SELECT ... FOR UPDATE locks exactly the 3 target rows
+  // for the duration of this transaction, closing the prior gap where a
+  // concurrent writer could change a row between the preflight read and
+  // the write that assumed it was unchanged.
+  let needsRestore = 0;
+  let alreadyRestored = 0;
+  let rulesUpgraded = 0;
+  let rulesStaleNotUpgraded = 0;
+  let sanityFailed = 0;
 
-  let allSane = true;
-  for (const plan of RESTORE_PLANS) {
-    const row = byId.get(plan.suiteId);
-    if (!row) {
-      console.error(`SANITY FAIL: suite ${plan.suiteId} (${plan.testName}) not found.`);
-      allSane = false;
-      continue;
-    }
-    if (row.capability_slug !== CAPABILITY_SLUG) {
-      console.error(`SANITY FAIL: suite ${plan.suiteId} belongs to '${row.capability_slug}', not '${CAPABILITY_SLUG}'.`);
-      allSane = false;
-      continue;
-    }
-    if (row.active !== false) {
-      console.error(`SANITY FAIL: suite ${plan.suiteId} (${plan.testName}) is already active=true — refusing to touch it.`);
-      allSane = false;
-      continue;
-    }
-    const inputMatches = JSON.stringify(row.input) === JSON.stringify(plan.oldInput);
-    if (!inputMatches) {
-      console.error(
-        `SANITY FAIL: suite ${plan.suiteId} (${plan.testName}) input is ${JSON.stringify(row.input)}, ` +
-          `expected ${JSON.stringify(plan.oldInput)} — someone already touched this row. Refusing to overwrite.`,
+  try {
+    await db.transaction(async (tx) => {
+      const ids = RESTORE_PLANS.map((p) => p.suiteId);
+      const current = await tx.execute(sql`
+        SELECT id::text AS id, test_name, input, active, quarantine_reason, capability_slug, validation_rules
+          FROM test_suites
+         WHERE id IN (${sql.join(ids.map((id) => sql`${id}::uuid`), sql`, `)})
+         FOR UPDATE
+      `);
+      const rows = (Array.isArray(current) ? current : (current as { rows?: unknown[] }).rows ?? []) as Array<{
+        id: string;
+        test_name: string;
+        input: Record<string, unknown>;
+        active: boolean;
+        quarantine_reason: string | null;
+        capability_slug: string;
+        validation_rules: unknown;
+      }>;
+      const byId = new Map(rows.map((r) => [r.id, r]));
+
+      for (const plan of RESTORE_PLANS) {
+        const row = byId.get(plan.suiteId);
+        const classification = classifyRow(plan, row);
+
+        if (classification.kind === "sanity_fail") {
+          console.error(`SANITY FAIL: suite ${plan.suiteId} (${plan.testName}) — ${classification.reason}`);
+          sanityFailed++;
+          continue;
+        }
+
+        if (classification.kind === "already_restored") {
+          if (classification.rulesUpToDate) {
+            console.log(`OK-SKIP (already restored): ${plan.testName}`);
+            console.log(`  current: active=true, input=${JSON.stringify(plan.newInput)}, quarantine_reason=(null) — matches this plan's target state exactly.`);
+            console.log(`  no write needed; rerun is idempotent.`);
+            console.log();
+            alreadyRestored++;
+            continue;
+          }
+
+          // Already restored, but with the pre-review not_null-only
+          // company_name check (MEDIUM finding). The row itself (active,
+          // input, quarantine_reason) is correct — only validation_rules
+          // is stale. --upgrade-rules is the dedicated, explicit opt-in
+          // for touching an otherwise-fine row a second time.
+          console.log(`OK-SKIP, STALE RULES: ${plan.testName}`);
+          console.log(`  current: active=true, input=${JSON.stringify(plan.newInput)} — correct.`);
+          console.log(`  current validation_rules still use company_name not_null (pre-review) instead of equals("${plan.baselineOutput.company_name}").`);
+          if (upgradeRules) {
+            console.log(`  --upgrade-rules is set: will upgrade validation_rules${apply ? "" : " (dry run — not written)"}.`);
+          } else {
+            console.log(`  pass --upgrade-rules to fix this without a full restore.`);
+          }
+          console.log();
+
+          if (!upgradeRules) {
+            rulesStaleNotUpgraded++;
+            continue;
+          }
+
+          rulesUpgraded++;
+          if (!apply) continue;
+
+          // Compare-and-set scoped to the row's CURRENT (already-restored)
+          // state — id AND active=true AND input=newInput — distinct from
+          // the needs_restore predicate below (id AND active=false AND
+          // input=oldInput). Only validation_rules/baseline_output change;
+          // active/input/quarantine_reason are untouched (they're already
+          // correct, which is exactly why this row is "already_restored").
+          const upgraded = await tx.execute(sql`
+            UPDATE test_suites
+               SET validation_rules = ${JSON.stringify(plan.validationRules)}::jsonb,
+                   baseline_output = ${JSON.stringify(plan.baselineOutput)}::jsonb,
+                   updated_at = NOW()
+             WHERE id = ${plan.suiteId}
+               AND active = true
+               AND input = ${JSON.stringify(plan.newInput)}::jsonb
+            RETURNING id
+          `);
+          const upgradedRows = Array.isArray(upgraded) ? upgraded : (upgraded as { rows?: unknown[] }).rows ?? [];
+          if (upgradedRows.length !== 1) {
+            throw new Error(
+              `Rule-upgrade UPDATE for suite ${plan.suiteId} (${plan.testName}) affected ` +
+                `${upgradedRows.length} rows, expected exactly 1.`,
+            );
+          }
+          console.log(`Rules upgraded: ${plan.testName} (${plan.suiteId})`);
+          continue;
+        }
+
+        // needs_restore
+        console.log(`OK (needs restore): ${plan.testName}`);
+        console.log(`  current: active=false, input=${JSON.stringify(plan.oldInput)}, quarantine_reason=(set)`);
+        console.log(`  planned: active=true,  input=${JSON.stringify(plan.newInput)}, quarantine_reason=NULL`);
+        console.log(`  validation_rules: rebuilt from live-verified output (${plan.validationRules.checks.length} checks)`);
+        console.log(`  baseline_output: rebuilt from live-verified output`);
+        console.log();
+        needsRestore++;
+
+        if (!apply) continue;
+
+        // Compare-and-set: the predicate re-asserts the exact pre-restore
+        // shape (id AND input=old AND active=false) at WRITE time, not just
+        // at the preflight read a moment earlier — the row is already
+        // locked by the SELECT ... FOR UPDATE above, so this is belt-and-
+        // suspenders against any future refactor that reads and writes in
+        // separate transactions. RETURNING + an affected-row-count assertion
+        // makes a silent 0-row update (predicate didn't match — someone
+        // changed the row between FOR UPDATE and here, which shouldn't be
+        // possible inside one transaction, but "shouldn't be possible" is
+        // exactly the class of assumption DEC-20260504-A exists to distrust)
+        // a loud failure instead of a silently-skipped write.
+        const updated = await tx.execute(sql`
+          UPDATE test_suites
+             SET active = true,
+                 input = ${JSON.stringify(plan.newInput)}::jsonb,
+                 validation_rules = ${JSON.stringify(plan.validationRules)}::jsonb,
+                 baseline_output = ${JSON.stringify(plan.baselineOutput)}::jsonb,
+                 quarantine_reason = NULL,
+                 test_status = 'normal',
+                 updated_at = NOW()
+           WHERE id = ${plan.suiteId}
+             AND active = false
+             AND input = ${JSON.stringify(plan.oldInput)}::jsonb
+          RETURNING id
+        `);
+        const updatedRows = Array.isArray(updated) ? updated : (updated as { rows?: unknown[] }).rows ?? [];
+        if (updatedRows.length !== 1) {
+          throw new Error(
+            `Compare-and-set UPDATE for suite ${plan.suiteId} (${plan.testName}) affected ` +
+              `${updatedRows.length} rows, expected exactly 1. The row was locked by this ` +
+              "transaction's SELECT ... FOR UPDATE and matched needs_restore a moment ago — " +
+              "this should be unreachable. Aborting the whole transaction rather than leaving " +
+              "a partial restore.",
+          );
+        }
+        console.log(`Applied: ${plan.testName} (${plan.suiteId})`);
+      }
+
+      if (!apply) {
+        // Dry run: always roll back, regardless of classification outcome
+        // (including sanity failures) — the summary/exit-code handling
+        // below is uniform for dry-run either way. No COMMIT is ever
+        // reached on this path.
+        throw new DryRunRollback();
+      }
+
+      if (sanityFailed > 0) {
+        throw new Error(`${sanityFailed} suite(s) failed sanity classification — see SANITY FAIL lines above.`);
+      }
+    });
+  } catch (err) {
+    if (err instanceof DryRunRollback) {
+      console.log("Dry run complete (transaction rolled back). No rows were modified. Re-run with --apply to write.");
+      console.log(
+        `Summary: ${needsRestore} would restore, ${alreadyRestored} already restored (OK-skip, rules up to date), ` +
+          `${rulesUpgraded} rules would be upgraded, ${rulesStaleNotUpgraded} have stale rules but --upgrade-rules ` +
+          `was not passed, ${sanityFailed} sanity failed.`,
       );
-      allSane = false;
-      continue;
+      process.exit(sanityFailed > 0 ? 1 : 0);
     }
-    console.log(`OK: ${plan.testName}`);
-    console.log(`  current: active=false, input=${JSON.stringify(row.input)}, quarantine_reason=${row.quarantine_reason ? "(set)" : "(null)"}`);
-    console.log(`  planned: active=true,  input=${JSON.stringify(plan.newInput)}, quarantine_reason=NULL`);
-    console.log(`  validation_rules: rebuilt from live-verified output (${plan.validationRules.checks.length} checks)`);
-    console.log(`  baseline_output: rebuilt from live-verified output`);
-    console.log();
-  }
-
-  if (!allSane) {
-    console.error("\nOne or more sanity checks failed. Aborting without writing anything.");
+    console.error("\nTransaction rolled back — no partial writes.");
+    console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
 
-  if (!apply) {
-    console.log("Dry run complete. No rows were modified. Re-run with --apply to write.");
-    process.exit(0);
-  }
-
-  console.log("Applying...");
-  for (const plan of RESTORE_PLANS) {
-    await db.execute(sql`
-      UPDATE test_suites
-         SET active = true,
-             input = ${JSON.stringify(plan.newInput)}::jsonb,
-             validation_rules = ${JSON.stringify(plan.validationRules)}::jsonb,
-             baseline_output = ${JSON.stringify(plan.baselineOutput)}::jsonb,
-             quarantine_reason = NULL,
-             test_status = 'normal',
-             updated_at = NOW()
-       WHERE id = ${plan.suiteId}
-    `);
-    console.log(`Applied: ${plan.testName} (${plan.suiteId})`);
-  }
   console.log(
-    "\nDone. updated_at was bumped without touching baseline_captured_at, so the " +
-      "PR #308 stale-baseline check (test-runner.ts) will flag these as stale on " +
-      "the next scheduled run and trigger an automatic baseline recapture against " +
-      "live output — belt-and-suspenders on top of the baseline_output already " +
-      "set here from this session's live verification.",
+    `\nDone. ${needsRestore} suite(s) restored, ${alreadyRestored} already-restored and unchanged (idempotent), ` +
+      `${rulesUpgraded} suite(s) had validation_rules upgraded to equals assertions${rulesStaleNotUpgraded > 0 ? `, ${rulesStaleNotUpgraded} still have stale rules (rerun with --upgrade-rules to fix)` : ""}. ` +
+      "updated_at was bumped (on restored/upgraded rows only) without touching baseline_captured_at, so the " +
+      "PR #308 stale-baseline check (test-runner.ts) will flag them as stale on the next scheduled " +
+      "run and trigger an automatic baseline recapture against live output — belt-and-suspenders on " +
+      "top of the baseline_output already set here from this session's live verification.",
   );
   process.exit(0);
 }

--- a/apps/api/scripts/restore-swedish-known-answers.ts
+++ b/apps/api/scripts/restore-swedish-known-answers.ts
@@ -349,6 +349,31 @@ const RESTORE_PLANS: RestorePlan[] = [
   },
 ];
 
+// ─── Legacy validation_rules shape (MEDIUM, Codex closing-pass review) ─────
+//
+// The version of this script that first ran against prod (before the
+// company_name-equals fix) wrote a validation_rules shape identical to the
+// current one EXCEPT its first check was `{ field: "company_name",
+// operator: "not_null" }` instead of the current equals-form. Derived
+// programmatically from each plan's CURRENT validationRules (swap only the
+// company_name check) rather than hand-duplicating the other 15 checks a
+// second time — that duplication would be its own drift risk (two literal
+// copies of "the same 15 checks" silently diverging over an edit to one).
+//
+// This is the EXACT shape --upgrade-rules is willing to touch. Anything
+// else — including a hypothetical future INTENTIONAL tightening of these
+// rules by an operator — must classify as sanity_fail (reported, left
+// alone), never silently treated as "stale" and overwritten. Recognizing
+// only this one known-precise legacy shape (instead of "any rules mismatch
+// is upgradeable", the pre-review version of this file) is what makes that
+// distinction possible.
+function deriveLegacyValidationRules(plan: RestorePlan): { checks: Array<Record<string, unknown>> } {
+  const checks = plan.validationRules.checks.map((check) =>
+    check.field === "company_name" ? { field: "company_name", operator: "not_null" } : check,
+  );
+  return { checks };
+}
+
 // Honest per-suite daily rate: the average of the 5 suite types that were
 // NEVER duplicated, so their historical test_results rate was never
 // contaminated by the scheduler's pre-fix N x N same-test-type amplifier
@@ -428,9 +453,13 @@ function printBudgetArithmetic(): void {
 // escalation-contract text ran into: the orchestrator applied this script
 // to prod between when it was written and when this review landed, so any
 // naive rerun today would hit that refusal on all 3 rows.
+type RulesState =
+  | "current" // matches plan.validationRules exactly — nothing to do
+  | "legacy_not_null"; // matches the ONE known legacy shape — --upgrade-rules may touch it
+
 type RowClassification =
   | { kind: "needs_restore" }
-  | { kind: "already_restored"; rulesUpToDate: boolean }
+  | { kind: "already_restored"; rulesState: RulesState }
   | { kind: "sanity_fail"; reason: string };
 
 function classifyRow(
@@ -457,14 +486,32 @@ function classifyRow(
   // behind. Recognizing it (rather than only the pre-restore state) is
   // what makes a rerun idempotent instead of a refusal.
   if (row.active === true && inputMatchesNew && row.quarantine_reason === null) {
-    // MEDIUM (Codex review): the version of this script that already ran
-    // against prod wrote not_null-only company_name checks. rulesUpToDate
-    // distinguishes "restored with the current (equals-assertion)
-    // validation_rules" from "restored, but with the older weaker rules" —
-    // the latter needs --upgrade-rules, not a fresh restore (the row is
-    // already active/correct otherwise; only the rules are stale).
-    const rulesUpToDate = JSON.stringify(row.validation_rules) === JSON.stringify(plan.validationRules);
-    return { kind: "already_restored", rulesUpToDate };
+    // MEDIUM (Codex closing-pass review): the prior version of this file
+    // treated ANY validation_rules mismatch as "stale, upgradeable" — which
+    // would silently overwrite a future INTENTIONAL rule change (an
+    // operator tightening these checks further, say) the moment someone
+    // reran this script with --upgrade-rules. Recognize only the ONE exact
+    // legacy shape this session itself wrote (not_null-only company_name,
+    // otherwise byte-identical to the current rules) as upgradeable.
+    // Anything else — including "close but not exact" — is sanity_fail:
+    // reported, left untouched, never guessed at.
+    const rulesMatchCurrent = JSON.stringify(row.validation_rules) === JSON.stringify(plan.validationRules);
+    if (rulesMatchCurrent) {
+      return { kind: "already_restored", rulesState: "current" };
+    }
+    const legacyRules = deriveLegacyValidationRules(plan);
+    const rulesMatchLegacy = JSON.stringify(row.validation_rules) === JSON.stringify(legacyRules);
+    if (rulesMatchLegacy) {
+      return { kind: "already_restored", rulesState: "legacy_not_null" };
+    }
+    return {
+      kind: "sanity_fail",
+      reason:
+        "row is otherwise correctly restored (active, correct input, no quarantine), but its " +
+        "validation_rules match neither the current equals-form nor the one known legacy " +
+        "not_null-form this script recognizes. Could be an intentional change made after this " +
+        "session — refusing to guess whether it's safe to overwrite. Left untouched.",
+    };
   }
 
   // Pre-restore state: the stale, Spotify-cloned, quarantined row Phase 4
@@ -546,7 +593,7 @@ async function main() {
         }
 
         if (classification.kind === "already_restored") {
-          if (classification.rulesUpToDate) {
+          if (classification.rulesState === "current") {
             console.log(`OK-SKIP (already restored): ${plan.testName}`);
             console.log(`  current: active=true, input=${JSON.stringify(plan.newInput)}, quarantine_reason=(null) — matches this plan's target state exactly.`);
             console.log(`  no write needed; rerun is idempotent.`);
@@ -555,14 +602,17 @@ async function main() {
             continue;
           }
 
-          // Already restored, but with the pre-review not_null-only
-          // company_name check (MEDIUM finding). The row itself (active,
-          // input, quarantine_reason) is correct — only validation_rules
-          // is stale. --upgrade-rules is the dedicated, explicit opt-in
-          // for touching an otherwise-fine row a second time.
-          console.log(`OK-SKIP, STALE RULES: ${plan.testName}`);
+          // rulesState === "legacy_not_null": already restored, but with
+          // the EXACT pre-review not_null-only company_name check (MEDIUM
+          // finding) this script itself wrote and nothing else — any other
+          // mismatch would have sanity-failed above instead of reaching
+          // here. The row itself (active, input, quarantine_reason) is
+          // correct — only validation_rules is the known-stale shape.
+          // --upgrade-rules is the dedicated, explicit opt-in for touching
+          // an otherwise-fine row a second time.
+          console.log(`OK-SKIP, STALE RULES (known legacy shape): ${plan.testName}`);
           console.log(`  current: active=true, input=${JSON.stringify(plan.newInput)} — correct.`);
-          console.log(`  current validation_rules still use company_name not_null (pre-review) instead of equals("${plan.baselineOutput.company_name}").`);
+          console.log(`  current validation_rules exactly match the known legacy not_null-company_name shape this script wrote — instead of equals("${plan.baselineOutput.company_name}").`);
           if (upgradeRules) {
             console.log(`  --upgrade-rules is set: will upgrade validation_rules${apply ? "" : " (dry run — not written)"}.`);
           } else {
@@ -579,11 +629,20 @@ async function main() {
           if (!apply) continue;
 
           // Compare-and-set scoped to the row's CURRENT (already-restored)
-          // state — id AND active=true AND input=newInput — distinct from
-          // the needs_restore predicate below (id AND active=false AND
-          // input=oldInput). Only validation_rules/baseline_output change;
-          // active/input/quarantine_reason are untouched (they're already
-          // correct, which is exactly why this row is "already_restored").
+          // state — id AND active=true AND input=newInput AND
+          // validation_rules=<the exact legacy shape> — distinct from the
+          // needs_restore predicate below (id AND active=false AND
+          // input=oldInput). Including validation_rules in the WHERE
+          // (Codex closing-pass MEDIUM) is what makes this a genuine CAS
+          // rather than an unconditional overwrite of whatever happens to
+          // be there: classifyRow() already proved the row matches this
+          // exact legacy shape a moment ago (under this transaction's
+          // SELECT ... FOR UPDATE lock), and the UPDATE re-asserts that at
+          // write time instead of trusting the read. Only
+          // validation_rules/baseline_output change; active/input/
+          // quarantine_reason are untouched (they're already correct,
+          // which is exactly why this row is "already_restored").
+          const legacyRules = deriveLegacyValidationRules(plan);
           const upgraded = await tx.execute(sql`
             UPDATE test_suites
                SET validation_rules = ${JSON.stringify(plan.validationRules)}::jsonb,
@@ -592,6 +651,7 @@ async function main() {
              WHERE id = ${plan.suiteId}
                AND active = true
                AND input = ${JSON.stringify(plan.newInput)}::jsonb
+               AND validation_rules = ${JSON.stringify(legacyRules)}::jsonb
             RETURNING id
           `);
           const upgradedRows = Array.isArray(upgraded) ? upgraded : (upgraded as { rows?: unknown[] }).rows ?? [];

--- a/apps/api/scripts/restore-swedish-known-answers.ts
+++ b/apps/api/scripts/restore-swedish-known-answers.ts
@@ -1,0 +1,426 @@
+/**
+ * Restore 3 of the 5 swedish-company-data known_answer suites that Phase 4
+ * (2026-08-17) deactivated for testing nothing distinct: all five carried
+ * the exact same input as "Spotify AB — known company"
+ * (`{"org_number":"556703-7485"}`) under a different company label —
+ * Klarna/Volvo/H&M/IKEA plus a stale name-search variant.
+ *
+ * This script reactivates THREE of those five — H&M, IKEA of Sweden AB,
+ * Klarna Bank AB — with corrected org_numbers verified against the live
+ * Bolagsverket-backed executor (see verification log in the PR/handoff;
+ * each returned company_name matches its suite label exactly). It rebuilds
+ * validation_rules and baseline_output from that live verification (the
+ * old rows had Spotify's validation_rules/baseline_output copy-pasted
+ * verbatim — org_number/vat_number/registered_date literals that would
+ * fail immediately against a different company's real data).
+ *
+ * NOT restored:
+ *   - "Volvo Car AB — known company": the registry's real legal name is
+ *     "Volvo Personvagnar Aktiebolag", not "Volvo Car AB" — verified via
+ *     org_number 556074-3089. Left deactivated pending a label decision
+ *     (rename vs. reword) rather than silently restoring under a label the
+ *     registry itself doesn't return. Candidate for a follow-up round.
+ *   - "Name search — Spotify AB (name via org_number field triggers
+ *     LLM+Allabolag resolution)": tests functionality the executor no
+ *     longer has. swedish-company-data was migrated to the Bolagsverket
+ *     HVD API (DEC-20260405-A); it only accepts organisationsnummer and
+ *     explicitly rejects name input (see swedish-company-data.ts's error
+ *     message and the manifest's "no name search" limitation). This suite
+ *     is orphaned, not merely mislabeled — it should be deleted, not
+ *     restored. Left deactivated.
+ *
+ * Budget arithmetic (Block 0084, swedish-company-data cost_class=free_quota,
+ * quota_cap=1000/day, test budget = min(1, floor(1000*0.10)) = 100/day):
+ *
+ *   Per-suite daily attempt counts are NOT uniform across test_type — this
+ *   was checked directly against test_results for the 5 most recent clean
+ *   days (2026-08-13 through 2026-08-17), per suite id:
+ *     known_answer (Spotify AB, the one suite untouched by the Phase 4
+ *       dedup) ................................ steady 18/day for 5/5 days
+ *     dependency_health ........................ steady ~2.2/day
+ *     edge_case ................................. steady ~2.8/day
+ *     known_bad .................................. steady ~2.2/day
+ *     negative .................................... steady ~2.6/day
+ *     schema_check ................................ steady ~3.0/day
+ *       (post-2026-08-13; was ~12/day on 08-10/08-11, before whatever
+ *       changed then — not relevant to this projection)
+ *
+ *   Current post-Phase-4 active set (6 suites, 1 known_answer + 5 others):
+ *     ~2.2 + 2.8 + 18 + 2.2 + 2.6 + 3.0 = ~30.8/day
+ *
+ *   Each RESTORED known_answer suite is the same test_type, same shape,
+ *   same debounce/stagger mechanics as Spotify's — so ~18/day each is the
+ *   best available same-shape estimate (not a generic average; it is the
+ *   observed, sustained, 5-day-stable rate for this exact suite type on
+ *   this exact capability):
+ *     30.8 + 3 suites x 18/day = 30.8 + 54 = ~84.8/day  ≈ 85/day
+ *
+ *   That is under the "~95 of 100" ceiling this task set, with ~10/day of
+ *   margin to 95 and ~15/day to the hard 100 cap. Restoring a 4th
+ *   (Volvo, if the label question above gets resolved) would land at
+ *   ~102.8/day — OVER the 100 hard cap — so 3 is the actual ceiling here,
+ *   not merely the instructed range's upper bound.
+ *
+ *   NOTE ON THE TASK'S STATED "~85 attempts/day" BASELINE: that number
+ *   describes almost exactly what this script projects for the
+ *   POST-RESTORE state (~84.8), not the pre-restore state. The real
+ *   pre-restore (current, 6-suite) baseline is ~31/day — confirmed against
+ *   capability_budget_counters, which additionally shows the *old*
+ *   11-suite configuration hitting the full 100/100 hard cap on every one
+ *   of the last 5 days (2026-08-13 through 2026-08-17), each time by
+ *   ~04:30-05:40 UTC. That's the concrete cost the Phase 4 dedup fixed;
+ *   this script spends about half of what it recovered.
+ *
+ * Usage:
+ *   npx tsx --env-file=<path to .env> scripts/restore-swedish-known-answers.ts
+ *   npx tsx --env-file=<path to .env> scripts/restore-swedish-known-answers.ts --apply
+ *
+ * Dry-run (no --apply) is the default and only prints the diff. --apply is
+ * required to write. This script is READ-ONLY against prod unless --apply
+ * is passed explicitly by an operator after review.
+ */
+import { config } from "dotenv";
+import { resolve } from "node:path";
+config({ path: resolve(import.meta.dirname, "../../../.env") });
+
+import { sql } from "drizzle-orm";
+import { getDb } from "../src/db/index.js";
+
+const CAPABILITY_SLUG = "swedish-company-data";
+
+interface RestorePlan {
+  suiteId: string;
+  testName: string;
+  oldInput: Record<string, unknown>;
+  newInput: Record<string, unknown>;
+  validationRules: { checks: Array<Record<string, unknown>> };
+  baselineOutput: Record<string, unknown>;
+}
+
+// Verified 2026-08-18 via guardedExecute (health_probe context — the daily
+// internal_test budget was exhausted from Phase 4 investigation activity;
+// health_probe is the one free_quota ALLOW_MATRIX cell that doesn't consume
+// the shared counter, appropriate for a bounded one-time manual check).
+// Each company_name below matches its suite label exactly.
+const RESTORE_PLANS: RestorePlan[] = [
+  {
+    suiteId: "cbaef0ad-f676-4cb9-a651-51da1c09cf4c", // "Klarna Bank AB — known company"
+    testName: "Klarna Bank AB — known company",
+    oldInput: { org_number: "556703-7485" },
+    newInput: { org_number: "556737-0431" },
+    validationRules: {
+      checks: [
+        { field: "company_name", operator: "not_null" },
+        { field: "org_number", value: "556737-0431", operator: "equals" },
+        { field: "vat_number", value: "SE556737043101", operator: "equals" },
+        { field: "country_code", value: "SE", operator: "equals" },
+        { field: "company_type", value: "Bankaktiebolag", operator: "equals" },
+        { field: "company_type_code", value: "BAB", operator: "equals" },
+        { field: "legal_form", operator: "not_null" },
+        { field: "legal_form_code", value: "41", operator: "equals" },
+        { field: "status", value: "active", operator: "equals" },
+        { field: "is_active", value: true, operator: "equals" },
+        { field: "registered_date", value: "2007-09-05", operator: "equals" },
+        { field: "registered_address", operator: "not_null" },
+        { field: "sni_codes", operator: "not_null" },
+        { field: "business_description", operator: "not_null" },
+        { field: "ongoing_procedures", operator: "not_null" },
+        { field: "alternative_names", operator: "not_null" },
+      ],
+    },
+    baselineOutput: {
+      company_name: "Klarna Bank AB",
+      org_number: "556737-0431",
+      vat_number: "SE556737043101",
+      country_code: "SE",
+      company_type: "Bankaktiebolag",
+      company_type_code: "BAB",
+      legal_form: "Bankaktiebolag",
+      legal_form_code: "41",
+      status: "active",
+      is_active: true,
+      registered_date: "2007-09-05",
+      deregistered_date: null,
+      deregistration_reason: null,
+      registered_address: {
+        street: "Sveavägen 46",
+        postal_code: "11134",
+        city: "STOCKHOLM",
+        country: "Sverige",
+        co_address: null,
+      },
+      sni_codes: [
+        { code: "64190", description: "Annan monetär finansförmedling" },
+        { code: "64920", description: "Annan kreditgivning" },
+      ],
+      business_description:
+        "Bolaget får bedriva 1. sådan rörelse som avses i 1 kap. 3 § lagen (2004:297) om bank- och finansieringsrörelse, samt 2. finansiell verksamhet och verksamhet som har ett naturligt samband därmed enligt 7 kap. 1 § lagen om bank- och finansieringsrörelse.",
+      ongoing_procedures: [],
+      alternative_names: [
+        { name: "Segoria", type: "Särskilt företagsnamn", registered_date: "2010-03-16" },
+        { name: "Svensk Inkassotjänst, SIKO", type: "Särskilt företagsnamn", registered_date: "2010-05-28" },
+      ],
+      legal_name: "Klarna Bank AB",
+      primary_registration_id: "556737-0431",
+      date_incorporated: "2007-09-05",
+      tier_2_available: false,
+      tier_2_available_reason:
+        "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked",
+      ubo_availability: "unavailable_no_registry",
+      ubo_availability_reason:
+        "Bolagsverket BO data not exposed programmatically at v1; verification pending public-source confirmation",
+    },
+  },
+  {
+    suiteId: "7b9f1101-a5d9-478e-804d-22ba5a757923", // "H&M — known company"
+    testName: "H&M — known company",
+    oldInput: { org_number: "556703-7485" },
+    newInput: { org_number: "556042-7220" },
+    validationRules: {
+      checks: [
+        { field: "company_name", operator: "not_null" },
+        { field: "org_number", value: "556042-7220", operator: "equals" },
+        { field: "vat_number", value: "SE556042722001", operator: "equals" },
+        { field: "country_code", value: "SE", operator: "equals" },
+        { field: "company_type", value: "Aktiebolag", operator: "equals" },
+        { field: "company_type_code", value: "AB", operator: "equals" },
+        { field: "legal_form", operator: "not_null" },
+        { field: "legal_form_code", value: "49", operator: "equals" },
+        { field: "status", value: "active", operator: "equals" },
+        { field: "is_active", value: true, operator: "equals" },
+        { field: "registered_date", value: "1943-08-07", operator: "equals" },
+        { field: "registered_address", operator: "not_null" },
+        { field: "sni_codes", operator: "not_null" },
+        { field: "business_description", operator: "not_null" },
+        { field: "ongoing_procedures", operator: "not_null" },
+        { field: "alternative_names", operator: "not_null" },
+      ],
+    },
+    baselineOutput: {
+      company_name: "H & M Hennes & Mauritz AB",
+      org_number: "556042-7220",
+      vat_number: "SE556042722001",
+      country_code: "SE",
+      company_type: "Aktiebolag",
+      company_type_code: "AB",
+      legal_form: "Övriga aktiebolag",
+      legal_form_code: "49",
+      status: "active",
+      is_active: true,
+      registered_date: "1943-08-07",
+      deregistered_date: null,
+      deregistration_reason: null,
+      registered_address: {
+        street: "Mäster Samuelsgatan 46 A",
+        postal_code: "10638",
+        city: "STOCKHOLM",
+        country: "Sverige",
+        co_address: null,
+      },
+      sni_codes: [{ code: "70100", description: "Verksamheter som utövas av huvudkontor" }],
+      business_description:
+        "Bolaget skall ha till föremål för sin verksamhet att direkt eller indirekt - bedriva handel med textil och konfektion, skor, accessoarer, kosmetik, ur, pennor, inredning till hemmet - främst textilier samt andra liknande konsumentvaror: - bedriva dagligvaruhandel och café- och restaurangrörelse: - äga och förvalta värdepapper, inventarier och fast egendom: - bedriva finansieringsverksamhet inom ramen för den ovan angivna verksamheten: samt - tillhandahålla tjänster knutna till den ovan angivna verksamheten.",
+      ongoing_procedures: [],
+      alternative_names: [],
+      legal_name: "H & M Hennes & Mauritz AB",
+      primary_registration_id: "556042-7220",
+      date_incorporated: "1943-08-07",
+      tier_2_available: false,
+      tier_2_available_reason:
+        "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked",
+      ubo_availability: "unavailable_no_registry",
+      ubo_availability_reason:
+        "Bolagsverket BO data not exposed programmatically at v1; verification pending public-source confirmation",
+    },
+  },
+  {
+    suiteId: "24523fa9-e74b-4268-86c6-d41270f780de", // "IKEA of Sweden AB — known company"
+    testName: "IKEA of Sweden AB — known company",
+    oldInput: { org_number: "556703-7485" },
+    newInput: { org_number: "556074-7551" },
+    validationRules: {
+      checks: [
+        { field: "company_name", operator: "not_null" },
+        { field: "org_number", value: "556074-7551", operator: "equals" },
+        { field: "vat_number", value: "SE556074755101", operator: "equals" },
+        { field: "country_code", value: "SE", operator: "equals" },
+        { field: "company_type", value: "Aktiebolag", operator: "equals" },
+        { field: "company_type_code", value: "AB", operator: "equals" },
+        { field: "legal_form", operator: "not_null" },
+        { field: "legal_form_code", value: "49", operator: "equals" },
+        { field: "status", value: "active", operator: "equals" },
+        { field: "is_active", value: true, operator: "equals" },
+        { field: "registered_date", value: "1960-11-21", operator: "equals" },
+        { field: "registered_address", operator: "not_null" },
+        { field: "sni_codes", operator: "not_null" },
+        { field: "business_description", operator: "not_null" },
+        { field: "ongoing_procedures", operator: "not_null" },
+        { field: "alternative_names", operator: "not_null" },
+      ],
+    },
+    baselineOutput: {
+      company_name: "IKEA of Sweden AB",
+      org_number: "556074-7551",
+      vat_number: "SE556074755101",
+      country_code: "SE",
+      company_type: "Aktiebolag",
+      company_type_code: "AB",
+      legal_form: "Övriga aktiebolag",
+      legal_form_code: "49",
+      status: "active",
+      is_active: true,
+      registered_date: "1960-11-21",
+      deregistered_date: null,
+      deregistration_reason: null,
+      registered_address: {
+        street: "Box 702",
+        postal_code: "34381",
+        city: "ÄLMHULT",
+        country: "Sverige",
+        co_address: null,
+      },
+      sni_codes: [{ code: "74110", description: "Industridesign och modedesign" }],
+      business_description:
+        "Föremålet för aktiebolagets verksamhet är att bedriva utveckling av och handel med möbler och andra heminredningsartiklar och att upplåta lös egendom till nyttjande samt att bedriva annan därmed förenlig verksamhet.",
+      ongoing_procedures: [],
+      alternative_names: [
+        { name: "Ten Swedish Designers", type: "Särskilt företagsnamn", registered_date: "2016-09-08" },
+      ],
+      legal_name: "IKEA of Sweden AB",
+      primary_registration_id: "556074-7551",
+      date_incorporated: "1960-11-21",
+      tier_2_available: false,
+      tier_2_available_reason:
+        "handler does not currently extract legal representatives from upstream registry; follow-up extraction task tracked",
+      ubo_availability: "unavailable_no_registry",
+      ubo_availability_reason:
+        "Bolagsverket BO data not exposed programmatically at v1; verification pending public-source confirmation",
+    },
+  },
+];
+
+function printBudgetArithmetic(): void {
+  console.log("Budget arithmetic (Block 0084, swedish-company-data, cap=100/day):");
+  console.log("  Current active-suite baseline (post Phase-4, empirically observed):");
+  console.log("    dependency_health  ~2.2/day");
+  console.log("    edge_case          ~2.8/day");
+  console.log("    known_bad          ~2.2/day");
+  console.log("    negative           ~2.6/day");
+  console.log("    schema_check       ~3.0/day");
+  console.log("    known_answer (Spotify, unchanged)  18.0/day");
+  console.log("    ---------------------------------------");
+  console.log("    baseline total     ~30.8/day");
+  console.log(`  + ${RESTORE_PLANS.length} restored known_answer suites x ~18.0/day each = ${(RESTORE_PLANS.length * 18).toFixed(1)}/day`);
+  const projected = 30.8 + RESTORE_PLANS.length * 18;
+  console.log(`  = projected total ~${projected.toFixed(1)}/day  (ceiling requested: ~95/day; hard cap: 100/day)`);
+  if (projected > 100) {
+    console.log("  *** OVER THE 100/DAY HARD CAP — DO NOT APPLY ***");
+  } else if (projected > 95) {
+    console.log("  *** OVER THE ~95/DAY REQUESTED CEILING — reconsider suite count ***");
+  } else {
+    console.log(`  OK — ${(95 - projected).toFixed(1)}/day of margin to the ~95 ceiling, ${(100 - projected).toFixed(1)}/day to the hard cap.`);
+  }
+  console.log();
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const db = getDb();
+
+  printBudgetArithmetic();
+
+  console.log(`Mode: ${apply ? "APPLY (writing to prod)" : "DRY RUN (no writes)"}\n`);
+
+  // Sanity check: confirm each target suite is currently inactive with the
+  // expected quarantine reason and the expected stale (Spotify-cloned) input,
+  // so this script can never accidentally "restore" something else.
+  const ids = RESTORE_PLANS.map((p) => p.suiteId);
+  const current = await db.execute(sql`
+    SELECT id::text AS id, test_name, input, active, quarantine_reason, capability_slug
+      FROM test_suites
+     WHERE id IN (${sql.join(ids.map((id) => sql`${id}::uuid`), sql`, `)})
+  `);
+  const rows = (Array.isArray(current) ? current : (current as { rows?: unknown[] }).rows ?? []) as Array<{
+    id: string;
+    test_name: string;
+    input: Record<string, unknown>;
+    active: boolean;
+    quarantine_reason: string | null;
+    capability_slug: string;
+  }>;
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  let allSane = true;
+  for (const plan of RESTORE_PLANS) {
+    const row = byId.get(plan.suiteId);
+    if (!row) {
+      console.error(`SANITY FAIL: suite ${plan.suiteId} (${plan.testName}) not found.`);
+      allSane = false;
+      continue;
+    }
+    if (row.capability_slug !== CAPABILITY_SLUG) {
+      console.error(`SANITY FAIL: suite ${plan.suiteId} belongs to '${row.capability_slug}', not '${CAPABILITY_SLUG}'.`);
+      allSane = false;
+      continue;
+    }
+    if (row.active !== false) {
+      console.error(`SANITY FAIL: suite ${plan.suiteId} (${plan.testName}) is already active=true — refusing to touch it.`);
+      allSane = false;
+      continue;
+    }
+    const inputMatches = JSON.stringify(row.input) === JSON.stringify(plan.oldInput);
+    if (!inputMatches) {
+      console.error(
+        `SANITY FAIL: suite ${plan.suiteId} (${plan.testName}) input is ${JSON.stringify(row.input)}, ` +
+          `expected ${JSON.stringify(plan.oldInput)} — someone already touched this row. Refusing to overwrite.`,
+      );
+      allSane = false;
+      continue;
+    }
+    console.log(`OK: ${plan.testName}`);
+    console.log(`  current: active=false, input=${JSON.stringify(row.input)}, quarantine_reason=${row.quarantine_reason ? "(set)" : "(null)"}`);
+    console.log(`  planned: active=true,  input=${JSON.stringify(plan.newInput)}, quarantine_reason=NULL`);
+    console.log(`  validation_rules: rebuilt from live-verified output (${plan.validationRules.checks.length} checks)`);
+    console.log(`  baseline_output: rebuilt from live-verified output`);
+    console.log();
+  }
+
+  if (!allSane) {
+    console.error("\nOne or more sanity checks failed. Aborting without writing anything.");
+    process.exit(1);
+  }
+
+  if (!apply) {
+    console.log("Dry run complete. No rows were modified. Re-run with --apply to write.");
+    process.exit(0);
+  }
+
+  console.log("Applying...");
+  for (const plan of RESTORE_PLANS) {
+    await db.execute(sql`
+      UPDATE test_suites
+         SET active = true,
+             input = ${JSON.stringify(plan.newInput)}::jsonb,
+             validation_rules = ${JSON.stringify(plan.validationRules)}::jsonb,
+             baseline_output = ${JSON.stringify(plan.baselineOutput)}::jsonb,
+             quarantine_reason = NULL,
+             test_status = 'normal',
+             updated_at = NOW()
+       WHERE id = ${plan.suiteId}
+    `);
+    console.log(`Applied: ${plan.testName} (${plan.suiteId})`);
+  }
+  console.log(
+    "\nDone. updated_at was bumped without touching baseline_captured_at, so the " +
+      "PR #308 stale-baseline check (test-runner.ts) will flag these as stale on " +
+      "the next scheduled run and trigger an automatic baseline recapture against " +
+      "live output — belt-and-suspenders on top of the baseline_output already " +
+      "set here from this session's live verification.",
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("FATAL", err);
+  process.exit(1);
+});

--- a/apps/api/scripts/sweep-duplicate-suites.ts
+++ b/apps/api/scripts/sweep-duplicate-suites.ts
@@ -1,0 +1,110 @@
+/**
+ * Read-only sweep: find capabilities with duplicate-input test suites — the
+ * `swedish-company-data` pattern found in Phase 4 (2026-08-17), where five
+ * `known_answer` suites (Klarna Bank AB / Volvo Car AB / H&M / IKEA of
+ * Sweden AB / a stale name-search variant) all carried the exact same
+ * `{"org_number":"556703-7485"}` input as the sixth, correctly-labeled
+ * suite ("Spotify AB — known company") — one company tested five times
+ * under five different names, quadrupling daily test-budget burn against
+ * Block 0084's 100/day cap while adding zero additional coverage.
+ *
+ * This script generalizes that finding: group ACTIVE test_suites by
+ * (capability_slug, test_type, input::text) and report every group with
+ * more than one DISTINCT test_name. Grouping includes test_type
+ * deliberately — a single input legitimately backs several DIFFERENT test
+ * types (the same known-good fixture commonly doubles as the
+ * dependency_health ping, the schema_check payload, and the piggyback
+ * baseline; that is normal architecture, not the bug). The swedish defect
+ * was specifically multiple suites of the SAME test_type (all
+ * `known_answer`) carrying different entity labels over one identical
+ * input — grouping by test_type is what isolates that pattern from the
+ * (much larger, entirely benign) cross-test-type fixture reuse.
+ *
+ * It does not modify anything — report only, per the restore task's
+ * read-only mandate for deliverable 3.
+ *
+ * Usage:
+ *   npx tsx --env-file=<path to .env> scripts/sweep-duplicate-suites.ts
+ */
+import { config } from "dotenv";
+import { resolve } from "node:path";
+config({ path: resolve(import.meta.dirname, "../../../.env") });
+
+import { sql } from "drizzle-orm";
+import { getDb } from "../src/db/index.js";
+
+interface DupGroupRow {
+  capability_slug: string;
+  test_type: string;
+  input_text: string;
+  suite_count: string | number;
+  test_names: string[];
+  suite_ids: string[];
+}
+
+async function main() {
+  const db = getDb();
+
+  const rows = await db.execute(sql`
+    SELECT
+      capability_slug,
+      test_type,
+      input::text AS input_text,
+      COUNT(*) AS suite_count,
+      array_agg(test_name ORDER BY test_name) AS test_names,
+      array_agg(id::text ORDER BY test_name) AS suite_ids
+    FROM test_suites
+    WHERE active = true
+    GROUP BY capability_slug, test_type, input::text
+    HAVING COUNT(DISTINCT test_name) > 1
+    ORDER BY COUNT(*) DESC, capability_slug
+  `);
+
+  const groups = (Array.isArray(rows) ? rows : (rows as { rows?: unknown[] })?.rows ?? []) as unknown as DupGroupRow[];
+
+  if (groups.length === 0) {
+    console.log("No capabilities found with duplicate-input active test suites.");
+    process.exit(0);
+  }
+
+  console.log(`Found ${groups.length} same-test-type duplicate-input group(s) across the platform.\n`);
+  console.log(
+    "slug".padEnd(32) +
+      "type".padEnd(16) +
+      "input".padEnd(50) +
+      "count".padEnd(7) +
+      "suite names",
+  );
+  console.log("-".repeat(170));
+
+  for (const g of groups) {
+    const count = typeof g.suite_count === "string" ? parseInt(g.suite_count, 10) : g.suite_count;
+    const inputShort = g.input_text.length > 46 ? g.input_text.slice(0, 43) + "..." : g.input_text;
+    console.log(
+      g.capability_slug.padEnd(32) +
+        g.test_type.padEnd(16) +
+        inputShort.padEnd(50) +
+        String(count).padEnd(7) +
+        g.test_names.join(" | "),
+    );
+  }
+
+  console.log(`\nTotal duplicate-input active suites (excess beyond 1 per group): ${
+    groups.reduce((acc, g) => {
+      const count = typeof g.suite_count === "string" ? parseInt(g.suite_count, 10) : g.suite_count;
+      return acc + (count - 1);
+    }, 0)
+  }`);
+  console.log(
+    "\nThis script is read-only. It reports duplicate-input suite groups; it does not\n" +
+      "deactivate, merge, or modify anything. Only swedish-company-data has been\n" +
+      "remediated so far (Phase 4, 2026-08-17 + this session's restore script).",
+  );
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("FATAL", err);
+  process.exit(1);
+});

--- a/apps/api/src/jobs/test-scheduler.test.ts
+++ b/apps/api/src/jobs/test-scheduler.test.ts
@@ -81,3 +81,40 @@ describe("suitesTestedFromResults (closing review round — heartbeat accounting
     expect(src).not.toMatch(/runnableSuites\.length\s*-\s*skippedBudgetExhausted/);
   });
 });
+
+describe("suite-scoped batch execution (HIGH-1, Codex 2026-08-18 review)", () => {
+  // pollCycle() itself has no DB harness (raw postgres advisory-lock client,
+  // live HTTP per capability, 5-10 minute cycles — test-harness exemption,
+  // DEC-20260504-A), so this pins the wiring shape directly against source,
+  // the same technique the block above uses for the heartbeat-accounting
+  // fix. The behavioral proof that suiteId actually narrows execution (not
+  // just that it's threaded through) lives in test-runner.test.ts's
+  // "runTests — suiteId scoping" describe block, which mocks the DB layer
+  // runTests() itself talks to.
+  it("findOverdueSuites' SQL selects each suite's own id, not just (slug, testType)", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL("./test-scheduler.ts", import.meta.url), "utf8");
+    expect(src).toContain('ts.id::text AS "suiteId"');
+  });
+
+  it("the OverdueSuite type and its mapper carry suiteId through from the query", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL("./test-scheduler.ts", import.meta.url), "utf8");
+    // Interface declares it (was slug/testType/lastRunAt only, pre-fix).
+    expect(src).toMatch(/interface OverdueSuite \{[^}]*suiteId: string;[^}]*\}/s);
+    // The row mapper actually populates it from the query result.
+    expect(src).toMatch(/return resultRows\.map\(\(r: any\) => \(\{[^}]*suiteId: r\.suiteId,[^}]*\}\)\);/s);
+  });
+
+  it("pollCycle's runTests() call passes the specific overdue suite's id — the actual fix to the former N x N call site", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(new URL("./test-scheduler.ts", import.meta.url), "utf8");
+    // Pre-fix this call read exactly:
+    //   runTests({ capabilitySlug: suite.slug, testType: suite.testType })
+    // — no suite-level narrowing, so it reloaded every suite sharing that
+    // (slug, testType) pair on every one of the batch's N due-suite rows.
+    expect(src).toMatch(
+      /runTests\(\{\s*capabilitySlug:\s*suite\.slug,\s*testType:\s*suite\.testType,\s*suiteId:\s*suite\.suiteId,?\s*\}\)/,
+    );
+  });
+});

--- a/apps/api/src/jobs/test-scheduler.ts
+++ b/apps/api/src/jobs/test-scheduler.ts
@@ -215,6 +215,7 @@ async function withAdvisoryLock<T>(
 interface OverdueSuite {
   slug: string;
   testType: string;
+  suiteId: string;
   lastRunAt: Date | null;
 }
 
@@ -268,6 +269,17 @@ export function slugStaggerMinute(slug: string, testType?: string): number {
  * applies — known-broken suites back off to daily/weekly even on the new
  * hourly cadence. The "no status creates a black hole" invariant from the
  * old tiered query is preserved by the ELSE branch.
+ *
+ * Each returned row carries its own `suiteId` (ts.id), not just
+ * (slug, testType). pollCycle() passes that id straight through to
+ * `runTests({..., suiteId})`, which scopes execution to exactly that one
+ * test_suites row. Before this, two suites sharing (slug, testType) — e.g.
+ * danish-company-data's 4 duplicate known_answer suites — produced 4
+ * identical (slug, testType) rows here, and each of the 4 loop iterations
+ * in pollCycle() called runTests({capabilitySlug, testType}) *without* a
+ * suite id, which reloaded and re-ran ALL 4 suites every time: a batch of
+ * N due suites did N x N executions, not N. See TestRunOptions.suiteId's
+ * doc comment in test-runner.ts for the full incident.
  */
 async function findOverdueSuites(): Promise<OverdueSuite[]> {
   const db = getDb();
@@ -279,6 +291,7 @@ async function findOverdueSuites(): Promise<OverdueSuite[]> {
   const rows = await db.execute(sql`
     SELECT
       c.slug,
+      ts.id::text AS "suiteId",
       ts.test_type AS "testType",
       (SELECT MAX(tr.executed_at) FROM test_results tr WHERE tr.test_suite_id = ts.id) AS "lastRunAt"
     FROM capabilities c
@@ -326,6 +339,7 @@ async function findOverdueSuites(): Promise<OverdueSuite[]> {
   return resultRows.map((r: any) => ({
     slug: r.slug,
     testType: r.testType,
+    suiteId: r.suiteId,
     lastRunAt: r.lastRunAt ? new Date(r.lastRunAt) : null,
   }));
 }
@@ -730,7 +744,16 @@ async function pollCycle(): Promise<void> {
             "test-scheduler-testing",
           );
 
-          const summary = await runTests({ capabilitySlug: suite.slug, testType: suite.testType });
+          // suiteId scopes this call to exactly the one overdue suite this
+          // batch entry represents — see findOverdueSuites' doc comment and
+          // TestRunOptions.suiteId in test-runner.ts. Without it, N
+          // same-(slug,testType) suites due in the same batch produced N x N
+          // executions (danish-company-data: 4 duplicates -> 16/batch).
+          const summary = await runTests({
+            capabilitySlug: suite.slug,
+            testType: suite.testType,
+            suiteId: suite.suiteId,
+          });
           totalPassed += summary.passed;
           totalFailed += summary.failed;
           slugsTested.add(suite.slug);

--- a/apps/api/src/lib/test-runner.test.ts
+++ b/apps/api/src/lib/test-runner.test.ts
@@ -36,13 +36,53 @@ vi.mock("../capabilities/index.js", () => ({
   getExecutor: () => mockExecutor,
 }));
 
+// Recursively walks a composed drizzle `and(eq(...), eq(...))` condition
+// object for embedded bind values (`Param` instances), the same technique
+// do.spend-cap.test.ts uses for raw sql`` tags — here applied to the
+// query-builder's `.where(and(...))` shape, where interpolated values are
+// wrapped one level deeper (SQL -> Param) than a raw tagged template.
+// Used both to assert the built condition really carries a suiteId filter
+// AND (in the mock `.where()` below) to make the mock behave like a real
+// DB: return only the row(s) matching that id when one is present.
+function findParams(node: unknown, acc: unknown[], depth = 0): void {
+  if (depth > 20 || node == null || typeof node !== "object") return;
+  const ctorName = (node as { constructor?: { name?: string } }).constructor?.name;
+  if (ctorName === "Param") {
+    acc.push((node as { value: unknown }).value);
+    return;
+  }
+  const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+  if (Array.isArray(chunks)) {
+    for (const c of chunks) findParams(c, acc, depth + 1);
+  }
+}
+
 const insertResultsCalls: unknown[] = [];
-let suiteRows: unknown[] = [];
+let suiteRows: Array<{ suite: { id: string } }> = [];
+const whereCalls: unknown[] = [];
 const mockDb = {
   select: () => ({
     from: () => ({
       innerJoin: () => ({
-        where: () => Promise.resolve(suiteRows),
+        where: (condition: unknown) => {
+          whereCalls.push(condition);
+          // Mirror real Postgres behavior: if the composed condition
+          // carries a bind value matching one of our fake suite ids, only
+          // that row would ever come back from the actual `test_suites`
+          // table. Suite-id-agnostic callers (no suiteId passed) see every
+          // row, exactly as before this fix — the pre-existing
+          // (capabilitySlug, testType) behavior is untouched.
+          const params: unknown[] = [];
+          findParams(condition, params);
+          const matchingIds = suiteRows
+            .map((r) => r.suite.id)
+            .filter((id) => params.includes(id));
+          const filtered =
+            matchingIds.length > 0
+              ? suiteRows.filter((r) => matchingIds.includes(r.suite.id))
+              : suiteRows;
+          return Promise.resolve(filtered);
+        },
       }),
     }),
   }),
@@ -96,6 +136,7 @@ describe("runTests — per-suite budget re-check (HIGH-1, 2026-08-17 review)", (
     mockAssertGuardedAllow.mockReset().mockResolvedValue(undefined);
     mockExecutor.mockReset().mockRejectedValue(new Error("simulated executor error"));
     insertResultsCalls.length = 0;
+    whereCalls.length = 0;
     suiteRows = [
       fakeSuiteRow("suite-1"),
       fakeSuiteRow("suite-2"),
@@ -155,6 +196,113 @@ describe("runTests — per-suite budget re-check (HIGH-1, 2026-08-17 review)", (
     expect(mockExecutor).toHaveBeenCalledTimes(4);
     expect(insertResultsCalls).toHaveLength(4);
     expect(summary.total).toBe(4);
+  });
+});
+
+// ─── Suite-scoped execution (Codex review, 2026-08-18) ──────────────────────
+//
+// HIGH-1: findOverdueSuites() (test-scheduler.ts) emits one row per due
+// SUITE, but the scheduler used to call runTests({capabilitySlug, testType})
+// per row without narrowing to that specific suite — and runTests() with
+// only (capabilitySlug, testType) reloads and re-executes EVERY active
+// suite sharing that pair. With N same-type suites all due in one poll
+// cycle, that produced N x N executions per cadence (danish-company-data's
+// 4 duplicate known_answer suites: a 4-entry batch ran 16 executions against
+// a 100/day budget — the exact quadratic blowup this section proves fixed).
+//
+// The fix is TestRunOptions.suiteId: an additive filter that, when present,
+// narrows the query to exactly one test_suites row. These tests prove two
+// things at the layer that actually matters (the built SQL condition + the
+// suites that get executed), not just the scheduler's call-site shape:
+//   1. passing suiteId narrows execution to exactly that suite, even when
+//      3 siblings sharing (capabilitySlug, testType) are also due.
+//   2. omitting suiteId is unchanged — every existing (slug[, testType])
+//      caller (manual-test-rerun.ts, event-triggers.ts, internal-tests.ts
+//      route) still gets every matching suite, so this is additive, not a
+//      breaking narrowing of default behavior.
+//   3. the danish-4-duplicate scenario, run the way the scheduler now runs
+//      it (one runTests() call per overdue suite, suiteId set each time),
+//      does exactly 4 executions for 4 due suites — linear, not 16.
+describe("runTests — suiteId scoping (HIGH-1, Codex 2026-08-18 review)", () => {
+  beforeEach(() => {
+    mockIsBudgetExhausted.mockReset();
+    mockAssertGuardedAllow.mockReset().mockResolvedValue(undefined);
+    mockExecutor.mockReset().mockRejectedValue(new Error("simulated executor error"));
+    insertResultsCalls.length = 0;
+    whereCalls.length = 0;
+    suiteRows = [
+      fakeSuiteRow("suite-1"),
+      fakeSuiteRow("suite-2"),
+      fakeSuiteRow("suite-3"),
+      fakeSuiteRow("suite-4"),
+    ];
+  });
+
+  it("passing suiteId narrows the built WHERE condition to that suite's id", async () => {
+    mockIsBudgetExhausted.mockResolvedValue(false);
+
+    await runTests({ capabilitySlug: "budget-test-cap", testType: "negative", suiteId: "suite-2" });
+
+    expect(whereCalls).toHaveLength(1);
+    const params: unknown[] = [];
+    findParams(whereCalls[0], params);
+    expect(params).toContain("suite-2");
+  });
+
+  it("suiteId scopes execution to exactly that one suite, even with 3 due siblings sharing (slug, testType)", async () => {
+    mockIsBudgetExhausted.mockResolvedValue(false);
+
+    const summary = await runTests({
+      capabilitySlug: "budget-test-cap",
+      testType: "negative",
+      suiteId: "suite-2",
+    });
+
+    // Only suite-2's executor call happened — not all 4.
+    expect(mockExecutor).toHaveBeenCalledTimes(1);
+    expect(insertResultsCalls).toHaveLength(1);
+    expect(summary.total).toBe(1);
+  });
+
+  it("omitting suiteId preserves the pre-fix (capabilitySlug, testType) behavior — every matching suite runs", async () => {
+    mockIsBudgetExhausted.mockResolvedValue(false);
+
+    const summary = await runTests({ capabilitySlug: "budget-test-cap", testType: "negative" });
+
+    expect(mockExecutor).toHaveBeenCalledTimes(4);
+    expect(insertResultsCalls).toHaveLength(4);
+    expect(summary.total).toBe(4);
+
+    // No id-scoping param was ever built for this call.
+    const params: unknown[] = [];
+    findParams(whereCalls[0], params);
+    for (const row of suiteRows) expect(params).not.toContain(row.suite.id);
+  });
+
+  it("the danish-4-duplicate scenario becomes LINEAR: 4 overdue suites, one runTests() call each (as the fixed scheduler now does) → exactly 4 executions total, not 16", async () => {
+    mockIsBudgetExhausted.mockResolvedValue(false);
+
+    // Simulates pollCycle()'s for-loop: one runTests() call per overdue
+    // suite row, each now carrying that row's own suiteId — the exact
+    // fix to test-scheduler.ts's loop at (formerly) line 733.
+    const overdueBatch = suiteRows.map((r) => r.suite.id);
+    let totalExecuted = 0;
+    for (const suiteId of overdueBatch) {
+      mockExecutor.mockClear();
+      const summary = await runTests({
+        capabilitySlug: "budget-test-cap",
+        testType: "negative",
+        suiteId,
+      });
+      totalExecuted += summary.total;
+    }
+
+    expect(overdueBatch).toHaveLength(4);
+    expect(totalExecuted).toBe(4); // linear: 4 due suites -> 4 executions
+    // Pre-fix this would have been 16 (each of the 4 loop iterations
+    // re-running all 4 suites) — asserting the exact pre-fix number here
+    // as a named contrast, not just "not 16".
+    expect(totalExecuted).not.toBe(4 * 4);
   });
 });
 

--- a/apps/api/src/lib/test-runner.test.ts
+++ b/apps/api/src/lib/test-runner.test.ts
@@ -37,28 +37,70 @@ vi.mock("../capabilities/index.js", () => ({
 }));
 
 // Recursively walks a composed drizzle `and(eq(...), eq(...))` condition
-// object for embedded bind values (`Param` instances), the same technique
-// do.spend-cap.test.ts uses for raw sql`` tags — here applied to the
-// query-builder's `.where(and(...))` shape, where interpolated values are
-// wrapped one level deeper (SQL -> Param) than a raw tagged template.
-// Used both to assert the built condition really carries a suiteId filter
-// AND (in the mock `.where()` below) to make the mock behave like a real
-// DB: return only the row(s) matching that id when one is present.
-function findParams(node: unknown, acc: unknown[], depth = 0): void {
-  if (depth > 20 || node == null || typeof node !== "object") return;
-  const ctorName = (node as { constructor?: { name?: string } }).constructor?.name;
-  if (ctorName === "Param") {
-    acc.push((node as { value: unknown }).value);
+// object and extracts each `eq(column, value)` as a {column, value} pair —
+// the same "walk queryChunks for bind values" technique do.spend-cap.test.ts
+// uses for raw sql`` tags, extended one level deeper to also identify WHICH
+// COLUMN each bound value belongs to (drizzle's query-builder `eq()` nests
+// as SQL -> [PgColumn, "=", Param] rather than a raw tag's flat chunk list).
+// Column identity is what makes the mock's `.where()` below correct: a
+// naive "does any bound value match a known suite id" check (the prior
+// version of this mock) can't tell "no id filter was in the query" apart
+// from "an id filter was present but simply didn't match any row" — for an
+// UNKNOWN suiteId, both look identical (no match found), so the old mock
+// fell back to returning every row for an unmatched id. Real Postgres does
+// not do that: `WHERE id = 'nonexistent'` returns zero rows regardless of
+// what else matched. Distinguishing by column, not by value, fixes that
+// (Codex closing-pass HIGH review, 2026-08-18).
+interface EqCondition {
+  column: string;
+  value: unknown;
+}
+
+function isNotWrapperStringChunk(chunk: unknown): boolean {
+  if (!chunk || typeof chunk !== "object") return false;
+  if ((chunk as { constructor?: { name?: string } }).constructor?.name !== "StringChunk") return false;
+  // Drizzle's StringChunk.value is string[], not a plain string.
+  const value = (chunk as { value?: unknown }).value;
+  return Array.isArray(value) && value.some((s) => typeof s === "string" && s.trim().toLowerCase() === "not");
+}
+
+function findEqConditions(node: unknown, acc: EqCondition[], depth = 0): void {
+  if (depth > 25 || node == null || typeof node !== "object") return;
+  const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
+  if (!Array.isArray(chunks)) return;
+
+  // runTests()'s conditions array includes `not(eq(testType, "piggyback"))`
+  // — an EXCLUSION, not a positive filter. Structurally it renders as
+  // `SQL[StringChunk("not "), SQL(<the wrapped eq>)]`: the "not " prefix
+  // sits in a sibling StringChunk one level above the eq it negates, not
+  // inside the eq's own chunk array, so a naive walk that recurses into
+  // everything picks up `{column: "test_type", value: "piggyback"}` as if
+  // it were a real filter — which broke every test in this suite the first
+  // time this mock was written this way (all rows in fixtures have
+  // testType "negative", so requiring testType to ALSO equal "piggyback"
+  // via the misread NOT clause made every row fail to match, yielding zero
+  // rows even for the plain capabilitySlug+testType case). Detect the
+  // "not " prefix and skip descending into the fragment it wraps entirely.
+  if (chunks.length > 0 && isNotWrapperStringChunk(chunks[0])) {
     return;
   }
-  const chunks = (node as { queryChunks?: unknown[] }).queryChunks;
-  if (Array.isArray(chunks)) {
-    for (const c of chunks) findParams(c, acc, depth + 1);
+
+  const columnChunk = chunks.find(
+    (c): c is { name: string } =>
+      !!c && typeof c === "object" && "name" in c && "table" in c && typeof (c as { name?: unknown }).name === "string",
+  );
+  const paramChunk = chunks.find(
+    (c) => !!c && typeof c === "object" && (c as { constructor?: { name?: string } }).constructor?.name === "Param",
+  ) as { value: unknown } | undefined;
+  if (columnChunk && paramChunk) {
+    acc.push({ column: columnChunk.name, value: paramChunk.value });
   }
+
+  for (const c of chunks) findEqConditions(c, acc, depth + 1);
 }
 
 const insertResultsCalls: unknown[] = [];
-let suiteRows: Array<{ suite: { id: string } }> = [];
+let suiteRows: Array<{ suite: { id: string; capabilitySlug: string; testType: string } }> = [];
 const whereCalls: unknown[] = [];
 const mockDb = {
   select: () => ({
@@ -66,21 +108,23 @@ const mockDb = {
       innerJoin: () => ({
         where: (condition: unknown) => {
           whereCalls.push(condition);
-          // Mirror real Postgres behavior: if the composed condition
-          // carries a bind value matching one of our fake suite ids, only
-          // that row would ever come back from the actual `test_suites`
-          // table. Suite-id-agnostic callers (no suiteId passed) see every
-          // row, exactly as before this fix — the pre-existing
-          // (capabilitySlug, testType) behavior is untouched.
-          const params: unknown[] = [];
-          findParams(condition, params);
-          const matchingIds = suiteRows
-            .map((r) => r.suite.id)
-            .filter((id) => params.includes(id));
-          const filtered =
-            matchingIds.length > 0
-              ? suiteRows.filter((r) => matchingIds.includes(r.suite.id))
-              : suiteRows;
+          const eqConditions: EqCondition[] = [];
+          findEqConditions(condition, eqConditions);
+          // Faithfully apply every recognized column filter — not just id.
+          // This is what makes "mismatched-slug id" testable: an id that
+          // exists in suiteRows but belongs to a different capability_slug
+          // must still yield zero rows, exactly as a real Postgres
+          // `WHERE id = 'x' AND capability_slug = 'y'` would when 'x'
+          // belongs to some other slug.
+          const COLUMN_TO_FIELD: Record<string, "id" | "capabilitySlug" | "testType"> = {
+            id: "id",
+            capability_slug: "capabilitySlug",
+            test_type: "testType",
+          };
+          const applicable = eqConditions.filter((c) => c.column in COLUMN_TO_FIELD);
+          const filtered = suiteRows.filter((r) =>
+            applicable.every((c) => r.suite[COLUMN_TO_FIELD[c.column]] === c.value),
+          );
           return Promise.resolve(filtered);
         },
       }),
@@ -106,12 +150,12 @@ import {
   runTests,
 } from "./test-runner.js";
 
-function fakeSuiteRow(id: string) {
+function fakeSuiteRow(id: string, overrides?: { capabilitySlug?: string; testType?: string }) {
   return {
     suite: {
       id,
-      capabilitySlug: "budget-test-cap",
-      testType: "negative",
+      capabilitySlug: overrides?.capabilitySlug ?? "budget-test-cap",
+      testType: overrides?.testType ?? "negative",
       testName: `duplicate-known-answer-${id}`,
       testMode: "live",
       input: {},
@@ -244,9 +288,9 @@ describe("runTests — suiteId scoping (HIGH-1, Codex 2026-08-18 review)", () =>
     await runTests({ capabilitySlug: "budget-test-cap", testType: "negative", suiteId: "suite-2" });
 
     expect(whereCalls).toHaveLength(1);
-    const params: unknown[] = [];
-    findParams(whereCalls[0], params);
-    expect(params).toContain("suite-2");
+    const eqConditions: EqCondition[] = [];
+    findEqConditions(whereCalls[0], eqConditions);
+    expect(eqConditions).toContainEqual({ column: "id", value: "suite-2" });
   });
 
   it("suiteId scopes execution to exactly that one suite, even with 3 due siblings sharing (slug, testType)", async () => {
@@ -273,10 +317,10 @@ describe("runTests — suiteId scoping (HIGH-1, Codex 2026-08-18 review)", () =>
     expect(insertResultsCalls).toHaveLength(4);
     expect(summary.total).toBe(4);
 
-    // No id-scoping param was ever built for this call.
-    const params: unknown[] = [];
-    findParams(whereCalls[0], params);
-    for (const row of suiteRows) expect(params).not.toContain(row.suite.id);
+    // No id-scoping condition was ever built for this call.
+    const eqConditions: EqCondition[] = [];
+    findEqConditions(whereCalls[0], eqConditions);
+    expect(eqConditions.find((c) => c.column === "id")).toBeUndefined();
   });
 
   it("the danish-4-duplicate scenario becomes LINEAR: 4 overdue suites, one runTests() call each (as the fixed scheduler now does) → exactly 4 executions total, not 16", async () => {
@@ -303,6 +347,75 @@ describe("runTests — suiteId scoping (HIGH-1, Codex 2026-08-18 review)", () =>
     // re-running all 4 suites) — asserting the exact pre-fix number here
     // as a named contrast, not just "not 16".
     expect(totalExecuted).not.toBe(4 * 4);
+  });
+
+  // ─── Fail-closed on a malformed suiteId (Codex closing-pass HIGH,
+  // 2026-08-18) ────────────────────────────────────────────────────────────
+  //
+  // `if (opts.suiteId)` was fail-OPEN: a falsy suiteId (null, "", or
+  // undefined-by-bug) silently dropped the id predicate and widened
+  // execution back to every suite matching (capabilitySlug, testType) — the
+  // exact quadratic failure this parameter exists to close. The fix checks
+  // presence via `!== undefined` and then requires a non-empty string,
+  // throwing otherwise. These are genuine runtime-shape tests, not just
+  // TypeScript exercises: `as never`/`as any` simulate exactly what a raw
+  // `any`-typed DB row (test-scheduler.ts's findOverdueSuites) could hand
+  // runTests() if a future refactor let a NULL suiteId column through.
+
+  it("suiteId: null (present but falsy) throws instead of silently widening scope", async () => {
+    mockIsBudgetExhausted.mockResolvedValue(false);
+
+    await expect(
+      runTests({ capabilitySlug: "budget-test-cap", testType: "negative", suiteId: null as never }),
+    ).rejects.toThrow(/suiteId was supplied but is not a non-empty string/);
+
+    // The failure happens before any suite executes — no partial/wrong-
+    // scope execution slipped through on the way to the throw.
+    expect(mockExecutor).not.toHaveBeenCalled();
+  });
+
+  it("suiteId: empty string (present but falsy) throws instead of silently widening scope", async () => {
+    mockIsBudgetExhausted.mockResolvedValue(false);
+
+    await expect(
+      runTests({ capabilitySlug: "budget-test-cap", testType: "negative", suiteId: "" }),
+    ).rejects.toThrow(/suiteId was supplied but is not a non-empty string/);
+    expect(mockExecutor).not.toHaveBeenCalled();
+  });
+
+  it("suiteId: unknown-but-valid-shaped id (no such suite) runs ZERO suites — never falls back to every row", async () => {
+    mockIsBudgetExhausted.mockResolvedValue(false);
+
+    const summary = await runTests({
+      capabilitySlug: "budget-test-cap",
+      testType: "negative",
+      suiteId: "suite-does-not-exist-9999",
+    });
+
+    // The exact regression the prior version of this mock couldn't catch
+    // (Codex: "the current mock returns all rows for unknown ids"): an
+    // unmatched id must yield zero rows, not every row in suiteRows.
+    expect(mockExecutor).not.toHaveBeenCalled();
+    expect(insertResultsCalls).toHaveLength(0);
+    expect(summary.total).toBe(0);
+  });
+
+  it("suiteId: id exists but belongs to a different capabilitySlug — zero rows, no cross-scope leak", async () => {
+    mockIsBudgetExhausted.mockResolvedValue(false);
+    // suite-5 is real, but registered under a DIFFERENT capability than
+    // the one this call scopes to — a real Postgres
+    // `WHERE id = 'suite-5' AND capability_slug = 'budget-test-cap'`
+    // would return zero rows for it, and this call must too.
+    suiteRows.push(fakeSuiteRow("suite-5", { capabilitySlug: "other-cap" }));
+
+    const summary = await runTests({
+      capabilitySlug: "budget-test-cap",
+      testType: "negative",
+      suiteId: "suite-5",
+    });
+
+    expect(mockExecutor).not.toHaveBeenCalled();
+    expect(summary.total).toBe(0);
   });
 });
 

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -91,6 +91,27 @@ export interface TestRunOptions {
   capabilitySlug?: string;
   tier?: ScheduleTier;
   testType?: string;
+  /**
+   * Scope execution to exactly one test_suites row (by id). Additive to
+   * capabilitySlug/testType, not a replacement for them — existing callers
+   * that omit it keep loading every active suite matching (capabilitySlug,
+   * testType) exactly as before.
+   *
+   * Added for the scheduler's per-suite batch entries (Codex review,
+   * 2026-08-18): findOverdueSuites() emits one row per due SUITE, but
+   * runTests({capabilitySlug, testType}) without this field reloads and
+   * re-executes EVERY active suite sharing that (slug, testType) pair.
+   * With N same-type suites, a batch of N due rows produced N x N
+   * executions per cadence (danish-company-data's 4 duplicate
+   * known_answer suites: 4 batch entries x 4 suites reloaded each = 16
+   * attempts against a 100/day budget). PR #318's isBudgetExhausted
+   * re-checks stopped the redundant calls from writing failed
+   * test_results rows once the budget ran out, but did nothing to stop
+   * the redundant *executions* themselves before that point — this field
+   * is the actual fix: the scheduler now passes the specific overdue
+   * suite's id, so one batch entry runs exactly its own suite.
+   */
+  suiteId?: string;
 }
 
 export interface TestRunSummary {
@@ -159,6 +180,9 @@ export async function runTests(
   }
   if (opts.testType) {
     conditions.push(eq(testSuites.testType, opts.testType));
+  }
+  if (opts.suiteId) {
+    conditions.push(eq(testSuites.id, opts.suiteId));
   }
 
   // T-1: Inner join with capabilities to skip deactivated/suspended capabilities.

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -110,6 +110,13 @@ export interface TestRunOptions {
    * the redundant *executions* themselves before that point — this field
    * is the actual fix: the scheduler now passes the specific overdue
    * suite's id, so one batch entry runs exactly its own suite.
+   *
+   * Fail-closed, not fail-open (Codex closing-pass HIGH, 2026-08-18): when
+   * this key is present (`!== undefined`), its value MUST be a non-empty
+   * string or runTests() throws. A falsy value silently ignored here would
+   * widen scope back to every suite matching (capabilitySlug, testType) —
+   * the exact bug this field exists to close — so "present but malformed"
+   * fails loudly instead of degrading into the old quadratic behavior.
    */
   suiteId?: string;
 }
@@ -181,7 +188,30 @@ export async function runTests(
   if (opts.testType) {
     conditions.push(eq(testSuites.testType, opts.testType));
   }
-  if (opts.suiteId) {
+  // Codex closing-pass HIGH: `if (opts.suiteId)` was fail-open — a falsy
+  // suiteId (null, "", or undefined-by-bug) from the scheduler silently
+  // dropped the id predicate and widened execution back to every suite
+  // matching (capabilitySlug, testType), which is the exact quadratic
+  // failure this parameter exists to close. The scheduler's OverdueSuite
+  // rows come off a raw `any`-typed SQL result (test-scheduler.ts's
+  // findOverdueSuites), so a NULL `suiteId` column reaching here would be
+  // typed as `string` by TypeScript but actually be `null` at runtime —
+  // exactly the class of bug this closes against. suiteId presence is
+  // detected by `!== undefined` (the scheduler ALWAYS supplies it; every
+  // other caller never passes the key at all, so it stays genuinely
+  // undefined for them and the field remains optional/backward-compatible)
+  // — once present, it must be a non-empty string or this throws instead
+  // of silently widening scope.
+  if (opts.suiteId !== undefined) {
+    if (typeof opts.suiteId !== "string" || opts.suiteId.length === 0) {
+      throw new Error(
+        `runTests: suiteId was supplied but is not a non-empty string (got ${JSON.stringify(opts.suiteId)}). ` +
+          "A falsy/malformed suiteId must never silently widen execution back to every suite matching " +
+          "(capabilitySlug, testType) — that is the exact N x N quadratic failure this parameter exists " +
+          "to close. test-scheduler.ts always supplies a real suite id from findOverdueSuites; a falsy " +
+          "value reaching here means the caller has a bug and must fail loudly, not silently widen scope.",
+      );
+    }
     conditions.push(eq(testSuites.id, opts.suiteId));
   }
 


### PR DESCRIPTION
## Summary
- **The scheduler was quadratic in same-type suites**: each due suite triggered a run of *every* active suite of that (capability, type) — 4 duplicate suites meant 16 executions per cadence. This silently explains months of daily budget exhaustion on multi-suite capabilities (danish, swedish). `runTests` now takes a suite id from the scheduler and executes exactly that suite — **fail-closed**: a falsy or invalid id throws rather than silently widening back.
- Swedish known-answer coverage restored truthfully: Klarna, H&M, and IKEA tested as their real selves (live-verified org numbers, `equals` identity assertions on the returned legal names), after the discovery that five suites had secretly tested one company under five labels. Budget projection redone from never-duplicated suite rates: ~23/day of the 95 ceiling.
- Restore/upgrade script: single transaction, `SELECT FOR UPDATE`, compare-and-set on every write (including the exact legacy rules shape — arbitrary drift is reported, never overwritten), three-state idempotent classification. Already applied to prod under the orchestrator's gate; current dry-run reports all three as up-to-date.
- Read-only duplicate-suite sweep committed: found the same-input-different-label pattern in 3 more capabilities (14 excess suites) — reported for follow-up, untouched.

## Verification
- 3 Codex review rounds (quadratic root-cause + race-safety HIGHs, identity-assertion MEDIUM, fail-open suiteId HIGH, legacy-shape CAS MEDIUM) — all closed; the review's own probe questions drove the last round.
- 23/23 targeted tests; fail-before evidence per fix incl. the falsy-widening case; the test mock rebuilt to filter by column identity (its old version couldn't detect the very bug under test, and its `not()` handling hid a second one).
- Full typecheck (6 surfaces), mjs syntax, dispatcher lint, PII strict: clean. PR #318's budget skips verified composing correctly with suite-scoped execution.
- DEC-20260504-C: scheduler wiring unchanged (index.ts:140 → startTestScheduler → pollCycle); post-deploy proof = per-suite (not N×N) execution counts in test_results within a day.

## Test plan
- CI green; then tomorrow's harness data should show swedish at ~23 attempts/day (was ~100/100 cap-outs) and danish executing linearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)