### PR TITLE
feat(x402): put the four growth bundles on the rail money actually arrives on

### DIFF
--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1233,6 +1233,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0089_deactivateUsCourtSearch",
       "runMigration0090_capabilityOutputContracts",
       "runMigration0091_bolStaleValidationRules",
+      "runMigration0092_x402GrowthBundles",
     ]);
   });
 });
@@ -1716,6 +1717,103 @@ describe("startup-migrations — block 0091 (stale beneficial-ownership assertio
     for (const query of stub.captured) {
       const chunks = (query as unknown as { queryChunks?: unknown[] }).queryChunks ?? [];
       expect(chunks.filter((c) => c instanceof Date || Buffer.isBuffer(c))).toEqual([]);
+    }
+  });
+});
+
+describe("startup-migrations — block 0092 (growth bundles onto the x402 rail)", () => {
+  // The defect this executes against: the four bundles created 2026-08-16 under
+  // DQ-9 shipped is_active = true (publicly listed) and x402_enabled = false
+  // (unpayable). Every euro of external revenue arrives over x402, so they have
+  // earned nothing since. Verified 2026-08-18 in the DB, in GET /x402/catalog,
+  // and by live probe.
+  const freshRun = () => makeStub({ queue: [{ count: 0 }, [], { count: 4 }, { count: 1 }] });
+
+  it("puts exactly the four growth bundles on the rail, and nothing else", async () => {
+    const { runMigration0092_x402GrowthBundles, X402_GROWTH_BUNDLE_SLUGS } = await import(
+      "./startup-migrations.js"
+    );
+    const stub = freshRun();
+    const result = await runMigration0092_x402GrowthBundles(stub);
+
+    const update = stub.renderedSql.find((s) => /update solutions/i.test(s));
+    expect(update, "an UPDATE against solutions is issued on first run").toBeDefined();
+    expect(update!.toLowerCase()).toContain("x402_enabled = true");
+    // Guarded on is_active so it can never surface a deactivated bundle.
+    expect(update!.toLowerCase()).toContain("is_active = true");
+    expect(update!.toLowerCase()).toContain("x402_enabled = false");
+
+    // The set is exact: these four and no others. lead-email-verify is already
+    // on the rail and must not be touched by this block.
+    expect([...X402_GROWTH_BUNDLE_SLUGS].sort()).toEqual([
+      "competitor-read",
+      "keyword-scout",
+      "page-seo-check",
+      "prospect-brief",
+    ]);
+    const updateQuery = dialect.sqlToQuery(stub.captured[2]);
+    expect(JSON.stringify(updateQuery.params) + updateQuery.sql).not.toContain(
+      "lead-email-verify",
+    );
+    expect(result.rows_affected).toBe(4);
+    expect(result.block).toBe("0092_x402GrowthBundles");
+  });
+
+  it("retires itself: once applied, a later boot issues NO update at all", async () => {
+    // This is the test that discriminates against the obvious implementation.
+    // A block idempotent only by WHERE clause would re-issue the UPDATE on every
+    // boot and re-enable a bundle an operator had deliberately switched off —
+    // the scheduled_testing_eligible footgun in CLAUDE.md. The ledger check must
+    // short-circuit before any write.
+    const { runMigration0092_x402GrowthBundles } = await import("./startup-migrations.js");
+    const stub = makeStub({
+      queue: [{ count: 0 }, [{ block: "0092_x402GrowthBundles" }]],
+    });
+    const result = await runMigration0092_x402GrowthBundles(stub);
+
+    expect(stub.renderedSql.some((s) => /update solutions/i.test(s))).toBe(false);
+    expect(stub.renderedSql.some((s) => /insert into startup_migration_ledger/i.test(s))).toBe(
+      false,
+    );
+    expect(result.rows_affected).toBe(0);
+    expect(result.outcome).toContain("no change");
+  });
+
+  it("records the ledger row only after the update has succeeded", async () => {
+    const { runMigration0092_x402GrowthBundles } = await import("./startup-migrations.js");
+    const stub = freshRun();
+    await runMigration0092_x402GrowthBundles(stub);
+
+    const updateAt = stub.renderedSql.findIndex((s) => /update solutions/i.test(s));
+    const ledgerAt = stub.renderedSql.findIndex((s) =>
+      /insert into startup_migration_ledger/i.test(s),
+    );
+    expect(updateAt).toBeGreaterThanOrEqual(0);
+    expect(ledgerAt).toBeGreaterThan(updateAt);
+    // A crash between the two is safe: the retry's UPDATE matches nothing.
+    expect(stub.renderedSql[ledgerAt].toLowerCase()).toContain("on conflict");
+  });
+
+  it("creates its ledger table idempotently before reading it", async () => {
+    const { runMigration0092_x402GrowthBundles } = await import("./startup-migrations.js");
+    const stub = freshRun();
+    await runMigration0092_x402GrowthBundles(stub);
+    expect(stub.renderedSql[0].toLowerCase()).toContain(
+      "create table if not exists startup_migration_ledger",
+    );
+    expect(stub.renderedSql[1].toLowerCase()).toContain("select block from startup_migration_ledger");
+  });
+
+  it("no captured statement binds a Date instance (DEC-20260504-A bind-encoder shape)", async () => {
+    const { runMigration0092_x402GrowthBundles } = await import("./startup-migrations.js");
+    const stub = freshRun();
+    await runMigration0092_x402GrowthBundles(stub);
+    for (const query of stub.captured) {
+      const chunks = (query as unknown as { queryChunks?: unknown[] }).queryChunks ?? [];
+      expect(
+        chunks.filter((c) => c instanceof Date || Buffer.isBuffer(c)),
+        "no Date/Buffer chunk reaches the SQL bind layer",
+      ).toEqual([]);
     }
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1558,6 +1558,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0089_deactivateUsCourtSearch,
   runMigration0090_capabilityOutputContracts,
   runMigration0091_bolStaleValidationRules,
+  runMigration0092_x402GrowthBundles,
 ];
 
 /**
@@ -2343,6 +2344,112 @@ export async function runMigration0091_bolStaleValidationRules(
         ? "no change (no suite still asserts the removed field names)"
         : `${total} suite(s) stopped asserting fields the executor does not return`,
     rows_affected: total,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+/**
+ * Block 0092 — put the four growth bundles on the rail that money arrives on.
+ *
+ * DQ-9 (2026-08-16) settled that the growth bundles get built and sold: they
+ * are composed entirely from capabilities we already run, and they are the
+ * highest-return work available against M1. Four were created the same day —
+ * `competitor-read`, `page-seo-check`, `prospect-brief`, `keyword-scout` — and
+ * shipped `is_active = true`, which put them on the public `/v1/solutions`
+ * catalogue, and `x402_enabled = false`, which kept them off `/x402/solutions`.
+ *
+ * Every euro of external revenue arrives over x402. A bundle that is listed but
+ * not on the rail cannot earn anything, and returns HTTP 404 to an agent that
+ * found it in the catalogue and tried to pay. Verified three ways on 2026-08-18:
+ * `x402_enabled = false` in the DB, absent from `GET /x402/catalog`, and 404 on
+ * a live probe. `lead-email-verify` is the control — same construction, same
+ * price band, `x402_enabled = true`, and 47 external sales in 30 days.
+ *
+ * This is the same shape of gap as DQ-11: a decision recorded as done, executed
+ * on one surface out of two.
+ *
+ * Safe to enable: the solution gate in `routes/x402-gateway-v2.ts` `ensureCache()`
+ * is `x402_enabled AND is_active`, and all fourteen component capabilities across
+ * the four bundles pass the stricter capability gate (`is_active`,
+ * `marketplace_eligible`, `lifecycle_state IN ('active','probation')`) with
+ * healthy recent harness runs and live external traffic.
+ *
+ * **Why this block retires itself.** Every other block here is idempotent by
+ * WHERE clause, which is right for repairs but wrong for a reversible business
+ * flag: `WHERE x402_enabled = false` would re-enable a bundle on the next boot
+ * after an operator had deliberately switched it off. That is exactly the
+ * `scheduled_testing_eligible` footgun CLAUDE.md warns about, where a
+ * boot-time rewrite silently reverts hand edits. So the block records itself in
+ * `startup_migration_ledger` and reads that ledger before acting: it flips the
+ * flag once, ever, and every later boot is a genuine no-op that leaves operator
+ * intent alone.
+ *
+ * Reversal is one flag per bundle (`x402_enabled = false`) and it now stays
+ * reversed. Nothing else about the bundles changes — price, composition and
+ * catalogue listing are untouched.
+ */
+export const X402_GROWTH_BUNDLE_SLUGS = [
+  "competitor-read",
+  "page-seo-check",
+  "prospect-brief",
+  "keyword-scout",
+] as const;
+
+export async function runMigration0092_x402GrowthBundles(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  const BLOCK = "0092_x402GrowthBundles";
+
+  // The ledger is created here rather than in a schema block so this migration
+  // is self-contained: nothing else depends on the table yet.
+  await tx.execute(sql`
+    CREATE TABLE IF NOT EXISTS startup_migration_ledger (
+      block text PRIMARY KEY,
+      applied_at timestamptz NOT NULL DEFAULT now(),
+      rows_affected integer NOT NULL DEFAULT 0
+    )`);
+
+  const prior = (await tx.execute(sql`
+    SELECT block FROM startup_migration_ledger WHERE block = ${BLOCK}
+  `)) as unknown as Array<{ block: string }>;
+
+  if (prior.length > 0) {
+    return {
+      block: BLOCK,
+      outcome: "no change (already applied once — operator intent is not overwritten)",
+      rows_affected: 0,
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+
+  const res = await tx.execute(sql`
+    UPDATE solutions
+    SET x402_enabled = true,
+        updated_at = now()
+    WHERE slug = ANY(${[...X402_GROWTH_BUNDLE_SLUGS]})
+      AND is_active = true
+      AND x402_enabled = false
+  `);
+  const affected = (res as { count?: number }).count ?? 0;
+
+  // Written after the UPDATE, never before: if the UPDATE throws, boot aborts
+  // with nothing recorded and the next boot retries. If the ledger write throws
+  // after a successful UPDATE, the retry's UPDATE matches nothing
+  // (`x402_enabled = false` is already false) and only the ledger row lands.
+  await tx.execute(sql`
+    INSERT INTO startup_migration_ledger (block, rows_affected)
+    VALUES (${BLOCK}, ${affected})
+    ON CONFLICT (block) DO NOTHING
+  `);
+
+  return {
+    block: BLOCK,
+    outcome:
+      affected === 0
+        ? "no change (growth bundles already on the x402 rail)"
+        : `${affected} growth bundle(s) put on the x402 rail — listed publicly but unpayable since 2026-08-16`,
+    rows_affected: affected,
     duration_ms: Date.now() - startedAt,
   };
 }


### PR DESCRIPTION
## What this does

Enables the USDC (x402) rail on the four growth bundles created 2026-08-16 under DQ-9: `competitor-read`, `page-seo-check`, `prospect-brief`, `keyword-scout`.

## Why

They shipped `is_active = true` — publicly listed on `/v1/solutions` — and `x402_enabled = false` — absent from `/x402/solutions`. **Every euro of external revenue arrives over x402.** So for two days they have been listed and unpayable: an agent that finds one in the catalogue and tries to pay gets HTTP 404.

`lead-email-verify` is the control: same construction, same price band, on the rail, **47 external sales / €9.40 in 30 days**.

This is the same shape of gap as DQ-11 — a decision recorded as done, executed on one surface out of two.

## Verification (three independent sources, 2026-08-18)

| check | result |
|---|---|
| prod DB | `x402_enabled = false` on all four, `is_active = true` |
| `GET /x402/catalog` | all four absent; `lead-email-verify` present |
| live probe | `/x402/solutions/competitor-read` → 404 |

Solution gate in `routes/x402-gateway-v2.ts` `ensureCache()` is `x402_enabled AND is_active`, so the flag is the only thing standing between these and the rail.

All **14 component capabilities** across the four bundles pass the stricter capability gate (`is_active`, `marketplace_eligible`, `lifecycle_state IN ('active','probation')`), with healthy recent harness runs and live external traffic — they are built from the platform's top real earners (`google-search`, `serp-analyze`, `email-validate`, `email-deliverability-check`, `keyword-suggest`, `tech-stack-detect`).

## The block retires itself — and why that matters

Every other block in `startup-migrations.ts` is idempotent by WHERE clause. That is correct for a schema repair and **wrong for a reversible business flag**: `WHERE x402_enabled = false` would re-enable a bundle on the next boot after an operator had deliberately switched it off. That is exactly the `scheduled_testing_eligible` footgun CLAUDE.md warns about, where a boot-time rewrite silently reverts hand edits.

So block 0092 records itself in a new `startup_migration_ledger` table and reads that ledger *before* acting. It flips the flag once, ever; every later boot is a genuine no-op.

Ledger write is ordered **after** the UPDATE: if the UPDATE throws, boot aborts with nothing recorded and the next boot retries; if the ledger write throws after a successful UPDATE, the retry's UPDATE matches nothing and only the ledger row lands.

## Tests (DEC-20260504-A)

Five tests, and they discriminate:

- **`retires itself: once applied, a later boot issues NO update at all`** — verified fail-before: reverting the ledger short-circuit to the WHERE-only variant makes this test fail (`1 failed | 110 passed`), restoring it passes (`111 passed`).
- exact slug set, guarded on `is_active`, `lead-email-verify` untouched
- ledger row written only after the UPDATE, with `ON CONFLICT`
- ledger table created idempotently before being read
- no `Date`/`Buffer` reaches the bind layer (PR-43 incident shape)

## Reversal

One flag per bundle (`x402_enabled = false`) — and it now stays reversed. Price, composition and catalogue listing are untouched.

## Note

`npm run typecheck` reports 3 pre-existing errors about an unresolvable `straleio` module. Confirmed **identical on clean `origin/main`** (byte-for-byte diff) — a local workspace-install artifact, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)