### PR TITLE
ops(gates): AuditRecord shape contract — working credential + blocking PR gate

### DIFF
--- a/.github/workflows/audit-shape-contract.yml
+++ b/.github/workflows/audit-shape-contract.yml
@@ -1,0 +1,46 @@
+# Blocking PR gate: the AuditRecord wire-shape contract between
+# apps/api/src/routes/audit.ts and strale-frontend's compliance-types.ts.
+#
+# Why this exists (Phase 2 finding, 2026-08-17): the weekly-drift cron was
+# believed to check this contract, but its private-repo checkout had never
+# succeeded (no cross-repo credential existed) — the check had never once
+# validated real frontend content. Weekly-on-main is also the wrong tier for
+# a contract break: a PR that changes the backend shape can merge and stay
+# broken for up to a week. This workflow runs ON the PRs that can break the
+# contract, and it BLOCKS (no continue-on-error).
+#
+# The paths filter includes this workflow file itself so the PR that
+# introduces or modifies the gate demonstrably executes it (DEC-20260504-C:
+# a gate's first proof of life is its own introducing PR).
+name: audit-shape-contract
+
+on:
+  pull_request:
+    paths:
+      - "apps/api/src/routes/audit.ts"
+      - "apps/api/scripts/check-shape-contracts.mjs"
+      - ".github/workflows/audit-shape-contract.yml"
+
+jobs:
+  shape-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: strale-io/strale-frontend
+          path: strale-frontend
+          # Private repo — founder-created fine-grained PAT, read-only
+          # Contents on strale-io/strale-frontend only (added 2026-08-18).
+          token: ${{ secrets.FRONTEND_READ_PAT }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # check-shape-contracts.mjs reads TS interface declarations textually —
+      # no build or npm ci needed, matching weekly-drift.yml's invocation.
+      - env:
+          STRALE_FRONTEND_PATH: ${{ github.workspace }}/strale-frontend
+        run: node apps/api/scripts/check-shape-contracts.mjs

--- a/.github/workflows/weekly-drift.yml
+++ b/.github/workflows/weekly-drift.yml
@@ -88,8 +88,13 @@ jobs:
         with:
           repository: strale-io/strale-frontend
           path: strale-frontend
-          # No token needed for public-repo read; if the repo is
-          # private, set a GH_PAT secret and reference it here.
+          # strale-frontend is PRIVATE — the default GITHUB_TOKEN cannot see
+          # it, and until 2026-08-18 this step silently 404'd on every run
+          # (masked by continue-on-error), so the AuditRecord shape check
+          # below had NEVER actually validated real frontend content.
+          # FRONTEND_READ_PAT is a founder-created fine-grained PAT,
+          # read-only Contents on strale-io/strale-frontend only.
+          token: ${{ secrets.FRONTEND_READ_PAT }}
         continue-on-error: true
 
       - id: audit-record-shape


### PR DESCRIPTION
## Summary
- Wires the founder-created `FRONTEND_READ_PAT` (read-only Contents, strale-frontend only) into weekly-drift's private-repo checkout — which had silently 404'd on every run since the gate was created (masked by continue-on-error; the AuditRecord check had never validated real frontend content).
- New **blocking** `audit-shape-contract` workflow on pull_request for exactly the paths that can break the contract (audit.ts, the check script, and the workflow itself — so this introducing PR is the DEC-20260504-C execution proof).

## Verification
- Both YAMLs validated; check script runs clean locally against the sibling checkout.
- **The proof is on this PR**: the new `audit-shape-contract` check must appear below and pass — its checkout step succeeding is the first-ever successful cross-repo credentialed read.
- Post-merge: weekly-drift will be manually dispatched once to prove the weekly path too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)