### PR TITLE
fix(test-infra): honest Browserless-dependency detection; dead heuristic removed

### DIFF
--- a/apps/api/src/lib/chromium-health.ts
+++ b/apps/api/src/lib/chromium-health.ts
@@ -2,19 +2,34 @@
  * Chromium/Browserless health monitor.
  *
  * Probes the Browserless.io managed service every 30 minutes with a real
- * page render (example.com). Exports isChromiumHealthy() for the test runner
- * to skip Browserless-dependent capabilities when the service is down,
- * preventing hundreds of timeout failures from polluting the SQS window.
+ * page render (example.com). Exports isChromiumHealthy() for capability
+ * executors on the live customer path (see data-provider.ts's
+ * executeWithFallback, which skips a fallback-chain provider whose
+ * requiredServices includes "browserless" when this reports unhealthy) to
+ * fail fast rather than wait out a timeout.
  *
- * Browserless-dependent capabilities are determined from the database
- * (capability_type = 'scraping') with a 5-minute cache.
+ * NOTE (2026-08-18): this module does NOT gate the scheduled test runner.
+ * That was the original intent — isBrowserlessCapability() was written for
+ * exactly that — but it had zero call sites anywhere in the codebase and was
+ * removed. Skip-on-unhealthy-provider for scheduled tests is handled by
+ * upstream-health-gate.ts's findUnhealthyUpstream(), wired into
+ * test-runner.ts's runTests() per-suite loop, and (as an earlier, cheaper
+ * gate) by test-scheduler.ts's own pre-runTests() provider-health filter.
+ * All of these share one source of truth for "which capabilities depend on
+ * Browserless": dependency-manifest.ts's curated `browserless.capabilities`
+ * list — the gate and this module's getBrowserlessCapabilityCount() read it
+ * via upstream-health-gate.ts's getBrowserlessDependentSlugs(), while the
+ * scheduler's pre-filter reads the manifest directly. Either way it is the
+ * curated list, never inferred from capability_type='scraping'. See that function's
+ * doc comment for why the capability_type heuristic was rejected (it missed
+ * capabilities hard-requiring Browserless that happen to be classified
+ * capability_type='ai_assisted', while over-including capabilities that
+ * keep working via web-provider.ts's fallback tiers when Browserless is
+ * down).
  *
  * State transitions are logged and trigger interrupt emails on critical changes.
  */
 
-import { eq } from "drizzle-orm";
-import { getDb } from "../db/index.js";
-import { capabilities } from "../db/schema.js";
 import { buildBrowserlessRequestUrl, stripToken } from "./browserless-launch.js";
 import { fireAndForget } from "./fire-and-forget.js";
 import { log, logError, logWarn } from "./log.js";
@@ -40,12 +55,9 @@ setTimeout(() => {
 
 async function refreshBrowserlessCache(): Promise<Set<string>> {
   try {
-    const db = getDb();
-    const rows = await db
-      .select({ slug: capabilities.slug })
-      .from(capabilities)
-      .where(eq(capabilities.capabilityType, "scraping"));
-    _browserlessSlugs = new Set(rows.map((r) => r.slug));
+    const { getBrowserlessDependentSlugs } = await import("./upstream-health-gate.js");
+    const slugs = await getBrowserlessDependentSlugs();
+    _browserlessSlugs = new Set(slugs);
     _browserlessCacheExpiry = Date.now() + CACHE_TTL_MS;
   } catch (err) {
     // On DB error, keep the stale cache rather than clearing it
@@ -59,15 +71,6 @@ async function refreshBrowserlessCache(): Promise<Set<string>> {
 /** Whether Chromium/Browserless is currently responding to render requests. */
 export function isChromiumHealthy(): boolean {
   return _healthy;
-}
-
-/**
- * Whether a capability depends on Browserless for execution.
- * Reads from cached Set (populated from DB). Safe to call synchronously —
- * cache is refreshed during probeChromiumHealth() every 30 minutes.
- */
-export function isBrowserlessCapability(slug: string): boolean {
-  return _browserlessSlugs.has(slug);
 }
 
 /** Number of capabilities that would be skipped when Chromium is down. */

--- a/apps/api/src/lib/event-triggers.ts
+++ b/apps/api/src/lib/event-triggers.ts
@@ -15,7 +15,12 @@ import { eq, and, inArray } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { capabilityHealth, capabilities } from "../db/schema.js";
 import { runTests } from "./test-runner.js";
-import { getCapabilityUpstreams, refreshUpstreamMapping, isCacheExpired } from "./upstream-health-gate.js";
+import {
+  getCapabilityUpstreams,
+  refreshUpstreamMapping,
+  isCacheExpired,
+  getBrowserlessDependentSlugs,
+} from "./upstream-health-gate.js";
 import { log, logError } from "./log.js";
 
 // ─── Rate limiter ────────────────────────────────────────────────────────────
@@ -64,11 +69,11 @@ async function getDependencyCapabilities(dependencyName: string): Promise<string
   let slugs: string[];
 
   if (dependencyName === "browserless") {
-    const rows = await db
-      .select({ slug: capabilities.slug })
-      .from(capabilities)
-      .where(and(eq(capabilities.capabilityType, "scraping"), eq(capabilities.isActive, true)));
-    slugs = rows.map((r) => r.slug);
+    // Shares upstream-health-gate.ts's curated (dependency-manifest.ts-driven)
+    // list rather than capability_type='scraping' — see that function's doc
+    // comment. This branch used to run its own capability_type query here;
+    // it had the same under/over-inclusion gap findUnhealthyUpstream did.
+    slugs = await getBrowserlessDependentSlugs();
   } else if (dependencyName === "anthropic") {
     const rows = await db
       .select({ slug: capabilities.slug })

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -30,8 +30,13 @@ import {
 import { analyzeAndRemediate, applyRemediation } from "./auto-remediation.js";
 import { checkUpstreamEscalation } from "./upstream-tracker.js";
 import { getUnconfiguredCapabilities } from "./credential-health.js";
-import { isChromiumHealthy, isBrowserlessCapability, probeChromiumHealth } from "./chromium-health.js";
-import { findUnhealthyUpstream, refreshUpstreamMapping, isCacheExpired } from "./upstream-health-gate.js";
+// chromium-health.ts's isChromiumHealthy/isBrowserlessCapability/
+// probeChromiumHealth used to be imported here but had zero call sites in
+// this file (2026-08-18 finding) — the Browserless-outage skip below is
+// findUnhealthyUpstream(), not anything from chromium-health.ts. See
+// chromium-health.ts's header comment for the full account of why that
+// module's test-runner-facing exports were removed instead of wired in.
+import { findUnhealthyUpstream } from "./upstream-health-gate.js";
 // Lifecycle automatic evaluation removed (DEC-20260503-B).
 import { logHealthEvent } from "./health-monitor.js";
 import { checkNewFailures, checkInfrastructureHealth } from "./meta-monitoring.js";
@@ -281,9 +286,21 @@ export async function runTests(
       continue;
     }
 
-    // Skip capabilities whose upstream dependency is unhealthy
-    // (prevents timeout failures from polluting the SQS window)
-    const unhealthyUpstream = findUnhealthyUpstream(suite.capabilitySlug);
+    // Skip capabilities whose upstream dependency is unhealthy (prevents
+    // timeout failures from polluting the test window). findUnhealthyUpstream
+    // is a synchronous Map read today and shouldn't throw, but this is the
+    // gate a Browserless-platform outage flows through — fail OPEN (run the
+    // suite) rather than let an unexpected error here silently abort the
+    // rest of the batch.
+    let unhealthyUpstream: string | null = null;
+    try {
+      unhealthyUpstream = findUnhealthyUpstream(suite.capabilitySlug);
+    } catch (err) {
+      logWarn("test-runner-upstream-check-failed", "upstream health check threw; failing open", {
+        capability_slug: suite.capabilitySlug,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
     if (unhealthyUpstream) {
       log.info(
         { label: "test-runner-skip-unhealthy-upstream", capability_slug: suite.capabilitySlug, upstream: unhealthyUpstream },

--- a/apps/api/src/lib/test-runner.upstream-skip.test.ts
+++ b/apps/api/src/lib/test-runner.upstream-skip.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── 2026-08-18: chromium-health.ts dead-import investigation ──────────────
+//
+// Pins the behavior of runTests()'s per-suite loop at the exact call site
+// (findUnhealthyUpstream) that supersedes chromium-health.ts's removed,
+// never-wired isBrowserlessCapability()/probeChromiumHealth() imports:
+//   1. Browserless (or any mapped upstream) down → suite silently skipped,
+//      no test_results row, no entry in the run summary.
+//   2. Upstream healthy → suite executes normally.
+//   3. The health check itself throwing → fails OPEN (suite still runs),
+//      matching Test Infrastructure Cost Principle A's spirit and the
+//      graceful-degradation pattern test-scheduler.ts's own provider-health
+//      filter already uses ("if health check fails, run all tests").
+//   4. A capability with no mapped upstream is never skipped by this gate,
+//      regardless of what findUnhealthyUpstream would say for OTHER slugs.
+//
+// upstream-health-gate.ts itself (mocked here) is unit-tested directly in
+// upstream-health-gate.test.ts, including the manifest-driven (not
+// capability_type) slug derivation. This file is purely about the wiring
+// inside test-runner.ts's loop.
+
+const mockFindUnhealthyUpstream = vi.fn();
+vi.mock("./upstream-health-gate.js", () => ({
+  findUnhealthyUpstream: (...args: unknown[]) => mockFindUnhealthyUpstream(...args),
+}));
+
+const mockAssertGuardedAllow = vi.fn();
+const mockIsBudgetExhausted = vi.fn();
+vi.mock("../capabilities/guarded-executor.js", () => ({
+  assertGuardedAllow: (...args: unknown[]) => mockAssertGuardedAllow(...args),
+  isBudgetExhausted: (...args: unknown[]) => mockIsBudgetExhausted(...args),
+  CapabilityInvocationRefusedError: class extends Error {},
+  CapabilityNotClassifiedError: class extends Error {},
+  BudgetExhaustedError: class extends Error {},
+}));
+
+const mockExecutor = vi.fn();
+vi.mock("../capabilities/index.js", () => ({
+  getExecutor: () => mockExecutor,
+}));
+
+const insertResultsCalls: unknown[] = [];
+let suiteRows: Array<{
+  suite: {
+    id: string;
+    capabilitySlug: string;
+    testType: string;
+    testName: string;
+    testMode: string;
+    input: Record<string, unknown>;
+    validationRules: { checks: unknown[] };
+    baselineOutput: null;
+    externalCostCents: number;
+    estimatedCostCents: number;
+    active: boolean;
+    lastClassification: null;
+  };
+  fieldReliability: null;
+  capabilityType: string;
+  outputSchema: null;
+}> = [];
+
+const mockDb = {
+  select: () => ({
+    from: () => ({
+      innerJoin: () => ({
+        where: () => Promise.resolve(suiteRows),
+      }),
+    }),
+  }),
+  insert: (table: unknown) => ({
+    values: (vals: unknown) => {
+      if (table === testResultsTable) insertResultsCalls.push(vals);
+      return Promise.resolve(undefined);
+    },
+  }),
+  update: () => ({
+    set: () => ({
+      where: () => Promise.resolve(undefined),
+    }),
+  }),
+};
+vi.mock("../db/index.js", () => ({ getDb: () => mockDb }));
+
+import { testResults as testResultsTable } from "../db/schema.js";
+import { runTests } from "./test-runner.js";
+
+function fakeSuiteRow(slug: string) {
+  return {
+    suite: {
+      id: `suite-${slug}`,
+      capabilitySlug: slug,
+      testType: "negative",
+      testName: `test-${slug}`,
+      testMode: "live",
+      input: {},
+      validationRules: { checks: [] },
+      baselineOutput: null,
+      externalCostCents: 0,
+      estimatedCostCents: 0,
+      active: true,
+      lastClassification: null,
+    },
+    fieldReliability: null,
+    capabilityType: "ai_assisted",
+    outputSchema: null,
+  };
+}
+
+describe("runTests — findUnhealthyUpstream skip gate (supersedes chromium-health.ts's dead imports)", () => {
+  beforeEach(() => {
+    mockFindUnhealthyUpstream.mockReset();
+    mockAssertGuardedAllow.mockReset().mockResolvedValue(undefined);
+    mockIsBudgetExhausted.mockReset().mockResolvedValue(false);
+    mockExecutor.mockReset().mockResolvedValue({
+      output: { ok: true },
+      provenance: { source: "test", fetched_at: new Date().toISOString() },
+    });
+    insertResultsCalls.length = 0;
+    suiteRows = [fakeSuiteRow("fake-browserless-test-cap")];
+  });
+
+  it("Browserless down → suite skipped silently: no test_results row, no result entry, executor never called", async () => {
+    mockFindUnhealthyUpstream.mockReturnValue("browserless");
+
+    const summary = await runTests({ capabilitySlug: "fake-browserless-test-cap" });
+
+    expect(mockExecutor).not.toHaveBeenCalled();
+    expect(insertResultsCalls.length).toBe(0);
+    expect(summary.total).toBe(0);
+    expect(summary.results).toEqual([]);
+  });
+
+  it("Browserless up → suite executes normally and records a result", async () => {
+    mockFindUnhealthyUpstream.mockReturnValue(null);
+
+    const summary = await runTests({ capabilitySlug: "fake-browserless-test-cap" });
+
+    expect(mockExecutor).toHaveBeenCalledTimes(1);
+    expect(insertResultsCalls.length).toBe(1);
+    expect(summary.total).toBe(1);
+    expect(summary.passed).toBe(1);
+  });
+
+  it("findUnhealthyUpstream throwing → fails open: suite still runs, doesn't abort the batch", async () => {
+    mockFindUnhealthyUpstream.mockImplementation(() => {
+      throw new Error("simulated upstream-health-gate malfunction");
+    });
+
+    const summary = await runTests({ capabilitySlug: "fake-browserless-test-cap" });
+
+    expect(mockExecutor).toHaveBeenCalledTimes(1);
+    expect(insertResultsCalls.length).toBe(1);
+    expect(summary.total).toBe(1);
+    expect(summary.passed).toBe(1);
+  });
+
+  it("a capability with no mapped upstream is never skipped by this gate", async () => {
+    // findUnhealthyUpstream itself would return null for any slug with no
+    // known upstream dependency — simulated directly since the mapping
+    // logic is upstream-health-gate.ts's own responsibility (tested there).
+    suiteRows = [fakeSuiteRow("some-capability-with-no-upstream")];
+    mockFindUnhealthyUpstream.mockImplementation((slug: string) =>
+      slug === "fake-browserless-test-cap" ? "browserless" : null,
+    );
+
+    const summary = await runTests({ capabilitySlug: "some-capability-with-no-upstream" });
+
+    expect(mockExecutor).toHaveBeenCalledTimes(1);
+    expect(insertResultsCalls.length).toBe(1);
+    expect(summary.total).toBe(1);
+  });
+});

--- a/apps/api/src/lib/upstream-health-gate.test.ts
+++ b/apps/api/src/lib/upstream-health-gate.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── 2026-08-18: chromium-health.ts dead-import investigation ──────────────
+//
+// test-runner.ts imported isChromiumHealthy/isBrowserlessCapability/
+// probeChromiumHealth from chromium-health.ts with zero call sites in that
+// file. Investigation concluded findUnhealthyUpstream() (this module) was
+// ALREADY the live mechanism performing that job in test-runner.ts's
+// per-suite loop — so the fix was removing the dead imports, not wiring
+// chromium-health.ts in a second time.
+//
+// That investigation also found the mapping this module (and, before this
+// change, chromium-health.ts's isBrowserlessCapability() and
+// event-triggers.ts's own copy) used to decide "which capabilities depend
+// on Browserless" — capability_type='scraping' — was wrong in both
+// directions against production data:
+//   - under-inclusive: web-extract, annual-report-extract,
+//     estonian-company-data, company-enrich hard-require Browserless (no
+//     fallback) but are capability_type='ai_assisted'
+//   - over-inclusive: most of the 41 capability_type='scraping' rows go
+//     through a 3-tier fallback and keep working without Browserless
+//
+// getBrowserlessDependentSlugs() replaces that heuristic with
+// dependency-manifest.ts's hand-curated `browserless.capabilities` list.
+// These tests pin the new wiring and the skip-gate semantics that consume it.
+
+const mockGetActiveProviders = vi.fn();
+vi.mock("./dependency-manifest.js", () => ({
+  getActiveProviders: (...args: unknown[]) => mockGetActiveProviders(...args),
+}));
+
+// Queue of rows returned by successive `.where()` calls against the
+// capabilities table. Call order inside this module is fixed: first the
+// browserless inArray/isActive query (from getBrowserlessDependentSlugs),
+// then — only when invoked via refreshUpstreamMapping — the ai_assisted
+// eq/isActive query.
+let whereResultQueue: Array<Array<{ slug: string }>> = [];
+const whereCalls: unknown[] = [];
+const mockDb = {
+  select: () => ({
+    from: () => ({
+      where: (condition: unknown) => {
+        whereCalls.push(condition);
+        return Promise.resolve(whereResultQueue.shift() ?? []);
+      },
+    }),
+  }),
+};
+vi.mock("../db/index.js", () => ({ getDb: () => mockDb }));
+
+import {
+  getBrowserlessDependentSlugs,
+  refreshUpstreamMapping,
+  findUnhealthyUpstream,
+  isUpstreamHealthy,
+  updateUpstreamHealth,
+  getCapabilityUpstreams,
+} from "./upstream-health-gate.js";
+
+function fakeBrowserlessProvider(capabilities: string[]) {
+  return { name: "browserless", capabilities };
+}
+
+beforeEach(() => {
+  mockGetActiveProviders.mockReset();
+  whereResultQueue = [];
+  whereCalls.length = 0;
+  // Reset module-level health state that would otherwise leak across tests.
+  updateUpstreamHealth("browserless", true);
+});
+
+describe("getBrowserlessDependentSlugs — manifest-driven, not capability_type", () => {
+  it("queries the DB for exactly the candidate slugs from dependency-manifest.ts's browserless provider, filtered to isActive", async () => {
+    mockGetActiveProviders.mockReturnValue([
+      fakeBrowserlessProvider(["web-extract", "annual-report-extract", "screenshot-url"]),
+      { name: "anthropic", capabilities: ["some-other-cap"] },
+    ]);
+    whereResultQueue = [[{ slug: "web-extract" }, { slug: "screenshot-url" }]]; // annual-report-extract inactive in DB
+
+    const slugs = await getBrowserlessDependentSlugs();
+
+    expect(slugs.sort()).toEqual(["screenshot-url", "web-extract"]);
+    // Exactly one DB round-trip for this call.
+    expect(whereCalls.length).toBe(1);
+  });
+
+  it("short-circuits with no DB call when the browserless provider has no curated capabilities", async () => {
+    mockGetActiveProviders.mockReturnValue([fakeBrowserlessProvider([])]);
+
+    const slugs = await getBrowserlessDependentSlugs();
+
+    expect(slugs).toEqual([]);
+    expect(whereCalls.length).toBe(0);
+  });
+
+  it("returns [] when no browserless provider is registered (retired/removed)", async () => {
+    mockGetActiveProviders.mockReturnValue([{ name: "anthropic", capabilities: ["x"] }]);
+
+    const slugs = await getBrowserlessDependentSlugs();
+
+    expect(slugs).toEqual([]);
+    expect(whereCalls.length).toBe(0);
+  });
+});
+
+describe("refreshUpstreamMapping — wires browserless slugs, not capability_type='scraping' rows", () => {
+  it("maps only the manifest-curated + active browserless slugs to the 'browserless' upstream", async () => {
+    mockGetActiveProviders.mockReturnValue([
+      fakeBrowserlessProvider(["web-extract", "company-enrich"]),
+    ]);
+    whereResultQueue = [
+      [{ slug: "web-extract" }, { slug: "company-enrich" }], // browserless query
+      [], // ai_assisted query — none in this test
+    ];
+
+    await refreshUpstreamMapping();
+
+    expect(getCapabilityUpstreams("web-extract")).toEqual(["browserless"]);
+    expect(getCapabilityUpstreams("company-enrich")).toEqual(["browserless"]);
+    // A capability with capability_type='scraping' that ISN'T in the
+    // curated manifest list (e.g. a fallback-tier capability like
+    // url-to-markdown) must not be tagged as browserless-dependent by this
+    // mapping — proving the old capability_type heuristic is gone.
+    expect(getCapabilityUpstreams("url-to-markdown")).toEqual([]);
+  });
+});
+
+describe("findUnhealthyUpstream — the skip gate test-runner.ts's per-suite loop calls", () => {
+  beforeEach(async () => {
+    mockGetActiveProviders.mockReturnValue([
+      fakeBrowserlessProvider(["web-extract"]),
+    ]);
+    whereResultQueue = [[{ slug: "web-extract" }], []];
+    await refreshUpstreamMapping();
+  });
+
+  it("Browserless down → returns 'browserless' for a browserless-dependent capability", () => {
+    updateUpstreamHealth("browserless", false);
+    expect(findUnhealthyUpstream("web-extract")).toBe("browserless");
+  });
+
+  it("Browserless up → returns null (runs normally)", () => {
+    updateUpstreamHealth("browserless", true);
+    expect(findUnhealthyUpstream("web-extract")).toBeNull();
+  });
+
+  it("dependency never probed yet → fails open (returns null, treated as healthy)", () => {
+    // isUpstreamHealthy() defaults unknown dependency names to healthy via
+    // `?? true` — this is the fail-open path for "no confirmed-bad signal
+    // yet" (e.g. before the first health probe has completed after boot).
+    expect(isUpstreamHealthy("browserless")).toBe(true); // seeded true in outer beforeEach
+    updateUpstreamHealth("some-upstream-never-probed", false as unknown as boolean); // no-op sanity
+    expect(findUnhealthyUpstream("web-extract")).toBeNull();
+  });
+
+  it("non-Browserless capability → never skipped by this gate regardless of Browserless health", () => {
+    updateUpstreamHealth("browserless", false);
+    // "some-other-capability" was never mapped to any upstream by
+    // refreshUpstreamMapping() in this test's setup.
+    expect(findUnhealthyUpstream("some-other-capability")).toBeNull();
+  });
+});

--- a/apps/api/src/lib/upstream-health-gate.ts
+++ b/apps/api/src/lib/upstream-health-gate.ts
@@ -6,10 +6,12 @@
  * any test for a capability that depends on that upstream.
  *
  * When an upstream is unhealthy, tests for dependent capabilities are skipped
- * (not failed) — preventing timeout failures from polluting the SQS window.
+ * (not failed) — preventing timeout failures from polluting the test window.
  *
- * Upstream → capability mapping is derived from the database (capability_type
- * and transparency_tag columns) with a 5-minute cache.
+ * Upstream → capability mapping is mostly derived from the database
+ * (capability_type / transparency_tag columns) with a 5-minute cache, EXCEPT
+ * for "browserless" — see getBrowserlessDependentSlugs() below for why that
+ * one reads dependency-manifest.ts's curated list instead.
  */
 
 import { eq, and, sql, inArray } from "drizzle-orm";
@@ -17,6 +19,7 @@ import { logError } from "./log.js";
 import { getDb } from "../db/index.js";
 import { capabilities } from "../db/schema.js";
 import { fireAndForget } from "./fire-and-forget.js";
+import { getActiveProviders } from "./dependency-manifest.js";
 
 // ─── Upstream health state ──────────────────────────────────────────────────
 
@@ -53,6 +56,59 @@ const FIXED_UPSTREAM_SLUGS: Record<string, string[]> = {
 };
 
 /**
+ * Capabilities that genuinely require Browserless with no working fallback —
+ * sourced from dependency-manifest.ts's curated `browserless.capabilities`
+ * list, NOT derived from capability_type='scraping'.
+ *
+ * capability_type='scraping' was the original heuristic here (and is what
+ * chromium-health.ts's now-removed isBrowserlessCapability() and
+ * event-triggers.ts's dependency mapping also used). It was measured against
+ * production on 2026-08-18 and rejected on both sides:
+ *   - Under-inclusion: web-extract, annual-report-extract,
+ *     estonian-company-data, and company-enrich all call Browserless
+ *     directly with no fallback (they're in dependency-manifest.ts's
+ *     browserless.capabilities list) but are classified
+ *     capability_type='ai_assisted', not 'scraping' — the old heuristic
+ *     never gated them on Browserless health at all.
+ *   - Over-inclusion: of the 41 capabilities classified
+ *     capability_type='scraping' in prod, most (e.g. accessibility-audit,
+ *     amazon-price, seo-audit, url-to-markdown, ...) go through
+ *     web-provider.ts / browserless-extract.ts's 3-tier fallback
+ *     (plain HTTP → Jina Reader → Browserless) and keep working when
+ *     Browserless is down — skipping their tests on a Browserless outage
+ *     hides real signal about capabilities that are actually fine.
+ *   - A third, separately-flagged case (irish/latvian/lithuanian-company-data,
+ *     swiss-company-data) turned out to be stale rather than a gap: those
+ *     four were migrated off Browserless entirely onto direct-API executors
+ *     under DEC-20260428-A (commits incl. 7311319) and no longer import
+ *     browserless-extract.js at all. They are correctly capability_type=
+ *     'stable_api' today and must NOT be added to any Browserless list.
+ *
+ * dependency-manifest.ts's list is hand-curated specifically for "fails
+ * completely without Browserless" (its own comment: "Only capabilities that
+ * genuinely REQUIRE Browserless ... are listed here") and is already the
+ * source of truth for three other subsystems (invariant-checker.ts,
+ * test-scheduler.ts's own pre-runTests() provider-health filter, and
+ * situation-assessment.ts's alert-affected-count), so reusing it here closes
+ * the gap without introducing a fourth parallel definition.
+ */
+export async function getBrowserlessDependentSlugs(): Promise<string[]> {
+  const browserlessProvider = getActiveProviders().find((p) => p.name === "browserless");
+  const candidateSlugs = browserlessProvider?.capabilities ?? [];
+  if (candidateSlugs.length === 0) return [];
+
+  const db = getDb();
+  const rows = await db
+    .select({ slug: capabilities.slug })
+    .from(capabilities)
+    .where(and(
+      inArray(capabilities.slug, candidateSlugs),
+      eq(capabilities.isActive, true),
+    ));
+  return rows.map((r) => r.slug);
+}
+
+/**
  * Refresh the capability → upstream mapping from the database.
  * Called periodically (on cache expiry) and at startup.
  */
@@ -60,14 +116,9 @@ export async function refreshUpstreamMapping(): Promise<void> {
   try {
     const db = getDb();
 
-    // Scraping capabilities → depend on Browserless
-    const scrapingRows = await db
-      .select({ slug: capabilities.slug })
-      .from(capabilities)
-      .where(and(
-        eq(capabilities.capabilityType, "scraping"),
-        eq(capabilities.isActive, true),
-      ));
+    // Browserless-dependent capabilities — see getBrowserlessDependentSlugs
+    // doc comment for why this is NOT a capability_type='scraping' query.
+    const browserlessSlugs = await getBrowserlessDependentSlugs();
 
     // AI-assisted capabilities → depend on Anthropic
     const aiRows = await db
@@ -81,10 +132,10 @@ export async function refreshUpstreamMapping(): Promise<void> {
     // Build the map
     const newMap = new Map<string, string[]>();
 
-    for (const row of scrapingRows) {
-      const existing = newMap.get(row.slug) ?? [];
+    for (const slug of browserlessSlugs) {
+      const existing = newMap.get(slug) ?? [];
       existing.push("browserless");
-      newMap.set(row.slug, existing);
+      newMap.set(slug, existing);
     }
 
     for (const row of aiRows) {


### PR DESCRIPTION
## Summary
- An investigation chip claimed the chromium-health imports in test-runner were dead machinery needing wiring — the evidence said otherwise: the generic upstream gate already covers Browserless-platform outages (provider probe → shared health map → per-suite skip), so the truly dead piece was `isBrowserlessCapability()` and its flawed `capability_type='scraping'` heuristic, now removed.
- The real detection gap was elsewhere: 4 capabilities that hard-require Browserless (web-extract, annual-report-extract, estonian-company-data, company-enrich) are `ai_assisted` — invisible to the old heuristic. New `getBrowserlessDependentSlugs()` reads the curated dependency-manifest list; chromium-health's count and event-triggers' independent copy of the same bug now share it.
- `capability_type` itself deliberately untouched: it feeds GDPR jurisdiction, audit-trail, and compliance code across 21 files — the wrong lever for a test-skip fix.
- The skip call site gained fail-open protection (an exception there previously aborted the whole test batch).

## Verification
- Codex cross-provider review: first-round APPROVE, no blocking findings; supersession argument traced end to end (provider probe → gate flip within 6h → silent skip, no test_results row, for all 4 hard-dependent slugs).
- 35/35 targeted tests, fail-before proofs, full typecheck (6 surfaces), all CI guards clean.
- Reviewer nits accepted: two test-precision notes (documented), one doc sentence fixed pre-merge.
- Composes with the pending Browserless burn-cut branch (disjoint files).

## Test plan
- CI green; the gate's behavior is exercised by the new unit tests (no prod behavior change unless Browserless is actually down — in which case suites now skip cleanly instead of timing out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)