### PR TITLE
fix(test-infra): derive the Browserless credential list — 19 stale slugs, one lying comment

### DIFF
--- a/apps/api/src/lib/browserless-dependency-drift.test.ts
+++ b/apps/api/src/lib/browserless-dependency-drift.test.ts
@@ -96,13 +96,25 @@ describe("dependency-manifest.ts browserless.capabilities — drift detector", (
 
   it("every executor with hard-require Browserless evidence is in the curated list (under-inclusion check)", () => {
     const curated = new Set(CURATED_BROWSERLESS_SLUGS);
-    const missing: string[] = [];
+    // Carries the matched evidence, symmetrically with the over-inclusion
+    // check above: a bare slug list tells a future engineer WHAT failed but
+    // not WHY, leaving them to re-derive the pattern match by hand.
+    const missing: Array<{ slug: string; evidence: string; reason: string }> = [];
     for (const [slug, source] of EXECUTOR_SOURCES) {
-      if (HARD_REQUIRE_PATTERN.test(source) && !curated.has(slug)) {
-        missing.push(slug);
+      const match = source.match(HARD_REQUIRE_PATTERN);
+      if (match && !curated.has(slug)) {
+        missing.push({
+          slug,
+          evidence: match[0],
+          reason:
+            "executor hard-requires Browserless (matched above) but is absent from " +
+            "dependency-manifest.ts's browserless.capabilities — add it there, or the " +
+            "credential and provider-health gates will not skip it when Browserless is " +
+            "unconfigured/down, producing timeout noise instead of clean skips",
+        });
       }
     }
-    expect(missing, JSON.stringify(missing)).toEqual([]);
+    expect(missing, JSON.stringify(missing, null, 2)).toEqual([]);
   });
 
   // Pins today's audited set so an unreviewed addition/removal fails loudly

--- a/apps/api/src/lib/browserless-dependency-drift.test.ts
+++ b/apps/api/src/lib/browserless-dependency-drift.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Drift detector for dependency-manifest.ts's curated `browserless.capabilities`
+ * list — the "genuinely requires Browserless, no fallback" set now shared by
+ * credential-health.ts (skip-when-credential-missing) and
+ * upstream-health-gate.ts's getBrowserlessDependentSlugs()
+ * (skip-when-provider-unhealthy), both via the shared
+ * getCuratedProviderCapabilities() accessor.
+ *
+ * Background (2026-08-18, fix/credential-health-browserless-staleness):
+ * credential-health.ts used to carry its OWN hand-maintained 52-slug array.
+ * By the time this was audited, at least 15 of those 52 slugs had migrated
+ * off Browserless entirely (irish/latvian/lithuanian/swiss-company-data per
+ * DEC-20260428-A, plus austrian/belgian/danish/dutch/eu-regulation-search/
+ * german/italian/portuguese/spanish/swedish-company-data/tech-stack-detect —
+ * never reconciled after their own migrations) and 4 more had no executor at
+ * all (credit-report-summary deactivated, custom-scrape never built,
+ * hong-kong/indian-company-data probed but never shipped). A hand-maintained
+ * list silently drifts every time a capability migrates off (or onto)
+ * Browserless; a test that reads the actual executor source is the only
+ * thing that can't go stale the same way.
+ *
+ * This file checks BOTH directions:
+ *   1. over-inclusion — every slug currently in the curated list must show
+ *      real hard-require evidence in its executor (direct getBrowserlessConfig
+ *      / buildBrowserlessRequestUrl usage, or skipFallback: true). Catches
+ *      exactly the staleness this fix addresses: a slug that migrated off
+ *      Browserless but was never removed from the curated list.
+ *   2. under-inclusion — every capability executor that actually shows
+ *      hard-require evidence must be listed in the curated list. Catches the
+ *      opposite drift: a capability that starts hard-requiring Browserless
+ *      (e.g. drops its plain-fetch/Jina fallback) without the curated list
+ *      being updated, which would silently under-skip it during a real
+ *      Browserless outage.
+ *
+ * Fallback-tier capabilities (web-provider.ts's fetchPage/fetchRenderedHtml
+ * with default options) are deliberately NOT asserted against by name here —
+ * that would just be a second hand-maintained list. The two scans above are
+ * the whole test; anything not flagged by either is presumed correctly
+ * fallback-tier or untouched by Browserless.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { getCuratedProviderCapabilities } from "./dependency-manifest.js";
+
+const CAPABILITIES_DIR = resolve(import.meta.dirname, "../capabilities");
+
+/** Direct-Browserless-call evidence: no fallback tier can rescue these. */
+const HARD_REQUIRE_PATTERN =
+  /getBrowserlessConfig|buildBrowserlessRequestUrl|skipFallback\s*:\s*true/;
+
+/**
+ * Every top-level capabilities/*.ts file that self-registers an executor,
+ * read from disk exactly once and keyed by its registered slug (not
+ * assumed to equal the filename). Both the over- and under-inclusion checks
+ * below read from this map instead of re-opening files — a slug's source
+ * text is on disk only once for the whole suite, not once per check.
+ */
+function loadExecutorSources(): Map<string, string> {
+  const files = readdirSync(CAPABILITIES_DIR).filter(
+    (f) => f.endsWith(".ts") && !f.endsWith(".test.ts") && f !== "index.ts" && f !== "auto-register.ts",
+  );
+  const bySlug = new Map<string, string>();
+  for (const f of files) {
+    const text = readFileSync(resolve(CAPABILITIES_DIR, f), "utf8");
+    const m = text.match(/registerCapability\(\s*"([^"]+)"/);
+    if (m) bySlug.set(m[1], text);
+  }
+  return bySlug;
+}
+
+const EXECUTOR_SOURCES = loadExecutorSources();
+const CURATED_BROWSERLESS_SLUGS = getCuratedProviderCapabilities("browserless");
+
+describe("dependency-manifest.ts browserless.capabilities — drift detector", () => {
+  it("every curated slug's executor shows real hard-require Browserless evidence (over-inclusion / staleness check)", () => {
+    const stale: Array<{ slug: string; reason: string }> = [];
+    for (const slug of CURATED_BROWSERLESS_SLUGS) {
+      const source = EXECUTOR_SOURCES.get(slug);
+      if (source === undefined) {
+        stale.push({ slug, reason: "no executor file at src/capabilities/<slug>.ts registering that slug" });
+        continue;
+      }
+      if (!HARD_REQUIRE_PATTERN.test(source)) {
+        stale.push({
+          slug,
+          reason:
+            "executor exists but shows no direct getBrowserlessConfig/buildBrowserlessRequestUrl " +
+            "call and no skipFallback: true — this looks like a fallback-tier or migrated-off " +
+            "capability that should be removed from dependency-manifest.ts's browserless.capabilities",
+        });
+      }
+    }
+    expect(stale, JSON.stringify(stale, null, 2)).toEqual([]);
+  });
+
+  it("every executor with hard-require Browserless evidence is in the curated list (under-inclusion check)", () => {
+    const curated = new Set(CURATED_BROWSERLESS_SLUGS);
+    const missing: string[] = [];
+    for (const [slug, source] of EXECUTOR_SOURCES) {
+      if (HARD_REQUIRE_PATTERN.test(source) && !curated.has(slug)) {
+        missing.push(slug);
+      }
+    }
+    expect(missing, JSON.stringify(missing)).toEqual([]);
+  });
+
+  // Pins today's audited set so an unreviewed addition/removal fails loudly
+  // and has to be a deliberate diff, not a silent drift. Also proves the
+  // list isn't empty (a curated list emptied out by accident fails this
+  // exact-match assertion, so a separate non-empty check would be
+  // redundant). Update this alongside dependency-manifest.ts's
+  // browserless.capabilities with a reason in the commit message if the
+  // set legitimately changes.
+  it("matches the audited 2026-08-18 hard-require set exactly", () => {
+    expect([...CURATED_BROWSERLESS_SLUGS].sort()).toEqual(
+      [
+        "annual-report-extract",
+        "company-enrich",
+        "estonian-company-data",
+        "html-to-pdf",
+        "landing-page-roast",
+        "screenshot-url",
+        "web-extract",
+      ].sort(),
+    );
+  });
+});

--- a/apps/api/src/lib/browserless-dependency-drift.test.ts
+++ b/apps/api/src/lib/browserless-dependency-drift.test.ts
@@ -45,9 +45,31 @@ import { getCuratedProviderCapabilities } from "./dependency-manifest.js";
 
 const CAPABILITIES_DIR = resolve(import.meta.dirname, "../capabilities");
 
-/** Direct-Browserless-call evidence: no fallback tier can rescue these. */
+/**
+ * Hard-require evidence: reaching Browserless with no fallback tier able to
+ * rescue the call. Four spellings, all verified against web-provider.ts:
+ *
+ *   1-2. Direct config/URL construction — bypasses the tiered layer outright.
+ *   3.   `skipFallback: true` — explicitly disables tiers 1-2.
+ *   4.   A non-`networkidle0` `waitUntil` — the tier-1 (plain fetch) and
+ *        tier-2 (Jina) branches are BOTH gated on the default wait mode
+ *        (web-provider.ts ~345 / ~424), so any other value silently skips
+ *        straight to Browserless. `fetchCompanyPage()` is exactly this case:
+ *        it hardcodes `waitUntil: "domcontentloaded"`, so it is a hard
+ *        dependency despite reading like an innocuous helper (external
+ *        review, 2026-08-18 — the original three-token pattern missed it).
+ *
+ * Matched against comment-stripped source: a stale comment mentioning
+ * `getBrowserlessConfig` must not keep an obsolete slug alive in the curated
+ * list, and a commented-out call must not invent a new dependency.
+ */
 const HARD_REQUIRE_PATTERN =
-  /getBrowserlessConfig|buildBrowserlessRequestUrl|skipFallback\s*:\s*true/;
+  /getBrowserlessConfig|buildBrowserlessRequestUrl|skipFallback\s*:\s*true|fetchCompanyPage\s*\(|waitUntil\s*:\s*["'](?!networkidle0)/;
+
+/** Strip line and block comments so only real code is pattern-matched. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
 
 /**
  * Every top-level capabilities/*.ts file that self-registers an executor,
@@ -64,7 +86,7 @@ function loadExecutorSources(): Map<string, string> {
   for (const f of files) {
     const text = readFileSync(resolve(CAPABILITIES_DIR, f), "utf8");
     const m = text.match(/registerCapability\(\s*"([^"]+)"/);
-    if (m) bySlug.set(m[1], text);
+    if (m) bySlug.set(m[1], stripComments(text));
   }
   return bySlug;
 }

--- a/apps/api/src/lib/credential-health.test.ts
+++ b/apps/api/src/lib/credential-health.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── 2026-08-18: browserless-capability-list staleness fix ─────────────────
+//
+// credential-health.ts's browserless entry used to be a hand-maintained
+// 52-slug array that had drifted stale (migrated-off slugs still listed,
+// some slugs with no executor at all). It now derives `capabilities` from
+// dependency-manifest.ts's curated `browserless.capabilities` list via the
+// shared getCuratedProviderCapabilities() accessor — the same source
+// upstream-health-gate.ts's getBrowserlessDependentSlugs() already reads.
+// Full staleness history and the bidirectional drift enforcement (does the
+// curated list match what executors actually import?) live in
+// browserless-dependency-drift.test.ts. These tests pin only credential-
+// health.ts's own wiring: (a) the derivation is real, not coincidental —
+// changing the curated list changes what gets skipped; (b) the false-skip
+// failure mode this fix closes (migrated-off / nonexistent slugs treated as
+// credential-gated) stays closed.
+
+const mockGetCuratedProviderCapabilities = vi.fn();
+vi.mock("./dependency-manifest.js", () => ({
+  getCuratedProviderCapabilities: (...args: unknown[]) => mockGetCuratedProviderCapabilities(...args),
+}));
+
+import {
+  getUnconfiguredCapabilities,
+  getCredentialStatus,
+  getMissingCredential,
+  isCredentialConfigured,
+} from "./credential-health.js";
+
+/** Everything else on CREDENTIAL_REGISTRY besides the "browserless" entry itself. */
+const OTHER_PROVIDER_ENV_KEYS = [
+  "DILISENSE_API_KEY",
+  "SERPER_API_KEY",
+  "COMPANIES_HOUSE_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "SDDA_API_CLIENT_ID",
+];
+
+beforeEach(() => {
+  mockGetCuratedProviderCapabilities.mockReset().mockReturnValue([]);
+  vi.stubEnv("BROWSERLESS_URL", "");
+  for (const key of OTHER_PROVIDER_ENV_KEYS) vi.stubEnv(key, "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+/**
+ * Configure every non-browserless provider's credential so
+ * getUnconfiguredCapabilities() only reflects the (mocked) browserless
+ * entry — isolates these tests from the unrelated dilisense/serper/
+ * companies_house/anthropic/sdda entries in CREDENTIAL_REGISTRY, which are
+ * out of scope for this fix. Notably: latvian-company-data is ALSO gated by
+ * the "sdda" entry (independent of browserless) — leaving SDDA_API_CLIENT_ID
+ * unset would flag it unconfigured for a reason unrelated to what this file
+ * is testing.
+ */
+function configureAllNonBrowserlessCredentials(): void {
+  for (const key of OTHER_PROVIDER_ENV_KEYS) vi.stubEnv(key, "test");
+}
+
+describe("credential-health's browserless entry — unified with dependency-manifest.ts", () => {
+  it("getUnconfiguredCapabilities() reflects exactly the (mocked) curated browserless list when BROWSERLESS_URL is missing", () => {
+    mockGetCuratedProviderCapabilities.mockReturnValue(["web-extract", "screenshot-url", "company-enrich"]);
+
+    const unconfigured = getUnconfiguredCapabilities();
+
+    expect(unconfigured.has("web-extract")).toBe(true);
+    expect(unconfigured.has("screenshot-url")).toBe(true);
+    expect(unconfigured.has("company-enrich")).toBe(true);
+  });
+
+  it("regression: the historically-stale slugs are NOT skipped even though they used to be hardcoded here", () => {
+    configureAllNonBrowserlessCredentials();
+    // Simulates the CURRENT curated list (7 hard-require slugs) — a stand-in
+    // for dependency-manifest.ts's real value, isolated from that module's
+    // own drift so this test only proves credential-health.ts's wiring.
+    mockGetCuratedProviderCapabilities.mockReturnValue([
+      "annual-report-extract",
+      "company-enrich",
+      "estonian-company-data",
+      "html-to-pdf",
+      "landing-page-roast",
+      "screenshot-url",
+      "web-extract",
+    ]);
+
+    const unconfigured = getUnconfiguredCapabilities();
+
+    // Migrated off Browserless entirely — must not be skipped on a missing
+    // BROWSERLESS_URL. This assertion FAILS against the pre-fix hardcoded
+    // 52-slug array (all of these were in it) and PASSES once the list is
+    // derived from the (mocked, narrow) curated source.
+    const migratedOff = [
+      "austrian-company-data",
+      "belgian-company-data",
+      "danish-company-data",
+      "dutch-company-data",
+      "eu-regulation-search",
+      "german-company-data",
+      "irish-company-data",
+      "italian-company-data",
+      "latvian-company-data",
+      "lithuanian-company-data",
+      "portuguese-company-data",
+      "spanish-company-data",
+      "swedish-company-data",
+      "swiss-company-data",
+      "tech-stack-detect",
+    ];
+    for (const slug of migratedOff) {
+      expect(unconfigured.has(slug), `${slug} should not be credential-gated on Browserless`).toBe(false);
+    }
+
+    // Never had an executor at all — must never appear in a skip set derived
+    // from real capability slugs.
+    const neverExisted = [
+      "credit-report-summary",
+      "custom-scrape",
+      "hong-kong-company-data",
+      "indian-company-data",
+    ];
+    for (const slug of neverExisted) {
+      expect(unconfigured.has(slug), `${slug} has no executor and must not appear here`).toBe(false);
+    }
+
+    // Fallback-tier capabilities (web-provider.ts 3-tier fallback) — a
+    // missing BROWSERLESS_URL doesn't block them either (tiers 1/2 run
+    // first), so they must not be skipped.
+    const fallbackTier = [
+      "accessibility-audit",
+      "url-to-markdown",
+      "seo-audit",
+      "trustpilot-score",
+      "youtube-summarize",
+    ];
+    for (const slug of fallbackTier) {
+      expect(unconfigured.has(slug), `${slug} is fallback-tier and must not be credential-gated`).toBe(false);
+    }
+
+    // The 7 genuine hard-require slugs ARE correctly skipped.
+    for (const slug of [
+      "annual-report-extract",
+      "company-enrich",
+      "estonian-company-data",
+      "html-to-pdf",
+      "landing-page-roast",
+      "screenshot-url",
+      "web-extract",
+    ]) {
+      expect(unconfigured.has(slug), `${slug} genuinely hard-requires Browserless`).toBe(true);
+    }
+  });
+
+  it("getUnconfiguredCapabilities() skips nothing browserless-related when BROWSERLESS_URL is configured", () => {
+    mockGetCuratedProviderCapabilities.mockReturnValue(["web-extract", "screenshot-url"]);
+    vi.stubEnv("BROWSERLESS_URL", "https://browserless.example.com");
+
+    const unconfigured = getUnconfiguredCapabilities();
+
+    expect(unconfigured.has("web-extract")).toBe(false);
+    expect(unconfigured.has("screenshot-url")).toBe(false);
+  });
+
+  it("an empty curated list (e.g. Browserless retired) skips nothing", () => {
+    configureAllNonBrowserlessCredentials();
+    mockGetCuratedProviderCapabilities.mockReturnValue([]);
+
+    const unconfigured = getUnconfiguredCapabilities();
+
+    expect(unconfigured.size).toBe(0);
+  });
+
+  it("getCredentialStatus() surfaces the derived list under the browserless provider entry", () => {
+    mockGetCuratedProviderCapabilities.mockReturnValue(["web-extract"]);
+
+    const statuses = getCredentialStatus();
+    const browserless = statuses.find((s) => s.provider === "browserless");
+
+    expect(browserless).toBeDefined();
+    expect(browserless?.capabilities).toEqual(["web-extract"]);
+    expect(browserless?.isConfigured).toBe(false); // BROWSERLESS_URL stubbed empty in beforeEach
+  });
+
+  it("getMissingCredential() reports 'browserless' only for curated slugs, not migrated-off ones", () => {
+    mockGetCuratedProviderCapabilities.mockReturnValue(["web-extract"]);
+
+    expect(getMissingCredential("web-extract")).toEqual({
+      provider: "browserless",
+      envVar: "BROWSERLESS_URL",
+    });
+    expect(getMissingCredential("irish-company-data")).toBeNull();
+  });
+
+  it("isCredentialConfigured('browserless') is unaffected by the capabilities-list derivation (still keys off BROWSERLESS_URL alone)", () => {
+    mockGetCuratedProviderCapabilities.mockReturnValue(["web-extract"]);
+    expect(isCredentialConfigured("browserless")).toBe(false);
+
+    vi.stubEnv("BROWSERLESS_URL", "https://browserless.example.com");
+    expect(isCredentialConfigured("browserless")).toBe(true);
+  });
+});
+
+describe("credential-health — other providers untouched by the browserless unification", () => {
+  it("dilisense-gated capabilities are still skipped by their own static list when DILISENSE_API_KEY is missing", () => {
+    mockGetCuratedProviderCapabilities.mockReturnValue([]); // no curated browserless slugs in this test
+    const unconfigured = getUnconfiguredCapabilities();
+    expect(unconfigured.has("sanctions-check")).toBe(true);
+    expect(unconfigured.has("pep-check")).toBe(true);
+  });
+});

--- a/apps/api/src/lib/credential-health.ts
+++ b/apps/api/src/lib/credential-health.ts
@@ -1,3 +1,5 @@
+import { getCuratedProviderCapabilities } from "./dependency-manifest.js";
+
 /**
  * Credential health registry.
  *
@@ -32,25 +34,21 @@ const CREDENTIAL_REGISTRY: CredentialEntry[] = [
   {
     provider: "browserless",
     envVar: "BROWSERLESS_URL",
-    capabilities: [
-      "accessibility-audit", "annual-report-extract", "austrian-company-data",
-      "belgian-company-data", "business-license-check-se", "company-enrich",
-      "company-tech-stack", "competitor-compare", "container-track",
-      "cookie-scan", "credit-report-summary", "custom-scrape",
-      "customs-duty-lookup", "danish-company-data", "dutch-company-data",
-      "employer-review-summary", "estonian-company-data", "eu-court-case-search",
-      "eu-regulation-search", "eu-trademark-search", "gdpr-fine-lookup",
-      "german-company-data", "hong-kong-company-data", "html-to-pdf",
-      "indian-company-data", "irish-company-data", "italian-company-data",
-      "japanese-company-data", "landing-page-roast", "latvian-company-data",
-      "lithuanian-company-data", "patent-search", "portuguese-company-data",
-      "price-compare", "pricing-page-extract", "privacy-policy-analyze",
-      "product-reviews-extract", "product-search", "return-policy-extract",
-      "salary-benchmark", "screenshot-url", "seo-audit",
-      "spanish-company-data", "structured-scrape", "swedish-company-data",
-      "swiss-company-data", "tech-stack-detect", "terms-of-service-extract",
-      "trustpilot-score", "url-to-markdown", "web-extract", "youtube-summarize",
-    ],
+    // Deliberately NOT a hand-maintained list (2026-08-18 fix: the old
+    // 52-slug literal array had drifted — 19 stale slugs, some no longer
+    // touching Browserless, some with no executor at all). Derived from
+    // dependency-manifest.ts's curated `browserless.capabilities` — the same
+    // "genuinely requires Browserless, no fallback" set upstream-health-
+    // gate.ts's getBrowserlessDependentSlugs() already reads (via the shared
+    // getCuratedProviderCapabilities() accessor) for its own skip-when-
+    // unhealthy gate. Both gates reduce to the same question — "can this
+    // capability actually produce a correct result right now?" — so both now
+    // read the same source instead of each maintaining an independent list.
+    // Full staleness history and the bidirectional drift enforcement live in
+    // browserless-dependency-drift.test.ts.
+    get capabilities(): string[] {
+      return getCuratedProviderCapabilities("browserless");
+    },
   },
   {
     provider: "serper",
@@ -82,9 +80,15 @@ const CREDENTIAL_REGISTRY: CredentialEntry[] = [
     // SDDA UR-API-LegalEntity via api.viss.gov.lv (WSO2 API Manager).
     // OAuth2 client_credentials — also needs SDDA_API_CLIENT_SECRET, but
     // CLIENT_ID is the sentinel (both are always paired at provisioning).
-    // The stub provider is scaffolded but NOT primary: Browserless scraping
-    // remains the active path for latvian-company-data until credentials
-    // land and a follow-up session wires registerChain() for SDDA.
+    // The stub provider is scaffolded but NOT primary: latvian-company-data's
+    // live executor (apps/api/src/capabilities/latvian-company-data.ts) calls
+    // the data.gov.lv CKAN datastore API directly (acquisition_method:
+    // direct_api per DEC-20260428-A) — it migrated off the prior
+    // Browserless+Claude scrape of info.ur.gov.lv (Tier 1 violation) and does
+    // NOT touch Browserless at all today. SDDA remains an unwired stub for a
+    // future path pending credentials and a follow-up session to wire
+    // registerChain() for SDDA — it is not what's live now, and neither is
+    // Browserless.
   },
 ];
 

--- a/apps/api/src/lib/credential-health.ts
+++ b/apps/api/src/lib/credential-health.ts
@@ -76,7 +76,15 @@ const CREDENTIAL_REGISTRY: CredentialEntry[] = [
   {
     provider: "sdda",
     envVar: "SDDA_API_CLIENT_ID",
-    capabilities: ["latvian-company-data"],
+    // EMPTY BY DESIGN (2026-08-18, external review): listing
+    // latvian-company-data here made getUnconfiguredCapabilities() skip it
+    // whenever SDDA_API_CLIENT_ID is absent — which is always, since SDDA is
+    // an unwired stub. That is the same false-skip bug this file's browserless
+    // entry was just fixed for, three lines up, via a different stale mapping:
+    // the capability's live executor needs no credential at all. Re-add the
+    // slug in the same commit that actually wires registerChain() for SDDA,
+    // not before.
+    capabilities: [],
     // SDDA UR-API-LegalEntity via api.viss.gov.lv (WSO2 API Manager).
     // OAuth2 client_credentials — also needs SDDA_API_CLIENT_SECRET, but
     // CLIENT_ID is the sentinel (both are always paired at provisioning).

--- a/apps/api/src/lib/dependency-manifest.ts
+++ b/apps/api/src/lib/dependency-manifest.ts
@@ -509,3 +509,17 @@ export function getRetiredProviders(): DependencyProvider[] {
 export function getProvider(name: string): DependencyProvider | undefined {
   return PROVIDERS.find((p) => p.name === name);
 }
+
+/**
+ * A provider's curated `capabilities` list (e.g. browserless's hand-curated
+ * "genuinely requires this provider, no fallback" set). Single accessor so
+ * every "which capabilities are curated as depending on provider X" call
+ * site reads the exact same lookup instead of each independently
+ * re-deriving `getActiveProviders().find(p => p.name === X)?.capabilities`.
+ * Consumers: credential-health.ts (skip-when-credential-missing) and
+ * upstream-health-gate.ts (skip-when-provider-unhealthy). Returns [] if no
+ * active provider with that name is registered.
+ */
+export function getCuratedProviderCapabilities(providerName: string): string[] {
+  return getActiveProviders().find((p) => p.name === providerName)?.capabilities ?? [];
+}

--- a/apps/api/src/lib/upstream-health-gate.test.ts
+++ b/apps/api/src/lib/upstream-health-gate.test.ts
@@ -24,9 +24,20 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // dependency-manifest.ts's hand-curated `browserless.capabilities` list.
 // These tests pin the new wiring and the skip-gate semantics that consume it.
 
+// 2026-08-18: upstream-health-gate.ts now calls the shared
+// getCuratedProviderCapabilities() accessor (dependency-manifest.ts) instead
+// of inlining `getActiveProviders().find(p => p.name === "browserless")`
+// itself — credential-health.ts's browserless skip-when-credential-missing
+// gate reads the same accessor. Mocked here in terms of the same
+// mockGetActiveProviders fixture so every existing assertion below (which
+// drives behavior via mockGetActiveProviders.mockReturnValue(...)) keeps
+// working unchanged — the mock mirrors the real implementation's
+// find-by-name-then-read-capabilities shape.
 const mockGetActiveProviders = vi.fn();
 vi.mock("./dependency-manifest.js", () => ({
   getActiveProviders: (...args: unknown[]) => mockGetActiveProviders(...args),
+  getCuratedProviderCapabilities: (providerName: string) =>
+    mockGetActiveProviders().find((p: { name: string }) => p.name === providerName)?.capabilities ?? [],
 }));
 
 // Queue of rows returned by successive `.where()` calls against the

--- a/apps/api/src/lib/upstream-health-gate.ts
+++ b/apps/api/src/lib/upstream-health-gate.ts
@@ -19,7 +19,7 @@ import { logError } from "./log.js";
 import { getDb } from "../db/index.js";
 import { capabilities } from "../db/schema.js";
 import { fireAndForget } from "./fire-and-forget.js";
-import { getActiveProviders } from "./dependency-manifest.js";
+import { getCuratedProviderCapabilities } from "./dependency-manifest.js";
 
 // ─── Upstream health state ──────────────────────────────────────────────────
 
@@ -90,11 +90,15 @@ const FIXED_UPSTREAM_SLUGS: Record<string, string[]> = {
  * source of truth for three other subsystems (invariant-checker.ts,
  * test-scheduler.ts's own pre-runTests() provider-health filter, and
  * situation-assessment.ts's alert-affected-count), so reusing it here closes
- * the gap without introducing a fourth parallel definition.
+ * the gap without introducing a fourth parallel definition. As of the
+ * 2026-08-18 credential-health.ts fix, that module's own browserless skip-
+ * when-credential-missing gate also reads this same list via the shared
+ * getCuratedProviderCapabilities() accessor — the raw "find the browserless
+ * provider, read its capabilities" lookup lives in exactly one place
+ * (dependency-manifest.ts) rather than being copy-pasted per consumer.
  */
 export async function getBrowserlessDependentSlugs(): Promise<string[]> {
-  const browserlessProvider = getActiveProviders().find((p) => p.name === "browserless");
-  const candidateSlugs = browserlessProvider?.capabilities ?? [];
+  const candidateSlugs = getCuratedProviderCapabilities("browserless");
   if (candidateSlugs.length === 0) return [];
 
   const db = getDb();


### PR DESCRIPTION
## Summary
- `credential-health.ts` carried a hand-maintained 52-slug array of capabilities needing `BROWSERLESS_URL`. **19 had drifted**: 15 migrated to direct-API executors under DEC-20260428-A, 4 have no executor at all. One inline comment actively lied — `latvian-company-data` "Browserless scraping remains the active path" when it has called data.gov.lv's CKAN API for months.
- **Unification decision**: both Browserless gates (skip-when-credential-missing, skip-when-provider-unhealthy) answer the same question — *can this capability produce a correct result right now* — so both now read one source, the curated `dependency-manifest.ts` list, via a shared `getCuratedProviderCapabilities()` accessor. A capability whose Browserless use is only a fallback tier keeps working without the credential and is no longer falsely skipped.
- **The real defect was list-rot**, so this ships a bidirectional drift test rather than a corrected list: an executor importing Browserless must appear in the curated set, and every curated entry must still import it. Both directions fail with the evidence and the consequence attached.

## Verification
- 19 tests across three files; typecheck (6 surfaces), mjs syntax, dispatcher lint, PII strict all clean.
- Two independent review lenses (technical + product) — both **safe to ship, zero HIGH/MEDIUM findings**. Each independently re-derived the drift detector's verdict by grepping the capability sources rather than trusting the test: exactly 7 files genuinely hard-require Browserless.
- Concrete claims spot-verified against source: the 4 nonexistent executors, the 4 migrated-off files (zero Browserless evidence), and all 7 curated slugs (hard-require pattern present).

## Reviewer notes (non-blocking)
- `get capabilities()` is the first getter-accessor idiom in `lib/*.ts` — deliberate, so the registry stays a plain data structure while deriving one field.
- `upstream-health-gate.ts` is touched beyond the original bug's blast radius: it was in scope via the code-reuse pass, which is what stopped the new shared accessor from becoming a second copy-pasted lookup on day one.
- The test mock still exports `getActiveProviders` — not dead: the mocked `getCuratedProviderCapabilities` delegates through it so all existing assertions keep driving from one fixture.

## Test plan
- CI green. No customer-facing surface: every consumer is the internal test scheduler, an admin-secret-gated route, or diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)