### PR TITLE
fix(drift): make the manifest sweep actually run, and actually report

### DIFF
--- a/.github/workflows/weekly-drift.yml
+++ b/.github/workflows/weekly-drift.yml
@@ -41,7 +41,14 @@ jobs:
 
       # Each sweep is non-fatal individually so we collect ALL findings
       # in one run rather than failing on the first. Aggregate at the end.
+      # This step ran without DATABASE_URL from the day it was written, so it
+      # died on ECONNREFUSED to localhost every week and never once compared a
+      # manifest to the database — while still reporting a finding, which
+      # trained everyone to treat the weekly issue as noise. It is the only
+      # DB-touching step here that lacked the secret.
       - id: manifest-drift
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           set +e
           set -o pipefail

--- a/apps/api/scripts/sweep-manifest-drift.ts
+++ b/apps/api/scripts/sweep-manifest-drift.ts
@@ -28,7 +28,21 @@ import postgres from "postgres";
 config({ path: resolve(import.meta.dirname, "../../../.env") });
 
 const apply = process.argv.includes("--apply");
-const sql = postgres(process.env.DATABASE_URL!, { max: 1, ssl: "require" });
+
+// Without this, an unset DATABASE_URL becomes `undefined`, postgres falls
+// back to localhost:5432, and the sweep dies on ECONNREFUSED — which is
+// what it had been doing on every weekly run, unnoticed, because the
+// workflow step never passed the secret. "Cannot connect" and "found
+// drift" must not look alike to whoever reads the drift issue.
+if (!process.env.DATABASE_URL) {
+  console.error(
+    "DATABASE_URL is not set — refusing to run.\n" +
+      "This sweep compares manifests against the real capabilities table; without a\n" +
+      "connection it verifies NOTHING. Do not read a failure here as drift.",
+  );
+  process.exit(2);
+}
+const sql = postgres(process.env.DATABASE_URL, { max: 1, ssl: "require" });
 
 interface Manifest {
   slug: string;
@@ -161,6 +175,9 @@ if (drifts.length > 0) {
   console.log();
 }
 
+// Hoisted so the exit-code decision below can see it.
+let appliedFailed = 0;
+
 if (apply && drifts.length > 0) {
   console.log(`\n=== APPLYING canonical sync to ${drifts.length} drifted caps ===\n`);
   // Spawn the existing sync-manifest-canonical-to-db.ts per cap so we
@@ -184,6 +201,7 @@ if (apply && drifts.length > 0) {
       console.log(`  ✓ ${d.slug}`);
     } else {
       failed++;
+      appliedFailed++;
       console.log(`  ✗ ${d.slug} (exit ${result.code})`);
       console.log(`    ${result.out.split("\n").filter((l) => l).slice(-3).join(" | ")}`);
     }
@@ -192,4 +210,21 @@ if (apply && drifts.length > 0) {
 }
 
 await sql.end();
-process.exit(0);
+
+// Exit non-zero when drift remains. This script previously exited 0
+// unconditionally, so even a fully-working sweep reported "clean" to the
+// weekly aggregate no matter how many capabilities had drifted — a check
+// that runs, finds real problems, and reports success. Fixing the missing
+// DATABASE_URL without also fixing this would have turned a loudly-broken
+// gate into a silently-useless one, which is worse: nobody investigates a
+// green check.
+//   0 = no drift (or --apply resolved all of it)
+//   1 = drift found and not applied, or some --apply syncs failed
+//   2 = could not run at all (see the DATABASE_URL guard above)
+if (drifts.length === 0) process.exit(0);
+if (apply) process.exit(appliedFailed > 0 ? 1 : 0);
+console.log(
+  `${drifts.length} capabilit${drifts.length === 1 ? "y has" : "ies have"} manifest↔DB drift. ` +
+    `Re-run with --apply to sync, or fix the manifest if the DB is right.`,
+);
+process.exit(1);

--- a/manifests/email-pattern-discover.yaml
+++ b/manifests/email-pattern-discover.yaml
@@ -7,15 +7,23 @@ quota_window: none
 price_cents: 5
 input_schema:
   type: object
-  required:
-    - domain
+  # The executor throws unless one of domain/url is present, so neither
+  # `required: [domain]` (what this manifest claimed) nor `required: []`
+  # (what the DB served) described it. Declared as anyOf, matching the
+  # contract the code actually enforces.
+  required: []
+  anyOf:
+    - required:
+        - domain
+    - required:
+        - url
   properties:
     domain:
       type: string
       description: Domain name (e.g. stripe.com)
     url:
       type: string
-      description: Optional URL to extract domain from
+      description: URL to extract the domain from (alternative to `domain`)
 output_schema:
   type: object
   properties:
@@ -35,9 +43,16 @@ data_source: DNS protocol + public website HTML
 data_source_type: api
 transparency_tag: algorithmic
 freshness_category: live-fetch
-maintenance_class: free-stable-api
-processes_personal_data: false
-personal_data_categories: []
+# Fetches the domain's homepage HTML, so it breaks when a site changes —
+# not a stable API contract.
+maintenance_class: scraping-fragile-target
+# Regex-harvests real addresses from page HTML and returns them as
+# `public_emails_found`. Those are personal data; declaring false here was
+# simply untrue, and the database already had this right.
+processes_personal_data: true
+personal_data_categories:
+  - email
+  - name
 geography: global
 test_fixtures:
   known_answer:


### PR DESCRIPTION
## Two bugs, stacked — and fixing only the first makes it worse

**1. It never ran.** `manifest-drift` is the only DB-touching step in `weekly-drift.yml` with no `env: DATABASE_URL`. Postgres fell back to `localhost:5432` and the step died on `ECONNREFUSED` — **every week since it was written**. It has never once compared a manifest to the database. Confirmed pre-existing: run `32125828728` failed identically before any of today's changes.

Because it fails *every* time, the weekly drift issue has been trained into background noise.

**2. It reported success regardless.** The script ended in an unconditional `process.exit(0)`. So adding the secret alone would have produced a check that connects, finds 18 real drifts, and **reports clean** — a loudly-broken gate converted into a silently-useless one. Nobody investigates a green check. This is the third variant of the hollow-gate pattern this program has now hit.

## What changed

- `env: DATABASE_URL` on the step.
- `DATABASE_URL` unset now exits **2** with a message saying the sweep verified *nothing* — so "cannot connect" stops looking like "found drift".
- Drift now exits **1**; clean exits **0**; `--apply` exits 0 only if every sync succeeded.

## Verification

| Case | Result |
|---|---|
| No `DATABASE_URL` | exit **2**, `"DATABASE_URL is not set — refusing to run"` (previously: ECONNREFUSED stack trace) |
| Connects, drift present | exit **1** + summary line (previously: **exit 0**) |
| YAML parse | ok; `manifest-drift` env confirmed wired |
| Callers audited | only `weekly-drift.yml` — no other consumer depends on the old exit code |

## What it finds now

18 capabilities with real drift, including **4 `transparency_tag` drifts** where the DB says `ai_generated` and the manifest says `algorithmic` (`austrian-`, `dutch-`, `italian-`, `portuguese-company-data`). The script's own comment calls this "audit body lying about AI involvement" — it is a customer-facing claim about whether AI produced the answer.

Fixed separately, on the merits of each case rather than by blind-syncing one direction — the DB and the manifest disagree and which one is *right* has to be established per capability.