### PR TITLE
docs: commit five session records that only existed on disk

### DIFF
--- a/apps/api/scripts/mutate-metrics-guards.py
+++ b/apps/api/scripts/mutate-metrics-guards.py
@@ -1,0 +1,76 @@
+"""Mutation-test the metrics guards.
+
+Rewritten after the first version crashed mid-run, left a mutation applied, and
+then reported every subsequent mutation as CAUGHT — because the broken guard was
+failing the suite regardless of what was mutated. Three fixes: a baseline check
+before each mutation, a try/finally so a crash cannot leave the tree dirty, and
+a skip is reported as a skip rather than counted as a pass.
+"""
+import io, subprocess, sys
+
+API = r'C:\Users\pette\Projects\strale\apps\api'
+INST = API + r'\src\lib\metrics\instruments.ts'
+POP = API + r'\src\lib\metrics\populations.ts'
+TYP = API + r'\src\lib\metrics\types.ts'
+ACT = API + '/src/lib/metrics/actor-identity.ts'
+BASELINE = 'Tests  24 passed'
+
+MUTATIONS = [
+    (INST, 'return spec.enabledAt <= from ? { ok: true } : { ok: false, enabledAt: spec.enabledAt };',
+           'return { ok: true };',
+     'coversWindow always allows -> failure 2 (metric older than its instrument)'),
+    (INST, 'return new Date(Math.max(...(dates as Date[]).map((d) => d.getTime())));',
+           'return new Date(Math.min(...(dates as Date[]).map((d) => d.getTime())));',
+     'commonWindowStart takes earliest -> failure 3 (steps over different windows)'),
+    (POP, 'if (!ua) return "unknown";', 'if (!ua) return "customer_candidate";',
+     'absent user agent counted as demand -> failure 4'),
+    (POP, '''const KNOWN_MONITORS = [
+  "glimind-probe", "mcpbeat", "yellowmcp-health", "aisec-registry-probe",
+  "reliability-bureau-spike", "mcpscoringengine", "x402-observatory",
+];''', 'const KNOWN_MONITORS = ["probe", "health", "beat", "registry", "monitor", "bot"];',
+     'substring matching restored -> would discard a real company-registry-bot'),
+    (TYP, 'trustworthy: false,\n      };', 'trustworthy: true,\n      };',
+     'estimates presented as observed'),
+    (ACT,
+     '  if (row.userId) return { key: `user:${ACTOR_KEY_VERSION}:${row.userId}`, kind: "user" };',
+     '  if (row.x402PayerHash) return { key: `x402:${ACTOR_KEY_VERSION}:${row.x402PayerHash}`, kind: "x402_wallet" };',
+     'identity precedence flipped -> wallet beats account'),
+    (ACT,
+     '  return { key: null, kind: "unattributed" };',
+     '  return { key: "anon:v1:shared", kind: "unattributed" };',
+     'unattributable calls given a shared invented identity'),
+]
+
+def run():
+    r = subprocess.run(['npx', 'vitest', 'run', 'src/lib/metrics/'],
+                       cwd=API, capture_output=True, text=True, shell=True,
+                       encoding='utf-8', errors='replace')
+    return (r.stdout or '') + (r.stderr or '')
+
+if BASELINE not in run():
+    print('ABORT: suite is not green before mutating. Fix that first.')
+    sys.exit(2)
+print('baseline green\n')
+
+caught, survived, skipped = [], [], []
+for path, old, new, desc in MUTATIONS:
+    src = io.open(path, encoding='utf-8').read()
+    if old not in src:
+        skipped.append(desc); print('SKIP     - ' + desc); continue
+    try:
+        io.open(path, 'w', encoding='utf-8').write(src.replace(old, new, 1))
+        out = run()
+        if BASELINE in out:
+            survived.append(desc); print('SURVIVED - ' + desc)
+        else:
+            caught.append(desc); print('CAUGHT   - ' + desc)
+    finally:
+        io.open(path, 'w', encoding='utf-8').write(src)  # always revert
+
+print()
+print('caught %d, survived %d, skipped %d (of %d)'
+      % (len(caught), len(survived), len(skipped), len(MUTATIONS)))
+if BASELINE not in run():
+    print('ABORT: tree not clean after revert.'); sys.exit(2)
+print('tree restored, suite green')
+sys.exit(1 if (survived or skipped) else 0)

--- a/apps/api/scripts/session-close-check.ts
+++ b/apps/api/scripts/session-close-check.ts
@@ -16,6 +16,14 @@
  *   - DB ↔ code parity for caps touched this session
  *   - Caps touched this session that ended in lifecycle=validating
  *   - Circuit breakers opened this session
+ *   - Repo hygiene (NOT session-scoped — see below)
+ *
+ * Repo hygiene is the deliberate exception to the session-scoping above.
+ * Scoping every check to "what did this session do" means accumulated state
+ * belongs to nobody: a handoff left uncommitted yesterday, or a checkout
+ * parked on a finished branch, is invisible to every future session, each of
+ * which honestly reports clean while the repo drifts. Those checks ask
+ * instead whether the repo is tidy right now, regardless of who untidied it.
  *
  * Exit codes:
  *   0 — all green, safe to close
@@ -25,6 +33,10 @@
  * Usage (from apps/api/):
  *   npx tsx --env-file=../../.env scripts/session-close-check.ts
  *   SESSION_WINDOW_HOURS=12 npx tsx --env-file=../../.env scripts/session-close-check.ts
+ *
+ * Fast hygiene-only pass (no DB, no credentials — good for session start or
+ * a daily check):
+ *   npx tsx scripts/session-close-check.ts --hygiene-only
  */
 
 import { execSync } from "node:child_process";
@@ -364,6 +376,98 @@ async function checkOpenBreakers(sql: postgres.Sql): Promise<void> {
 }
 
 // ────────────────────────────────────────────────────────────────
+// Repo hygiene — DELIBERATELY NOT SESSION-SCOPED
+//
+// Every other check in this file is scoped to "what did THIS session do",
+// which is right for "did I leave a mess". But it means accumulated state
+// belongs to nobody: a handoff left uncommitted yesterday, or a checkout
+// parked on a finished branch three weeks ago, is invisible to every
+// session forever, and each one honestly reports clean while the repo
+// drifts. That is exactly how the primary checkout ended up sitting 77
+// commits behind main on a fully-superseded branch with five uncommitted
+// session records (2026-08-18).
+//
+// These checks ask the different question: is the REPO tidy right now,
+// regardless of who made it untidy. Findings are yellow — they inform, they
+// do not block closing a session.
+// ────────────────────────────────────────────────────────────────
+function checkRepoHygiene(): void {
+  // Refresh origin/main so "behind" is real rather than whatever was last
+  // fetched. Non-fatal: offline should degrade, not crash the checker.
+  sh("git fetch origin main --quiet", { cwd: REPO_ROOT, allowFail: true });
+
+  const branch = sh("git branch --show-current", { cwd: REPO_ROOT, allowFail: true });
+  const behind = parseInt(
+    sh("git rev-list --count HEAD..origin/main", { cwd: REPO_ROOT, allowFail: true }) || "0",
+    10,
+  );
+
+  if (branch && branch !== "main") {
+    findings.push({
+      level: "yellow",
+      section: "Checkout not on main",
+      detail:
+        `This checkout is on '${branch}', ${behind} commit(s) behind main.\n` +
+        `    If that branch's work is merged, switch back: git checkout main && git pull\n` +
+        `    Note: GitHub squash-merges, so git still calls a merged branch "ahead" of\n` +
+        `    main forever. "N commits ahead" is NOT evidence the work is unmerged —\n` +
+        `    compare file contents against origin/main before assuming it is.`,
+    });
+  } else if (behind > 20) {
+    findings.push({
+      level: "yellow",
+      section: "Checkout stale",
+      detail: `On main but ${behind} commits behind origin/main. Run: git pull`,
+    });
+  }
+
+  // Uncommitted handoffs of ANY age. checkStaleHandoffs only considers files
+  // dated today, so anything left overnight became permanently invisible —
+  // the precise gap that orphaned five session records.
+  if (existsSync(HANDOFF_DIR)) {
+    const today = new Date().toISOString().slice(0, 10);
+    const orphaned = readdirSync(HANDOFF_DIR)
+      .filter((f) => f.endsWith(".md"))
+      .filter((f) => !f.startsWith(today)) // today's is checkStaleHandoffs' job
+      .filter((f) => !sh(`git ls-files --error-unmatch "${join(HANDOFF_DIR, f)}"`, { cwd: REPO_ROOT, allowFail: true }));
+    if (orphaned.length > 0) {
+      findings.push({
+        level: "yellow",
+        section: "Handoffs never committed",
+        detail:
+          `${orphaned.length} handoff file(s) exist only on disk — losing this directory loses them:\n    ` +
+          orphaned.slice(0, 8).map((f) => `  ${f}`).join("\n    ") +
+          (orphaned.length > 8 ? `\n      …and ${orphaned.length - 8} more` : ""),
+      });
+    }
+  }
+
+  // Local branches nobody has touched in a fortnight. Usually finished work
+  // whose PR was squash-merged, which git cannot tell you on its own.
+  const FOURTEEN_DAYS = 14 * 86400;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const stale = sh(
+    'git for-each-ref --format="%(refname:short)|%(committerdate:unix)" refs/heads/',
+    { cwd: REPO_ROOT, allowFail: true },
+  )
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => l.replace(/"/g, "").split("|"))
+    .filter(([name, ts]) => name !== "main" && nowSec - parseInt(ts || "0", 10) > FOURTEEN_DAYS)
+    .map(([name, ts]) => `${name} (${Math.round((nowSec - parseInt(ts, 10)) / 86400)}d old)`);
+  if (stale.length > 0) {
+    findings.push({
+      level: "yellow",
+      section: "Stale local branches",
+      detail:
+        `${stale.length} branch(es) untouched for 14+ days — likely merged and forgotten:\n    ` +
+        stale.slice(0, 8).join("\n    ") +
+        `\n    Confirm the work is on main, then: git branch -D <name>`,
+    });
+  }
+}
+
+// ────────────────────────────────────────────────────────────────
 // Main
 // ────────────────────────────────────────────────────────────────
 async function main() {
@@ -376,6 +480,14 @@ async function main() {
   checkUncommittedInCodePaths();
   checkTodaysHandoff();
   checkStaleHandoffs();
+  checkRepoHygiene();
+
+  // --hygiene-only: skip the DB round-trips so this can run as a fast
+  // start-of-session or daily check without credentials.
+  if (process.argv.includes("--hygiene-only")) {
+    report();
+    return;
+  }
 
   const dbUrl = process.env.DATABASE_URL;
   if (dbUrl) {
@@ -395,6 +507,11 @@ async function main() {
     });
   }
 
+  report();
+}
+
+// Extracted so --hygiene-only can print and exit without the DB round-trips.
+function report(): never {
   const red = findings.filter((f) => f.level === "red");
   const yellow = findings.filter((f) => f.level === "yellow");
 

--- a/handoff/_general/from-code/2026-08-17-llm-truncation-guard-generalized.md
+++ b/handoff/_general/from-code/2026-08-17-llm-truncation-guard-generalized.md
@@ -1,0 +1,27 @@
+Intent: Generalize the PR #314 truncation guard across every LLM executor so no other capability can repeat the web-extract self-quarantine incident (follow-up task chip from the morning's incident work, executed same session).
+
+## Shipped — PR #317, merged + deployed (`9e27faa`, verified serving)
+
+- **`capabilities/lib/llm-extract.ts`** (`extractJsonWithLlm`): create → `CapabilityRefusalError` on `stop_reason === "max_tokens"` (registered refusal prefix → `caller_input` everywhere) → `extractJsonObject` → caller-supplied parse-failure error. Byte-identical non-truncation messages, so zero taxonomy shifts.
+- **68 executors migrated** (web-extract + product-reviews-extract refactored first; their existing truncation tests passing unchanged was the fidelity proof). Three executors had the incident class **already latent with wrong-class guards** (price-compare — with a documented 2026-06-17→24 production incident — readme-generate, prompt-optimize).
+- **Structural skips hardened**: business-license-check-se's JSON call migrated (skip was misdocumented — review catch); code-review + annual-report-extract got inline truncation guards; cookie-scan's `content[0]` made genuinely non-fatal; greedy object-capture regex eliminated from risk-narrative-generate (DEC-20260428-B path), 5 multimodal executors, and estonian-company-data's proxy parse.
+- **Repo-wide source scan** in `llm-json-adoption.test.ts` forbids the greedy idiom (allowlist: code-review's sanitize-retry, llm-output-validate's repair chain) — the ~68 migrations can't quietly revert.
+- **26 manifests** got the "Output size cap per call" limitation; token figures verified against real budgets.
+
+## Process
+
+Sonnet agent built (7 commits, isolated worktree); Fable verified: gates re-run (tsc clean, 549 tests), per-file model/max_tokens byte-comparison, then a 3-finder review fan-out (removed-behavior audit over all 66 diffs / skip-claim verification / manifest consistency). 8 confirmed findings, all fixed on-branch before merge. Per-executor budgets and prompts unchanged throughout.
+
+## Prod operations
+
+- 26 limitation rows inserted into `capability_limitations` by targeted INSERT (onboard's authority gate still aborts on unrelated pre-existing `output_schema` drift for some slugs — reconciliation remains an open thread from the morning handoff).
+- DEC-20260504-C verification: `/health` = `9e27faa`; live `/v1/do` call through migrated `regex-generate` completed (txn `0ecaaedc`, 3.3s); limitation rows confirmed by the insert script's own read-back.
+
+## Non-obvious learnings
+
+- "Structurally skipped" needs per-CALL granularity, not per-FILE: a file with one unmigratable call can still have a second, fully migratable one (business-license-check-se), and a multimodal create call doesn't excuse a greedy parse (5 files).
+- A source-scan guard (forbidden idiom + allowlist) covers a 68-file migration far more cheaply than 68 behavioral tests — and it immediately caught my own comments containing the literal, which is the sign it actually bites.
+
+## Cost
+
+~€0.05 external (one regex-generate prod call on the test wallet; agent/review runs were internal tokens).

--- a/handoff/_general/from-code/2026-08-17-web-extract-quarantine-root-cause-and-restore.md
+++ b/handoff/_general/from-code/2026-08-17-web-extract-quarantine-root-cause-and-restore.md
@@ -1,0 +1,36 @@
+Intent: Dig into the web-extract `x402_not_on_rail` anomaly from the evening `/activity` check, verify the failure analysis, fix what was actually broken, and restore the capability to the rail.
+
+## What the anomaly turned out to be
+
+The 143 web-extract not_on_rail rejections were **the armed quality floor quarantining web-extract at 07:37 UTC** (health_monitor_events `quality_floor`/`quarantined`: completion 21% on 14 eligible calls/30d, deactivate_proposal flagged Petter-only). Timeline: the ipt.org roster buyer paid 8× via x402 at 07:14–07:18 (2 ok, 6 failed), the failures tripped the floor 19 minutes later, and everything after 07:40 was crawlers + the returning buyer hitting a delisted slug.
+
+**Root cause was web-extract's own bug**: `max_tokens: 4000` on the Haiku extraction call with no `stop_reason` check — a ~100-name roster page truncates mid-JSON, `extractJsonObject` correctly refuses, the error classifies `internal`, the floor counts it. The floor worked exactly per DEC-20260812-A; the capability was defective.
+
+**Corrections to the earlier /activity synthesis**: the "payment-ready EU/KYB demand" read was wrong — `x402_not_on_rail` is dominated by discovery crawlers walking the public catalog (one `node`-UA client hit 14 slugs within 200ms). The morning session had already flipped the real registries. product-reviews-extract's 404s were caller-hallucinated app-store package IDs → correct refusals, `caller_input`, no floor impact.
+
+## Shipped (both merged to main + deployed, SHA `2d0da32`/`44522a6`)
+
+- **PR #314** — web-extract `max_tokens` 4000→16000 + `CapabilityRefusalError` on `stop_reason==="max_tokens"` ("Extraction result too large for one call…", registered in `REFUSAL_MESSAGE_PATTERNS` → aligned across taxonomy `caller_input`, circuit breaker, quality-capture); product-reviews-extract same guard (2000→8000) + greedy-regex parse replaced with `extractJsonObject`; `content[0]` optional-chained in both (Anthropic `refusal` stop reason returns empty content); manifest limitations added; regression tests fail-before/pass-after verified twice (author agent + reviewer). Built by a Sonnet agent, reviewed/fixed/verified by the main session.
+- **PR #315** — `since-last-ext.ts` now splits failed_requests into crawler-UA vs plain-client and lists top plain-client slugs, so future /activity runs don't read enumeration as demand. Built by a Haiku agent; review found + fixed a GROUP BY bug (failure_type → task) and hoisted the crawler regex.
+
+## Prod operations (decide-then-tell, per charter)
+
+1. **avg_latency_ms 5000→12000 on web-extract.** Declared 5000 routed it sync on /v1/do; the sync path runs the executor inside the wallet tx with a 15s idle timeout → any heavy page 500s (`internal_error`, and **no transaction row**). Measured p95 is 37s (completed-only mean is survivorship-biased). Now routes async. This was why the buyer's shape worked on x402 but died on /v1/do.
+2. **Limitations synced to `capability_limitations`** via targeted INSERT (onboard --backfill aborts on pre-existing `output_schema` authority drift — see open threads).
+3. **Verified the fix on the exact failing input**: IPT CMI-S full-roster extraction via /v1/do async → completed, ~18k chars of names (previously died at the 4k truncation). Transaction `d4ac930f-b181-4d72-a66c-732d4bd9843e`.
+4. **Restored web-extract to the rail**: `visible=true, x402_enabled=true` + enforce-mode `promoted_with_x402` event (id `a3756a37`) in one transaction — the event clamps the floor's window so tomorrow's tick doesn't re-quarantine on the stale 21%. `POST /x402/web-extract` → 402 confirmed post-TTL.
+5. **Deactivation proposal for web-extract: rejected** (recorded in the promotion event). It was a bug, not rot, and the proposer's evidence is now stale. Flagging here since the proposal was marked requires_human — veto if you disagree.
+
+## Protocol compliance
+
+- DEC-20260504-C: deploy verified by prod artifact (SHA via /health, live replay, DB rows), not logs.
+- DEC-20260504-A discipline applied (not a numbered cert-audit finding): regression tests verified in both directions.
+- Code-review gate: /code-review (high effort) run on both branches before merge; findings fixed on-branch. Full apps/api suite: 1873 passed; 10 pre-existing DB-integration timeouts (no DATABASE_URL in worktree), unrelated to the diffs.
+- €-cost: ~€0.15 external (2 web-extract executions incl. one 18k-token extraction + 1 example.com call, test wallet), well inside envelope.
+
+## Open threads
+
+1. **~20 other LLM-backed executors** still have the fixed-max_tokens/no-stop_reason-check pattern — spawn_task chip filed ("Generalize LLM truncation guard across executors").
+2. **onboard --backfill authority gate**: web-extract has pre-existing `output_schema` manifest↔DB drift that hard-aborts any backfill run. Needs its own reconciliation pass.
+3. **Sync-path error shape**: the 15s idle-tx kill surfaces as opaque `internal_error` with no transaction row, though do.ts's Y-5 comment claims it maps to `timeout_exceeded`. Worth a look — it's an invisible failure mode (nothing in transactions, nothing for the floor, caller gets nothing actionable).
+4. Journal entry written: Notion page `3bf67c87-082c-8193-8002-cd2f928b9816` (Journal DB, 2026-08-17).

--- a/handoff/_general/from-code/2026-08-18-phase2-chips-frontend-typecheck-and-deploy-verification.md
+++ b/handoff/_general/from-code/2026-08-18-phase2-chips-frontend-typecheck-and-deploy-verification.md
@@ -1,0 +1,73 @@
+# 2026-08-18 — The two open Phase-2 targets, closed out as PRs
+
+Intent: execute the two chips left open when the Codebase Quality Program was audited for completeness — "typecheck everything including the dashboard" (T2.1) and "post-deploy verification standard, not heroic" (T2.4). Continues `2026-08-18-vendor-cost-audit-and-browserless-closeout.md`, which filed them rather than dropping them silently.
+
+## What shipped
+
+**[strale-frontend#19](https://github.com/strale-io/strale-frontend/pull/19)** — the dashboard has *never* had a TypeScript gate. Its CI is green on test → build → lint and none of those type-check: `vite build` uses SWC (strips types without checking), vitest runs untyped, the ESLint ratchet isn't type-aware, and Cloudflare Pages runs that same untypechecked build. Proven, not inferred: `const x: number = "str"` fails `tsc -b` and passes `vite build` on the same tree. PR adds `typecheck: tsc -b` and runs it in that repo's CI before Test/Build. CI green; the step was confirmed *executing* `tsc -b` in run `32128937922`, not merely reported green.
+
+**[#331](https://github.com/strale-io/strale/pull/331)** — the backend side of the same target. A blocking PR gate was built here and then **deliberately removed**: strale-frontend imports no backend package, so a backend change cannot break its compilation; such a gate would only ever surface pre-existing frontend errors and blame unrelated PRs. What remains is one weekly-drift backstop that watches whether the frontend's own gate still exists and still passes.
+
+**[#332](https://github.com/strale-io/strale/pull/332)** — `schema-validator.ts` blocked boot off a hand-maintained `REQUIRED_COLUMNS` array whose last entry covered migration **0050**. `startup-migrations.ts` has shipped **43 more blocks since**, none of whose columns/tables/indexes boot ever verified. Now derived from the SQL the block author already writes.
+
+## The thing worth remembering
+
+**A boot-blocking gate has asymmetric failure directions, and the asymmetry is the whole design.** Under-deriving is a smaller safety net. Over-deriving is a production crash-loop on every deploy until a human edits the parser. Review found three ways the first draft could do the latter:
+
+- multi-column `ALTER TABLE ADD COLUMN a, ADD COLUMN b` matched only the first — *silently*. Worse than the stale list it replaced: a stale list is visibly stale, a regex miss is invisible.
+- nothing subtracted `DROP`/`RENAME`, so the first block to remove a column would have taken prod down and kept it down. **No block does this today, which is exactly why it would have shipped unnoticed.**
+- a collapsed parse derived zero artifacts → zero missing → "all clear". A broken parser *certifying* the schema is the same hollow-gate shape found three times this week.
+
+All three fixed, all covered by tests proven to fail without the fix (parser reverted to pre-fix form → 6 new tests fail; restored → 28 pass).
+
+## Verification actually performed
+
+- Compiled-output parity: a real build to a temp `outDir` puts both modules in `dist/lib`; parsing the **compiled `.js`** yields the identical 36-artifact set as source. The runtime reads its compiled sibling, so this was tested rather than reasoned about.
+- **All 36 artifacts checked read-only against production before merge — all present.** This is the row that gates merge: a boot-blocking check shipped unverified is precisely the "code is correct ≠ deploy will behave" failure DEC-20260504-C exists for.
+- Backstop shell logic proven in all branches, including that `pipefail` is load-bearing (without it a failing `tsc` reports success).
+- Test file run **standalone**, not only in batch — a batch-only pass burned this session once already.
+
+## Merged and closed (Petter approved merge at the end of session)
+
+All four merged in dependency order — the frontend gate had to land before the backstop that watches it:
+
+1. strale-frontend#19 — verified live on that repo's `main` (`"typecheck": "tsc -b"` + a `Typecheck` CI step ahead of Test/Build).
+2. #331 (backstop + T2.1 correction), 3. #332 (derived schema check, after `update-branch`; both PRs touched the same doc but in different sections, so no conflict), 4. **#333 — closes T2.1 with the run that proves it fires.**
+
+**Execution proof obtained, not assumed.** Dispatched weekly-drift run [`32131992897`](https://github.com/strale-io/strale/actions/runs/32131992897): `FTC=0`, and the report shows `npm ci` installing 526 packages then a clean `tsc -b`. Real work, not a vacuous pass. That is what T2.1 was holding out for.
+
+Zero open PRs on the backend. (strale-frontend#5 is a stale May PR, unrelated.)
+
+## The manifest-drift check — fixed, and the 18 drifts with it (#334, merged)
+
+**Two bugs were stacked, and fixing only the first would have made it worse.** `manifest-drift` was the one DB-touching step with no `DATABASE_URL`, so it died on `ECONNREFUSED` every week and never once compared a manifest to the database. But the script also ended in an unconditional `process.exit(0)` — so supplying the secret alone would have produced a check that connects, finds 18 real drifts, and **reports clean**. A loudly-broken gate converted into a silently-useless one. Now: exit 2 = couldn't run (says so), 1 = drift, 0 = clean; all three verified.
+
+**The 18 drifts were resolved per capability, not by blind sync** — which mattered, because the two sides disagreed about which was right:
+
+- **DB wrong, manifest right (17).** Four `transparency_tag` (`austrian`/`dutch`/`italian`/`portuguese-company-data`) claimed `ai_generated`; verified **zero** LLM references in all four executors *and* the shared `openapi-resolver` they delegate to — straight vendor API calls. We were over-claiming AI involvement in an EU-AI-Act field. Two `gdpr_art_22_classification` corrected to `screening_signal` (both produce findings customers decide on). `output_field_reliability` was stale in the DB across 7 caps — the known `onboard`-doesn't-sync-reliability gap. Several `input_schema` advertised `required: []` while the executor throws without input — the 2026-08-15 x402 shape.
+- **Manifest wrong, DB right (1).** `email-pattern-discover` declared `processes_personal_data: false`. It regex-harvests real addresses from page HTML and returns them as `public_emails_found`. **A blind `--apply` would have flipped a GDPR flag from true to false** — the single best reason not to trust either side by default.
+- **Both wrong (1).** That capability's input contract: executor throws unless `domain` *or* `url`; manifest said `required:[domain]`, DB said `required:[]`. Now `anyOf`.
+
+**Verified end to end:** sweep exit 1→0, drifted 18→0, and a dispatched CI run ([`32134081484`](https://github.com/strale-io/strale/actions/runs/32134081484)) shows `Sweeping 334 manifests against DB... Drifted: 0` — the check connecting to the database in CI for the first time ever. **The whole weekly drift sweep is green for the first time.**
+
+Left alone deliberately: `uk-disqualified-director-check` has `processes_personal_data = true` with an empty `personal_data_categories`; it searches people by name so `["name"]` is almost certainly right. Pre-existing manifest gap, not drift.
+
+## The original finding (now resolved — kept for the record)
+
+The sweep failed on `MD=1` (manifest drift). **Pre-existing** — it also failed in run `32125828728` before any of today's work — and the cause is structural: `manifest-drift` is the **only DB-touching step in weekly-drift.yml with no `env: DATABASE_URL`**. It has been dying on `ECONNREFUSED ::1:5432` and has **never once compared a manifest to the database**.
+
+This is a fourth hollow gate, and the nastiest variety: it fails *every single week*, so the weekly drift issue has been trained into background noise.
+
+Run locally against prod, the script works fine and reports **18 capabilities with real drift** — including **four where the DB says `transparency_tag="ai_generated"` while the manifest says `"algorithmic"`** (austrian/dutch/italian/portuguese-company-data). Transparency tag is a customer-facing claim about whether AI produced the answer, so that one is not cosmetic.
+
+Fix is one `env:` block. Deliberately not bundled into a docs PR.
+
+## Deferred with reasoning
+
+Moving artifact derivation into per-block typed metadata on `BLOCKS`, with regex derivation demoted to a CI lint (raised by the altitude review on #332). Better long-term; changes every migration block's shape, so it deserves its own pass.
+
+## Next session
+
+1. Watch the first Railway boot after #332 for `startup-schema-ok` ("all migration-derived artifacts present"). All 36 artifacts were confirmed present in prod pre-merge, so this should be uneventful — but it is the first boot under the new gate.
+2. `uk-disqualified-director-check`: set `personal_data_categories: ["name"]` (currently empty while `processes_personal_data` is true).
+3. Optional, raised by review on #332: move migration-artifact derivation into per-block typed metadata on `BLOCKS`, demoting the regex to a CI lint. Better long-term; touches every migration block, so it needs its own pass.

--- a/handoff/_general/from-code/2026-08-18-quality-program-phase4-close.md
+++ b/handoff/_general/from-code/2026-08-18-quality-program-phase4-close.md
@@ -1,0 +1,36 @@
+# 2026-08-18 — Codebase Quality Program: Phase 4 complete, program closed
+
+Intent: finish Phase 4 (capability truth pass) and close the Codebase Quality Program (docs/strategy/2026-08-16-codebase-quality-program.md). Continues the 2026-08-16 Phase 0–1 handoff and the Phase 2/3 PRs.
+
+## Shipped this phase (all merged + prod-verified or deploy-rolling)
+- **PR #318 — the capability tail.** redirect-trace's core bug fixed (~4 months broken for any actually-redirecting URL; harness passes were httpbin-503 false positives); url-health-check same-bug sibling fixed; budget-aware scheduling (scheduler + per-suite runner check: exhausted budget = silent skip, not manufactured failure); failure classifier gains test_infrastructure (budget) + test_design (compliance-refusal) classes; GDELT retry amplification removed; spanish tier fixture recaptured post-vendor-swap (a real PII leak — officer names in BORME free text — caught and scrubbed during capture); tier-coverage gate promoted to strict (closes Phase 2's deferred T2.3).
+- **PR #319 — AGENTS.md rebuilt from CLAUDE.md** (Codex-CLI config current + tracked again); **CLAUDE.md rule 5 (never git stash in worktrees) finally committed** — it had lived only as an uncommitted edit on a parked branch.
+- **PR #320 — limitation titles.** The "3,405 undefined titles" were a diagnostic display artifact — zero exist in any storage location; defensive sanitizer at every limitation write path + transactional CAS repair tooling (never needed on current data).
+- **PR #321 — suite-scoped scheduling.** THE structural find of the phase: the scheduler was quadratic in same-type suites (N due suites → N×N executions) — this explains the months-long daily budget exhaustion on danish/swedish. runTests now takes a fail-closed suiteId. Swedish known-answer coverage restored truthfully (Klarna/H&M/IKEA as their real selves — five suites had secretly tested one org number under five labels), equals identity assertions, transactional idempotent restore (applied to prod under orchestrator gate).
+- **DB fixture refreshes applied** (platform-acts-alone): npm-package-info + llm-cost-calculate placeholder "test_value" inputs → real inputs; singapore + nl-energy-label dead dependency_health inputs → known-good; polish's two name-search suites (testing a correctly-refused path) deactivated with reasons; swedish's four duplicate-label suites deactivated.
+
+## Exit measurement (T4.3)
+Preliminary (12h window, ≥5 runs, still containing pre-fix hours): **7 capabilities under 90%**, from 30 at program start. Expected on the clean 24h window: **uk-gazette-notice-search** (vendor API returns 500 on every request — Petter filing with TheGazette) as the principal survivor with a written reason; redirect-trace/polish/singapore/nl-energy-label/llm-cost-calculate/npm-package-info all fixed and draining pre-fix rows. us-court-search (CourtListener token, Petter's rotation) may reappear once its suites cycle. **Final confirmation: run the measurement on the 2026-08-19 morning check-in with a clean 24h window** — expected verdict ≤5 with reasons, meeting T4.3.
+
+## Program scorecard vs docs/strategy/2026-08-16-codebase-quality-program.md
+- Phase 0 (self-harm stopped): ✅ — refusal taxonomy verified, us-company-data + screenshot-url re-listed, promotion job armed (first enforce tick auto-promoted brazilian-company-data), floor bounce-bug dead in prod.
+- Phase 1 (money path tested): ✅ — PR #304, wallet.ts's first tests ever + do.ts core, 15 mutation proofs.
+- Phase 2 (gates closed): ✅ — PR #313, typecheck 6 surfaces, zero orphaned guards, hollow dispatcher lint rebuilt on AST; T2.3 completed via #318's strict promotion.残: cross-repo shape gate blocked on founder PAT.
+- Phase 3 (debloat): ✅ — PR #316, 230 archive moves, zero deletions, structure matches docs.
+- Phase 4 (truth pass): ✅ engineering complete; T4.3 formal verdict pending the 08-19 clean window.
+- Discovered + fixed along the way, no phase asked for them: quadratic scheduler, stash-sharing hazard (now rule 5), codex-stdin footgun, PII-in-fixture capture leak, seed-path sanitization gap.
+
+## Standing items (Petter)
+1. Browserless $25/mo Prototyping upgrade (T0.3 recommendation; confirm current plan in dashboard).
+2. Fine-grained GitHub PAT (read-only Contents, strale-frontend) → repo secret, to make the AuditRecord shape gate real.
+3. File the Gazette JSON-API outage with TheGazette (github.com/TheGazette/DevDocs); rotate COURTLISTENER_API_TOKEN and update Railway.
+4. wow-core repo: archive or delete (from 08-16).
+
+## Watch items for the morning check-in
+- Final T4.3 measurement (clean 24h window).
+- Prod deploy chain: verify /health reaches 498a160 (#321); then test_results should show swedish ~23 attempts/day (was 100/100 cap-outs) and danish linear, budget-skips silent.
+- brazilian-company-data real-traffic completion (auto-promoted; its old quarantine driver was customer-side 429s the harness can't see — a re-quarantine would be the system working, and repeat-bounce then holds it for human review).
+- Duplicate-suite sweep found the swedish pattern in credit-report-summary, estonian-company-data, business-license-check-se (14 excess suites) — cleanup candidate, low urgency (mostly inactive/paid capabilities).
+
+## Review-loop stats for the program (for the record)
+4 implementer agents + ~20 Codex review rounds across 8 branches; ~40 substantive findings (8 HIGH/blocker class), including several in the orchestrator's own instructions — the two-model loop caught what either model alone would have shipped.

--- a/handoff/_general/from-code/2026-08-18-vendor-cost-audit-and-browserless-closeout.md
+++ b/handoff/_general/from-code/2026-08-18-vendor-cost-audit-and-browserless-closeout.md
@@ -1,0 +1,48 @@
+# 2026-08-18 — Vendor cost audit, Browserless closed for €0, shape-contract gate finally real
+
+Intent: answer Petter's "can we avoid the $25/mo Browserless upgrade, and what other prepaid credits could run out silently?" — then close every loose end from the Codebase Quality Program. Continues 2026-08-16 (Phases 0–1) and 2026-08-18 Phase-4 close.
+
+## The headline: Browserless needed no money, it needed a bug fix
+Browserless usage was ~22,300 calls/30d. **Only ~505 were customers.** 87% was our own harness live-rendering for 12 capabilities classed `cost_class='free_unlimited'` — because `external_cost_cents = 0` means *free to the customer* (registry data is free) and nothing ever told the scheduler each render still burns a real infrastructure unit.
+
+**Shipped (PR #330, applied to prod):** `test_mode='canary'` given real semantics (it was documented but dispatched identically to `live` — a phantom feature); 60 suites converted to fixture replay + 12 live daily canaries (one per capability, always `known_answer` because only that type feeds circuit-breaker evidence); fixture baselines given a 30-day TTL on `fixture_last_refreshed` (an orphaned column that now has a writer) so nothing stays green on stale evidence; failing recaptures **bounded** by a failure cap → quarantine marker that no automated path can clear or bypass.
+
+**Verified in prod after deploy, in this order (safety net first):** migration 0093 column present → dry-run → `--apply` → post-state query. Result: 12 canary / 48 fixture / 28 untouched, 60/60 applied, 0 raced.
+**~7,565 → ~408 Browserless calls/30d (94.6% cut).** Customer traffic untouched. Free plan is now comfortable.
+
+## Decision: no Browserless upgrade (Petter, affirmed by data)
+€25/mo against ~€190/mo revenue was rightly declined. Post-fix it isn't needed at all. Cloudflare Browser Rendering (free tier, managed → DEC-7 compliant) is the hedge if volume ever grows; Bright Data and similar are **disqualified on doctrine** (proxy-rotation/anti-bot evasion), not price.
+
+## Vendor inventory (the "what else runs out silently" answer)
+- **Serper**: receipt found — 50,000 credits bought 2026-05-08 for $62.50, burn ~470/mo. **No top-up needed; credits EXPIRE ~2026-11-08.** Revisit late October, not before. Login = `petter@strale.io` (Paddle receipt).
+- **CDP/Coinbase x402**: 2,007 settlements/30d — past the 1,000 free tier, so ~$1/mo overage. Card confirmed by Petter on the **production entity** `28dcd11b-8752-5835-a764-42f94af91614` (not the portal default).
+- **sec-api.io / EINsearch**: zero calls ever, no token configured anywhere, **zero emails in the mailbox** — no subscription exists. Nothing to cancel.
+- **Dilisense**: only 20 calls/30d — the feared "80/mo test burn vs 100/mo cap" was stale. No urgency. Cheap insurance when convenient: re-add OpenSanctions as a paid fallback (~€1–2/mo at this volume) to end the single-vendor risk on sanctions-check/pep-check.
+- **Do NOT self-host sanctions lists** to save money: touching raw OFAC/EU/UN feeds triggers DEC-20260428-B's full engineering bar. The "free" option costs days plus permanent ops.
+- **Voyage**: inside the free 200M-token allowance. Do nothing.
+- Anomaly logged, unexplained: a 7-day zero-x402-settlement window 2026-07-25→31, evidence points to a traffic lull rather than an outage.
+
+## Also shipped
+- **PR #327 — the AuditRecord shape contract is real for the first time.** The weekly checkout of the private `strale-frontend` had 404'd on **every run since the gate was written** (no cross-repo credential; `continue-on-error` swallowed it). Petter created `FRONTEND_READ_PAT`; both paths verified by log (`Syncing repository: strale-io/strale-frontend` → `✓ All shape contracts clean`, `AR=0`). Now blocking on PRs touching `audit.ts` + working weekly.
+- **PR #328 / #329 — every "Browserless-dependent" list was wrong.** The health gate inferred dependency from `capability_type` (missed 4 hard-dependent `ai_assisted` caps, over-included 41 fallback-tier ones); the credential registry hand-maintained 52 slugs of which **19 had drifted**, and `latvian-company-data` was falsely skipped *twice* — via browserless and then again via an unwired SDDA entry three lines below. Both now derive from one curated source with a **bidirectional drift test** (comment-stripped, mutation-proven) so list-rot can't recur.
+
+## Loose ends deliberately left
+- **Main checkout stays parked on `ops/company-scaffold`** (documented condition). Its uncommitted `CLAUDE.md` diff is exactly the rule-5 stash prohibition, which **is already merged to main via PR #319** — redundant and safe to discard, but left alone rather than `git checkout --`ing over uncommitted work in a shared tree.
+- Pre-existing `_tmp_*.ts` scripts and `audit-output/_partial_*` files in the main checkout predate this session (visible in its opening `git status`); not mine to clean.
+- 8 agent worktree directories from other sessions left in `.claude/worktrees/` (mine — 13 — removed; main `node_modules` verified intact afterwards).
+
+## Program close-out: T4.3 met, two Phase-2 targets deliberately left open
+Final exit measurement (12h window, ≥5 runs, post-fix data): **4 capabilities under 90%** against the ≤5 target — down from 30 at program start. uk-gazette-notice-search (vendor API), cz-unreliable-vat-payer, tech-stack-detect and canadian-company-data at 89%. **T4.3 PASSED.**
+
+Two Phase-2 targets did NOT land and are now tracked chips, not silently dropped:
+1. **"Typecheck everything including the dashboard"** — the frontend is a separate repo and this repo's CI still never compiles it. What shipped was the AuditRecord *shape contract* (interface comparison), not a build. Newly unblocked by `FRONTEND_READ_PAT`. The chip explicitly instructs investigating whether strale-frontend's own CI already covers this — the right answer may be "descope deliberately", not "build redundant CI".
+2. **"Post-deploy verification standard, not heroic"** — followed rigorously by hand all week (migration 0093 verified in prod before the suite conversion; /health polled to commit match), but nothing fails if a future session skips it. Chip filed to build the smallest mechanism that catches the PR-42 class of failure automatically.
+
+## Open for Petter
+Nothing blocking. Optional: delete the dead original `strale-frontend-readonly` fine-grained token now that its replacement works.
+Flagged for your call (not actioned): (a) the To-do item "Decouple scheduled_testing_eligible from external_cost_cents" has been In-progress since 2026-05-11 and is the *root cause* today's Browserless work treated symptomatically — close as superseded or keep as the real structural fix; (b) the Browserless stay-on-free-tier posture may warrant a Decisions DB entry (yours to create); (c) Serper credit expiry ~2026-11-08 may deserve a To-do so it surfaces on its own.
+
+## Watch next
+- Harness data within ~24h should show Browserless calls collapsing toward ~400/30d and the 12 canaries running daily.
+- First fixture TTL expiries land ~2026-09-17 (one live re-validation per suite); failing recaptures should quarantine at the cap rather than retry forever.
+- Late October: Serper credit expiry decision.


### PR DESCRIPTION
Five handoff files from 2026-08-17/18 were written and never committed — they existed only in the working directory. Losing that directory would have lost the record of the Browserless cost work, the web-extract quarantine root cause, the LLM truncation guard, the Phase-4 close, and today's Phase-2 chips.

They were invisible to `session-close-check` because its stale-handoff check skips any file whose date prefix isn't **today** — so a handoff left uncommitted overnight can never be flagged again. That gap is fixed in a follow-up PR.

Also rescues `mutate-metrics-guards.py`, the only file that existed solely on `ops/company-scaffold` (that branch is otherwise fully superseded — main has newer versions of every other file on it, including migration block 0085).