### PR TITLE
docs: land 15 research documents stranded on unmerged branches

### DIFF
--- a/archive/sessions/stranded-research-2026-05/burst-probe-capability-health-blind-spot-2026-05-15.md
+++ b/archive/sessions/stranded-research-2026-05/burst-probe-capability-health-blind-spot-2026-05-15.md
@@ -1,0 +1,172 @@
+# capability_health gateway-502 blind-spot — production-realistic burst probe
+
+**Date:** 2026-05-15
+**Triggered by:** LT/CH/HR triage finding ([apps/api/docs/lt-ch-hr-outage-triage-2026-05-15.md](lt-ch-hr-outage-triage-2026-05-15.md), commit `dd40aa7`). LT showed `capability_health.total_failures=0` despite observed real failures during Batch 4's 15-concurrent burst.
+**Method:** Three tiers of parallel-call bursts at increasing concurrency (5, 10, 15) with before/after `capability_health` snapshots. All calls used canonical fixture entities from each manifest's `known_answer.input`.
+**Total wallet spend:** ~€2.20 (44 successful charges of €0.05; 6 failed calls not charged: 5 Tier-3 429s + 1 Tier-3 500).
+
+---
+
+## Hypothesis under test
+
+**H1:** The parallel-call amplification pattern that triggered the audit's gateway-502s requires the audit's specific 15-concurrent burst shape. At production-realistic load (5 concurrent calls across 5 countries), gateway-502s do NOT emerge, so the blind spot doesn't materially affect v1-readiness conclusions.
+
+**H2 (counter):** Gateway-502s emerge at lower concurrency than the audit suggests. The blind spot is operationally real, and `capability_health` cannot be trusted for v1-readiness verdicts until the metric is fixed.
+
+---
+
+## Tier 1: 5 concurrent calls (production-realistic)
+
+5 capabilities: SE, UK, FR, CH, SG. Three runs with 60-second cool-downs.
+
+### Run results
+
+| Run | Wall-time | Latency range | HTTP statuses |
+|---|---|---|---|
+| 1 | 4.6s | 0.78s – 4.40s | 5× 200 |
+| 2 | 2.3s | 0.35s – 2.12s | 5× 200 |
+| 3 | 2.8s | 0.89s – 2.59s | 5× 200 |
+
+15 of 15 calls succeeded. Zero 502s. Zero 429s. Zero application errors.
+
+### capability_health diff after Tier 1
+
+| Capability | Before | After | Delta |
+|---|---|---|---|
+| swedish-company-data | F=5, S=13 | F=5, S=16 | F+0, S+3 ✓ |
+| uk-company-data | F=0, S=8 | F=0, S=11 | F+0, S+3 ✓ |
+| french-company-data | F=0, S=17 | F=0, S=20 | F+0, S+3 ✓ |
+| swiss-company-data | F=8, S=8 | F=8, S=11 | F+0, S+3 ✓ |
+| singapore-company-data | F=2, S=6 | F=2, S=9 | F+0, S+3 ✓ |
+
+All 15 successes correctly recorded. Metric is accurate at this load.
+
+### Tier 1 verdict: **CLEAN**
+
+At production-realistic load, no failure pathology emerges. The 24h canary green-rate confirmations that DEC-20260513-F's verdict rests on are trustworthy at this concurrency.
+
+---
+
+## Tier 2: 10 concurrent calls
+
+10 capabilities: Tier 1's 5 + NO, FI, BE, CZ, HR. Two runs.
+
+### Run results
+
+| Run | Wall-time | Latency range | HTTP statuses |
+|---|---|---|---|
+| 1 | 4.8s | 1.07s – 4.42s | 10× 200 |
+| 2 | 4.7s | 0.97s – 4.35s | 10× 200 |
+
+20 of 20 calls succeeded. Zero 502s. Zero 429s.
+
+### capability_health diff after Tier 2
+
+| Capability | Before T2 | After T2 | Delta |
+|---|---|---|---|
+| belgian-company-data | F=0, S=6 | F=0, S=8 | F+0, S+2 ✓ |
+| croatian-company-data | F=4, S=5 | F=4, S=7 | F+0, S+2 ✓ |
+| cz-company-data | F=0, S=7 | F=0, S=9 | F+0, S+2 ✓ |
+| finnish-company-data | F=0, S=7 | F=0, S=9 | F+0, S+2 ✓ |
+| norwegian-company-data | F=0, S=7 | F=0, S=9 | F+0, S+2 ✓ |
+| (Tier-1 5) | varied | varied | F+0, S+2 each ✓ |
+
+All 20 successes correctly recorded. Metric accuracy holds.
+
+### Tier 2 verdict: **CLEAN**
+
+At 2× production-realistic load, no failure pathology emerges. The metric remains trustworthy.
+
+---
+
+## Tier 3: 15 concurrent calls (matches audit-burst shape)
+
+Tier 1+2's 10 + IE, GR, EE, PL, SK. Single run.
+
+### Run result
+
+Wall-time 8.5s. **6 non-200 responses observed.**
+
+| Capability | Status | Latency | Failure mode |
+|---|---|---|---|
+| belgian-company-data | 429 | 0.29s | Strale rate-limit (10 req/sec per key) |
+| singapore-company-data | 429 | 0.31s | Strale rate-limit |
+| estonian-company-data | 429 | 0.29s | Strale rate-limit |
+| greek-company-data | 429 | 0.30s | Strale rate-limit |
+| polish-company-data | 429 | 0.33s | Strale rate-limit |
+| slovak-company-data | 500 | 3.40s | Application: Slovak RPO upstream rate-limit (60 req/min) |
+| (remaining 9) | 200 | 4.13s – 8.15s | success |
+
+Notably: **no gateway-502s reproduced.** Today's Tier 3 burst hit Strale's own rate-limiter (HTTP 429 returned within 0.3s) before saturating Railway's gateway. This differs from the audit's Batch 4 morning, when 15-concurrent calls produced gateway-502s — possibly because the audit hit a different Railway state (cold capability cache, slower routing, etc.). The exact reproduction of 502s requires conditions this probe didn't recreate.
+
+### capability_health diff after Tier 3
+
+| Capability | Status | Tracked? |
+|---|---|---|
+| 9 successful capabilities | 200 | ✓ S+1 each |
+| slovak-company-data | 500 | ✓ F+1 (last_failure_at updated to 10:55:58Z) |
+| belgian-company-data | 429 | **✗ neither F nor S incremented** |
+| singapore-company-data | 429 | **✗ neither F nor S incremented** |
+| estonian-company-data | 429 | **✗ neither F nor S incremented** |
+| greek-company-data | 429 | **✗ neither F nor S incremented** |
+| polish-company-data | 429 | **✗ neither F nor S incremented** |
+
+**The 5 rate-limit 429s are invisible to capability_health.** This is the same blind-spot class as the audit's gateway-502s: pre-execution failures that bypass the application layer and therefore bypass the failure-counter update path. The audit hit 502s; today's Tier 3 hit 429s; both classes are blind.
+
+The single application-level 500 (Slovak RPO upstream rate-limit) **was** correctly recorded — confirming that capability_health works for executor-level failures but is blind to pre-executor rejections.
+
+### Tier 3 verdict: **BLIND SPOT IS REAL AT 15-CONCURRENT**
+
+5 of 15 calls returned 429s with zero record in capability_health. A v1-readiness verdict relying on capability_health to confirm "no recent failures" at this load shape would be empirically wrong.
+
+---
+
+## Overall verdict
+
+**The capability_health blind spot is REAL at Tier 3 concurrency (15+) but ACADEMIC at production-realistic load (≤10 concurrent).**
+
+### What's affected
+
+- **Pre-execution failures** (Strale rate-limiter 429s, Railway gateway 502s, idempotency-key rejections, max_price_cents budget rejections, capability-not-found 400s) — all of these bypass the application layer and therefore bypass capability_health's update path.
+- **Application-level failures** (handler throws, upstream returns 5xx, breaker opens, timeout-in-handler) — these ARE correctly tracked. Confirmed by Tier 3's SK 500 from the Slovak RPO upstream rate-limit.
+
+### What's not affected at production-realistic load
+
+- 5-concurrent: zero pre-execution failures observed across 3 runs. Metric is trustworthy.
+- 10-concurrent: zero pre-execution failures observed across 2 runs. Metric is trustworthy.
+- DK/DE 24h canary green-rate confirmations that DEC-20260513-F rests on: those run at single-call cadence, well below any concurrency that would trigger the blind spot. **Verdict trustworthy.**
+
+### What IS affected — the cases where the blind spot matters
+
+- Bulk audits (like Batch 4's 15-concurrent burst).
+- Concurrent customer traffic spikes that exceed Strale's 10-req/sec-per-key rate limit.
+- Customer integrations that retry aggressively on transient errors and saturate the rate-limit window.
+
+### Recommended P1 To-do priority (https://www.notion.so/36167c87082c81ddbc85d0e7f68a0270)
+
+**STAY P1 as v1.1+ work. Do NOT escalate to v1-launch-gate.**
+
+Reasoning:
+1. The blind spot does not affect any v1-readiness verdict that rests on production-realistic-load metrics (Tier 1 and Tier 2 evidence).
+2. Customers calling at sub-10-req/sec patterns will never trigger it.
+3. The fix (track pre-execution failures in a separate counter or instrument the rate-limit middleware) is non-trivial but tractable — it's appropriate scope for v1.1+ work, not a v1 blocker.
+4. The audit's Batch 4 itself proved the blind spot only matters at 15-concurrent — and that load pattern isn't a customer use case for v1.
+
+### Confidence: HIGH
+
+- Production data (3 tier runs, 50 total calls).
+- Clear empirical contrast (Tier 1+2 clean vs Tier 3 with measurable blind events).
+- Architectural reasoning matches the empirical result (pre-execution layer can't touch capability_health).
+
+---
+
+## Open questions for chat
+
+1. **Should the v1.1+ fix scope include 429s, 502s, or both?** This probe surfaced 429s as the blind class; the audit surfaced 502s. They're both pre-execution but they're different code paths. Recommend scoping the fix to *all pre-execution rejections* via a single `gateway_failures` column or a separate `pre_execution_events` table.
+2. **Why didn't Tier 3 reproduce the audit's 502 pattern?** Audit at 15-concurrent → 502s. Today at 15-concurrent → 429s. Possible causes: cold handler cache in the audit's Railway state, the audit hitting a Strale rate-limit *before* the rate-limit middleware fired (logic bug?), or Railway gateway timeout characteristics that vary by region/load. Worth a separate investigation for the v1.1+ fix design.
+3. **Is the Strale 10-req/sec-per-key rate limit calibrated correctly for v1?** With 15-concurrent calls firing in 0.3s, the limit triggers immediately. If Counterparty Assurance orchestrates 8-12 capability calls per customer transaction, a single customer running 2 concurrent transactions could hit the rate limit. Recommend reviewing the rate-limit calibration before launch.
+4. **Methodology note for future audits:** sequential or shard-by-host calls avoid the entire blind spot. The audit's parallel pattern was a methodology choice, not a customer pattern. Worth documenting in the audit playbook.
+
+---
+
+*Generated by Claude Code session 2026-05-15. Wallet spend: €2.20 (44 successful charges). Worktree: strale-research, branch `docs/identity-field-coverage-2026-05-15`. No code changes, no DB writes, no PR. The audit-doc and triage-doc verdicts stand.*

--- a/archive/sessions/stranded-research-2026-05/dk-handler-routing-2026-05-15.md
+++ b/archive/sessions/stranded-research-2026-05/dk-handler-routing-2026-05-15.md
@@ -1,0 +1,76 @@
+# DK handler routing verification — 2026-05-15
+
+**Trigger:** Active Vendor Stack canonical page (Notion `35367c87082c812e88d1dc6bdbfbd4f5`) lists DK as "CVR (Danish Central Business Register)" — implying direct Erhvervsstyrelsen `distribution.virk.dk` integration. The 2026-05-15 identity field-coverage audit Batch 2 empirically observed DK failing with a `cvrapi.dk 50/day` quota exhaustion. One source is wrong; this verification establishes ground truth.
+
+**Verdict:** **cvrapi.dk (free tier)**
+
+**Confidence:** high
+
+The handler source is unambiguous — single `const CVR_API = "https://cvrapi.dk/api"`, response parser keyed against cvrapi.dk's flat field shape, provenance object already self-declares `upstream_vendor: "cvrapi.dk"` and `acquisition_method: "vendor_aggregation"` with a `source_note` that explicitly says "Migration to direct datacvr.virk.dk system-to-system access is queued."
+
+The Active Vendor Stack canonical page is the drifted artifact. The audit's framing was correct.
+
+## Evidence
+
+### Upstream URL
+- `apps/api/src/capabilities/danish-company-data.ts:10` — `const CVR_API = "https://cvrapi.dk/api"`.
+- Request constructed at line 57-61: `${CVR_API}?country=dk&vat={cvr}` (or `&search={name}`).
+- Result: every runtime call hits `https://cvrapi.dk/api?country=dk&...`. No conditional routing, no fallback to Virk anywhere in the file.
+
+### Auth pattern
+- `apps/api/src/capabilities/danish-company-data.ts:62-68`. Request headers are `Accept: application/json` and `User-Agent: Strale/1.0 (hello@strale.io) danish-company-data`. **No `Authorization` header, no API key, no basic-auth pair.** This is the cvrapi.dk free-tier fingerprint (the paid tier uses HTTP basic with the token as username; we are not on that path).
+- Grep of `apps/api` for `CVRAPI|VIRK|DISTRIBUTION_VIRK|CVRBASEN|CVR_DEV` (case-insensitive) returns zero env-var declarations or token references in `.env.example`, `apps/api/src/config/`, or anywhere else. Only documentary mentions (limitations seed text, audit-helpers' `datacvr.virk.dk` primary-source URL constant, and prior audit docs) exist. No env-var-backed credential path for any DK upstream.
+
+### Response shape
+Parser at `apps/api/src/capabilities/danish-company-data.ts:86-110` reads these top-level keys from the JSON body: `name`, `vat`, `companydesc`, `industrycode`, `industrydesc`, `address`, `zipcode`, `city`, `startdate`, `employees`, `enddate`, plus an `error` field for the documented quota-exhaustion shape.
+
+This matches cvrapi.dk's published free-tier response shape exactly. It does not match:
+- **Virk distribution.virk.dk** — would be ElasticSearch hit envelope (`hits.hits[]._source.Vrvirksomhed.cvrNummer`).
+- **cvrbasen.dk** — flat but with `names[]`, `company_form`, etc.
+- **cvr.dev** — Danish-keyed fields.
+
+### Env-var declarations
+Grep summary (case-insensitive, `CVRAPI|VIRK|DISTRIBUTION_VIRK|CVRBASEN|CVR_DEV` across `apps/api`):
+
+- Zero matches in `.env.example` or `apps/api/src/config/`.
+- Zero matches in any `.env.*` file.
+- `apps/api/src/lib/audit-helpers.ts:13` — `"danish-company-data": "https://datacvr.virk.dk"` — this is the **audit-trail primary-source URL constant** (the user-facing "trace back to upstream record" pointer in the audit body), not a runtime upstream. It correctly points at the underlying public register, while the handler reaches that register via cvrapi.dk as the Tier-2 wrapper.
+- `apps/api/src/lib/startup-migrations.ts:697,728` — comments only ("DK cvrapi.dk — empirical floor ~50/day, no per-day reset_dom needed").
+- `apps/api/src/db/seed-limitations.ts:52` — limitation copy mentioning `datacvr.virk.dk` as where customers can look up sole proprietorships manually.
+
+No upstream credential is plumbed anywhere. This is consistent with the cvrapi.dk free tier (no auth required) and inconsistent with every other candidate upstream.
+
+### Provenance self-declaration
+The handler's own provenance object (lines 137-148) already self-declares the Tier-2 vendor-aggregation reality:
+
+```
+source: "cvrapi.dk"
+source_url: "https://cvrapi.dk/"
+acquisition_method: "vendor_aggregation"
+upstream_vendor: "cvrapi.dk"
+primary_source_reference: "https://datacvr.virk.dk/enhed/virksomhed/{cvr}"
+source_note: "Tier-2 vendor-mediated public records (DEC-20260428-A). cvrapi.dk's redistribution terms are not formally published; CVR basic company data is on the EU High-Value Datasets list (Reg. (EU) 2023/138). Migration to direct datacvr.virk.dk system-to-system access is queued."
+```
+
+In other words: the handler is correctly labelled internally. The drift is only in the Active Vendor Stack page, which collapses the wrapper-vs-direct distinction.
+
+## Implications
+
+### For canonical docs
+The **Active Vendor Stack** page (Notion `35367c87082c812e88d1dc6bdbfbd4f5`) needs an update on the DK row. Current text reads "CVR (Danish Central Business Register)" which a reader would interpret as direct Erhvervsstyrelsen integration. The accurate description is along the lines of:
+
+> Tier-2: cvrapi.dk (third-party JSON wrapper of Erhvervsstyrelsen's CVR). Free tier, ~50/day soft quota. Direct datacvr.virk.dk system-til-system access queued.
+
+This is the same wrapper-presented-as-direct drift pattern that hit DE in the earlier OpenRegister case. Worth doing a sweep of the page for similar collapses on other rows when the operator next opens the page (out of scope here).
+
+### For the Journal risk entry
+The Journal entry at `36167c87082c819ea49fcaa96e42833a` framed the DK risk as cvrapi.dk-quota-driven. That framing is confirmed correct by this verification. **No amendment needed.** The entry is the authoritative record going forward.
+
+### For the Virk migration workstream
+The Virk system-til-system migration To-do (`36167c87-082c-81e4-b80f-ea036fbcebc5`) is still correctly scoped. The handler's own `source_note` already names "Migration to direct datacvr.virk.dk system-to-system access" as queued, and the in-source comment at line 7-9 records the application URL (`https://datacvr.virk.dk/artikel/system-til-system-adgang-til-cvr-data`) and the contact email (`cvrselvbetjening@erst.dk`). No re-scoping needed.
+
+## Open questions for chat
+
+1. **Active Vendor Stack update timing.** Update now (alongside this finding's surfacing) or batch with a wider AVS audit that also checks for the same wrapper-collapse on other rows (specifically: BE/CBEAPI is known Tier-2, but worth checking AT/IE/LV/LT/SG/CZ/EE/PL/FR/SE/NO/FI/UK rows for similar drift in the AVS page text)?
+2. **Tier-2 disclosure consistency.** The handler's provenance is correctly Tier-2-labelled at runtime, but the AVS page is the canonical Tier-1/Tier-2 reader-facing artifact. Should there be a CI guard (similar to `check-platform-facts-drift.mjs`) that asserts the AVS page rows match each capability handler's `acquisition_method`? Out of scope for this prompt, but the gap exists.
+3. **No other surprises.** The handler is otherwise straightforward. The cvrapi.dk free-tier path with quota-aware error messaging is the entire DK execution path.

--- a/archive/sessions/stranded-research-2026-05/fr-directors-truncation-2026-05-15.md
+++ b/archive/sessions/stranded-research-2026-05/fr-directors-truncation-2026-05-15.md
@@ -1,0 +1,106 @@
+# FR directors truncation — root-cause investigation
+
+**Date:** 2026-05-15
+**Triggered by:** Batch 2 audit finding ([apps/api/docs/identity-field-coverage-2026-05-15.md](identity-field-coverage-2026-05-15.md), FR per-country detail section).
+**Verdict:** **Strale-side cap.** Upstream returns full `dirigeants` array; the FR handler slices it to the first 3 entries.
+**Fix shape:** One-line change (raise or remove `slice(0, 3)`), plus manifest schema reconciliation for the companion fields.
+**Recommended next step:** Queue a fix prompt. Effort = minutes for the code, ~15 min for tests + manifest update.
+
+---
+
+## RNE / upstream behaviour
+
+The FR capability does **not** call INPI's RNE API directly. It calls **`recherche-entreprises.api.gouv.fr`** ([apps/api/src/capabilities/french-company-data.ts:6](../src/capabilities/french-company-data.ts#L6)), which is the French government's national-data aggregator (operated by etalab / DINUM). Recherche-Entreprises is an open, no-auth, free API that aggregates SIRENE + RNE + multiple ancillary datasets.
+
+The endpoint used is `GET /search?q=<query>&page=1&per_page=1` ([french-company-data.ts:35](../src/capabilities/french-company-data.ts#L35)). The `per_page` parameter controls *how many matching companies* are returned, not how many directors per company. Per the Recherche-Entreprises public documentation, the `dirigeants` field on each company is the **full** statutory representative list as ingested from RNE — no upstream truncation.
+
+The handler itself confirms the upstream returns the full list: line 75 emits `total_directors: allDirectors.length` from the raw response, which is then sliced to 3 for the `directors` field. If the upstream had already truncated, `total_directors` would be at most 3 — and the Batch 2 audit observed values of 15, 20, and 20, proving the upstream returns the full list.
+
+**Conclusion: the upstream is not the source of the 3-entry cap.**
+
+## Strale handler behaviour (the adapter)
+
+[apps/api/src/capabilities/french-company-data.ts:55-58](../src/capabilities/french-company-data.ts#L55-L58):
+
+```ts
+const allDirectors = Array.isArray(c.dirigeants) ? c.dirigeants : [];
+const directors = allDirectors.slice(0, 3).map((d: any) =>
+  `${d.prenoms || ""} ${d.nom || ""}`.trim() + (d.qualite ? ` (${d.qualite})` : ""),
+);
+```
+
+The cap is the explicit `.slice(0, 3)` on line 56. The companion fields `directors_truncated` (line 74) and `total_directors` (line 75) deliberately disclose the truncation to consumers.
+
+**Inline comment (lines 53-54):**
+
+> Directors: keep the slice(0, 3) but expose truncation transparency via companion fields so consumers know more directors exist beyond the slice.
+
+**Git history:**
+
+- The `.slice(0, 3)` was present at the capability's **original** introduction in commit `094a597` (bulk-add commit "Add 22 new capabilities: 15 EU company registries + 7 validation utilities"). No rationale documented at the time.
+- Commit `c523485` (2026-05-09, "fix(P2 doctrine sweep): null instead of fabricated defaults across 5 capabilities") explicitly **kept** the slice and *added* `directors_truncated` + `total_directors` as transparency fields. The commit message labels the cap as "(defensible payload management)" — i.e. the slice was preserved as a payload-size precaution, not because the data wasn't available.
+
+So the cap is intentional but not load-bearing: it was a payload-size hedge introduced at first-implementation, retained for transparency in May 2026, and never benchmarked against actual payload sizes.
+
+## Root cause
+
+The 3-entry cap is a Strale-side payload-size hedge in [french-company-data.ts:56](../src/capabilities/french-company-data.ts#L56). The upstream (`recherche-entreprises.api.gouv.fr`) returns the full `dirigeants` array. There is no source-level limitation. The cap exists because someone wrote `.slice(0, 3)` at first-implementation and the doctrine sweep on 2026-05-09 explicitly chose to keep it while adding transparency rather than to remove it.
+
+## Fix shape options
+
+### Option A — Minimal (remove cap entirely)
+
+```ts
+const allDirectors = Array.isArray(c.dirigeants) ? c.dirigeants : [];
+const directors = allDirectors.map((d: any) =>
+  `${d.prenoms || ""} ${d.nom || ""}`.trim() + (d.qualite ? ` (${d.qualite})` : ""),
+);
+```
+
+- **Effort:** ~5 min code + ~10 min test + manifest update.
+- **Payload risk:** typical major French entities have 15-25 directors at ~50-80 bytes each → 1-2 KB extra payload. Negligible at €0.05/call pricing.
+- **Pathological risk:** very large French entities (state-owned, banking groups, mutuelles) may have 50-200+ statutory representatives. A payload of ~16 KB is still well within HTTP norms and Strale's per-response practices but worth a guard.
+- **Companion-field handling:** `directors_truncated` becomes structurally always `false`. Can keep for backwards compat or drop. `total_directors` becomes redundant with `directors.length`. Can drop. Either way the manifest's `output_schema` needs an update.
+- **Breaking-change risk:** zero for consumers reading `directors` (more entries, same shape). Consumers reading `directors_truncated` will see the value flip from `true` to `false` for major entities — they may have used it as a "should I fetch more?" trigger, which becomes moot.
+
+### Option B — Bounded (raise cap to a safe ceiling) — **RECOMMENDED**
+
+```ts
+const DIRECTORS_CAP = 50;
+const allDirectors = Array.isArray(c.dirigeants) ? c.dirigeants : [];
+const directors = allDirectors.slice(0, DIRECTORS_CAP).map((d: any) =>
+  `${d.prenoms || ""} ${d.nom || ""}`.trim() + (d.qualite ? ` (${d.qualite})` : ""),
+);
+// directors_truncated and total_directors stay; will be false/length for
+// the vast majority of entities (capping only the long-tail pathological case).
+```
+
+- **Effort:** identical to Option A.
+- **Payload risk:** bounded at ~4 KB for the directors block. Predictable.
+- **Pathological coverage:** the 50-cap protects against runaway state-entity payloads without changing behaviour for any normal company.
+- **Companion-field handling:** `directors_truncated` keeps its honest meaning (true for the rare entity with >50 representatives). `total_directors` keeps its meaning (full count). No manifest change.
+- **Breaking-change risk:** zero.
+
+### Option C — Clean (remove cap + companion fields, schema reconciliation)
+
+Drop the slice, drop `directors_truncated`, drop `total_directors`. Update the manifest schema + `output_field_reliability` accordingly. Update any frozen-fixture tests.
+
+- **Effort:** ~30 min — touches manifest + frozen tests + executor.
+- **Surface change:** consumers lose two fields. The Capability × Country Coverage Matrix and downstream Counterparty Assurance orchestrator (if it reads these) need re-checking.
+- **Justification:** cleaner API. But the cleanup is a future-tense win and the disclosure has product value (a consumer asking "did I get all directors?" gets a yes/no answer).
+- Not recommended for v1 — premature cleanup.
+
+### Recommendation
+
+**Option B.** One-liner constant + slice cap raised to 50. Preserves the honest-disclosure pattern from the 2026-05-09 doctrine sweep. Zero breaking-change risk. Closes the FR directors-coverage gap for all normal entities.
+
+## Followups
+
+1. **Queue fix prompt.** Apply Option B. Update the FR per-country detail in [identity-field-coverage-2026-05-15.md](identity-field-coverage-2026-05-15.md) to reflect "full director coverage (cap 50)" after the fix lands.
+2. **Capability × Country Coverage Matrix (Notion).** FR's directors-coverage cell should change from "yes (capped at 3, true count 15-20)" to "yes (capped at 50)" once the fix ships.
+3. **Same-pattern check for other capabilities.** Grep `apps/api/src/capabilities/` for `.slice(0, 3)` or similar director/officer/UBO truncations. The doctrine sweep on 2026-05-09 touched 5 capabilities — verify whether any of the others (austrian, belgian, german, etc.) carry an equivalent slice that was kept "for payload management." If found, treat as part of the same fix.
+4. **No code modified in this session** per investigation-only scope.
+
+---
+
+*Generated by Claude Code 2026-05-15. Read-only investigation. No code changes. Branch: `docs/identity-field-coverage-2026-05-15`.*

--- a/archive/sessions/stranded-research-2026-05/identity-field-coverage-2026-05-15.md
+++ b/archive/sessions/stranded-research-2026-05/identity-field-coverage-2026-05-15.md
@@ -1,0 +1,742 @@
+# Identity field-coverage audit — 2026-05-15
+
+**Status:** Phase 1 **COMPLETE.** 20 of 20 countries probed across four batches. 17 scored cleanly, 3 returned outage-class failures during Batch 4 (CH, HR, LT — sustained upstream/capability instability), 2 are quota-blocked (DE, DK — covered in prior batches). Phase 2 (SI Openapi WW-Top probe) and Phase 3 (US Topograph-listed state scout) deferred to follow-up sessions per session scoping.
+
+**Purpose:** Empirical follow-up to DEC-20260513-F's "20/20 v1-ready" verdict. DEC-20260513-F's certification rests on canonical-input fixture validation (one entity per capability) plus 24h canary green-rate for DK and DE only. This audit tests whether the "v1-ready" verdict holds when the capability is probed with multiple real entities (not just the fixture), and quantifies which canonical-identity fields populate at what rate across entity samples.
+
+**Batches:**
+- Batch 1 (2026-05-15, 5 countries): SE, UK, DE, SI, SG. Chosen to cover Nordics baseline, UK identifier quirks, OpenRegister free-tier quota surfacing, the known SI structural gap, and a non-EU sanity check.
+- Batch 2 (2026-05-15, 5 countries): NO, DK, FR, BE, CZ. Continues Nordics + adds FR (first country with directors), BE (CBEAPI Tier-2 wrapper), CZ (ARES).
+- Batch 3 (2026-05-15, 5 countries): FI, IE, EE, PL, LV. Tests the CKAN-thinness hypothesis (refuted) + 2 direct-registry Eastern European integrations.
+- Batch 4 (2026-05-15, 5 countries): CH, GR, HR, LT, SK. Phase 1 closeout. Surfaced multiple sustained capability/upstream issues (Zefix outage, Sudreg circuit-breaker open, data.gov.lt Spinta degraded) — 3 of 5 countries failed empirical scoring this session.
+
+**Methodology:** prod API at `https://strale-production.up.railway.app/v1/do` with test API key `sk_live_0d56f39c`. 3 real entities per country: canonical fixture (the `known_answer.input` per DEC-20260513-F) plus 2 well-known publicly-listed or otherwise large entities from the same jurisdiction. Identifiers validated against each capability's input schema before invocation.
+
+**Total cost:** €2.30 across four batches (46 successful calls × €0.05). Many calls failed without wallet charge — most prominently in Batch 4 due to upstream outages and circuit-breaker blocks. Wallet: €33.99 → €33.39 (Batch 1) → €32.79 (Batch 2) → €32.04 (Batch 3) → €31.69 (Batch 4). Well within the €10 per-batch hard cap.
+
+**Doc references:**
+- DEC-20260513-F — 20/20 Identity v1-ready certification
+- DEC-20260515-A — US scope upgrade and Topograph blueprint
+- DEC-20260513-B — bad-fixture cascade pattern (identifier-validation requirement)
+- DEC-20260508-D — DE/OpenRegister free-tier quota disclosure
+
+---
+
+## Methodology
+
+### Entity selection rules
+
+1. Entity #1 is the manifest's `test_fixtures.known_answer.input` (the canonical fixture entity that DEC-20260513-F's verdict rests on).
+2. Entities #2 and #3 are drawn from well-known publicly-listed or otherwise large entities in the same jurisdiction, selected from public knowledge of the country's top companies by revenue or market cap.
+3. Each entity's identifier is validated against the capability's `input_schema` before invocation to prevent bad-fixture-cascade per DEC-20260513-B.
+4. Where the country's legal-form distribution allows, the 3-entity set covers at least 2 distinct legal forms. Where it doesn't (Sweden is overwhelmingly AB; Singapore listed companies are all "Local Company"), the pilot notes the constraint inline rather than forcing a non-representative form.
+
+### Canonical field set
+
+10 fields scored per country, drawn from the prompt's spec:
+
+1. **Legal name** — official registered name
+2. **Registration number** — primary identifier (org_number / company_number / reg_number / uen)
+3. **Status** — active / dissolved / liquidation / registered / etc.
+4. **Registration date** — incorporation date / registration date
+5. **Address** — registered office address (any non-null shape: object or string)
+6. **Legal form** — corporate form (AB / PLC / LLP / SE / AG / d.d. / d.o.o. / etc.)
+7. **Directors** — statutory representatives (with roles where available)
+8. **Industry code** — NACE / SNI / SIC / sector classifier
+9. **VAT number** — country-equivalent tax ID
+10. **LEI** — Legal Entity Identifier
+
+### Scoring criterion
+
+A field is **populated** if its value is non-null AND non-empty (empty string, empty array, empty object → not populated) AND not a placeholder string (`"unknown"`, `"-"`, `"N/A"`). Cells score `X/3` where X is the number of entities for which the field met the criterion.
+
+A field that is **not in the capability's response schema at all** is scored `–` (en-dash), not `0/3`. The distinction matters: `0/3` means the schema declares the field but no entity populated it (an empirical gap); `–` means the capability cannot return that field at all (a schema/source gap).
+
+For DE, where 0 of 3 entities executed successfully due to OpenRegister quota exhaustion, fields are scored `quota` to denote that the schema supports them but no empirical data was gathered.
+
+---
+
+## Phase 1 — EU+UK+NO+CH+SG live capabilities (5-country pilot)
+
+### Field coverage matrix
+
+| Country | Legal name | Reg # | Status | Reg date | Address | Legal form | Directors | Industry code | VAT | LEI |
+|---------|-----------|-------|--------|----------|---------|------------|-----------|---------------|-----|-----|
+| BE      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | –         | 0/3           | 3/3 | –   |
+| CH      | outage    | outage| outage | outage   | outage  | outage     | –         | –             | –   | –   |
+| CZ      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | –         | 3/3 (NACE)    | 3/3 | –   |
+| DE      | quota     | quota | quota  | quota    | quota   | quota      | quota     | quota         | –   | quota |
+| DK      | quota     | quota | quota  | quota    | quota   | quota      | –         | quota         | –   | –   |
+| EE      | 3/3       | 3/3   | 3/3    | –        | 3/3     | 3/3        | –         | –             | 0/3 | –   |
+| FI      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | –         | 3/3 (NACE)    | 3/3*| –   |
+| FR      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | 3/3       | 3/3 (NAF)     | 3/3 | –   |
+| GR      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | 1/3‡      | 2/3 (NACE)‡   | 3/3 | –   |
+| HR      | outage    | outage| outage | outage   | outage  | outage     | –         | outage        | outage | – |
+| IE      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | –         | 3/3 (PO)†     | 0/3 | –   |
+| LT      | outage    | outage| outage | outage   | –       | outage     | –         | –             | –   | –   |
+| LV      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | –         | –             | 0/3 | –   |
+| NO      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | –         | 3/3 (NACE)    | 3/3 | –   |
+| PL      | 3/3       | 3/3   | 3/3    | 0/3      | 0/3     | 3/3        | –         | –             | 3/3 | –   |
+| SE      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | –         | 3/3 (SNI)     | 3/3 | –   |
+| SG      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | –         | –             | –   | –   |
+| SI      | 3/3       | 3/3   | –      | –        | 3/3     | 3/3        | –         | –             | –   | –   |
+| SK      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | **3/3**   | 3/3 (NACE)    | –§  | –   |
+| UK      | 3/3       | 3/3   | 3/3    | 3/3      | 3/3     | 3/3        | –         | 2/3 (SIC)     | 0/3 | –   |
+
+`*` FI returns `vat_number` (and `website`) but the manifest's output_schema does not declare them. Schema undercount, not overcount. Recommend updating schema to declare these.
+`†` IE: `principal_object_code` populated 3/3 (NACE-compatible); `nace_v2_code` is null 3/3 (declared `rare`, consistent).
+`‡` GR: directors populated 1/3 because the fixture (000237954001) resolves to an NBG branch (`is_branch=true`, no board) and GR-2 (44132307000) resolved to a sole proprietorship (ΑΤΟΜΙΚΗ, no board). GR-3 (OTE) returned 10 directors with roles. Industry code 2/3 — fixture's branch entry has none. Entity-mix problem, not capability problem.
+`§` SK schema does not declare `vat_number` despite Slovak companies carrying DIČ (derivable from IČO). Schema gap; treat as missing-field finding rather than 0/3.
+
+**Outage rows (CH/HR/LT):** all three Batch 4 capabilities returned sustained errors across the session — CH (Zefix `External service temporarily unavailable` on every attempt including retries), HR (Sudreg API timeouts → circuit breaker open until 09:09Z+), LT (data.gov.lt Spinta degraded — capability returns 502 / internal_error even for the fixture identifier `304151376`). These are operational signals worth treating as v1-launch blockers pending re-test under quieter conditions. See per-country detail.
+
+### Reading the matrix
+
+- **`X/3`** — schema supports the field; X of 3 entities populated it.
+- **`–`** — capability's response schema does not include the field.
+- **`quota`** — capability execution blocked at upstream-API quota (DE: OpenRegister 50/month free tier; DK: cvrapi.dk 50/day free tier). Schema supports the field but no empirical data was gathered this session. Circuit breaker tripped in both cases.
+- **`outage`** — capability execution blocked by sustained upstream outage or capability-level degradation (Batch 4 CH/HR/LT). Distinct from `quota` (which is calendar-bounded recovery): `outage` is open-ended and needs operational triage.
+
+**Schema-vs-reality mismatches (declared fields, empirically `0/3`):**
+- UK `vat_number` — Companies House profile endpoint does not return VAT. Recommend dropping from schema.
+- BE `industry` — CBEAPI.be wrapper does not surface NACE codes from KBO/BCE. Recommend dropping from schema or hooking a KBO Open Data direct ingest.
+- IE `vat_number` — CRO Open Data CKAN does not include VAT. Recommend dropping or hooking Revenue's VIES lookup.
+- EE `vat_number` — Äriregister capability does not surface KMKR (Estonian VAT). EE VAT can be derived (`EE` + 9 digits) but the executor doesn't.
+- LV `vat_number` — `data.gov.lv` CKAN does not include VAT. LV VAT can be derived (`LV` + reg_number for 40NNN-prefix entities) but executor doesn't.
+- PL `address` — KRS capability declares the field but returned null 3/3 across major listed entities (Orlen, KGHM, MARTOM). Significant gap.
+- PL `registration_date` — same pattern, declared null 3/3.
+
+### Per-country detail
+
+#### SE — swedish-company-data (Bolagsverket HVD)
+
+**Entities tested:**
+- E1: Spotify AB, org_number `556703-7485` (fixture)
+- E2: Aktiebolaget Volvo, org_number `556012-5790`
+- E3: H & M Hennes & Mauritz AB, org_number `556042-7220`
+
+**Legal-form constraint:** All 3 entities are Aktiebolag (AB). Sweden's company-form distribution is overwhelmingly dominated by AB for the entity size range used here; the pilot did not force a non-representative form. Bolagsverket HVD also covers HB, KB, EK, etc. but those are not represented in the top-listed slice.
+
+**Anomalies:**
+- E2 (Volvo) `registered_address.street` is `null` while E1 (Spotify) and E3 (H&M) have populated streets. City + postal code present for all. This is a real registry-level data sparsity for older entities, not a capability bug. The `registered_address` object is non-null in all 3 cases (so the field counts as populated by the scoring criterion), but the *completeness* of the address varies.
+
+**Field notes:**
+- `sni_codes` is an array of `{code, description}` pairs; every entity has at least 1 entry. SE counts as full SNI coverage.
+- `vat_number` is algorithmically derived from `org_number` (10-digit orgnr + `01` suffix); always populated.
+- No `directors` or `lei` fields in the SE schema. Directors data is not in the HVD subset; LEI is a GLEIF artifact and would require a join against `lei-lookup` capability.
+
+#### UK — uk-company-data (Companies House)
+
+**Entities tested:**
+- E1: TESCO PLC, company_number `00445790` (fixture, PLC)
+- E2: ASTRAZENECA PLC, company_number `02723534` (PLC)
+- E3: KPMG LLP, company_number `OC301540` (LLP)
+
+**Legal-form constraint:** 2 distinct forms covered (PLC, LLP). The `business_type` field correctly differentiates `plc` from `llp`. Companies House supports more forms (ltd, ltd-by-guar, plc, llp, scot-llp, partnership) but these 3 entities are representative.
+
+**Anomalies:**
+- E3 (KPMG LLP) `sic_codes` is an empty array `[]` while E1 and E2 have populated SIC arrays. LLPs at Companies House routinely have empty SIC arrays — Companies House does not require SIC for LLPs. This is a real source gap, not a capability bug. Scored `2/3` for industry code.
+- Initial pick OC305597 (intended as KPMG LLP) returned "not found" — the actual KPMG LLP number is OC301540. Substituted and retried (no wallet charge for the failed call).
+
+**Field notes:**
+- No `vat_number` is returned in any response despite the field being declared as optional in the schema. Companies House does not expose VAT on the basic profile endpoint; VAT comes from a separate HMRC service. Scored `0/3` (schema declares the field, but empirically never populated — distinct from `–`).
+- No `directors` or `lei` fields in the UK schema. Companies House `/officers` is a separate endpoint and a separate capability (`uk-companies-house-officers`); this capability returns only the company profile.
+- UK capability response is **noticeably thinner** than SE: 8 fields vs 16. No business description, no alternative names, no `is_active` boolean. The `status` is returned as a plain string ("active") with no enum normalization.
+
+#### DE — german-company-data (OpenRegister Tier-2)
+
+**Entities tested (intended):**
+- E1: SAP SE, company_name `"SAP SE"` (fixture, SE form)
+- E2: Siemens AG, company_name `"Siemens AG"` (AG form)
+- E3: BMW AG, company_name `"Bayerische Motoren Werke Aktiengesellschaft"` (AG form)
+
+**Execution status: 0 of 3 entities executed successfully.**
+
+- E1 returned HTTP 402 "Payment Required" from OpenRegister upstream. The free tier (50 req/month, resets on the 1st of the month) is exhausted for 2026-05.
+- E2 and E3 hit the circuit breaker (state `open` until `2026-05-15T07:33:13Z`). Per DEC-20260503-B the breaker trips after 3 consecutive failures and the 402 from E1 was apparently the 3rd consecutive failure in a 30-day window — suggesting the quota had been progressively burned by prior production traffic + earlier health probes earlier in May.
+- No wallet charge applied for any of the 3 attempts (DEC-14 alignment confirmed in the wallet-balance progression).
+
+**Operational finding (the original pilot rationale):** the DE pilot was scoped specifically to "surface any quota issue early before scaling to 20 countries" per session direction. Surface it does. The quota was empirically depleted *before* this audit's first call — the 402 on the canonical fixture means OpenRegister rejected the first paid request of this audit session. Either the May free-tier allowance has already been consumed by production traffic, or there's a mid-month overrun pattern worth investigating.
+
+**Recommended follow-up for chat:**
+1. Pull the DE 2026-05 call log from the transactions table — verify how the 50 free credits were consumed and on what dates.
+2. If consumption is from real customer traffic, decision point per DEC-20260505-H (Pro-tier upgrade gated on customer attachment + audit-retention written confirmation).
+3. If consumption is from health probes or smoke tests, tune the probe schedule against the 50/month cap.
+4. Re-run the DE pilot after 2026-06-01 (next quota reset) or after a Pro upgrade.
+
+**Schema-supported fields (cannot empirically score this session):** `directors`, `lei`, `industry_codes`, `incorporated_at`, `legal_form`, `capital`, etc. DE is the *only* country in this pilot whose schema declares `directors` and `lei` — making it the highest-priority country to re-test once quota is restored.
+
+#### SI — slovenian-company-data (data.gov.si CKAN)
+
+**Entities tested:**
+- E1: KRKA, tovarna zdravil, d.d., Novo mesto, reg_number `5043611000` (fixture, d.d. = Delniška družba)
+- E2: PETROL, Slovenska energetska družba, d.d., Ljubljana, reg_number `5025796000` (d.d.)
+- E3: Poslovni sistem Mercator d.o.o., reg_number `5300231000` (d.o.o. = Družba z omejeno odgovornostjo)
+
+**Legal-form constraint:** 2 distinct forms covered (d.d., d.o.o.). The `legal_form` field cleanly differentiates.
+
+**Anomalies:** None per entity. Every entity returned every schema-declared field non-null. The capability is structurally consistent at the entity level.
+
+**Structural source gap confirmed (DEC-20260513-F):**
+- `status` — not in schema. Open feed does not distinguish active vs dissolved.
+- `registration_date` (incorporation date) — not in schema.
+- `industry_code` (SKD/NACE) — not in schema.
+- `directors` — not in schema.
+- `vat_number` — not in schema.
+- `lei` — not in schema.
+
+The thin-coverage is *not* an empirical gap (0/3 fields populated despite schema) but a *schema/source* gap: the data.gov.si CKAN open subset does not contain these fields at all. The audit's three entities confirm this is consistent across both d.d. and d.o.o. forms. Reactivation requires a paid AJPES restPrsInfo contract with redistribution rights or EU HVD expansion (per manifest's limitation block).
+
+**Implication:** SI is the canonical example of a country where the v1-ready certification is *correct on what's returned* but *thin on what KYB/compliance customers expect to see*. The follow-up session's Phase 2 (Openapi WW-Top probe of the same 3 SI entities) is the empirical test of whether Openapi closes the gap.
+
+#### SG — singapore-company-data (data.gov.sg CKAN / ACRA)
+
+**Entities tested:**
+- E1: SINGAPORE AIRLINES LIMITED, uen `197200078R` (fixture, Local Company)
+- E2: SINGAPORE TELECOMMUNICATIONS LIMITED, uen `199201624D` (Local Company)
+- E3: OVERSEA-CHINESE BANKING CORPORATION LIMITED, uen `193200032W` (Local Company)
+
+**Legal-form constraint:** Only 1 distinct `entity_type` ("Local Company") across the 3 entities. Singapore's `entity_type` is finer-grained than expected — top listed entities are all Local Company. Sole Proprietorships, Partnerships, Limited Liability Partnerships, Foreign Company branches all exist as distinct `entity_type` values in the ACRA dataset, but those are not represented in the top-tier-by-revenue slice. The pilot did not force a non-representative entity to satisfy the "2 distinct forms" rule for SG. Note as a methodology variance.
+
+**Anomalies:** None per entity. All 3 fields populated identically.
+
+**Field notes:**
+- `registered_street` and `registered_postal_code` are populated for all 3 entities, but the `registered_address` is the literal concatenation `"<STREET>, Singapore <POSTAL>"` — no building number, no unit. This matches the manifest's documented limitation (data.gov.sg ACRA dataset publishes street + postal only).
+- No `directors`, `industry_code`, `vat_number`, or `lei` fields in the SG schema. Directors and shareholders require paid ACRA BizFile+. Singapore has no separate VAT (UEN doubles as tax ID for GST). LEI would require a GLEIF cross-walk.
+- `status` is the string `"Registered"` (not "active") — different vocabulary from EU capabilities. Solutions that filter on status would need to normalize. Not a bug, but a wire-shape consistency note.
+
+#### NO — norwegian-company-data (Brønnøysund Register Centre)
+
+**Entities tested:**
+- E1: DNB BANK ASA, org_number `984851006` (fixture)
+- E2: EQUINOR ASA, org_number `923609016`
+- E3: Norsk Hydro ASA, org_number `914778271`
+
+**Legal-form constraint:** All 3 are Allmennaksjeselskap (ASA — public limited). Norway's top-listed slice is dominated by ASA. Brønnøysund also covers AS, ENK, SA, ANS, DA, STI, but those are not represented in the entity sample. Same constraint as SE.
+
+**Anomalies:** None per entity. All 10 schema-declared fields populated for all 3 entities.
+
+**Field notes:**
+- `vat_number` is algorithmically derived (orgnr + `MVA` suffix); always populated.
+- `industry_code` is NACE-compatible (e.g. `64.190` for banks, `06.100` for crude petroleum extraction, `24.420` for aluminium production); 3/3 populated.
+- `employee_count` is populated as a plain integer (7491 / 21327 / 391) — useful for solutions that filter on company size.
+- No `directors` or `lei` fields in the NO schema. Brønnøysund exposes director data via a separate endpoint (`/enheter/{orgnr}/roller`) that this capability does not call.
+
+#### DK — danish-company-data (cvrapi.dk / CVR)
+
+**Entities tested (intended):**
+- E1: Novo Nordisk A/S, cvr_number `24256790` (fixture, A/S)
+- E2: A.P. Møller - Mærsk A/S, cvr_number `22756214` (A/S)
+- E3: Vestas Wind Systems A/S, cvr_number `10403782` (A/S)
+
+**Execution status: 0 of 3 entities executed successfully.**
+
+- E1 returned `"The Danish business registry API quota has been temporarily exceeded. Please try again in a few hours."` from cvrapi.dk upstream.
+- E2 and E3 hit the circuit breaker (state `open` until `2026-05-15T07:49:56Z`). Same pattern as DE in Batch 1.
+- No wallet charge for any of the 3 attempts.
+
+**Operational finding:** Per the manifest, `danish-company-data` runs on cvrapi.dk's free tier with a conservative IP-quota cap of 50/day (the documented limit is higher but the manifest records "Empirical floor ~50/day; documented limit higher but conservative cap chosen until we observe one clean cycle"). The quota is exhausted before this Batch 2 session's first call, which means earlier health probes + customer traffic in the past 24 hours have already saturated the daily cap. Same recommendation as DE: pull the past-24-hour DK call log from the transactions table.
+
+**Schema-supported fields (cannot empirically score this session):** `status`, `address`, `cvr_number`, `start_date`, `company_name`, `business_type`, `industry_code`, `employee_range`. Schema does **not** declare `directors`, `vat_number`, or `lei` — even when the quota is restored DK will score `–` on those columns.
+
+**Schema-vs-reality flag (anticipated):** DK companies all have CVR-derived VAT numbers (CVR doubles as VAT-ID), so absence of `vat_number` from the schema is a *missing field*, not a source gap. Suggest adding `vat_number` to the DK schema as a derived field (mirroring SE's `org_number → vat_number` pattern).
+
+#### FR — french-company-data (INSEE / SIRENE via api.gouv.fr)
+
+**Entities tested:**
+- E1: TOTALENERGIES SE, siren `542051180` (fixture, business_type=5800 → SE)
+- E2: L'OREAL, siren `632012100` (business_type=5599 → SA)
+- E3: BNP PARIBAS, siren `662042449` (business_type=5599 → SA)
+
+**Legal-form constraint:** 2 distinct INSEE legal-form codes covered (5800 = SE, 5599 = SA). Note FR's `business_type` is the INSEE numeric code, not a human label — solutions that filter on legal form would need an INSEE code map.
+
+**Anomalies:**
+- Director name overlap: "JACQUES ASCHENBROICH" appears on both TotalEnergies (E1) and BNP Paribas (E3) boards. Verified accurate against public records — Aschenbroich serves on multiple French boards. Not a capability bug; a real-world cross-board directorship.
+- L'OREAL's `company_name` is a list of trade names in parentheses ("L'OREAL (KERASTASE ; MIZANI ; L'OREAL PROFESSIONNEL PARIS ; ESSIE PROFESSIONNEL ; BAXTER OF CALIFORNIA ; BIOL)"). The leading name is the official `dénomination sociale`; the parenthesized tail is the `nom commercial`. Solutions parsing the name field need to split on `(`.
+
+**Field notes — first country in this audit with directors coverage:**
+- `directors` is a 3-element array per entity, with role labels ("Administrateur" / "Président du conseil d'administration" / "Directeur Général" / "Personne ayant le pouvoir d'engager…").
+- `directors_truncated: true` for all 3 entities — the executor caps the payload at 3 directors.
+- `total_directors` reveals the true counts: 15 (TotalEnergies), 20 (L'Oréal), 20 (BNP Paribas). The 3-cap is a payload-size decision, not a source limitation. For KYB customers needing full director rosters, the cap will need to be raised or paginated.
+- `vat_number` is algorithmically derived (FR + 2-digit check + SIREN); 3/3 populated.
+- `activity_code` is the NAF/APE code (French national NACE variant, e.g. `70.10Z` for holding-company management). 3/3 populated.
+- No `lei` in the schema. INSEE does not include LEI in the SIRENE response.
+
+**Implication:** FR is the audit's first proof that the schema *can* declare and populate `directors` for a free public registry. The 3-cap is a Strale-side product decision and an obvious tuning target before the v1 launch. The matrix's `3/3` for FR directors should be read as "3 of 3 entities have ≥3 directors returned, but the true count is 15–20."
+
+#### BE — belgian-company-data (CBEAPI.be wrapper of KBO/BCE)
+
+**Entities tested:**
+- E1: ANHEUSER-BUSCH INBEV, enterprise_number `0417497106` (fixture, Société anonyme)
+- E2: SOLVAY, enterprise_number `0403091220` (Société anonyme)
+- E3: PROXIMUS, enterprise_number `0202239951` (Société anonyme de droit public)
+
+**Legal-form constraint:** 2 distinct sub-forms covered: standard SA (E1/E2) and the public-law variant "Société anonyme de droit public" for Proximus (E3, formerly state-owned). Belgium's legal-form vocabulary is bilingual (Dutch NV / French SA); all 3 entities returned the French form-label.
+
+**Anomalies:**
+- **Schema-vs-reality mismatch:** `industry` field is declared in the output schema (type `string`) but is `null` for all 3 entities. The CBEAPI.be wrapper does not surface NACE codes from KBO/BCE despite the schema promising the field. This is the BE equivalent of the UK `vat_number` finding from Batch 1. Recommendation: drop from schema or migrate to a direct KBO Open Data ingest that exposes NACE.
+- `commercial_name` is `null` for all 3 entities (declared `rare` in field reliability, so 0/3 is consistent).
+- `abbreviation` is populated only for E1 ("A.P.I." — Anheuser-Busch InBev's abbreviation). 1/3.
+
+**Field notes:**
+- `vat_number` is algorithmically derived (BE + enterprise_number); 3/3 populated.
+- `registration_date` is populated even for very old entities (Solvay: 1863-12-26, Proximus: 1930-07-19). The CBEAPI.be wrapper handles historical dates cleanly.
+- `establishments_count` is populated 3/3 (5 / 2 / 186). Useful as a proxy for company-size filtering.
+- No `directors` or `lei` fields in the BE schema. KBO/BCE does expose director data via the FPS Economy SFTP feed; CBEAPI.be wrapper does not surface it.
+
+#### CZ — cz-company-data (ARES / Czech Ministry of Finance)
+
+**Entities tested:**
+- E1: Škoda Auto a.s., ico `00177041` (fixture, a.s. = akciová společnost, legal_form_code=121)
+- E2: ČEZ, a. s., ico `45274649` (a.s., legal_form_code=121)
+- E3: O2 Czech Republic a.s., ico `60193336` (a.s., legal_form_code=121)
+
+**Legal-form constraint:** All 3 entities are akciová společnost (a.s.), legal_form_code `121`. Czech top-listed slice is dominated by a.s.; s.r.o. (společnost s ručením omezeným, code 112) and v.o.s. / k.s. are common in SMB but not in the entity sample.
+
+**Anomalies:** None per entity. All 11 schema-declared fields populated for all 3 entities.
+
+**Field notes:**
+- `legal_form_code` is returned as a numeric string (`"121"`) — different vocabulary from FR's `business_type` (also numeric) and SE/SG (human-readable string). Solutions filtering on legal form need a per-country code lookup. Wire-shape consistency note.
+- `nace_codes` is an array of NACE codes; entity counts vary (13 for Škoda, 42 for ČEZ, 27 for O2) — Czech companies declare many secondary NACE activities, more than the typical 1-2 in other EU registries.
+- `vat_number` is algorithmically derived (CZ + IČO); 3/3 populated.
+- `last_updated` field carries the ARES dataset's freshness date per entity (2026-04-16, 2026-04-19, 2026-04-06). Useful provenance signal, not present in most other EU capabilities.
+- `primary_source` is `"ros"` for all 3 (ROS = Registr osob, the Czech base register). Indicates the underlying ARES route.
+- No `directors` or `lei` fields in the CZ schema. ARES exposes "statutární orgán" (statutory body) data via a separate endpoint that this capability does not call.
+
+#### FI — finnish-company-data (PRH / avoindata.prh.fi)
+
+**Entities tested:**
+- E1: Nokia Oyj, business_id `0112038-9` (fixture, Oyj)
+- E2: Stora Enso Oyj, business_id `1039050-8` (Oyj)
+- E3: Neste Oyj, business_id `1852302-9` (Oyj)
+
+**Legal-form constraint:** All 3 entities are Oyj (Public limited company). Finland's top-listed slice is dominated by Oyj. PRH also covers Oy, Ay, Ky, Osk, ry, but none are represented in the entity sample. Same constraint as NO/SE.
+
+**Anomalies:** None per entity. All 3 entities returned every schema-declared field plus 2 additional fields (`website`, `vat_number`) that are NOT declared in `output_schema`.
+
+**Field notes:**
+- **Schema-undercount (inverse of UK/BE pattern):** the response includes `vat_number` (FI + business_id minus the dash and check digit) and `website` (e.g. `"www.nokia.com"`), but the `output_schema` properties section does not declare them. Customers reading the schema would not know to expect them. Recommend adding both to the schema. This is the opposite of the schema-vs-reality mismatch — capability returns *more* than declared.
+- `industry_code` is NACE-compatible (5-digit, e.g. `70100`, `17120`, `19200`); 3/3 populated.
+- `registration_date` is populated even for old entities (Nokia: 1896-12-19, well within HVD coverage). PRH handles historical dates cleanly.
+- Address is a comma-delimited string with street, number, postal code, city: `"Karakaari, 7, 02610 ESBO"`.
+- `website` is null for Neste (E3) but populated for Nokia + Stora Enso. Useful for KYB enrichment when present.
+- No `directors` or `lei` fields in the FI schema. PRH `/bis/v1/{businessId}` exposes director-equivalent data via the `bisCacheTime` payload (companyForms array, businessLines array, registeredOffices array, names array). The capability does not currently surface it. Free-path direct-build candidate.
+
+#### IE — irish-company-data (CRO Open Data Portal CKAN)
+
+**Entities tested:**
+- E1: STRIPE PAYMENTS EUROPE, LIMITED, cro_number `513174` (fixture, LTD)
+- E2: CRH PUBLIC LIMITED COMPANY, cro_number `12965` (PLC)
+- E3: RYANAIR HOLDINGS PUBLIC LIMITED COMPANY, cro_number `249885` (PLC)
+
+**Legal-form constraint:** 2 distinct forms covered (LTD + PLC). Irish CRO Open Data also covers UNLTD, EXTERNAL, INDUSTRIAL_PROVIDENT, LBG, but those are not represented in the entity sample.
+
+**Anomalies:**
+- IE-2 (CRH) returned a transient `internal_error` on first attempt with no wallet charge. Succeeded on retry. Single transient failure across 15 Batch-3 calls; not a pattern but worth a Sentry/source_health glance.
+- `eircode` is populated 2/3 — Ryanair Holdings (E3, 1996 incorporation) has `null` eircode. Per manifest's documented limitation: "The Eircode field was introduced in 2014 and is populated for newer registrations and recently-updated entities." Consistent.
+- `nace_v2_code` is null 3/3 (declared `rare` in field reliability, so consistent with the manifest).
+- Status string is `"Normal"` — third distinct status vocabulary in this audit ("active" / "Registered" / "Reģistrēts" / "Normal"). Wire-shape consistency note.
+
+**Field notes:**
+- **Schema-vs-reality mismatch:** `vat_number` declared in `output_schema` properties but populated `0/3`. Irish VAT (`IE` + 7 chars or 8 chars + letter) comes from Revenue, not CRO. Same recommendation as UK: drop or hook a VIES lookup.
+- `principal_object_code` populated 3/3 (`65.23`, `74.15`, `74.84` — NACE-compatible Principal Object codes). Treated as the de-facto industry-code field for IE in the matrix, with `nace_v2_code` as the rare richer alternative.
+- `last_annual_return_date` / `next_annual_return_date` / `last_accounts_date` populated for all 3 — useful KYB freshness signal. Unique to IE among audited capabilities.
+- No `directors` or `lei` fields in the IE schema. CRO Open Data exposes directors via a *separate dataset* on opendata.cro.ie (the Directors dataset). Free-path direct-build candidate (likely the same CKAN endpoint pattern as the current capability).
+
+#### EE — estonian-company-data (e-Äriregister / ariregister.rik.ee)
+
+**Entities tested:**
+- E1: Bolt App Services AS, registry_code `17449106` (fixture, AS = Aktsiaselts)
+- E2: Aktsiaselts Tallink Grupp, registry_code `10238429` (AS)
+- E3: Pipedrive OÜ, registry_code `11958539` (OÜ = Osaühing / private LLC)
+
+**Legal-form constraint:** 2 distinct forms (AS, OÜ). Estonian e-Äriregister covers TÜ, FIE, MTÜ, KÜ, NB, SA also, but those are not represented in the top-listed slice.
+
+**Anomalies:**
+- **Wire-shape inconsistency in `business_type`:** E1 (Bolt AS) returns `"1"` (numeric code), E2 (Tallink AS) returns `"1"` (numeric code), E3 (Pipedrive OÜ) returns `"OÜ (Private limited company)"` (human-readable string). The capability handler is inconsistent — apparently the AS branch returns a code while the OÜ branch returns a label. Solutions parsing `business_type` will see this as two different shapes.
+- E2 (Tallink) and E3 (Pipedrive) have populated `historical_names` arrays (former names: "Hansatee Grupp", "New Pipe Technologies OÜ"). E1 (Bolt) has empty array. Historical-name tracking is rare among audited capabilities and useful for KYB.
+- The capability scrapes ariregister (the manifest flags `maintenance_class: scraping-stable-target`). Latency for E1 was 3.07s — noticeably slower than the direct-API capabilities (typically <1s). Worth a freshness/circuit-breaker note.
+
+**Field notes:**
+- **Schema-vs-reality mismatch:** `vat_number` declared in `output_schema` properties but populated `0/3`. Estonian KMKR can be derived (`EE` + 9 digits) — same gap as LV.
+- **Structural source/schema gap (SI-style minor):** EE schema does NOT declare `registration_date` or `industry_code`. Both are visible at ariregister.rik.ee on the public-facing entity page; the capability scrape doesn't surface them. Capability-level gap, not source-level — the upstream has the data.
+- No `directors` or `lei` fields in the EE schema. The Estonian e-Business Register exposes director ("juhatuse liige") and shareholder data on the public entity page; the capability does not surface it. Free-path direct-build candidate via the same scrape route, subject to the manifest's "blocked from certain IP ranges" caveat.
+
+#### PL — polish-company-data (KRS via krs-pobierz.ms.gov.pl)
+
+**Entities tested:**
+- E1: PPHU MARTOM Sp. z o.o., krs_number `0000033945` (fixture, Sp. z o.o.)
+- E2: ORLEN SPÓŁKA AKCYJNA, krs_number `0000028860` (SA)
+- E3: KGHM POLSKA MIEDŹ SPÓŁKA AKCYJNA, krs_number `0000023302` (SA)
+
+**Legal-form constraint:** 2 distinct forms (Sp. z o.o. + Spółka Akcyjna). Polish KRS also covers SK, SKA, SP, F (Foundation), Stowarzyszenie, but those are not represented in the entity sample.
+
+**Anomalies:**
+- **Two schema-vs-reality mismatches:** `address` and `registration_date` are both declared in `output_schema` properties but populated `null` for all 3 entities, including the canonical fixture (MARTOM). This is the most severe schema-vs-reality finding in the audit so far — 2 fields, including basic identity data, are promised but never delivered. Worth a code-level investigation: is the KRS scrape failing to extract these fields, or is it source-level?
+- The fixture's manifest example output already shows `address: null` and `registration_date: null` — so this is a *known* gap in the manifest, not a regression. The capability ships with these fields declared in the schema despite the example admitting they're always null. Recommend either fixing the scrape or dropping from schema.
+- The response includes 3 additional fields not declared in `output_schema.properties`: `nip` (Polish NIP tax number, 10 digits), `register_type` (`"commercial"` for all 3 — likely the KRS-vs-CEIDG-vs-Stowarzyszenie selector), and `share_capital` (e.g. `"1451177561,25 PLN"`). Schema-undercount, similar to FI.
+
+**Field notes:**
+- `vat_number` is derived from NIP (`PL` + NIP); 3/3 populated. Schema declares it.
+- `legal_form` is populated 3/3 (`"SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ"`, `"SPÓŁKA AKCYJNA"`) — Polish-language label, not a code. Different vocabulary from CZ's `"121"` and FR's `"5800"`.
+- `share_capital` is populated 3/3 with currency suffix — useful KYB signal, but not declared in schema (see above).
+- No `directors` or `lei` fields in the PL schema. KRS exposes statutory representatives ("organ reprezentujący") via a separate section of the same scrape page. Free-path direct-build candidate; the scrape route already has access.
+
+#### LV — latvian-company-data (Latvian Open Data Portal CKAN / data.gov.lv)
+
+**Entities tested:**
+- E1: Air Baltic Corporation AS, reg_number `40003245752` (fixture, AS = Akciju sabiedrība)
+- E2: Akciju sabiedrība "Latvenergo", reg_number `40003032949` (AS)
+- E3: "Latvijas Mobilais Telefons" SIA (LMT), reg_number `50003050931` (SIA = Sabiedrība ar ierobežotu atbildību / private LLC)
+
+**Legal-form constraint:** 2 distinct forms (AS + SIA). data.gov.lv also covers IK (individual merchant), KS, PS, biedrība, but those are not represented in the entity sample.
+
+**Anomalies:**
+- Status string is `"Reģistrēts"` (Latvian for "registered") — yet another vocabulary in the cross-country status pattern.
+
+**Field notes:**
+- **Schema-vs-reality mismatch:** `vat_number` declared in `output_schema` properties but populated `0/3`. LV VAT (PVN) is derivable from `reg_number` for the 40NNN-prefix legal-entity range (PVN = `LV` + reg_number for those entities). The capability doesn't derive it. Either drop from schema or compute.
+- **Structural source gap (SI-style minor):** `industry_code` (NACE) is NOT in the LV schema and not surfaced. data.gov.lv publishes a separate dataset with NACE codes that this capability doesn't ingest. Source has it; current capability doesn't. Capability-level gap.
+- `sepa_creditor_id` populated 3/3 (`LV78ZZZ40003245752`, `LV61ZZZ40003032949`, `LV67ZZZ50003050931`) — unique to LV among audited capabilities. Useful for SEPA-payment KYB workflows.
+- `atvk_code` populated 3/3 (Latvian administrative-territorial classification) — unique to LV.
+- `register_type` is `"Komercreģistrs"` for all 3 (Commercial Register).
+- No `directors` or `lei` fields in the LV schema. data.gov.lv publishes a separate dataset ("Patiesie labuma guvēji" — beneficial owners) per the manifest's coverage limitation. The director-equivalent ("amatpersonas" — officials) dataset is also published separately. Free-path direct-build candidate (both UBO and directors via separate CKAN ingest).
+
+**CKAN-thinness hypothesis verdict for IE + LV:** *mostly refuted.* Both registries return rich identity fields (12+ each). SI's thinness is unique among the audited CKAN-based registries — SI's `data.gov.si` open subset is structurally narrower than IE's `opendata.cro.ie` and LV's `data.gov.lv`. The hypothesis that "CKAN-based open-data registries are SI-style thin" does not hold.
+
+#### CH — swiss-company-data (Zefix PublicREST API)
+
+**Entities tested (intended):**
+- E1: Roche Holding AG, uid `CHE-101.602.521` (fixture, post-PR-#107 corrected, AG)
+- E2: Nestlé SA, uid `CHE-105.805.977` (SA)
+- E3: Google Switzerland GmbH, uid `CHE-110.474.423` (GmbH — intended for legal-form diversity)
+
+**Execution status: 0 of 3 entities executed successfully.**
+
+- E1 and E2 returned `External service temporarily unavailable` (Zefix upstream) on the first parallel attempt. E1 retry returned the same error. A later CH-1 sanity check returned a Railway gateway 502 (capability timed out waiting for Zefix).
+- E3 returned the same Zefix error on the first attempt; not retried after the systemic-failure halt.
+- No wallet charge for any of the 3 attempts.
+
+**Operational finding:** Zefix appears to be in a sustained outage or significantly degraded as of 2026-05-15 ~08:30Z. The PR #107 fixture correction (`CHE-101.602.521` → Roche, ACTIVE) is *not* the issue — the capability fails to fetch even the canonical fixture. Recommendation: queue a re-test in 1-4 hours under quieter conditions. If Zefix is still down at v1 launch, the CH capability needs a circuit-breaker-aware status surfacing strategy.
+
+**Schema-supported fields (cannot empirically score this session):** company_name, uid, ehraid, ch_id, legal_form, status, canton, municipality, address, purpose, registration_date, deletion_date, data_source, data_source_url, data_attribution. Schema declares `vat_number` as nullable but the example in the manifest doesn't include it, hinting at a known absence — flag for follow-up but cannot empirically confirm.
+
+**No `directors` or `lei` fields in the CH schema.** Zefix exposes statutory-representative ("Zeichnungsberechtigte" / "Personnes habilitées à signer") data via a separate Zefix endpoint that this capability does not call. Free-path direct-build candidate once upstream recovers.
+
+#### GR — greek-company-data (GEMI Open Data API)
+
+**Entities tested:**
+- E1: ΕΘΝΙΚΗ ΤΡΑΠΕΖΑ ΤΗΣ ΕΛΛΑΔΟΣ Α.Ε. (National Bank of Greece branch), gemi_number `000237954001` (fixture, ΑΕ — `is_branch=true`)
+- E2: ΜΠΑΧΛΙΤΖΑΝΑΚΗΣ ΕΜΜΑΝΟΥΗΛ ΤΟΥ ΜΙΧΑΗΛ (sole proprietor), gemi_number `044132307000` (ΑΤΟΜΙΚΗ — atomiki, sole proprietorship)
+- E3: ΟΡΓΑΝΙΣΜΟΣ ΤΗΛΕΠΙΚΟΙΝΩΝΙΩΝ ΤΗΣ ΕΛΛΑΔΟΣ Α.Ε. (OTE — Hellenic Telecommunications), via `afm: "094019245"` after first GR-3 guess (`010249716000`) returned "no Greek company found"
+
+**Memory contradiction surfaced:** the prompt context's memory referenced PR #116 correcting the fixture to "HELLENiQ ENERGY Holdings SA, returning 11 directors with roles + industry_code 19200000 populated." The actual fixture (`000237954001`) resolves to a **National Bank of Greece branch**, not HELLENiQ Energy. The manifest's expected_fields are consistent with NBG (`is_branch=true`, `registration_date=1941-01-01`, `vat_number=EL094014201`, `business_type=ΑΕ`). The memory was stale or pointed to a different PR; the manifest's actual content is authoritative. **Recommendation: chat should reconcile the memory entry against the manifest.**
+
+**Legal-form constraint:** 2 distinct forms covered (ΑΕ + ΑΤΟΜΙΚΗ). The OTE result also returned ΑΕ. The audit's pick of `044132307000` as a "guess for NBG main entity" instead resolved to a sole proprietorship — a useful methodology lesson that GEMI numbers are not name-stable across the registry.
+
+**Anomalies:**
+- E1 (NBG branch): `directors: []` empty array — consistent with `is_branch=true` (branches don't carry their own boards).
+- E1: `industry_code: null` and `industry_description: null` — same branch-vs-main pattern.
+- E2 (sole proprietor): `directors: []` empty array — atomiki entities have no board by definition.
+- E3 (OTE): `directors` populated with **10 entries** including Greek-script and Latin-script names with role labels in Greek (Πρόεδρος & Διευθ. Σύμβουλος, Αντιπρόεδρος, Ανεξάρτητο μη Εκτελεστικό Μέλος, etc.). No 3-entry cap unlike FR — GR returns the full board.
+
+**Field notes:**
+- The `directors: 1/3` score is **misleading** as a coverage signal: 2 of 3 entities legitimately have no board (a branch and a sole proprietorship). For an entity-mix of main ΑΕ companies, the directors coverage would likely score 3/3. Note for v1 readiness assessment: GR directors capability *does work* when the entity has a board.
+- `industry_code` uses Greek 8-digit NACE format (`61900000` for telecoms, `63121000` for web portals).
+- `vat_number` is algorithmically derived from `afm` (`EL` + 9-digit AFM); 3/3 populated.
+- `is_branch` flag is `guaranteed` per manifest reliability — important KYB signal that this audit confirms.
+- No `lei` field in the GR schema.
+
+**GR vs FR directors comparison:** GR returns the **full** directors array uncapped (10 for OTE). FR caps at 3 with `directors_truncated`/`total_directors` companions (15-20 true counts). GR's payload-handling is cleaner from a customer-data-completeness standpoint; FR's is cleaner from a payload-size-bound standpoint. See `apps/api/docs/fr-directors-truncation-2026-05-15.md` for the FR fix proposal — the GR pattern (full array) is the alternative if Strale standardises on "return what the source has."
+
+#### HR — croatian-company-data (Sudski registar REST API)
+
+**Entities tested (intended):**
+- E1: Hrvatski Telekom d.d., oib `81793146560` (fixture, d.d.)
+- E2: INA d.d., oib `27759560625` (d.d., oil major)
+- E3: Konzum d.o.o., oib `29955634590` (d.o.o. — intended for legal-form diversity)
+
+**Execution status: 0 of 3 entities executed successfully.**
+
+- First parallel attempt: all 3 returned `"The operation was aborted due to timeout"`. Sudreg upstream timing out for every request.
+- Circuit breaker opened immediately after the 3 timeouts; subsequent retries (after the GR/SK work completed) returned `circuit_state: open, next_retry_at: 2026-05-15T08:58:22Z`. A later retry after 08:58Z returned a fresh timeout, suggesting the upstream remains slow even after breaker reset.
+- No wallet charge.
+
+**Operational finding:** Sudreg API is degraded as of 2026-05-15 ~08:30Z+. The audit's parallel-call pattern (15 concurrent capability calls) likely amplified the latency by competing for the same egress connection pool, but the standalone retry also timed out — so the upstream itself is sluggish. Recommendation: re-test under sequential single-call conditions in a quieter window.
+
+**Schema-supported fields (cannot empirically score):** all 14 declared output fields (oib, mbs, status, status_code, company_name, short_name, legal_form, legal_form_abbr, vat_number, country_code, mb, potpuni_mbs, address, main_activity_code, registered_date, email). HR schema is the **richest** of all 20 audited (matched by IE's 13-field schema), so a full re-test would meaningfully validate v1 readiness.
+
+**No `directors` or `lei` fields in the HR schema.** Per the manifest's coverage limitation: "Public OAuth2 API returns entity profile, addresses, legal form, activity codes, and registered capital, but does not expose board members (uprava) or shareholders. Board composition and beneficial ownership require the paid certified extract (izvadak) from the court registry." HR is on the **paid-only directors** track — not a free-path direct-build candidate (unlike CZ/NO/FI/IE/EE/PL/LV).
+
+#### LT — lithuanian-company-data (data.gov.lt Spinta JSON API)
+
+**Entities tested (intended):**
+- E1: AB "Energijos skirstymo operatorius" (ESO), company_code `304151376` (fixture, AB)
+- E2: Telia Lietuva AB, company_code `121215434` (AB)
+- E3: UAB Bitė Lietuva, company_code `110688521` (UAB — intended for legal-form diversity)
+
+**Execution status: 0 of 3 entities executed successfully.**
+
+- First parallel attempt: E1 (fixture) returned `internal_error`; E2 + E3 returned Railway gateway 502s.
+- Sequential retries against the fixture (`304151376`): one returned internal_error, then a 502. Retry on E2 (Telia 121215434): repeated 502s + internal_errors. Retry on E3 (110688521): same pattern. Substituting a different entity (Ignitis Grupė AB `301844044`) also returned internal_error.
+- Even the canonical fixture identifier `304151376` is consistently failing this session. **This is the most concerning Batch 4 finding** — DEC-20260513-F's "20/20 v1-ready" verdict for LT rests on the fixture canary, and the fixture cannot be empirically reproduced today.
+- No wallet charge.
+
+**Operational finding:** the LT capability is in a sustained degraded state. data.gov.lt's Spinta API has historically been slow (the manifest's `freshness_category: live-fetch` is technically true but the latency is high enough that Strale's request times out). Without a code-level investigation it is unclear whether the underlying issue is (a) upstream degradation, (b) a regression in Strale's LT handler, or (c) the parallel-call amplification pattern seen in Batch 4. **Recommendation: queue a code-level investigation similar to the FR truncation prompt, scoped to LT.**
+
+**Schema-supported fields (cannot empirically score this session):** company_name, company_code, legal_form, legal_form_en, legal_form_type, status, status_en, status_date, registration_date, deregistration_date, is_active, jurisdiction. Note LT schema does **not** declare `address` (manifest limitation explicitly notes: "Address is not included in this response. The Lithuanian JAR open-data API splits company addresses into a separate dataset (buveines/Buveine) keyed by legal-entity UUID"). This is a structural source/capability split, like LV's NACE split — flag `–` for address even when capability recovers.
+
+**No `directors` or `lei` fields in the LT schema.** data.gov.lt publishes director-equivalent data via a separate dataset per the manifest's coverage limitation. Free-path direct-build candidate (CKAN sibling pattern like LV).
+
+#### SK — slovak-company-data (RPO via api.statistics.sk)
+
+**Entities tested:**
+- E1: SEXES spol. s r. o., ico `36674141` (fixture, s.r.o. = Spoločnosť s ručením obmedzeným)
+- E2: Slovenské elektrárne, a.s., ico `35829052` (a.s. = Akciová spoločnosť)
+- E3: VOLKSWAGEN SLOVAKIA, a.s., ico `35757442` (a.s.)
+
+**Legal-form constraint:** 2 distinct forms covered (s.r.o. + a.s.). The fixture is a small s.r.o. (the audit's first non-public-listed fixture entity).
+
+**Anomalies:**
+- All 3 entities required at least one retry due to either Slovak RPO platform rate-limit (60 req/min shared across Strale's egress) or Railway gateway 502s on the first parallel attempt. Per the manifest, RPO's 60 rpm is a per-IP burst limit shared across all of Strale's traffic — the parallel-call pattern saturates it quickly. **Recommendation:** add intra-Strale request pacing for SK or accept that bursty traffic will hit the rate limit until volume grows enough to justify authenticated access.
+- After retries with single-call cadence, all 3 succeeded.
+
+**Field notes — second country with empirical directors coverage:**
+- E1 (SEXES, s.r.o.): `directors: ["Dejan Naprudnik"]` — 1 director, consistent with small s.r.o.
+- E2 (Slovenské elektrárne, a.s.): `directors: 10 entries` (Rastislav Fleško, Zoran Kupkovič, Andrej Rubint, Branislav Strýček, Lukáš Maršálek (member + first vice-chair), Martin Mráz, Michal Kremeň, Michal Novosád, Milan Molnár). Note: Lukáš Maršálek appears twice with different role descriptions — likely a registry quirk where the same person held two consecutive registered roles.
+- E3 (VW Slovakia, a.s.): `directors: 3 entries` (Dipl. Ing. Wolfram Kirchert, Kai-Stefan Linnenkohl, Mgr. Agnieszka Olenderek).
+- No directors-cap behavior — SK returns the full statutory body array.
+- **SK joins FR as the second country in this 20-country audit with empirical full-directors coverage.** Different shape than FR: SK returns names with academic-title prefixes (Ing., Mgr., Dipl. Ing.) but no separate role labels in the array; FR returns concatenated name+role labels.
+
+**Schema-vs-reality findings:**
+- **SK manifest does NOT declare `vat_number`.** Slovak companies have DIČ (VAT-ID) which is `SK` + IČO + a check pattern. The audit's 3 successful calls returned no vat_number field. This is a *schema gap*, not a 0/3 mismatch — and a notable one for a country audit since DIČ is the canonical EU VAT-ID. **Add `vat_number` to the SK output_schema.**
+- Diacritic encoding (`š`, `č`, `ť`, `ž`, `á`, `ý`) preserved correctly in JSON responses. No encoding issues.
+- `status` is the string `"active"` (English) — consistent with most other capabilities.
+- `legal_form` is human-readable Slovak label; `legal_form_code` is numeric ("112" for s.r.o., "121" for a.s.) — same dual-shape pattern as CZ.
+- `last_updated` populated 3/3 (2025-07-07, 2026-03-31, 2026-04-22) — useful provenance signal, matches CZ's pattern.
+
+**Source: ŠÚ SR / Statistical Office of the Slovak Republic, Register právnických osôb (RPO). CC-BY 4.0.** The SK directors coverage is therefore *free* (no auth needed beyond the rate limit). This makes SK uniquely positioned among 20 countries: free + empirical full directors + 60-rpm cap.
+
+---
+
+## Phase 2 — SI Openapi WW-Top probe
+
+**Status: DEFERRED.**
+
+Per session scoping (pilot-only, 5 countries), Phase 2 runs in the follow-up session that completes the remaining 15 EU+CH+NO+APAC countries. The SI direct results above (3 entities, schema/source gap confirmed) are the baseline; the Openapi WW-Top probe will use the same 3 SI matična številka identifiers (`5043611000`, `5025796000`, `5300231000`) to compare field coverage.
+
+**Cost estimate carried forward:** ~€0.30 (3 calls × €0.10 base × 1.22 IT VAT) at Openapi WW-Top rates. Requires `OPENAPI_API_KEY` env var on the runner.
+
+---
+
+## Phase 3 — US Topograph-listed state scout
+
+**Status: DEFERRED to standalone session.**
+
+Per session scoping, Phase 3 is a separate session. Phase 3 is *exploratory* (US integrations are not yet built per DEC-20260515-A) and does not depend on the Phase 1 / Phase 2 results, so it can run standalone.
+
+---
+
+## Synthesis (final — 20 of 20 countries, Phase 1 COMPLETE)
+
+### Countries with full directors coverage (empirically verified)
+
+- **FR** (Batch 2) — `directors` array populated 3/3 with role labels. `total_directors` reveals the true count (15–20 per entity); the payload-cap-at-3 is a Strale-side product decision, not a source limitation. INSEE/SIRENE supplies director data free of charge via api.gouv.fr. **Fix shape:** raise cap to 50 per `apps/api/docs/fr-directors-truncation-2026-05-15.md`.
+- **SK** (Batch 4) — `directors` array populated 3/3 with the **full** statutory body (1, 10, and 3 entries across the audit's 3 entities). No payload cap. Names include academic titles but no separate role labels. Slovak ŠÚ SR / RPO is the source — free, CC-BY 4.0, 60-rpm rate limit.
+- **GR** (Batch 4) — partial: `directors` populated 1/3 (10 entries for OTE), but the 2 missing cases are *legitimately* board-less entities (a branch + a sole proprietorship). For a mainstream ΑΕ entity mix, GR likely scores 3/3. **Counts as a positive empirical signal pending a re-test with a board-bearing entity mix.**
+
+**Verdict:** 2 confirmed (FR + SK) + 1 conditional (GR) of 20. Up from 1-of-15 at Batch 3 close. The "build directors wherever data is free" principle now has multiple concrete templates to follow.
+
+### Countries with thin directors coverage (free-path direct-build candidates)
+
+Grouped by build complexity:
+
+**A. Single-source extension (cheap — scrape route already exists):**
+- **EE** — Add "juhatuse liige" extraction to existing e-Äriregister scrape.
+- **PL** — Add "organ reprezentujący" extraction to existing KRS scrape.
+
+**B. Sibling endpoint on same upstream (medium — one new endpoint):**
+- **NO** — Brønnøysund `/enheter/{orgnr}/roller` (free, documented).
+- **CZ** — ARES statutární orgán endpoint (free).
+- **FI** — PRH `/bis/v1` extended endpoint for hallitus (free).
+- **IE** — CRO Open Data Directors dataset on opendata.cro.ie (free, CKAN).
+- **LV** — data.gov.lv "amatpersonas" + "Patiesie labuma guvēji" (free, CKAN — two siblings, not one).
+- **LT** — data.gov.lt Spinta director-equivalent dataset (free, but **blocked by current capability degradation** — see outage note).
+- **CH** — Zefix has separate Zeichnungsberechtigte endpoint (free, but **blocked by current Zefix outage** — see outage note).
+
+**C. New ingest (higher cost — vendor switch or new pipeline):**
+- **BE** — KBO Open Data SFTP first-party ingest (replaces CBEAPI.be wrapper). Already flagged in manifest as longer-term target.
+- **SE** — Bolagsverket HVD expansion (waiting on EU HVD directive expansion to include directors).
+- **DK** — cvrapi.dk coverage unknown until quota resets; CVR/Erhvervsstyrelsen does have director data.
+
+**D. UK — sibling capability already exists:**
+- `uk-companies-house-officers` is a separate slug. Strategy decision: keep separate vs. fold inline.
+
+**E. Paid-only / out-of-scope for free-path build:**
+- **SG** — ACRA BizFile+ (paid). Cobalt-style aggregator route.
+- **HR** — Sudski registar paid izvadak only. Public OAuth2 API does not expose board members or shareholders per manifest. Paid-tier upgrade decision.
+
+**Tally:** of 20 audited, 2 have directors inline + free (FR, SK) + 1 conditional (GR) + 1 sibling exists (UK) + 9 free-path direct-build candidates (EE, PL, NO, CZ, FI, IE, LV, LT-degraded, CH-degraded) + 3 new-ingest candidates (BE, SE, DK) + 2 paid-only (SG, HR) + 1 structural-gap (SI) + 1 quota-blocked entirely (DE — schema *declares* directors, can't verify until quota reset).
+
+### Countries with structural source gaps (SI-style — disclosure not build)
+
+- **SI** — confirmed: status, registration date, industry code, directors, VAT, LEI all absent from the data.gov.si open subset. The DEC-20260513-F disclosure is accurate and load-bearing.
+
+**CKAN-thinness hypothesis verdict:** *refuted.* Batch 3 tested IE (CRO Open Data CKAN) and LV (data.gov.lv CKAN) — both returned 12+ rich identity fields. SI's structural thinness is *unique* among the audited CKAN-based registries and traces to the data.gov.si open subset specifically, not to CKAN as an architecture. The other 14 countries — including 2 CKAN-based ones — have reasonable identity coverage.
+
+### Countries with quota-blocked re-test (2)
+
+- **DE** — OpenRegister 50/month free-tier exhausted on or before 2026-05-15 07:22Z. Schema supports directors and LEI; cannot be empirically scored until quota reset (2026-06-01) or Pro-tier upgrade.
+- **DK** — cvrapi.dk 50/day free-tier exhausted before this audit's Batch 2 first call. Re-test viable after the daily reset (~2026-05-16).
+
+Both are real operational signals worth investigating before the v1 launch.
+
+### Countries with outage-class blockage (3) — Batch 4 finding
+
+- **CH** — Zefix returned `External service temporarily unavailable` for every attempted call, including retries against the canonical fixture (Roche `CHE-101.602.521`). Later attempts also timed out at the Railway gateway. Sustained Zefix issue as of 2026-05-15 ~08:30Z+.
+- **HR** — Sudreg API timing out on every request. Circuit breaker repeatedly opened (08:58Z, 09:09Z reset cycles). Even post-breaker-reset retries timed out.
+- **LT** — data.gov.lt Spinta capability in a degraded state. The canonical fixture (`304151376` ESO) failed across multiple retries, alternating between 502 (Railway gateway timeout) and `internal_error`. **This is the most concerning Batch 4 finding** — DEC-20260513-F's "20/20 v1-ready" verdict for LT rests on the fixture canary, and the fixture is not reproducible today.
+
+**`outage` vs `quota`:** quota is calendar-bounded recovery (DE: monthly, DK: daily). Outage is open-ended — needs operational triage. CH and HR may self-recover when upstreams stabilise. LT may require a code-level investigation similar to the FR truncation prompt.
+
+### Schema-vs-reality findings
+
+Cumulative across all batches — 7 declared-but-empirically-0/3 mismatches + 4 schema-undercount findings + 1 schema-gap:
+
+**Mismatches (declared, empirically `0/3`):**
+- UK `vat_number` (Batch 1) — drop or hook HMRC.
+- BE `industry` (Batch 2) — CBEAPI.be doesn't surface NACE. Drop or direct-KBO ingest.
+- IE `vat_number` (Batch 3) — drop or hook Revenue VIES.
+- EE `vat_number` (Batch 3) — derivable algorithmically, executor doesn't.
+- LV `vat_number` (Batch 3) — derivable for 40NNN-prefix entities, executor doesn't.
+- PL `address` (Batch 3) — null 3/3, fixture acknowledges. **Most severe** — basic identity field, code-level investigation needed.
+- PL `registration_date` (Batch 3) — same pattern as PL `address`.
+
+**Schema-undercount (capability returns more than schema declares):**
+- FI (Batch 3) — returns `vat_number` + `website` but undeclared. Add to schema.
+- PL (Batch 3) — returns `nip` + `register_type` + `share_capital` but undeclared.
+
+**Schema gap (capability does not return + does not declare):**
+- SK `vat_number` (Batch 4) — Slovak companies have DIČ (`SK` + IČO + check). SK manifest doesn't declare or derive it. Notable for an EU country audit. **Add to SK output_schema.**
+
+**Wire-shape inconsistencies:**
+- `status` vocabulary: 5+ distinct values across 20 countries (`active`, `Normal`, `Registered`, `Reģistrēts`, `Teisinis statusas neįregistruotas` planned but LT outage, etc.). Wire-shape normalisation pass needed before v1.
+- `legal_form` / `business_type` is numeric-coded in some (CZ "121", FR "5800", PL legal_form is label but SK has both), human-readable in others. **EE has an intra-capability bug** — numeric for AS branch, label for OÜ branch.
+- GR uses Greek-script labels for both business_type ("ΑΕ") and director roles. Solutions need Greek-aware handling.
+
+### Schema-vs-reality mismatches (declared fields, empirically `0/3`)
+
+Significant growth in this category across Batch 3 — 5 new findings + 2 from prior batches:
+
+- **UK `vat_number`** (Batch 1) — Companies House profile does not return VAT. Drop or hook HMRC.
+- **BE `industry`** (Batch 2) — CBEAPI.be does not surface NACE. Drop or direct-KBO ingest.
+- **IE `vat_number`** *(Batch 3)* — CRO Open Data does not include VAT. Same shape as UK. Drop or hook Revenue VIES lookup.
+- **EE `vat_number`** *(Batch 3)* — Äriregister does not surface KMKR. Derivable algorithmically (`EE` + 9 digits) but executor doesn't.
+- **LV `vat_number`** *(Batch 3)* — `data.gov.lv` does not include PVN. Derivable for 40NNN-prefix entities but executor doesn't.
+- **PL `address`** *(Batch 3)* — declared but `null` 3/3 across major listed entities. The fixture's example output also shows `null`, indicating a *known* known issue not fixed since manifest authoring. **Most severe mismatch in the audit** — basic identity field declared but never returned. Worth a code-level investigation: scrape bug or genuinely absent from KRS public page?
+- **PL `registration_date`** *(Batch 3)* — same pattern as PL `address`. Declared, always null, fixture-acknowledged.
+
+**Schema-undercount findings (reverse — capability returns more than schema declares):**
+- **FI** *(Batch 3)* — returns `vat_number` (derived) and `website` but schema does not declare either. Add to schema.
+- **PL** *(Batch 3)* — returns `nip`, `register_type`, `share_capital` but schema does not declare them. `nip` is the underlying tax-ID source for `vat_number` — declare both.
+
+### Sibling directors/officers capabilities discovered
+
+Final inventory across all batches — no country-scoped sibling exists for any of NO/DK/FR/BE/CZ/FI/IE/EE/PL/LV/CH/GR/HR/LT/SK. The only siblings in `apps/api/src/capabilities/`:
+- `uk-companies-house-officers.ts` (UK-specific, free)
+- `officer-search.ts` (multi-country, currently UK + US only per its docstring; EU was removed under DEC-20260427-I commercial-KYB scraping ban)
+- `gleif-l2-ubo-lookup.ts` (global GLEIF, not country-scoped)
+
+**The Phase 4 build queue** (free-path director siblings) totals 9 candidates across NO/CZ/FI/IE/EE/PL/LV/LT/CH, plus 3 new-ingest cases (BE/SE/DK), plus the FR truncation fix (one-line). UK is already shipped as a separate slug. SK and FR ship inline. GR also ships inline (conditional).
+
+### Wire-shape inconsistencies — cross-country status + legal-form vocabulary
+
+Tracked across 15 countries, the `status` field is anything but standardised:
+- `"active"` — SE, NO, FI, CZ, FR, BE
+- `"Registered"` — SG
+- `"Reģistrēts"` — LV
+- `"Normal"` — IE
+- `"active"` — UK
+- `"active"` — EE, PL (both surface the English word despite local-language elsewhere — executor-normalised likely)
+- (DE/DK quota-blocked)
+
+`legal_form` / `business_type` is also inconsistent:
+- Numeric code: CZ (`"121"`), FR (`"5800"` / `"5599"`), EE for AS branch only (`"1"`)
+- Human-readable label: SE (`"Aktiebolag"`), NO (`"Allmennaksjeselskap"`), UK (`"plc"`), IE (`"LTD - Private Company..."`), BE (`"Société anonyme"`), LV (`"Akciju sabiedrība"`), PL (`"SPÓŁKA AKCYJNA"`), FI (`"Public limited company"`), EE for OÜ branch (`"OÜ (Private limited company)"`)
+
+EE's intra-capability inconsistency (numeric for AS, label for OÜ) is the worst case. Solutions filtering on legal form across countries currently need 15+ vocabulary-per-country maps. Worth a dedicated wire-shape normalisation pass before v1 launch.
+
+### Cross-batch Notion follow-ups (single bucket)
+
+Final consolidated list of Notion-canonical-page updates surfaced across Batches 1-4. Chat to work through these in a separate Notion-update session — none implemented in this audit doc.
+
+**Capability × Country Coverage Matrix:**
+- Drop "directors" coverage claim for any country other than FR, SK, GR (conditional) — audit confirms 17 of 20 don't return directors in the primary identity capability.
+- FR: mark "yes (capped at 3, true count 15–20; fix queued)".
+- SK: mark "yes (full board, free, 60-rpm cap)".
+- GR: mark "yes when entity is a board-bearing main entity (not branch / sole proprietor)".
+- Add `outage` flag for CH, HR, LT pending operational triage.
+- Add `quota` flag for DE, DK pending calendar reset.
+
+**Active Vendor Stack:**
+- Confirm DE OpenRegister 50/month + DK cvrapi.dk 50/day quotas are accurately documented (DEC-20260508-D for DE; DK manifest's "Empirical floor ~50/day" deserves equivalent decision-DB cross-reference).
+- Add an operational health note for Zefix (CH), Sudreg (HR), and data.gov.lt Spinta (LT) given the 2026-05-15 sustained issues.
+
+**Per-capability schema cleanups (queue as a coordinated PR):**
+- Drop the 7 `0/3` declared fields: UK/IE/EE/LV `vat_number`, BE `industry`, PL `address` + `PL registration_date`. Or implement what they promise.
+- FI schema: declare the returned `vat_number` and `website` (currently schema-undercount).
+- PL schema: declare returned `nip`, `register_type`, `share_capital`.
+- SK schema: add `vat_number` (DIČ — derivable from IČO).
+- EE: fix the `business_type` intra-capability inconsistency (AS-branch returns "1", OÜ-branch returns label). One-shape decision needed.
+
+**Stale memory entries:**
+- The GR fixture memory entry (referencing HELLENiQ Energy + PR #116) is inconsistent with the actual manifest, which has the NBG branch. Reconcile or remove.
+
+### Methodology learnings (for Phase 4 + future audits)
+
+1. **Parallel-call amplification is real.** Batch 4's 15-concurrent-call pattern saturated CH/HR/LT capabilities and the Slovak RPO rate limit simultaneously. Sequential cadence resolved SK. Future audits should consider call-pacing or split-by-country-group execution.
+2. **Identifier guesses are expensive in audit time.** The audit's GR-2 (sole proprietor by accident), GR-3 first try (no Greek company found), LT-3 (Bitė guess), HR-3 (Konzum guess), UK-3 first try (OC305597) all cost retry cycles. Future batches should use authoritative identifier lookups (open registries' bulk indexes) rather than guesses.
+3. **Outage detection should happen at the matrix level, not buried in per-country detail.** The `outage` row notation introduced in Batch 4 is a useful Phase-N pattern for any future audit.
+4. **Memory drift is a real risk.** The GR/PR-#116 memory entry pointed at a fixture that doesn't exist in the manifest. Future audits should treat the manifest as authoritative and flag memory discrepancies.
+
+### Phase 1 verdict on v1 readiness
+
+DEC-20260513-F certified all 20 identity capabilities as "v1-ready" on the basis of canonical-fixture validation + 24h canary green-rate for DK and DE. The 4-batch empirical audit refines that verdict:
+
+**v1-ready as certified (15 of 20):** BE, CZ, EE, FI, FR, IE, LV, NO, PL, SE, SG, SK, GR (conditional on board-bearing entity mix), UK, plus SI (whose structural thinness is correctly disclosed in the manifest). These return identity fields reliably across multi-entity probes. **PL has a code-level bug** (address + registration_date null 3/3) that should be triaged before launch but isn't a launch blocker — the fields are non-essential for the primary KYB workflows.
+
+**v1-ready with caveats (2 of 20):** DE and DK are blocked by free-tier quotas at audit time, not by capability defects. DE needs the Pro-tier or operational-traffic decision; DK needs daily reset. Both should be re-confirmed before launch but aren't fundamental blockers.
+
+**v1 blockers pending operational triage (3 of 20):** CH, HR, LT failed empirical scoring this session due to sustained upstream/capability issues. CH (Zefix outage) and HR (Sudreg API timeouts) may self-resolve. **LT is the most concerning** — even the canonical fixture failed across multiple retries, contradicting DEC-20260513-F's "v1-ready" certification for LT today. Recommendation: do not ship LT in v1 without a code-level investigation. CH and HR are conditionally ship-able pending operational confirmation in the 24-48 hours before launch.
+
+**Directors coverage:** 2 of 20 (FR, SK) confirmed; 1 conditional (GR); 9 free-path direct-build candidates queued for Phase 4. **This is the single largest v1 improvement opportunity** — implementing the 9 sibling capabilities or single-source-extensions would lift directors coverage from 10% (2/20) to 60% (12/20), all from free sources. The chat principle "build directors wherever data is free" has a clear backlog.
+
+**Wire-shape consistency:** at v1 launch, status vocabulary and legal_form vocabulary will vary substantially across countries. Customers integrating across multiple jurisdictions will need to normalise per-country. Suggested v1 mitigation: ship a `*_normalised` companion field on the wire (English `active`/`inactive` + ISO legal-form code) for the highest-volume jurisdictions — defer the full normalisation to v1.1.
+
+---
+
+## Open questions for chat
+
+1. **DE quota** — was the 50/month allowance consumed by customer traffic or by health probes? Pull the May call log on `german-company-data` from the transactions table to determine. If health probes, retune the schedule (probes shouldn't burn paid quota — Principle A in CLAUDE.md). If customer traffic, the Pro-tier decision per DEC-20260505-H is hot.
+2. **UK `vat_number` field** — declared in output_schema but empirically `0/3` populated across this pilot. Either drop from schema (don't promise what isn't returned) or hook the HMRC VAT-by-CRN lookup. Suggest adding to the v1 launch punch list.
+3. **SG status vocabulary** — returns `"Registered"` not `"active"`. Cross-country status normalization is a separate workstream; flag for the wire-shape consistency review.
+4. **SE registered_address completeness** — Volvo's `street` is null. Is this consistent across older AB entries (pre-1950 registration)? Worth a sanity check against another pre-1950 entity in the follow-up.
+5. **Methodology — directors-aware scoring** — should the follow-up score `directors` as `–` (schema gap) or as `0/3` (build gap)? This pilot used `–` consistently; chat to confirm before applying to the remaining 15 countries.
+6. **DK quota** — same operational question as DE. cvrapi.dk's daily quota was already exhausted at session start. Pull the past-24h `danish-company-data` transactions to determine whether customer traffic, scheduled probes, or both are saturating the 50/day cap. The DK manifest's "Empirical floor ~50/day; documented limit higher" note suggests there may be headroom to raise the cap if cvrapi.dk's real limit is higher.
+7. **DK missing `vat_number` in schema** — Danish companies all have CVR-derived VAT numbers (CVR doubles as VAT-ID with a check digit). Suggest adding `vat_number` to the DK output_schema as a derived field, mirroring SE's `org_number → vat_number` pattern. Low-effort schema win.
+8. **BE `industry` field** — declared but always null (3/3). CBEAPI.be wrapper does not surface NACE from KBO/BCE. Either drop from schema or accelerate the planned KBO Open Data first-party ingest. Suggest adding to the v1 launch punch list alongside UK `vat_number`.
+9. **FR directors payload cap at 3** — `directors_truncated: true` for all 3 entities tested; true counts are 15–20. KYB customers will need full rosters. Decision: raise the cap, paginate, or accept that customers needing full rosters must call a separate endpoint? Tag for v1 product decision.
+10. **CZ `legal_form_code` as numeric string** — returned as `"121"` not `"akciová společnost"`. Consistent with FR's `business_type: "5800"` shape. Are we standardising on numeric codes everywhere with human-readable labels in a `_label` companion field? Cross-country wire-shape consistency review item.
+11. **PL `address` + `registration_date` both `null` 3/3** *(Batch 3 finding)* — Most severe schema-vs-reality mismatch in the audit. The fixture's example output already shows these as null, so it's a known issue not fixed. Is the KRS scrape failing to extract these fields, or is the public KRS page genuinely missing them? Code-level investigation before v1.
+12. **EE `business_type` intra-capability inconsistency** *(Batch 3 finding)* — AS-branch returns `"1"` (numeric code), OÜ-branch returns `"OÜ (Private limited company)"` (human label). Real bug. Pick one shape and normalise the other branch.
+13. **FI / PL schema-undercount** *(Batch 3 finding)* — Both return fields not declared in `output_schema`. FI: `vat_number`, `website`. PL: `nip`, `register_type`, `share_capital`. Declare them. Easy schema wins.
+14. **Build-queue prioritisation for directors siblings** *(Batch 3 finding)* — 9 free-path direct-build candidates surfaced across Batches 1+2+3 (SE/UK exists, NO/CZ/BE/FI/IE/EE/PL/LV available). Which order? Suggest scoring by: (a) likely KYB customer demand by jurisdiction, (b) capability-extension cost (same scrape route = cheap; new integration = costly), (c) wire-shape consistency wins. Worth a chat decision before Batch 4 surfaces another batch of candidates.
+15. **CKAN-thinness hypothesis refuted** *(Batch 3 finding)* — IE and LV CKAN-based registries returned 12+ rich fields each. SI's structural thinness is unique to the data.gov.si open subset, not a CKAN-architecture issue. Worth correcting any prior briefing that implied otherwise.
+16. **CH/HR/LT outage triage** *(Batch 4 finding)* — Zefix and Sudreg outages may self-resolve; LT's degradation appears persistent and code-level. Decision: do we ship LT in v1 with the existing DEC-20260513-F certification holding, or block on the LT fixture recovering? Recommend the latter — fixture-non-reproducibility is a stronger signal than calendar-bounded quota.
+17. **GR fixture vs memory mismatch** *(Batch 4 finding)* — Memory said HELLENiQ via PR #116; manifest has NBG branch. Investigate which is canonical. If memory is correct, the manifest wasn't updated; if manifest is correct, memory is stale.
+18. **SK manifest schema gap on `vat_number`** *(Batch 4 finding)* — Slovak DIČ is derivable from IČO. Low-effort schema win.
+19. **GR vs FR directors strategy** *(Batch 4 finding)* — GR returns full director arrays uncapped; FR caps at 3 with companions. Standardise on one pattern across the platform? GR's "return everything" is cleaner for KYB; FR's "cap with disclosure" is cleaner for payload control. Pick one.
+
+---
+
+*Generated by Claude Code session 2026-05-15 (four batches, Phase 1 COMPLETE). Wallet spend: €2.30 total (€0.60 Batch 1 + €0.60 Batch 2 + €0.75 Batch 3 + €0.35 Batch 4). Worktree: strale-research, branch `docs/identity-field-coverage-2026-05-15`. No code changes, no DB changes, no PR. Phase 2 (SI Openapi WW-Top probe) + Phase 3 (US Topograph state scout) remaining.*

--- a/archive/sessions/stranded-research-2026-05/lt-ch-hr-outage-triage-2026-05-15.md
+++ b/archive/sessions/stranded-research-2026-05/lt-ch-hr-outage-triage-2026-05-15.md
@@ -1,0 +1,232 @@
+# LT / CH / HR outage triage — 2026-05-15
+
+**Trigger:** Batch 4 of identity field-coverage audit ([apps/api/docs/identity-field-coverage-2026-05-15.md](identity-field-coverage-2026-05-15.md), commit `9a5ba15`) surfaced three outage-class findings: LT (`lithuanian-company-data`), CH (`swiss-company-data`), HR (`croatian-company-data`).
+**Scope:** LT (primary, contradicts DEC-20260513-F most directly), CH and HR (secondary, reliability questions). DK and DE explicitly out of scope per session direction.
+**Method:** `capability_health` + `transactions` 14-day DB query + direct upstream curl probe (Sudreg with Strale's OAuth2 creds, Zefix with Strale's basic auth, data.gov.lt unauthenticated) + post-triage re-probe via Strale's prod API.
+**Total wallet spend:** €0.15 (3 final re-probes × €0.05 — under the €0.20 cap; original prompt expected €0). All other queries were direct DB / direct upstream / Railway env via `railway run`.
+
+---
+
+## Headline verdict
+
+**All three capabilities are working as of 2026-05-15 ~11:50Z.** The Batch 4 failures were a **clustered transient incident** that has already self-resolved. None of the three is structurally broken. DEC-20260513-F's "20/20 v1-ready" verdict stands, with two structural caveats raised for future operational hardening (see Cross-cutting synthesis).
+
+Per-country verdicts:
+
+| Country | Verdict | Root cause | Action |
+|---|---|---|---|
+| LT | **SHIP IN V1** | (c) Transient flake — Strale-side egress saturation during parallel-call burst. Upstream healthy throughout. | None required. Optional: instrument the classifier-load latency for future visibility. |
+| CH | **SHIP IN V1** | (c) Transient flake — Zefix returned `fetch failed` for a ~2h window on 2026-05-15. Upstream healthy now. | None required. |
+| HR | **SHIP IN V1** | (c) Transient flake — Sudreg timed out for ~30 min on 2026-05-15 morning. Upstream healthy now, breaker auto-reset on probe. | None required. |
+
+---
+
+## LT — lithuanian-company-data
+
+### Empirical timeline (14-day `transactions` history)
+
+| Date | completed | failed | notes |
+|---|---|---|---|
+| 2026-05-15 | 0 | 21 | Batch 4 + test scheduler; errors include `fetch failed` |
+| 2026-05-14 | 10 | 50 | Mostly negative tests + a few `fetch failed` |
+| 2026-05-13 | 14 | 46 | Mostly negative-test fixtures |
+| 2026-05-12 | 12 | 53 | Same |
+| 2026-05-11 | 13 | 48 | Same |
+| 2026-05-10 | 13 | 52 | Same |
+| 2026-05-09 | 10 | 50 | Same |
+| 2026-05-08 | 12 | 48 | Same |
+| 2026-05-07 | 12 | 48 | Same |
+| 2026-05-06 | 3 | 12 | Partial-day data |
+
+The "failed" daily counts of 46-53 are dominated by the test scheduler's *negative* fixtures probing for invalid inputs (e.g. `INVALID_TEST_VALUE_12345`, `No Lithuanian company found for code 301524699`) and missing-input handling tests. Those are expected failures, not real outages. The real signal is the `completed` count of 10-14/day on 8 of 9 historical days — LT was healthy through 2026-05-14 and broke on 2026-05-15.
+
+### `capability_health` current state (queried 2026-05-15 ~11:30Z)
+
+```
+state: closed
+consecutive_failures: 0
+total_failures: 0          ← anomaly: never recorded a real executor failure
+total_successes: 3
+last_failure_at: null
+last_success_at: 2026-05-13T19:27:27.058Z
+```
+
+`total_failures: 0` is anomalous given the transactions table shows 50+ failed entries/day. This means **the gateway-level 502s and `internal_error` responses from Batch 4 never propagated to the `capability_health` update path** — capability_health tracks executor-level pass/fail, but the Batch 4 failures happened in the gateway / pre-execution layer (Railway 502, fetch timeout before the handler ran). This is a real instrumentation gap worth a follow-up (see Cross-cutting synthesis).
+
+### Direct upstream probe result
+
+`GET https://get.data.gov.lt/datasets/gov/rc/jar/iregistruoti/JuridinisAsmuo/:format/json?eq(ja_kodas,304151376)&limit(10)` → **HTTP 200, 0.80s, valid Spinta response with ESO data.**
+
+Forma classifier endpoint also returned HTTP 200 with the full 26 KB classifier dataset. data.gov.lt Spinta upstream is healthy.
+
+### Root cause classification: **(c) Transient flake — already self-resolved**
+
+Three contributing factors:
+
+1. **Strale-side egress saturation.** Batch 4's 15-concurrent-call pattern hit data.gov.lt with multiple sequential Forma + Statusas classifier loads (~15s each on cold cache) at the same time as CH (Zefix), HR (Sudreg), and SK (RPO). Railway's egress pool saturated → some node fetch calls failed with `fetch failed` before reaching the upstream.
+2. **LT executor classifier-load pattern.** The `ensureClassifiers()` function in `lithuanian-company-data.ts:76-95` fetches up to 20 pages × 100 records on a 24h cache miss. With a 15s timeout per request, a cold-cache call can chew 30s+ of budget before the actual entity lookup. Under load, this is fragile.
+3. **Coincidental cache-miss window.** The 24h classifier cache likely expired or was wiped between 2026-05-13 19:27Z (last_success_at) and the 2026-05-15 audit start. The first call after the cache miss would have re-warmed; under parallel-call burst, every concurrent call competed to re-warm simultaneously.
+
+### Recommended action
+
+**SHIP IN V1.** No code change required for launch. Post-launch operational improvements (separate prompts):
+
+1. **Instrument capability_health for non-executor failures.** Add a `gateway_failures` or `pre_execution_failures` column to track 502s / fetch timeouts that bypass the executor. Today the table is blind to that failure mode for LT.
+2. **Pre-warm the LT classifier cache at deploy time.** A one-shot cache load on startup would eliminate the cold-miss-under-load risk. ~5 lines in `auto-register.ts` or a dedicated startup hook.
+3. **Treat LT as "high-egress-cost capability" for future parallel-call patterns.** Audits and bulk-test runs should sequence LT calls rather than parallelise.
+
+---
+
+## CH — swiss-company-data
+
+### Empirical timeline (14-day `transactions` history)
+
+| Date | completed | failed | notes |
+|---|---|---|---|
+| 2026-05-15 | 0 | 29 | Batch 4 — all `fetch failed` errors from Zefix |
+| 2026-05-14 | 10 | 50 | Mostly negative-test fixtures |
+| 2026-05-13 | 13 | 62 | Same |
+| 2026-05-12 | 0 | 65 | Likely Zefix outage day |
+| 2026-05-11 | 1 | 60 | Same |
+| 2026-05-10 | 0 | 60 | Same |
+| 2026-05-09 | 0 | 65 | Same |
+| 2026-05-08 | 0 | 60 | Same |
+| 2026-05-07 | 0 | 60 | Same |
+| 2026-05-06 | 0 | 15 | Partial-day data |
+
+CH has a noticeably weaker positive-completion history than the EU baseline. From 05-06 to 05-12 the daily completed count is 0-1, jumping to 10-13 on 05-13 and 05-14, then dropping to 0 on 05-15. The 65-failed-per-day floor is dominated by the test scheduler's negative tests, but the positive-test gap is real and suggests **Zefix has had a longer-tail of intermittent issues in May than the Batch 4 audit alone surfaced.**
+
+### `capability_health` current state
+
+```
+state: closed
+consecutive_failures: 0
+total_failures: 8
+total_successes: 7
+last_failure_at: 2026-05-15T08:54:45.009Z
+last_success_at: 2026-05-15T10:20:27.728Z
+```
+
+Breaker is closed, recent successes are real. CH recovered after the audit (last_success_at is 10:20Z, after the Batch 4 calls at ~08:30Z).
+
+### Direct upstream probe result
+
+Probe via Strale's `railway run` (using `ZEFIX_USERNAME` / `ZEFIX_PASSWORD`):
+`GET https://www.zefix.admin.ch/ZefixPublicREST/api/v1/company/uid/CHE101602521` → **HTTP 200, 0.21s, 24,978 bytes — Roche Holding AG full record.**
+
+Note: Zefix accepts UID *only* without dashes (`CHE101602521`). The dashed format (`CHE-101.602.521`) returns HTTP 200 with `[]` (empty array — the bad-fixture trap from the 2026-05-13 CH incident that drove the `guaranteed-fields-sentinel` introduction). The executor's `normalizeUid()` in `providers/swiss-company-data.ts:33-36` correctly strips dashes before the call, so this is not a defect — it's an architectural detail worth knowing.
+
+Post-triage re-probe via Strale `/v1/do`: `swiss-company-data` for `CHE-101.602.521` → **completed in 479ms, returned Roche Holding AG**. End-to-end working.
+
+### Root cause classification: **(c) Transient flake — already self-resolved**
+
+Zefix had `fetch failed` errors on Strale's egress between ~08:30Z and 10:20Z on 2026-05-15. Could be Zefix-side rate-limit triggered by Batch 4's burst, could be Railway-side egress pool exhaustion, or both. By 10:20Z the issue cleared and successive Strale calls have succeeded. No structural defect in the executor.
+
+### Recommended action
+
+**SHIP IN V1.** No action required. Note: CH's longer-tail positive-completion gap on 2026-05-06 through 2026-05-12 deserves a separate follow-up to determine whether Zefix has an under-the-radar reliability problem or whether Strale's test scheduler simply doesn't run many positive CH probes per day.
+
+---
+
+## HR — croatian-company-data
+
+### Empirical timeline (14-day `transactions` history)
+
+| Date | completed | failed | notes |
+|---|---|---|---|
+| 2026-05-15 | 0 | 4 | Batch 4 — 4 `operation was aborted due to timeout` |
+| 2026-05-14 | — | — | **No records at all** |
+| 2026-05-13 | 3 | 0 | Healthy |
+| 2026-05-12 | 12 | 16 | Healthy (failed = negative tests) |
+| 2026-05-11 | 23 | 22 | Healthy |
+| 2026-05-10 | 26 | 26 | Healthy |
+| 2026-05-09 | 24 | 24 | Healthy |
+| 2026-05-08 | 24 | 24 | Healthy |
+| 2026-05-07 | 26 | 26 | Healthy |
+| 2026-05-06 | 22 | 22 | Healthy |
+| 2026-05-05 | 22 | 22 | Healthy |
+| 2026-05-04 | 14 | 14 | Healthy (partial-day) |
+
+HR has the cleanest baseline pattern of the three: roughly 22-26 completed per day from 2026-05-04 through 2026-05-12, with completed = failed (each healthy positive test paired with one negative-fixture test). Then **two anomalies**: 2026-05-13 drops to 3 completed (with zero failures — the test scheduler started skipping HR), 2026-05-14 has zero records, and 2026-05-15 has 4 timeout failures. The 24-48h pre-Batch-4 quiet period suggests HR had already started degrading by ~05-13.
+
+### `capability_health` current state
+
+```
+state: open  ← breaker still showing OPEN despite upstream being healthy
+consecutive_failures: 4
+total_failures: 4
+total_successes: 4
+last_failure_at: 2026-05-15T08:59:52.852Z
+last_success_at: 2026-05-13T19:27:31.326Z
+opened_at: 2026-05-15T08:59:52.852Z
+next_retry_at: 2026-05-15T09:09:52.852Z
+backoff_minutes: 10
+```
+
+`next_retry_at` was 09:09Z — by the time of this triage (~11:30Z), the breaker should have transitioned to half-open and tested. It appears to have stayed `open` because no traffic hit HR between 09:09Z and the triage probe. The post-triage re-probe (below) closed it.
+
+### Direct upstream probe result
+
+OAuth2 token retrieved via Strale's `SUDREG_CLIENT_ID` / `SUDREG_CLIENT_SECRET` (~0.5s).
+`GET https://sudreg-data.gov.hr/api/javni/detalji_subjekta?tip_identifikatora=oib&identifikator=81793146560&expand_relations=true` → **HTTP 200, 0.31s, 35,667 bytes — Hrvatski Telekom d.d. full record.**
+
+Sudreg upstream is healthy.
+
+Post-triage re-probe via Strale `/v1/do`: `croatian-company-data` for OIB `81793146560` → **completed in 921ms, returned Hrvatski Telekom d.d.** End-to-end working — and the breaker presumably transitioned to half-open then closed on this call.
+
+### Root cause classification: **(c) Transient flake — already self-resolved**
+
+Sudreg had a ~30-minute outage window on 2026-05-15 morning (08:30Z-09:00Z) that timed out 4 consecutive Batch 4 calls and tripped the breaker with a 10-minute backoff. After the breaker reset window, no traffic hit HR until the triage re-probe at 11:50Z, which then succeeded. The 2026-05-14 zero-records-day is itself suspicious — Sudreg may have been degraded for >24h prior to the audit and Strale's test scheduler stopped probing it. Worth a separate operational investigation but not a v1 launch blocker.
+
+### Recommended action
+
+**SHIP IN V1.** No action required. Operational follow-up:
+
+1. **Investigate the 2026-05-14 zero-records-day.** Why did the test scheduler stop probing HR? Was the breaker open then too, or was there a separate scheduler issue?
+2. **Consider tightening the breaker backoff for transient-only upstreams.** 10-minute backoff on 4 failures is conservative; if Sudreg's outage windows are typically <5 min, a 5-min initial backoff would reduce false-positive-open periods.
+
+---
+
+## Cross-cutting synthesis
+
+### Input for DEC-20260513-F supersession
+
+DEC-20260513-F's "20/20 v1-ready" verdict is **empirically defensible** after this triage. The Batch 4 audit found three capabilities in a sustained-failure state at the moment of probing, but post-triage:
+
+- **17 capabilities** pass canonical-fixture probe consistently (Batch 1-3 evidence + Batch 4's GR and SK).
+- **2 capabilities are quota-managed** by design: DE (OpenRegister monthly cap), DK (cvrapi.dk daily cap). Both resolved per existing decisions (DK per DEC-20260513-D auto-recovery 2026-05-11; DE per user-acknowledged "no upgrade until v1 launch").
+- **3 capabilities (LT, CH, HR) had transient failures during Batch 4 that have already self-resolved.** Re-probe confirms all 3 work end-to-end. None is structurally broken. Net contribution to v1 readiness: ZERO blockers, two operational caveats (capability_health gateway-failure gap + parallel-call amplification pattern).
+
+The corrected v1 readiness picture: **20/20 ship-able**, with two operational caveats logged for post-launch hardening:
+
+1. **`capability_health` gateway-failure blind spot.** LT's `total_failures: 0` despite real failures proves the table only sees executor-level failures, not 502s / gateway timeouts. Affects every capability's circuit-breaker accuracy.
+2. **Parallel-call amplification pattern.** 15-concurrent calls during Batch 4 saturated Strale's egress pool and contributed to LT/CH/HR's clustered failures. Future bulk operations should sequence calls or batch by upstream-host to avoid this.
+
+Neither is a v1 launch blocker.
+
+### Pattern check
+
+LT/CH/HR's failure types were **architecturally independent**:
+- **LT** — data.gov.lt Spinta (CKAN-flavored JSON, unauthenticated, 24h classifier cache).
+- **CH** — Zefix admin.ch (REST, HTTP Basic Auth, no caching).
+- **HR** — sudreg-data.gov.hr (REST, OAuth2 client_credentials with 6h-cached bearer token, no result caching).
+
+Three different upstream architectures, three different auth schemes, three different cache strategies. The shared variable was **Strale's egress pool** (Railway region: US East / Virginia per `project_railway_region.md`) and the **15-concurrent call pattern** at ~08:30Z on 2026-05-15.
+
+This is a strong signal that the right hardening target is **Strale-side call orchestration**, not per-capability fixes.
+
+### Notion follow-ups
+
+3 canonical pages need updating from the audit + triage findings (chat works through in a separate Notion-update session):
+
+1. **Capability × Country Coverage Matrix** — LT, CH, HR rows: drop any "outage" or "do-not-ship" tags introduced by Batch 4 audit doc. Restore to standard ship status. Add an "operational note" cross-link to this triage doc for the historical context.
+2. **Active Vendor Stack** — verify Zefix, Sudreg, data.gov.lt entries have current operational health notes; flag Sudreg's intermittent reliability as a watchpoint per the 2026-05-13/05-14 zero-records-day finding.
+3. **Internals → Bug fix framework** (or wherever incident retrospectives live) — log the 2026-05-15 parallel-call amplification incident as a documented pattern, with the recommended sequencing strategy for future bulk audits.
+
+### Future-prompt cleanup (out of scope for this prompt)
+
+This investigation created temporary files in `C:/Users/pette/Projects/strale-work/` (db-query.mjs, db-query2.mjs, sudreg-probe.sh) and `C:/tmp/` (db-query.mjs, zefix-probe.txt, sudreg.txt, c1.txt). These are gitignored or in /tmp; not committed. A future housekeeping prompt should sweep them.
+
+---
+
+*Generated by Claude Code session 2026-05-15. Wallet spend: €0.15 (3 re-probes). Worktree: strale-research, branch `docs/identity-field-coverage-2026-05-15`. No code changes, no DB writes, no PR. The audit's "do not ship LT in v1" provisional flag is RETRACTED.*

--- a/archive/sessions/stranded-research-2026-05/rate-limit-and-ca-orchestration-concurrency-2026-05-15.md
+++ b/archive/sessions/stranded-research-2026-05/rate-limit-and-ca-orchestration-concurrency-2026-05-15.md
@@ -1,0 +1,232 @@
+# Rate-limit config + CA orchestration concurrency — pre-v1 action verdict
+
+**Date:** 2026-05-15
+**Triggered by:** [burst-probe-capability-health-blind-spot-2026-05-15.md](burst-probe-capability-health-blind-spot-2026-05-15.md) (commit `335c59c`) verdict "academic for v1" rested on two assumptions chat was uncertain about: (A) the 10 req/sec rate-limit is a deliberate production setting, (B) "production-realistic load" of 5 concurrent calls matches actual customer fan-out.
+**Method:** read-only code investigation across rate-limit middleware, CA / solution orchestration code, and pre-execution rejection emission paths. Zero upstream calls. Zero wallet spend.
+
+---
+
+## Headline verdict
+
+**NO PRE-V1 ACTION REQUIRED.** The burst probe verdict stands.
+
+- Rate-limit (10 req/sec per key on POST `/v1/do`, `/v1/solutions/:slug/execute`, etc.) is a **deliberate production setting** per DEC-21, not a stale dev default.
+- CA orchestration is not yet implemented as a distinct route, but the closest existing analogue (KYB Complete solutions via `/v1/solutions/.../execute`) internalises capability fan-out inside a *single HTTP request* — internal `Promise.all` parallelism does NOT consume rate-limit budget.
+- Pre-execution rejection visibility is **partial, not blind**: every 429 is logged at the `request-complete` Pino log line via `middleware/request-context.ts:46-49` with `status_code: 429`. Operators can grep logs; what's missing is metric aggregation.
+
+The P1 To-do (https://www.notion.so/36167c87082c81ddbc85d0e7f68a0270) stays P1 as v1.1+ work. **Do NOT escalate to v1-launch-gate.** Burst probe's verdict is confirmed.
+
+---
+
+## Rate-limit configuration
+
+### Location
+
+- Module: [apps/api/src/lib/rate-limit.ts](../src/lib/rate-limit.ts)
+- Factory functions: `rateLimitByKey(maxRequests, windowMs)` (line 111), `rateLimitByIp(maxRequests, windowMs)` (line 150).
+- Companion module for day-scale limits: [apps/api/src/lib/db-rate-limit.ts](../src/lib/db-rate-limit.ts) (`rateLimitByIpDb` — used for signup, auth-recover only).
+
+### Current values (all in-process sliding window, in-memory)
+
+From the explicit map in [rate-limit.ts:13-18](../src/lib/rate-limit.ts#L13-L18):
+
+| Route | Limit | Per |
+|---|---|---|
+| POST `/v1/do` | 60 req/min | IP |
+| POST `/v1/do` | **10 req/sec** | API key |
+| `/mcp/*` | 60 req/min | IP |
+| `/v1/wallet/*` | 5 req/sec | API key |
+| `/v1/internal/*` | 120 req/min | IP |
+
+The "10 req/sec per key" matches the value DEC-21 documents in CLAUDE.md ("Rate limiting: 10 req/sec per key + €100/hour spend cap"). Same limit applies to `/v1/solutions/:slug/execute` via [solution-execute.ts:35](../src/routes/solution-execute.ts#L35) and `/v1/web3-assurance` via [web3-assurance/routes.ts:47](../src/web3-assurance/routes.ts#L47).
+
+### Enforcement mechanism
+
+In-process Hono middleware. **NOT** Railway gateway level — the rate-limiter lives entirely inside the application. Implications:
+- State is per-replica: today 1 Railway replica (per [rate-limit.ts:24-26](../src/lib/rate-limit.ts#L24-L26) comment), so the limit is real. If Strale scales to 2+ replicas, the effective limit multiplies by replica count without any code change.
+- State is in-memory: lost on every deploy. Customers get a fresh quota immediately after each Railway redeploy. Acceptable per the explicit "cheap hedge, not a safety control" note (F-0-002) in the source.
+
+### Git history
+
+The `rateLimitByKey(10, 1000)` value on POST `/v1/do` was introduced in commit `d54c701` (2026-02-26, "Add rate limiting, LangChain tool, and Python SDK") with the commit body documenting: *"Rate limiting middleware: sliding window counters (in-memory) — 10 req/sec per API key on POST /v1/do, 5 req/sec per key on wallet and transaction routes, 3 req/min per IP on POST /v1/auth/register."* No subsequent commits have changed the value.
+
+The value matches DEC-21's documented limit. The setting is unchanged since first introduction in February 2026 — but **the absence of change does not make it stale**. DEC-21 explicitly chose 10 req/sec as the production limit; the value persists because it's been the right value, not because it's been forgotten.
+
+### Classification: **DELIBERATE PRODUCTION SETTING**
+
+- Source: DEC-21 (Feb 2026 MVP decisions).
+- Documented in CLAUDE.md authoritatively.
+- Codified in [rate-limit.ts:14-15](../src/lib/rate-limit.ts#L14-L15) as the canonical legitimate-current-user listing.
+- Unchanged since first introduction → no churn signal of being wrong-by-omission.
+
+This is **NOT** a stale dev default. Bumping it pre-v1 would supersede DEC-21 and warrant its own DEC.
+
+---
+
+## CA orchestration concurrency
+
+### Discovery: no dedicated CA orchestrator in code
+
+- `find apps/api/src -type f \( -name "*counterparty*" -o -name "*ca-*" -o -name "*orchestrat*" \)` returns only `onboarding-gates-orchestrator.test.ts` — unrelated.
+- No `counterparty-assurance` capability slug, no `ca-check` route, no `verify-counterparty` endpoint.
+- Code references to "Counterparty Assurance" exist as **policy comments** (e.g., DEC-20260420-H scraping ban in [auto-register.ts](../src/capabilities/auto-register.ts)), not as orchestrator implementations.
+
+### Closest existing analogue: solutions executor
+
+[apps/api/src/routes/solution-execute.ts](../src/routes/solution-execute.ts) + [apps/api/src/lib/solution-executor.ts](../src/lib/solution-executor.ts) implement the `/v1/solutions/:slug/execute` endpoint that bundles N capabilities and runs them inside a single HTTP request. KYB Complete and Invoice Verify (per DEC-20260302-A and current solution seed) are the closest existing analogues to a CA-style orchestration.
+
+### Solution-execute concurrency shape
+
+From [solution-executor.ts:243-249](../src/lib/solution-executor.ts#L243-L249):
+
+> - Steps with parallelGroup != null share a group and run concurrently
+> - Steps with parallelGroup == null are sequential (each in its own group)
+
+Implementation: steps within a `parallelGroup` are awaited via `Promise.all(executions)` at [solution-executor.ts:361](../src/lib/solution-executor.ts#L361). Groups themselves execute sequentially (`for (const { steps: groupSteps } of sortedGroups)` at line 270).
+
+### KYB Complete fan-out shape (read from `apps/api/scripts/seed-kyb-solutions.ts`)
+
+A KYB Complete solution has roughly 4 sequential phases with internal parallelism:
+
+| Phase | Concurrent capabilities |
+|---|---|
+| 1 | up to 3 (identity + initial validations) |
+| 2 | up to 3 (sanctions + PEP + adverse media) |
+| 3 | up to 5 (registry checks across providers) |
+| 4 | up to 4 (UBO + LEI + tail signals) |
+
+Maximum intra-group concurrency: ~5. Total capability calls per CA-style check: ~14 across phases.
+
+### Critical observation — rate-limit doesn't see internal fan-out
+
+The rate-limit middleware [`rateLimitByKey(10, 1000)`](../src/routes/solution-execute.ts#L35) gates at the **HTTP request entry** — it counts incoming POSTs per second per API key. A single `/v1/solutions/kyb-complete-XX/execute` call counts as **1 request** against the 10/sec budget, regardless of whether it fans out internally to 5 or 50 capability calls.
+
+Implications:
+- A customer running 1 CA-check per second hits the rate-limit at 10 customers' worth of traffic, not at 1 customer × 14 capability fan-out.
+- A single batch script calling `/v1/solutions/.../execute` 11 times in 1 second would trigger the limit. A single batch script calling once per second for 11 seconds would not.
+
+### Classification: **NOT-YET-BUILT, BUT EXISTING ANALOGUE INTERNALISES FAN-OUT**
+
+CA itself isn't built. KYB Complete (the analogue) issues 1 HTTP request per check and fans out internally via Promise.all. The customer-perceived concurrency shape is **1 HTTP request per CA-check**, well within the 10 req/sec limit for any realistic per-customer rate.
+
+The hypothesis that "real customer concurrency is customers × fan-out" is wrong for the solutions pattern: **fan-out happens server-side inside one request, not over multiple HTTP requests.**
+
+---
+
+## Pre-execution rejection visibility
+
+### Rate-limit middleware emits no specific log
+
+[rate-limit.ts:124-131](../src/lib/rate-limit.ts#L124-L131) and [180-189](../src/lib/rate-limit.ts#L180-L189) return the 429 JSON via `apiError("rate_limited", ...)` directly. **No `c.get("log").warn(...)` call before the return.** The rate-limit module itself emits zero log records.
+
+### Generic request-complete logger DOES capture 429s
+
+[middleware/request-context.ts:43-49](../src/middleware/request-context.ts#L43-L49) runs as the first middleware on every request and logs `request-complete` after the response is sent:
+
+```typescript
+c.get("log").info(
+  { label: "request-complete", status_code: c.res.status, duration_ms },
+  "request-complete",
+);
+```
+
+When a 429 fires, the rate-limit middleware writes the response → control returns up the middleware chain → `requestContext` logs `request-complete` with `status_code: 429, duration_ms: <X>`. This emits to the structured Pino logger, which goes to stdout in production (and therefore to Railway's log stream visible in the dashboard).
+
+### What's NOT tracked
+
+- No per-route 429 counter / metric.
+- No `source_health` row for rate-limit rejections.
+- No `capability_health.total_failures` increment (confirmed empirically by the burst probe).
+- No Sentry / external aggregation (Strale doesn't use Sentry).
+- No alerting threshold on 429 rate.
+
+### Classification: **PARTIAL VISIBILITY**
+
+Per-request 429s are logged structurally in stdout via `request-complete`. An operator running `railway logs | grep '"status_code":429'` can see them happen. What's missing is *aggregation* — without metrics, you can't know "what fraction of /v1/do calls hit the rate limit last hour" without scraping logs.
+
+**Not fully blind.** The audit-time concern that "we have no visibility into rate-limit rejections" was *partially* wrong; the correct concern is "we have logs but no metrics."
+
+---
+
+## Verdict matrix lookup
+
+| Rate-limit | CA concurrency | Pre-exec visibility | Verdict |
+|---|---|---|---|
+| ~~stale-dev-default~~ | parallel-fan-out | fully blind | bump rate-limit + add logging |
+| ~~stale-dev-default~~ | sequential | fully blind | bump rate-limit (logging optional) |
+| ~~stale-dev-default~~ | parallel-fan-out | partial visibility | bump rate-limit |
+| ~~deliberate-production~~ | parallel-fan-out | fully blind | add gateway-rejection logging |
+| **deliberate-production** | **sequential** (at HTTP layer) | **partial visibility** | (off-table — see below) |
+| ~~deliberate-production~~ | parallel-fan-out | partial visibility | no pre-v1 action |
+
+The actual row is **deliberate-production + sequential-at-HTTP-layer + partial visibility**, which doesn't match a row in the prompt's matrix exactly — it's a stronger case than any of the listed rows because:
+
+1. Rate-limit is deliberate AND well-documented (DEC-21).
+2. CA-style fan-out happens inside a single HTTP request, so the relevant concurrency is "1 per CA-check", not "fan-out × CA-checks".
+3. 429s are logged structurally (Pino), just not metricized.
+
+→ **Verdict: NO PRE-V1 ACTION REQUIRED.** Stronger than any of the no-pre-v1-action rows.
+
+---
+
+## Recommended pre-v1 work items
+
+### Required: NONE
+
+The burst probe verdict stands. The capability_health blind spot remains a v1.1+ observability work item.
+
+### Optional pre-v1 hardening (chat decides)
+
+These are *non-blocking* improvements that could be added pre-v1 if the cost is acceptable:
+
+#### Option 1: Add rate-limit-specific log emit (10 min PR)
+
+In [lib/rate-limit.ts](../src/lib/rate-limit.ts), before the `return c.json(apiError(...))` at lines 124 and 178, add:
+
+```typescript
+c.get("log")?.warn({
+  label: "rate-limited",
+  scope: "by_key", // or "by_ip"
+  key,
+  limit: maxRequests,
+  retry_after_seconds: result.retryAfterSeconds,
+}, "rate-limit-rejected");
+```
+
+**Benefit:** lets operators grep `"label":"rate-limited"` in logs with structured fields (key, scope, retry-after) instead of relying on generic `status_code: 429`. Improves troubleshooting if a customer reports being throttled.
+
+**Effort:** ~10 minutes. ~6 lines per middleware × 2 middlewares. Breaking-change risk: zero. No DEC needed.
+
+#### Option 2: Increment a gateway-rejections counter on rate-limited responses (1-2 hours PR)
+
+Add a separate `gateway_rejections` table or column to track pre-execution rejections in aggregate. This is effectively the v1.1+ P1 To-do done early.
+
+**Benefit:** solves the capability_health blind spot directly.
+
+**Effort:** ~1-2 hours. New table (migration) + middleware integration. Breaking-change risk: low. Probably warrants a DEC since it's a schema addition.
+
+#### Option 3: Raise 10 req/sec to 30 req/sec for batch-friendly customers (zero-line code change + DEC)
+
+If chat believes v1 customer patterns will include batch-import scripts hitting >10/sec from a single key, raise the limit. This supersedes DEC-21's value.
+
+**Benefit:** fewer false-positive 429s for legitimate customer batch workflows.
+
+**Risk:** larger surface for abuse from a stolen key. The 60 req/min per IP and €100/hour spend cap mitigate but don't eliminate.
+
+**Effort:** 5 minutes code change + DEC supersession entry. Effort is mostly in the decision, not the code.
+
+### Recommendation to chat
+
+**Ship Option 1 if and only if the v1 launch window has 10 minutes to spare.** It's pure-upside operational hardening with no design tradeoffs. Skip Options 2 and 3 — they belong in v1.1+.
+
+---
+
+## Open questions for chat
+
+1. **Replica count assumption.** [rate-limit.ts:24-26](../src/lib/rate-limit.ts#L24-L26) assumes 1 Railway replica. Confirm this is still the deployment shape for v1 launch. If multi-replica is on the v1 roadmap, the rate-limit's effective multiplier matters and v1.1+ should add a Redis-backed shared counter (or migrate to Cloudflare's rate-limit primitives).
+2. **Burst probe vs audit 502 reproduction gap.** The audit hit 502s at 15-concurrent; today's Tier 3 hit 429s at 15-concurrent. Different failure mode under nominally-identical load. Investigating this is *not* a v1 blocker but is a useful trace to follow in v1.1+ when fixing the blind spot.
+3. **Solution-execute internal-fan-out budget.** Today KYB Complete fans out up to 5 capabilities per group. If CA proper lands with 8-10 capabilities per parallel group, internal `Promise.all` concurrency rises. Internal calls don't hit the rate-limit but they do hit upstream rate-limits (per the Slovak RPO 60 rpm finding from the burst probe). Worth thinking through CA's per-group cap before launch — separate prompt scope.
+
+---
+
+*Generated by Claude Code session 2026-05-15. Wallet spend: €0 (read-only). Worktree: strale-research, branch `docs/identity-field-coverage-2026-05-15`. No code changes, no DB writes, no PR. The capability_health blind-spot triage chain (audit → triage → burst-probe → this) concludes with NO pre-v1 action required.*

--- a/archive/sessions/stranded-research-2026-05/si-openapi-wwtop-probe-2026-05-15.md
+++ b/archive/sessions/stranded-research-2026-05/si-openapi-wwtop-probe-2026-05-15.md
@@ -1,0 +1,166 @@
+# SI Openapi WW-Top probe — v1 directors gap closure
+
+**Date:** 2026-05-15
+**Triggered by:** DEC-20260513-F SI structural-gap finding + 2026-05-15 audit Batch 1 ([identity-field-coverage-2026-05-15.md](identity-field-coverage-2026-05-15.md)) confirmation that `slovenian-company-data` (via `data.gov.si` CKAN) does not surface directors. Openapi addendum (Article 7.3 redistribution rights) countersigned; Openapi access provisioned via env vars on Railway.
+**Method:** Direct Openapi WW-Top probes from Railway runtime (using prod token via OAuth scope exchange) + comparison against existing `slovenian-company-data` capability outputs (from Batch 1 cache, same fixture entities).
+**Wallet cost (Openapi side):** ~€0.24–€1.08 depending on whether HTTP 204 No-Content responses are billed (Openapi docs don't make this explicit). 2 confirmed 200 successful responses × €0.10 nominal × 1.22 IT VAT ≈ €0.24 minimum, plus up to 7 additional 204 probes if billed = €1.08 maximum. Both well within the €2 hard cap. Strale wallet: €0 (no `/v1/do` calls in this probe).
+
+---
+
+## Openapi access verification
+
+**Env-var naming correction.** The prompt referenced `OPENAPI_API_KEY` but the actual env vars on Railway are `OPENAPI_COM_API_TOKEN_PROD` (32 chars) + `OPENAPI_COM_API_TOKEN_SANDBOX` (32 chars) + `OPENAPI_COM_EMAIL` (16 chars). The naming mismatch was the first finding — chat should reconcile any prior briefing that says `OPENAPI_API_KEY`.
+
+**Authentication mechanism.** Openapi.com uses a two-step OAuth pattern, NOT direct Bearer of the API key:
+
+1. **Token issuance:** `POST https://oauth.openapi.it/token` with HTTP Basic auth (email + API key) and request body `{"scopes": ["GET:company.openapi.com/WW-top"], "ttl": <seconds>}`. Returns a short-lived opaque token (24 chars, observed 10-min TTL).
+2. **API call:** `GET https://company.openapi.com/WW-top/{country}/{identifier}` with `Authorization: Bearer <opaque-token>`.
+
+A naive Bearer of `OPENAPI_COM_API_TOKEN_PROD` against the WW-Top endpoint returns `HTTP 401, {"success":false,"message":"Wrong Token","error":125.22}`. The OAuth scope exchange is mandatory.
+
+**Endpoint pattern verified:** `GET https://company.openapi.com/WW-top/SI/{vatCode}` where `{vatCode}` matches `^SI\d{8}$` or `^\d{8}$` (8-digit Slovenian VAT or VAT-derived TIN). **The 10-digit matična številka (the CKAN identifier) is NOT a valid input** — it must be the VAT code. This is a significant adapter-layer concern for any future Openapi-SI capability build: customers passing the matična številka would need a lookup step before hitting Openapi.
+
+**Coverage assessment via 7-VAT probe:**
+
+| Entity (intended) | VAT probed | Result | Entity actually returned |
+|---|---|---|---|
+| Krka d.d. | SI82646716 | **204 No Content** | — (not found) |
+| Petrol d.d. | SI80267432 | **200 OK, 4199 bytes** | PETROL, Slovenska energetska družba, d.d. ✓ |
+| Telekom Slovenije d.d. | SI60841911 | **204 No Content** | — (not found) |
+| Lek d.d. | SI88262602 | **204 No Content** | — (not found) |
+| Mercator d.o.o. | SI45884595 | **200 OK, 4425 bytes** | Poslovni sistem Mercator d.o.o. ✓ |
+| (other major SI) | SI78664015 | **204 No Content** | — |
+| (other major SI) | SI17033139 | **204 No Content** | — |
+
+**5 of 7 well-known SI corporations returned 204 No Content.** Openapi WW-Top's SI catalog is materially incomplete — only Petrol and Mercator (of the 7 entities probed) are in the WW-Top dataset. Krka, the canonical Batch 1 fixture, is **NOT in Openapi's WW-Top SI catalog**.
+
+---
+
+## Per-fixture findings
+
+### Fixture 1 — Petrol d.d. (CKAN `5025796000`, Openapi VAT `SI80267432`)
+
+**Openapi WW-Top response:**
+- HTTP 200, 6.56s latency, 4199 bytes JSON
+- Top-level keys: `id, lastUpdateTimestamp, companyName, nativeCompanyName, companySize, taxCode, vatCode, leiCode, markers, address, activityStatus, incorporationDate, contacts, internationalClassification, nationalClassification, balanceSheets`
+- **NO directors / officers / representatives / shareholders / people / board / management fields.**
+- Rich: LEI (`549300CAAOUTT4QDOZ16`), NACE primary+secondary, NAICS primary+secondary, SIC primary+secondary, address with GPS coordinates (14.50929, 46.06462), NUTS1/NUTS2/NUTS3 regional codes, balance sheets (financial data per year), company-size classification ("Very large company"), phone/fax/website contacts.
+- Encoding: `nativeCompanyName` contains mojibake (`Slovenska energetska dru�ba` — Č rendered as � replacement char). UTF-8 handling defect on the SI character set in this specific field. `companyName` (the non-native variant) handles diacritics by stripping them ("Slovenska energetska druzba").
+
+**CKAN response (from Batch 1):**
+- HTTP 200, 374ms latency
+- Top-level keys: `company_name, reg_number, hseid, legal_form, registration_office, address, settlement, postal_code, post_office, country, jurisdiction`
+- **NO directors field** (confirmed structural gap per DEC-20260513-F).
+- Lean: identity data only. UTF-8 clean (`družba` renders correctly).
+
+### Fixture 2 — Mercator (CKAN `5300231000`, Openapi VAT `SI45884595`)
+
+**Openapi WW-Top response:**
+- HTTP 200, 6.63s latency, 4425 bytes JSON
+- Top-level keys: identical to Petrol's response shape.
+- **NO directors field.** Same gap.
+- LEI: `549300X47J0FW574JN34`. ACTIVE status, incorporationDate 1989-12-05, 2 balance sheet years included.
+
+**CKAN response (from Batch 1):**
+- HTTP 200, 651ms latency
+- Same lean identity shape as Petrol. No directors.
+
+### Fixture 3 — Krka d.d. (CKAN `5043611000`, Openapi VAT `SI82646716`)
+
+**Openapi WW-Top response:**
+- HTTP 204 No Content. Latency 4.7s.
+- Krka — Slovenia's largest pharma company, publicly traded on Ljubljana Stock Exchange — is NOT in Openapi's WW-Top SI catalog.
+
+**CKAN response (Batch 1 fixture):**
+- HTTP 200, 916ms latency
+- Full lean identity shape returned.
+
+This contradicts the prior expectation that Openapi WW-Top covers SI's major listed entities. Krka's absence is the most concerning data point.
+
+---
+
+## Comparison table (Petrol + Mercator, the 2 fixtures Openapi has)
+
+| Field | data.gov.si CKAN | Openapi WW-Top |
+|---|---|---|
+| Legal name | ✓ (UTF-8 clean) | ✓ (mojibake on `nativeCompanyName`, clean on `companyName`) |
+| Registration / VAT | ✓ (matična številka 10-digit) | ✓ (VAT 8-digit + trade-register-number marker) |
+| LEI | ✗ | ✓ (Petrol, Mercator both have LEI) |
+| Status | ✗ (CKAN gap) | ✓ (`activityStatus: ACTIVE`) |
+| Registration / incorporation date | ✗ (CKAN gap) | ✓ (`incorporationDate`) |
+| Address | ✓ (string format) | ✓ (structured object with street, town, zip, country, GPS coords, NUTS codes) |
+| Legal form | ✓ (d.d. / d.o.o. label) | ✗ (not surfaced — only `companySize` available) |
+| Industry codes | ✗ (CKAN gap) | ✓ (NACE + NAICS + SIC, primary+secondary) |
+| Directors / officers | ✗ | **✗ (same gap)** |
+| Phone / fax / website | ✗ | ✓ |
+| Financial data (balance sheets) | ✗ | ✓ |
+| Company-size classification | ✗ | ✓ |
+| Latency | ~600ms | ~6.6s |
+| Cost per call | €0 (free open data) | ~€0.12 incl. VAT |
+
+---
+
+## Synthesis
+
+**Does Openapi WW-Top close the SI directors gap?** **NO.** No directors, officers, representatives, shareholders, board, management, or executive fields exist in the response for either of the 2 successful probes. The SI directors gap is **not addressable via Openapi WW-Top.**
+
+**Does Openapi WW-Top close OTHER SI gaps?** **YES, partially:**
+- `activityStatus` closes the CKAN-status gap.
+- `incorporationDate` closes the CKAN-registration-date gap.
+- NACE/NAICS/SIC closes the CKAN-industry-code gap.
+- LEI is a new value not in CKAN.
+- Balance sheets are a new value (not in scope for the audit's canonical-10-field set but high KYB value).
+
+**Response quality concerns:**
+- UTF-8 mojibake on `nativeCompanyName` for Slovenian special characters (`ž → �`). Risk for downstream display.
+- SI coverage is partial: 5 of 7 well-known SI corporations returned 204. **Krka, the canonical Batch 1 fixture, is absent.**
+- Latency is materially worse than CKAN (~10× slower: 6.6s vs 600ms).
+
+**Cost:** confirmed at €0.10 nominal + 22% IT VAT ≈ €0.12 per successful call. 204 responses may or may not be billed (Openapi docs ambiguous on this).
+
+---
+
+## Verdict
+
+**KEEP CKAN as SI Tier-1. Consider Openapi as a SUPPLEMENT for `activityStatus`, `incorporationDate`, NACE, and LEI when those fields are needed — NOT as a directors closure.**
+
+Specifically:
+
+1. **Do NOT replace CKAN with Openapi.** Reasons:
+   - Openapi doesn't have Krka (canonical fixture). Replacing would regress the canonical-fixture test.
+   - Openapi doesn't have directors either — neither closes the gap that motivated the probe.
+   - Openapi is 10× slower than CKAN.
+   - Openapi costs €0.12/call vs €0 for CKAN.
+   - Openapi has a UTF-8 mojibake defect on SI native names.
+
+2. **Do consider Openapi as a Tier-2 enrichment supplement** for the fields CKAN lacks (status, regdate, NACE, LEI, balance sheets). The supplement would be:
+   - A separate capability slug, e.g. `si-company-enrich-openapi`, gated on a customer explicitly opting in.
+   - Customers wanting full identity coverage pay the €0.12 supplement; customers happy with CKAN's lean shape pay nothing.
+   - This is the SI-equivalent of the Tier-1 + Tier-2 architecture from DEC-20260515-A for US (state-direct + Cobalt fallback).
+
+3. **For directors specifically, neither CKAN nor Openapi closes the gap.** SI directors require a different path entirely (AJPES restPrsInfo paid contract, or another vendor). Out of scope for v1 per DEC-20260513-F's structural-gap exemption.
+
+**Confidence: HIGH.** The empirical comparison is unambiguous — Openapi's WW-Top SI catalog lacks directors and lacks coverage of Krka. Both findings are reproducible.
+
+---
+
+## Recommended next actions for chat
+
+1. **Update DEC-20260513-F supersession / follow-up** to explicitly note that Openapi WW-Top does NOT close the SI directors gap. The structural-gap exemption stands for v1.
+2. **Active Vendor Stack:** add Openapi as a "Tier-2 enrichment, partial SI coverage" entry with the field-list it adds (status, regdate, NACE, LEI, balance sheets, company-size). Note the 5-of-7-VAT coverage finding so future engineers don't assume full SI coverage.
+3. **Capability × Country Coverage Matrix:** SI row stays as-is for identity (CKAN-direct, no directors). If a `si-company-enrich-openapi` capability ships, add a separate "enrichment" cell.
+4. **No new SI directors capability build for v1.** The directors gap remains source-absent for SI.
+5. **Openapi other-EU30 coverage survey** is a separate session — the audit's findings on coverage gaps for SI (5 of 7 entities absent) raises a question whether other EU30 countries Openapi claims to cover have similarly thin catalogs. Worth probing 2-3 well-known entities per claimed country before relying on Openapi WW-Top as a Tier-2 supplement broadly.
+6. **OPENAPI_API_KEY env-var naming.** Any internal docs / briefings that reference `OPENAPI_API_KEY` should be corrected to `OPENAPI_COM_API_TOKEN_PROD` + `OPENAPI_COM_EMAIL` (the Basic-auth pair) + clarify the OAuth scope-exchange step.
+
+---
+
+## Open questions for chat
+
+1. **Are 204 No-Content responses billed by Openapi?** Their docs don't specify. If billed, the 7-VAT probe cost ~€0.84; if not, ~€0.24. Worth a direct question to Openapi support (Shaun De Lucia per the addendum context).
+2. **SI VATs of major listed entities:** I used `SI82646716` for Krka based on public records. Possibility 1: that's not Krka's actual VAT. Possibility 2: Openapi just doesn't have Krka. The 204 response doesn't disambiguate. Worth a Openapi-support clarification on their SI coverage map.
+3. **Tier-2 enrichment capability vs caller-orchestrated.** Two design choices for the Openapi supplement: (a) a Strale capability that proxies + tags the cost transparently, (b) document Openapi as a customer-BYO route. Probably (a) for consistency with the rest of the catalog, but worth chat's call.
+
+---
+
+*Generated by Claude Code session 2026-05-15. Openapi-side spend: ~€0.24–€1.08 depending on 204 billing. Strale wallet: €0 (no `/v1/do` calls). Worktree: strale-research, branch `docs/identity-field-coverage-2026-05-15`. No code changes, no DB writes, no PR.*

--- a/archive/sessions/stranded-research-2026-05/us-topograph-state-scout-2026-05-15.md
+++ b/archive/sessions/stranded-research-2026-05/us-topograph-state-scout-2026-05-15.md
@@ -1,0 +1,198 @@
+# US Topograph 14-state scout — v1 access viability
+
+**Date:** 2026-05-15
+**Scope:** 14 Topograph-listed states (CO, DE, FL, GA, IL, MA, MN, NV, NJ, NY, PA, TX, WA, WY) + SAM.gov federal entity registry.
+**Method:** Direct HTTP probes against state SOS endpoints + web research per state for API docs / bulk-data / paid-only paths. No Strale capability calls. No Strale-vendor probes.
+**Wallet cost:** €0.
+
+---
+
+## Headline verdict
+
+Per the prompt's three-category scheme (free API / paid signup / scrape-only), the empirical reality is **four categories**:
+
+1. **Free API** (2): NY, SAM.gov.
+2. **Free bulk download** (4 + 1 overlap with NY): CO, FL, MA, WA. NY also qualifies via Socrata.
+3. **Paid signup required** (8): DE, GA, IL, MN, NV, NJ, PA, WY.
+4. **Mixed / partial-free** (1): TX (free Comptroller franchise-tax API; paid SOSDirect for full SOS records).
+
+Every state offers a free *HTML search form* — but under DEC-20260428-A Strale doesn't operate scrapers, so HTML-form access is not a Tier-1 path. The relevant question is whether each state offers an *ingestion-friendly* free path (API or bulk).
+
+**v1 ship-ability summary:**
+- **Tier 1 direct (ship in v1, free path exists):** 7 of 15 — CO, FL, MA, NY, WA, TX (partial), SAM.gov.
+- **Tier 2 via Cobalt (ship in v1 via aggregator):** 8 of 15 — DE, GA, IL, MN, NV, NJ, PA, WY.
+
+This aligns with DEC-20260515-A's architecture (Tier 1 = direct, Tier 2 = Cobalt fallback). The Topograph blueprint's "14 documented direct-SOS states" assumption holds at the *documented-access* level but only ~half of the 14 are *free direct-API* states; the other half are paid-only and must go via Cobalt for v1.
+
+---
+
+## Per-state findings
+
+### Colorado (CO)
+- **Endpoint:** `https://www.coloradosos.gov/biz/BusinessEntityCriteriaExt.do` (HTML form). **Free bulk path:** `https://data.colorado.gov/Business/Business-Entities-in-Colorado/4ykn-tg5h` (Socrata, dataset `4ykn-tg5h`).
+- **Access pattern:** **Free bulk download** via Colorado Information Marketplace (Socrata SODA API on data.colorado.gov).
+- **Probe result:** Main SOS endpoint returned 200 + HTML form. Open data dataset documented via the state's data portal.
+- **Coverage:** 1M+ records — name, address, agent, officers, status, type, creation date.
+- **Directors in response:** Yes (per Socrata schema).
+- **v1 recommendation:** **Ship Tier 1 direct (bulk-ingest pattern).** Same architectural shape as LV (data.gov.lv) and LT (data.gov.lt) — periodic CSV/SODA ingest, no HTML scraping. Build effort comparable to existing CKAN-based capabilities.
+
+### Delaware (DE)
+- **Endpoint:** `https://icis.corp.delaware.gov/Ecorp/EntitySearch/NameSearch.aspx` (HTML form).
+- **Access pattern:** **Paid signup required.** No free API. No free bulk. Free web search returns only File Number + name (insufficient for KYB).
+- **Probe result:** 200 + HTML form (46 KB). No documented public API endpoint.
+- **Coverage:** Detailed entity data requires paid certificate orders or commercial subscription.
+- **v1 recommendation:** **Cobalt Tier 2 only.** Delaware is one of the most-incorporated US states (corporate domicile capital), so Cobalt's catalog coverage of DE is essential for v1.
+
+### Florida (FL)
+- **Endpoint:** `https://search.sunbiz.org/Inquiry/CorporationSearch/` (HTML form, returned 403 to bare curl — likely WAF). **Free bulk path:** `https://dos.fl.gov/sunbiz/other-services/data-downloads/` (SFTP).
+- **Access pattern:** **Free bulk download** via Sunbiz SFTP — fixed-length text files with daily event files + quarterly full snapshots. Free SFTP credentials issued on request.
+- **Coverage:** Complete state corporation registry.
+- **Directors in response:** Yes (per Sunbiz schema).
+- **v1 recommendation:** **Ship Tier 1 direct (bulk-ingest pattern).** Sunbiz is the canonical free-bulk state in the US. SFTP credential workflow is the only setup cost.
+
+### Georgia (GA)
+- **Endpoint:** `https://ecorp.sos.ga.gov/BusinessSearch` (HTML form, 403 to bare curl).
+- **Access pattern:** **Paid signup required.** No free API. Bulk data via GTA partnership: $500 one-time or $5,000/year for weekly extracts.
+- **v1 recommendation:** **Cobalt Tier 2.** Defer paid GTA evaluation to v1.1+ unless GA-specific customer volume justifies the $5K/year.
+
+### Illinois (IL)
+- **Endpoint:** `https://apps.ilsos.gov/businessentitysearch/` (HTML form, 403 to bare curl).
+- **Access pattern:** **Paid signup required.** Free web search is explicitly licensed for individual use only — bulk copying prohibited. 7-dataset paid bulk file sold under contract (free access only for academics/journalists/NGOs).
+- **v1 recommendation:** **Cobalt Tier 2.** IL paid bulk is a contract negotiation, not appropriate v1 work.
+
+### Massachusetts (MA)
+- **Endpoint:** `https://corp.sec.state.ma.us/CorpWeb/CorpSearch/CorpSearch.aspx` (HTML form, returned 302 then timeout on probe). **Free bulk path:** `https://www.mass.gov/info-details/the-corporations-book` — Corporations Book + downloadable data files.
+- **Access pattern:** **Free bulk download** (annual + periodic). Covers taxable MA entities. No real-time API.
+- **Coverage:** Most of what KYB needs; freshness is the main limit (annual updates).
+- **v1 recommendation:** **Ship Tier 1 direct (bulk-ingest pattern), disclose annual freshness.** Like SI, the source publishes on a slow cadence — disclose in capability limitations rather than promise live-fetch.
+
+### Minnesota (MN)
+- **Endpoint:** `https://mblsportal.sos.mn.gov/Business/Search` (HTML form, 200 on probe).
+- **Access pattern:** **Paid signup required.** Active Business Data CSV via weekly order, $30/week for commercial (free for media/researchers/non-commercial).
+- **v1 recommendation:** **Cobalt Tier 2.** MN paid-bulk is cheap ($30/week ≈ $1,500/year) and could be a v1.1+ candidate for upgrade from Cobalt-Tier-2 to direct ingest if customer volume justifies.
+
+### Nevada (NV)
+- **Endpoint:** `https://esos.nv.gov/EntitySearch/OnlineEntitySearch` (HTML form, 200 + small response — likely redirect to SilverFlume).
+- **Access pattern:** **Paid signup required (ambiguous).** SilverFlume references an "API" + bulk entity search but access requires a non-public agreement with NV SOS / third-party developer. Not free public API.
+- **v1 recommendation:** **Cobalt Tier 2.** Direct inquiry to NV SOS deferred to v1.1+ if NV-specific demand emerges.
+
+### New Jersey (NJ)
+- **Endpoint:** `https://www.njportal.com/DOR/BusinessNameSearch/Search` (HTML form, 200 on probe).
+- **Access pattern:** **Paid signup required.** Free name search + entity browsing; structured data downloads (lists, abstracts, status reports) are pay-per-record. No API. No free bulk.
+- **v1 recommendation:** **Cobalt Tier 2.**
+
+### New York (NY)
+- **Endpoint:** Public web inquiry at `https://apps.dos.ny.gov/publicInquiry/` (HTML form, returned 000/connection error on probe — likely Cloudflare). **Free API path:** `https://catalog.data.gov/dataset/corporations-and-other-entities-all-filings` via Socrata SODA on data.ny.gov.
+- **Access pattern:** **Free API + bulk download** (Socrata SODA). Full filings + status-history + 30-day delta datasets all on data.ny.gov.
+- **Coverage:** Cleanest US state for KYB ingestion. Real-time SODA REST API + downloadable CSV.
+- **Directors in response:** Yes (Socrata schema).
+- **v1 recommendation:** **Ship Tier 1 direct (Socrata API pattern).** Highest-priority v1 build — NY is the second-most-common US incorporation state after DE and Socrata API is straight Tier 1.
+
+### Pennsylvania (PA)
+- **Endpoint:** `https://file.dos.pa.gov/search/business` (HTML form, 403 on probe).
+- **Access pattern:** **Paid signup required.** No API. Free per-entity HTML search only. Bulk lists via BCCO at $0.25/name — not a feasible bulk-ingest path at KYB scale.
+- **v1 recommendation:** **Cobalt Tier 2.**
+
+### Texas (TX)
+- **Endpoint:** SOS at `https://direct.sos.state.tx.us/` (SOSDirect, paid $1/search). **Free API path:** `https://api-doc.comptroller.texas.gov/` (Texas Comptroller Franchise Tax Account Status — free, no auth).
+- **Access pattern:** **Mixed.** Comptroller's CPA API is free + no-auth, covers franchise tax status + SOS file number + entity name. Full SOS officer/agent data only via paid SOSDirect.
+- **Coverage:** Comptroller API gives entity verification + status — useful for sanctions screening + identity confirmation. Doesn't give officers/agents.
+- **v1 recommendation:** **Ship Tier 1 direct for Comptroller API (limited fields). Pair with Cobalt Tier 2 for full SOS records.** This is the most architecturally interesting state — a partial direct path + Cobalt fallback for missing fields.
+
+### Washington (WA)
+- **Endpoint:** `https://ccfs.sos.wa.gov/` (HTML form, 200 on probe). **Free bulk path:** CCFS Advanced Search → CSV export.
+- **Access pattern:** **Free bulk download** via CSV export from Advanced Search (no login required). No REST API.
+- **Coverage:** Paginated bulk download — workable for ingestion without scraping the HTML form.
+- **v1 recommendation:** **Ship Tier 1 direct (bulk-ingest pattern).** The Corporations Data Extract that historically existed has been retired; the Advanced Search CSV export is the supported path.
+
+### Wyoming (WY)
+- **Endpoint:** `https://wyobiz.wyo.gov/Business/FilingSearch.aspx` (HTML form, 200 on probe).
+- **Access pattern:** **Paid signup required.** Free per-entity HTML search. Bulk via paid subscription only (pricing not published online — request via [Business Database Download form](https://sos.wyo.gov/Forms/Business/General/WYSOS-BusinessDatabaseDownload.pdf)).
+- **v1 recommendation:** **Cobalt Tier 2.**
+
+### SAM.gov (federal)
+- **Endpoint:** `https://api.sam.gov/entity-information/v3/entities` (API endpoint, returned 404 on probe without auth — expected). **Docs:** `https://open.gsa.gov/api/entity-api/`.
+- **Access pattern:** **Free API with mandatory API key.** Free public registration via sam.gov.
+- **Coverage:** Federal Entity Management API. Public role: 10 req/day; system account with "Read Public": 1,000 req/day. System-account approval takes 1-4 weeks.
+- **Directors in response:** SAM.gov returns POC (point-of-contact) info, not corporate-officers — different semantic field than EU directors.
+- **v1 recommendation:** **Ship Tier 1 direct.** API key registration adds 1-4 weeks lead time — start the registration process now if v1 launch is within 6 weeks.
+
+---
+
+## Synthesis
+
+### Free-API states (Tier 1 direct, ship in v1)
+
+- **NY** — Socrata SODA API on data.ny.gov. Cleanest US state for KYB. Real-time. Build effort: ~1 day (similar to lv/lt-company-data).
+- **SAM.gov** — Federal Entity Management API. Free key registration required (1-4 week lead time). Build effort: ~1 day after key arrives.
+
+### Free bulk-download states (Tier 1 direct, ship in v1 via ingest-and-index)
+
+- **CO** — Socrata SODA on data.colorado.gov. Similar pattern to NY.
+- **FL** — Sunbiz SFTP bulk files. Requires SFTP credential request (free).
+- **MA** — Corporations Book + data files via mass.gov. Slow refresh cadence (annual). Disclose freshness.
+- **WA** — CCFS CSV export from Advanced Search. Paginated bulk download.
+- **TX (Comptroller, partial)** — Franchise Tax CPA API free + no-auth. Limited field set vs full SOS records.
+
+**Total Tier 1 direct candidates: 7 of 15.** Build effort: ~6-8 days for all (each takes ~1-1.5 days, can parallelise across multiple engineering streams).
+
+### Paid-signup states (Cobalt Tier 2 for v1, evaluate paid signup for v1.1+)
+
+- **DE** — Paid certificate orders / commercial subscription. **Critical: DE is the most-incorporated US state — Cobalt's DE coverage must be verified before v1.**
+- **GA** — GTA partnership $500 one-time or $5K/year.
+- **IL** — Contract-based bulk file (academic/journalist exemption only for free).
+- **MN** — $30/week CSV (cheap upgrade candidate for v1.1+ if NJ volume materialises).
+- **NV** — SilverFlume agreement-gated API. Direct inquiry deferred.
+- **NJ** — Per-record paid downloads.
+- **PA** — $0.25/name BCCO lists (not bulk-feasible).
+- **WY** — Paid bulk subscription (pricing not published).
+
+**Total Cobalt Tier 2 reliance: 8 of 15.** All routed through Cobalt for v1.
+
+### Scrape-only states (Cobalt Tier 2 only for v1)
+
+**None strict.** Every state offers either a free API, free bulk path, or paid-API path. The "scrape-only" category is empty by construction once DEC-20260428-A is applied: every HTML-form-only state with no API + no bulk falls into "paid-signup" (because Cobalt's paid tier IS the scrape-equivalent, just legally licensed).
+
+### Blockers / further investigation needed
+
+- **NV** — API existence is referenced in SilverFlume marketing but access mechanism is agreement-gated. Worth a direct inquiry to NV SOS *before* relying on Cobalt for NV in v1.
+- **Cobalt's actual state coverage** — The Cobalt sign-up is still pending per Active Vendor Stack. Before v1 launch, verify Cobalt's catalog actually covers all 8 Tier-2 states (DE, GA, IL, MN, NV, NJ, PA, WY). If any are missing, that's a v1 launch gap.
+- **MA freshness** — Annual update cadence may be too stale for KYB. Decision: ship with limitation-disclosed, or layer a real-time Cobalt fallback for fresh-filing scenarios?
+- **TX Comptroller field gap** — The Comptroller API covers franchise-tax status + entity name but doesn't include officers/agents. Pair with Cobalt for full coverage, or accept the limitation in v1?
+
+---
+
+## v1 build queue implications
+
+**Tier 1 direct capabilities to build for v1:** 7
+- `us-ny-company-data` (Socrata SODA — highest priority, real-time + cleanest)
+- `us-co-company-data` (Socrata SODA)
+- `us-fl-company-data` (Sunbiz SFTP ingest)
+- `us-ma-company-data` (data files ingest, slow refresh)
+- `us-wa-company-data` (CCFS CSV bulk)
+- `us-tx-company-data` (Comptroller CPA API, partial fields)
+- `us-sam-entity` (SAM.gov v3 — federal, separate slug)
+
+**States served via Cobalt orchestration for v1:** 8
+- DE, GA, IL, MN, NV, NJ, PA, WY — all flow through a generic `us-cobalt-company-data` capability that takes a state code + entity identifier and proxies to Cobalt.
+
+**Estimated total Tier 1 build effort:** ~8-12 person-days. NY + CO share a Socrata-SODA pattern (1-day each), FL + WA share a bulk-ingest pattern (1.5 days each), MA is bespoke (1 day), TX Comptroller is REST-API (1 day), SAM.gov is REST-API after key arrives (1 day).
+
+**Cobalt coverage gap risk:** if Cobalt's catalog is missing any of DE/GA/IL/MN/NV/NJ/PA/WY, that's a v1 launch blocker. Verify before signing the Cobalt contract.
+
+**Other US capabilities not in this scout's scope:** EINsearch, sec-api.io, Docket Alarm, CourtListener+RECAP — these are separate non-SOS US capabilities listed in the Active Vendor Stack. Their viability is a separate workstream.
+
+---
+
+## Open questions for chat
+
+1. **Cobalt catalog coverage verification.** Before signing the Cobalt contract, confirm with their team that DE, GA, IL, MN, NV, NJ, PA, WY are all in their catalog with KYB-grade field coverage (status + officers + registered agent + formation date). If any are missing, that's a v1 launch decision point.
+2. **SAM.gov API key registration timeline.** SAM.gov system-account approval takes 1-4 weeks. If v1 launch is <4 weeks away, start the registration NOW.
+3. **TX Comptroller partial-fields decision.** TX Comptroller API gives franchise-tax status + entity verification but not officers/agents. Options for v1: (a) ship `us-tx-company-data` with the limitation disclosed, (b) ship Comptroller direct + Cobalt fallback for the missing fields, (c) skip direct and rely entirely on Cobalt. The cleanest is (b) but it doubles per-call cost — chat decides based on TX customer demand projection.
+4. **MA freshness handling.** Annual bulk refresh may be too stale for some KYB scenarios. Same decision shape as TX — direct + Cobalt overlay, or accept the limitation.
+5. **NV direct inquiry.** Worth a 30-minute email to NV SOS asking about API access terms. Could turn NV from Cobalt Tier 2 → Tier 1 direct if response is favourable. Deferred to v1.1+ unless chat wants to chase NV-specifically.
+6. **The "scrape-only" category is empty under DEC-20260428-A.** Worth confirming with chat that this interpretation is right: every state with HTML-form-only access falls into "Cobalt Tier 2" rather than "blocked entirely." The implicit assumption is Cobalt is licensed to access these states legally on Strale's behalf. Verify this is consistent with Cobalt's actual ToS.
+
+---
+
+*Generated by Claude Code session 2026-05-15. Read-only investigation. Zero wallet spend (no Strale capability calls). Worktree: strale-research, branch `docs/us-topograph-scout-2026-05-15`. No code changes, no DB writes, no PR.*

--- a/docs/research/2026-05-07-bg-registry-build-path.md
+++ b/docs/research/2026-05-07-bg-registry-build-path.md
@@ -1,0 +1,110 @@
+# Bulgaria Registry — Build Path Verification Memo
+
+**Date:** 2026-05-07
+**Country:** BG (Bulgaria)
+**Status:** Research only. No code, no manifest, no routing changes in scope.
+**Predecessor:** [2026-05-06 live registry coverage audit](2026-05-06-live-registry-coverage-audit.md), DEC-20260507-A (gap-7).
+
+## 1. Headline classification
+
+**Tier 1 — VIABLE.** Bulgaria publishes the entire Commercial Register (Търговски регистър, BRRA) as **CC-0 licensed XML open data** on `data.egov.bg`. Date-based incremental files contain new + updated companies. Government maintains an official anonymisation/export script at `github.com/governmentbg/brra-opendata`.
+
+**Recommendation: BUILD via bulk-ingest path.** Pattern matches BE KBO Open Data ingest and RO ONRC bulk dump (already established in repo). Effort estimate **M (3–10 days)**.
+
+## 2. API + data surface findings
+
+### Path A — `data.egov.bg` open data XML (FREE, RECOMMENDED)
+
+- **Authority:** Агенция по вписванията (Registry Agency, BRRA) — under the Ministry of Justice.
+- **Open data portal:** `https://data.egov.bg/`
+- **Structure:** Date-based files containing records of new and updated companies (per OpenCorporates 2018 sourcing notes; OpenCorporates loaded ~970,000 BG companies from this source). Government export tool [governmentbg/brra-opendata](https://github.com/governmentbg/brra-opendata) processes the raw BRRA XML into open-data-ready (anonymised) form.
+- **Format:** XML.
+- **Anonymisation:** EGN/LNCh (Bulgarian national identifier numbers) are replaced with a hash+salt string before publication. This is the legal compliance step — the rest of the company-identity tuple is preserved.
+- **Authentication:** None.
+- **Cost:** Free.
+- **License:** **CC-0 (public domain)** — no attribution requirement, full commercial reuse permitted.
+- **Tier classification:** **Tier 1** — direct govt source, doctrine-clean, free, redistribution-clean.
+
+### Path B — `api.brra.bg` (Registry Agency direct API, paid)
+
+- The Registry Agency operates a direct API at `http://api.brra.bg` supporting both JSON (`Accept: application/json`) and XML (`Accept: text/xml`) responses. This is separate from the open data publication.
+- **Access model:** "Service API" — referenced in the egov-requirements GitHub repo as an integration point. Free for local government bodies; commercial pricing not surfaced in this spike.
+- **Tier classification:** Tier 1 (govt source) but not needed if the open-data XML covers identity needs.
+- **Use case:** Live single-entity lookup, if real-time freshness is required vs. periodic bulk-ingest cadence.
+
+### Path C — `portal.registryagency.bg` web portal (HTML)
+
+- **URL:** `https://portal.registryagency.bg/en/`
+- Free public access, English-language option, full document downloads (acts of establishment, beneficial-owner declarations, historic filings).
+- HTML only — scraping forbidden under DEC-20260428-A. Excluded.
+
+### Path D — Tier 3 scraping
+
+- Forbidden. Excluded.
+
+## 3. Per-field depth (data.egov.bg XML)
+
+| Field | Available |
+|---|---|
+| Company number | ✓ |
+| Legal name + previous names | ✓ |
+| Legal status | ✓ |
+| Incorporation date | ✓ |
+| Dissolution date | ✓ |
+| Legal form / business type | ✓ |
+| Industry codes (NACE/CAEN equivalent) | ✓ (free-text — only ~4% map cleanly to standard schemes per OpenCorporates) |
+| Registered address | ✓ |
+| Officers (managers, directors) | ✓ |
+| Shareholders | ✓ |
+| Filings | ✓ |
+| Branches | ✓ |
+| UBO (beneficial owners) | ✓ available via portal; XML feed coverage: needs verification at ingest time (likely included; CJEU Nov 2022 access restrictions may apply post-publication) |
+
+**Caveat:** Industry-code free-text entry is a known data-quality issue. Strale would either (a) surface raw text as-is, (b) pass through a normalization step (LLM or rule-based mapping). For an identity-only v1 the raw text is fine; the consumer can normalise on read.
+
+## 4. Pricing
+
+- **Free** — `data.egov.bg` is open data, CC-0 license, no auth, no rate limit fee.
+- Hosting / bandwidth costs at our end (download the XML, store in our DB) — minor for a country dump of ~1M companies.
+
+## 5. Redistribution
+
+- **CC-0 public domain** is the most permissive open-data license available. No attribution required, no share-alike, full commercial redistribution, no restrictions on derivative works.
+- **DEC-20260428-A Tier-1 doctrine compliance:** Direct govt source, machine-readable structured data, no scraping. Fully compliant.
+
+## 6. Freshness
+
+- Date-based files containing new + updated records — the cadence is daily / near-daily based on OpenCorporates' ingestion pattern.
+- Bulk-ingest model: Strale snapshots daily (or weekly), serves from local DB. Same pattern as BE KBO + RO ONRC builds.
+
+## 7. Build effort estimate
+
+**M (3–10 days)** — direct copy of BE KBO Open Data ingest pattern.
+
+Components:
+1. Download daily XML files from `data.egov.bg` BRRA dataset.
+2. Parse XML → DB rows (use `governmentbg/brra-opendata` as reference for schema).
+3. Implement diff/upsert against existing local mirror.
+4. Build `bg-company-data` capability — accept BG company number, return identity tuple from local DB.
+5. Index by name, number, status.
+
+Risks:
+- Industry-code free-text quality (low — surface as-is).
+- XML schema evolution (low — government schema typically stable; mitigate by versioning on ingest).
+- Daily volume (low — ~1M companies total, daily delta likely <1k rows).
+
+## 8. Recommendation
+
+**Build BG via bulk-ingest path (Tier 1).** Single-country self-build, doctrine-clean, free, reuses BE KBO ingest pattern. Schedule alongside other gap-recovery builds; LU does not block this work.
+
+Open question for build session: confirm UBO field coverage in the published XML (vs the auth-gated portal). If UBO is portal-only, identity-tuple coverage is still complete and v1-acceptable; UBO can come later via a separate capability if needed.
+
+## Sources
+
+- [OpenCorporates Bulgaria announcement (2018)](https://blog.opencorporates.com/2018/04/04/new-jurisdiction-bulgaria-970000-companies/) — confirms CC-0 XML publication, date-based incremental files, ~970k companies, full field set.
+- [governmentbg/brra-opendata GitHub](https://github.com/governmentbg/brra-opendata) — official Bulgarian government open-data export script. Reference for XML schema.
+- [data.egov.bg open data portal](https://data.egov.bg/) — host for the BRRA dataset.
+- [Министерство на електронното управление — Open Data](https://e-gov.bg/wps/portal/agency-en/home/data/open-data) — Ministry of e-Government statement on Bulgaria's open data publication regime.
+- [European e-Justice Portal — BG business registers](https://e-justice.europa.eu/topics/registers-business-insolvency-land/business-registers-eu-countries/bg_en) — official statement on business register access.
+- [api.brra.bg integration reference (governmentbg/egov-requirements)](https://github.com/governmentbg/egov-requirements/blob/master/integration.md) — confirms JSON+XML API at `api.brra.bg`.
+- [EPZEU portal](https://portal.registryagency.bg/en/) — verified public web portal exists; out of scope (HTML scraping forbidden).

--- a/docs/research/2026-05-07-cy-registry-build-path.md
+++ b/docs/research/2026-05-07-cy-registry-build-path.md
@@ -1,0 +1,115 @@
+# Cyprus Registry — Build Path Verification Memo
+
+**Date:** 2026-05-07
+**Country:** CY (Cyprus)
+**Status:** Research only. No code, no manifest, no routing changes in scope.
+**Predecessor:** [2026-05-06 live registry coverage audit](2026-05-06-live-registry-coverage-audit.md), DEC-20260507-A (gap-7).
+
+## 1. Headline classification
+
+**Tier 1 — VIABLE.** The Department of Registrar of Companies and Intellectual Property publishes open data on `data.gov.cy` (Cyprus National Open Data Portal). Coverage spans organisations, registered offices, and officers across five entity types: companies, foreign companies, commercial names, cooperatives, old cooperatives.
+
+**Recommendation: BUILD via data.gov.cy bulk-ingest path.** A free wrapper API (Apitalks) exists on top of the same data and could be used as a fast-path proof-of-concept, but for v1 production Strale should ingest the official open-data publication directly to avoid third-party dependency.
+
+**Effort:** **M (3–10 days)**.
+
+## 2. API + data surface findings
+
+### Path A — `data.gov.cy` open data (FREE, RECOMMENDED for v1)
+
+- **Authority:** Department of Registrar of Companies and Intellectual Property, under the Ministry of Energy, Commerce and Industry of the Republic of Cyprus.
+- **Open data portal:** `https://www.data.gov.cy/en/group/30` — landing page for DRCOR datasets.
+- **Confirmation of dataset existence:** Apitalks (the Apple Cyprus wrapper API operator) explicitly states their data "originates from the Office of the Registrar of Companies and Intellectual Property in Cyprus, catalogued on the National Open Data Portal Cyprus." Coverage:
+  - Organisation lists
+  - Registered office directories
+  - Officer information
+- **Entity types covered:** companies, foreign companies, commercial names, cooperatives, old cooperatives.
+- **Format:** CSV (consistent with data.gov.cy's standard publication format; rendered HTML inspection of the portal group page was inconclusive — confirm at ingest time).
+- **License:** data.gov.cy operates under EU Open Data Directive 2019/1024 transposition; default published license is Creative Commons Attribution (CC-BY) for Cypriot government open data. **Confirm the specific dataset license at ingest time** — CY hasn't unambiguously surfaced this for the registrar group during research.
+- **Authentication:** None.
+- **Cost:** Free.
+- **Tier classification:** **Tier 1** — direct govt-published open data, doctrine-clean.
+
+### Path B — Apitalks wrapper API (free, third-party)
+
+- **URL:** `https://api.store/cyprus-api/republic-of-cyprus-ministry-of-finance-api/register-of-registered-companies-commercial-names-and-cooperatives-in-cyprus-api`
+- **What it is:** REST wrapper over the same `data.gov.cy` DRCOR open-data publication. "Operation and development of APIs are currently fully funded by company Apitalks and its usage is for free." Status: "early access."
+- **Use case:** Fast prototyping or supplementary live-lookup. Not recommended for production — third-party dependency on a "fully funded by company Apitalks" pricing model that could change without notice.
+- **Tier classification:** Effectively Tier 1 (data is govt open data) wrapped by a third-party — but the dependency on Apitalks's continued free operation makes it less predictable than direct ingest.
+
+### Path C — DRCOR `efiling.drcor.mcit.gov.cy` portal
+
+- **URL:** `https://efiling.drcor.mcit.gov.cy/DrcorPublic/SearchForm.aspx?sc=0&cultureInfo=en-AU`
+- **Free public search:** Returns name, registration number, company type, subtype, name status, registration date, organisation status, status date.
+- **Document downloads:** €10 per "bulk filing package" — financial audits, annual returns, share allotments, officer changes, capital increases. Available for 24h on the user's account before deletion.
+- **Tier classification:** HTML portal — scraping forbidden under DEC-20260428-A. Excluded.
+
+### Path D — UBO register
+
+- **URL:** Operated by DRCOR.
+- **Pricing:** €3.50 per entity, restricted to authorised entities (per Kyckr 2025 guide).
+- **Status:** Out of scope for v1 identity-only build; defer.
+
+### Path E — Tier 2 commercial vendors (Kyckr, BvD/Orbis, Creditsafe)
+
+- Standard EU coverage; redistribution-clean if vendor contract carries primary-source provenance per DEC-20260428-A.
+- Use case: fallback if direct ingest hits unforeseen data-quality issues.
+
+## 3. Per-field depth (data.gov.cy publication via Apitalks-confirmed schema)
+
+| Field | Available |
+|---|---|
+| Organisation name | ✓ |
+| Registration number | ✓ |
+| Organisation type | ✓ (company, foreign company, commercial name, cooperative, old cooperative) |
+| Status | ✓ |
+| Registration date | ✓ |
+| Registered office address | ✓ |
+| Officers (name + position) | ✓ |
+| Subtype | ✓ (per portal output) |
+| Status date | ✓ (per portal output) |
+| Financials | ✗ — paid filing packages only (€10/batch) |
+| UBO | ✗ — paid (€3.50/entity, restricted access) |
+
+Identity-tuple coverage is complete for v1. Financials and UBO are deferred.
+
+## 4. Pricing
+
+- **Free** — data.gov.cy bulk publication.
+- Paid (out of scope for v1): €10/filing-package downloads from DRCOR portal; €3.50/entity UBO lookups.
+
+## 5. Redistribution
+
+- data.gov.cy default license: CC-BY (per EU Open Data Directive 2019/1024 transposition standard for Cypriot government open data). **Confirm the specific dataset's license string at ingest time** — research did not surface unambiguous CC0 vs CC-BY for the DRCOR group.
+- If CC-BY: attribute "Department of Registrar of Companies, Cyprus" alongside other Tier-1 attributions in the audit body's `provenance` block. Operationally identical to existing IE/SK/RO patterns.
+
+## 6. Freshness
+
+- Update cadence not surfaced in research. Other Cypriot government open data datasets typically follow monthly snapshots. **Confirm at ingest time.**
+
+## 7. Build effort estimate
+
+**M (3–10 days)** — bulk-ingest pattern (BE KBO / RO ONRC reuse).
+
+Components:
+1. Locate and download the DRCOR datasets from `data.gov.cy` (organisations + registered-office + officers files).
+2. Confirm format (CSV expected) and license string.
+3. Parse → DB rows; index by name, number, status.
+4. Build `cy-company-data` capability — accept registration number, return identity tuple from local DB.
+
+Smaller dataset than RO/BG (Cyprus has ~250k–300k registered entities total vs. BG's ~1M and RO's ~5M), so storage/ingest is trivial.
+
+## 8. Recommendation
+
+**Build CY via data.gov.cy bulk-ingest (Tier 1).** Doctrine-clean, free, identity-tuple complete. Confirm dataset format + license at ingest start.
+
+If urgency demands a same-day proof-of-concept, the **Apitalks wrapper** is a reasonable bridge — but production should not depend on a single third-party's "fully funded by us, free" sustainability commitment.
+
+## Sources
+
+- [Apitalks — Cyprus Companies API page](https://api.store/cyprus-api/republic-of-cyprus-ministry-of-finance-api/register-of-registered-companies-commercial-names-and-cooperatives-in-cyprus-api) — confirms data.gov.cy as source, lists field coverage, confirms five entity types, confirms officer-level data.
+- [data.gov.cy — Department of Registrar of Companies group](https://www.data.gov.cy/en/group/30) — landing page (datasets listing not extracted in this spike's web fetches).
+- [Kyckr — Cyprus Company Registry guide 2025](https://www.kyckr.com/blog/cyprus-company-registry-search) — pricing for portal access (free search, €10 filings, €3.50 UBO), field-level coverage.
+- [DRCOR e-filing portal](https://efiling.drcor.mcit.gov.cy/DrcorPublic/SearchForm.aspx?sc=0&cultureInfo=en-AU) — verified portal exists; out of scope (HTML scraping forbidden).
+- [European e-Justice Portal — CY business registers](https://e-justice.europa.eu/topics/registers-business-insolvency-land/business-registers-eu-countries/cy_en) — official statement on Cyprus business register.
+- [OpenCorporates — Cyprus DRCOR jurisdiction](https://opencorporates.com/registers/58) — third-party aggregator confirms the registry data is loadable.

--- a/docs/research/2026-05-07-gap-recovery-synthesis.md
+++ b/docs/research/2026-05-07-gap-recovery-synthesis.md
@@ -1,0 +1,94 @@
+# Gap-Recovery Candidates — Cross-Country Synthesis
+
+**Date:** 2026-05-07
+**Spike:** `research/gap-recovery-candidates`
+**Per-country memos:**
+- [LU](2026-05-07-lu-registry-build-path.md)
+- [BG](2026-05-07-bg-registry-build-path.md)
+- [CY](2026-05-07-cy-registry-build-path.md)
+- [HU](2026-05-07-hu-registry-build-path.md)
+
+## 1. Headline finding
+
+**2 of 4 close as Tier-1 self-build candidates** (BG, CY). **2 stay in gap pending parallel work** (LU, HU). Of the gap-7 (per DEC-20260507-A), this spike removes BG and CY as build-eligible — provisional gap-5 if both BG and CY build sessions ship.
+
+## 2. Per-country summary
+
+| Country | Classification | Source | License | Effort | Recommendation |
+|---|---|---|---|---|---|
+| **BG** | Tier 1 — buildable | data.egov.bg BRRA XML open data | **CC-0** (public domain) | M (3–10 days) | **Build now.** Direct copy of BE KBO + RO ONRC bulk-ingest pattern. |
+| **CY** | Tier 1 — buildable | data.gov.cy DRCOR open data | CC-BY (most likely; confirm at ingest) | M (3–10 days) | **Build now.** Smaller dataset (~250–300k entities); identity-tuple complete. |
+| **LU** | Stays in gap | LBR API exists but enterprise/paid-only; no CC0 open-data publication | (commercial agreement) | L (10–20 days) | **Defer.** Wait for Kyckr eval / Openapi case 151296 / revenue-justified LBR contract. |
+| **HU** | Stays in gap | No govt API; no open-data publication; only paid HU-native wrappers (companyapi.hu €42–100/mo subscription, OPTEN enterprise) | (commercial agreement) | S (subscription path) | **Defer.** Fixed-cost subscription violates DEC-20260506-G. Wait for Kyckr/Openapi or volume-justified contract. |
+
+## 3. Priority ranking
+
+1. **BG (highest)** — CC-0 license is the cleanest possible. Largest entity count of the buildable two (~1M companies). Build pattern already mature in the repo (BE KBO, RO ONRC). Single-country self-build with no vendor dependency.
+2. **CY (second)** — Smaller dataset, simpler ingest. Apitalks wrapper available as same-day prototype bridge. License confirmation (CC-BY vs CC-0) is the only open data-quality question.
+3. **LU (deferred)** — Highest single-country business value (financial hub, biggest ICP gap), but no doctrine-clean v1-economic path. Defer pending parallel work.
+4. **HU (deferred)** — Closes only via Tier-2 vendor; cheapest option (companyapi.hu) is a fixed €42/mo floor. Defer pending Kyckr/Openapi.
+
+**Build-session sequencing recommendation:** BG first (largest impact, cleanest license), then CY (second; lower complexity makes it good follow-up). Each build session ~M effort. Total to close BG + CY: ~6–20 days of capability work.
+
+## 4. Notion follow-ups for chat
+
+The following are flagged for chat to file post-spike. CC does not file Notion content directly per session governance.
+
+### Decision candidates
+
+- **DEC-20260507-?: BG defaults to data.egov.bg BRRA XML open data as primary identity provider.** Tier 1 (DEC-20260428-A compliant), CC-0 license, self-build via existing BE KBO bulk-ingest pattern. Estimated effort M.
+- **DEC-20260507-?: CY defaults to data.gov.cy DRCOR open data as primary identity provider.** Tier 1, license-CC-BY-likely (confirm at ingest), self-build via bulk-ingest pattern.
+- **DEC-20260507-?: LU and HU remain in gap pending parallel vendor evaluation.** Specifically: HU is gated on Kyckr eval AND Openapi case 151296; LU is gated on those two PLUS the option of a direct LBR API contract once revenue justifies it.
+
+### To-do candidates (file in To-do DB)
+
+- **bg-company-data — bulk ingest from data.egov.bg.** M effort. Pattern: BE KBO ingest. Reuse `governmentbg/brra-opendata` GitHub repo as schema reference.
+- **cy-company-data — bulk ingest from data.gov.cy.** M effort. Pattern: data.gov.cy CKAN download; small dataset.
+- **(deferred) LU and HU coverage** — re-evaluate when Kyckr eval lands AND/OR Openapi case 151296 clears.
+
+### Active Vendor Stack updates
+
+- Add `data.egov.bg` (Bulgaria Registry Agency BRRA) as primary provider for BG company-data. License: CC-0. Format: XML.
+- Add `data.gov.cy` (Cyprus DRCOR) as primary provider for CY company-data. License: CC-BY (confirm at ingest). Format: CSV (likely).
+- Note `companyapi.hu` (WellData Kft.) and OPTEN as candidate Tier-2 fallbacks for HU pending future evaluation.
+- Note LBR enterprise API as candidate Tier-1 fallback for LU pending revenue-justified contract.
+
+### Coverage Matrix updates
+
+- BG: gap → buildable (planned).
+- CY: gap → buildable (planned).
+- LU: stays in gap; annotate "deferred pending Kyckr/Openapi/contract."
+- HU: stays in gap; annotate "deferred pending Kyckr/Openapi/volume-justified subscription."
+- Gap-7 → gap-5 once BG and CY ship; gap-7 → provisional-gap-5 status when this synthesis is filed.
+
+## 5. Doctrine notes
+
+### Tier-1 / Tier-2 / Tier-3 classification calls
+
+- **BG:** Unambiguous Tier 1. CC-0 govt-published structured XML, doctrine model case.
+- **CY:** Unambiguous Tier 1 for data.gov.cy direct ingest. The Apitalks wrapper option was considered Tier 1 (data is govt open data) wrapped by a third-party with a free-tier sustainability question — the synthesis recommends direct ingest for production despite the wrapper being usable as a prototype.
+- **LU:** Tier 1 paid-enterprise API exists. The classification "stays in gap" is purely an economics call (DEC-20260506-G no-fixed-cost), not a doctrine call. If revenue conditions change, LU is a doctrine-clean Tier-1 build.
+- **HU:** No govt-published machine-readable surface. Tier-2 wrappers source primary from MoJ OCCR — primary-source provenance is plausibly clean (DEC-20260428-A Tier-2 compliant) but the fixed-cost gate keeps HU deferred.
+
+### Close calls / scraping rejections
+
+- All four countries have HTML web portals that would have been scraping candidates pre-DEC-20260428-A. All four are excluded under Tier-1 doctrine. No close calls — the doctrine cleanly rejects each.
+
+## 6. Open questions
+
+1. **CY license string.** data.gov.cy default is CC-BY but the specific DRCOR dataset's license was not directly extracted in this spike. Confirm at ingest start before deciding attribution-block design.
+2. **CY update cadence.** Not surfaced in research. Assume monthly until verified at ingest.
+3. **BG UBO field coverage in the open-data XML.** OpenCorporates' 2018 ingest predates the CJEU November 2022 UBO-restriction ruling. Whether the data.egov.bg publication still includes UBO post-CJEU needs confirmation at ingest start. Identity-tuple v1 is not blocked either way.
+4. **LU LBR API pricing.** Not published. Direct contact would be needed to size the fixed-cost commitment for a future revenue-justified evaluation.
+5. **Kyckr's HU and LU coverage.** Sits in the parallel `research/kyckr-evaluation` spike — synthesis there will clarify whether either country closes via Kyckr.
+6. **Openapi case 151296.** External gating event; affects HU and LU closure paths.
+
+## 7. Inventory of fetches used in this spike
+
+13 web fetches and 6 web searches (well within the 20-fetch budget). Per-country breakdown:
+- LU: 2 searches + 3 fetches
+- BG: 2 searches + 2 fetches (1 dataset fetch returned 403; OpenCorporates blog and search results provided sufficient corroboration)
+- CY: 2 searches + 4 fetches (1 fetch returned 404; 1 fetch on the data.gov.cy dataset listing was inconclusive — Apitalks page was the load-bearing source for field coverage)
+- HU: 2 searches + 3 fetches
+
+Two unreachable fetches (data.egov.bg dataset detail pages 403; data.gov.cy organisation-filter URL 404) did not block the analysis — search-result snippets and corroborating third-party sources covered the gap.

--- a/docs/research/2026-05-07-hu-registry-build-path.md
+++ b/docs/research/2026-05-07-hu-registry-build-path.md
@@ -1,0 +1,126 @@
+# Hungary Registry — Build Path Verification Memo
+
+**Date:** 2026-05-07
+**Country:** HU (Hungary)
+**Status:** Research only. No code, no manifest, no routing changes in scope.
+**Predecessor:** [2026-05-06 live registry coverage audit](2026-05-06-live-registry-coverage-audit.md), DEC-20260507-A (gap-7).
+
+## 1. Headline classification
+
+**Tier 1 — NOT VIABLE at v1 economics.** No official Hungarian government API for programmatic registry access. The Ministry of Justice's `e-cegjegyzek.hu` portal offers free basic web search (HTML only) and paid extended access, but no machine-readable bulk data publication on any open-data portal surfaces during research. Cégközlöny (the Company Gazette) is a publication-event stream, not a structured registry feed.
+
+**Tier 2 — VIABLE BUT FIXED-COST.** Two Hungarian-native commercial wrappers (companyapi.hu / WellData Kft., OPTEN) offer paid API access sourced primary from the Ministry of Justice OCCR register. companyapi.hu publishes pricing: 15,990–37,990 HUF/month (~€42–100/month subscription, no PAYG tier). OPTEN is enterprise/custom-priced (no public pricing).
+
+**Recommendation: STAYS IN GAP at v1.** Tier-2 fixed-cost subscription at €42–100/month conflicts with DEC-20260506-G (no-fixed-cost stance) and DEC-20260507-D (no BYO-credentials). HU closes when one of: (a) the parallel Kyckr evaluation lands favourably and Kyckr's HU coverage is solid, (b) the Openapi gating decision (case 151296) clears with HU coverage, (c) a HU-native vendor with PAYG pricing surfaces, or (d) revenue justifies the fixed-cost subscription commitment.
+
+## 2. API + data surface findings
+
+### Path A — `e-cegjegyzek.hu` (Ministry of Justice, official)
+
+- **Authority:** Igazságügyi Minisztérium Céginformációs Szolgálat (Ministry of Justice, Company Information Service).
+- **Public URL:** `https://www.e-cegjegyzek.hu/` and `https://www.e-cegjegyzek.hu/?ceginformacio`
+- **Free access:** HTML web search only — search by name, registration number (cégjegyzékszám), tax number (adószám). Returns basic company information.
+- **Paid access:** "Accessing all further content is subject to a charge" (per EU e-Justice portal). Pricing not published; legacy reports indicate per-document charges via electronic-signature-gated access.
+- **API:** **None published.** No open developer documentation; no machine-readable endpoint surfaces in research.
+- **Tier classification:** Tier 1 web portal — HTML scraping forbidden under DEC-20260428-A. Excluded.
+
+### Path B — Cégközlöny (Company Gazette)
+
+- **URL:** `http://www.e-cegkozlony.gov.hu/` and `https://cegportal.im.gov.hu/frontend/cegkozlony`
+- **What it is:** Official journal of the Ministry of Justice — publication channel for company-event notices (incorporation, dissolution, capital changes). Free.
+- **Use case as registry source:** Not suitable. Cégközlöny is publication-event-stream, not a structured registry-state feed. Mirrors the LU RESA model.
+- **Tier classification:** Free Tier-1 surface but doesn't meet the use case.
+
+### Path C — companyapi.hu (WellData Kft. wrapper, paid subscription)
+
+- **URL:** `https://companyapi.hu/`
+- **Operator:** WellData Kft. — Hungarian commercial vendor.
+- **Source data:** "Directly from the Hungarian Ministry of Justice's Company Information Service" — claimed primary-source provenance (verify in vendor agreement under DEC-20260428-A Tier-2 due diligence).
+- **Pricing tiers (subscription, no PAYG):**
+  - **Starter:** 15,990 HUF/month (~€42) — 1,000 requests
+  - **Advanced:** 24,990 HUF/month (~€65) — 5,000 requests
+  - **Pro:** 37,990 HUF/month (~€100) — 10,000 requests
+  - All prices excl. VAT; custom high-volume pricing on request.
+- **Field coverage:** Up to 32 fields per plan tier — company fundamentals (name, VAT, registry number, address), financial metrics (revenue, assets, equity), ownership/management, banking info, activity classifications.
+- **Redistribution:** Not stated on public pricing page. Subject to vendor contract review under DEC-20260428-A Tier-2.
+- **Tier classification:** **Tier 2 — fixed-cost subscription**. Conflicts with DEC-20260506-G unless escalated.
+
+### Path D — OPTEN (commercial vendor)
+
+- **URL:** `https://www.opten.hu/ceginformacios-szolgaltatasok?lang=en`
+- **Operator:** OPTEN — Hungarian market-leader (520k companies, 420k individual entrepreneurs, 140k other organisations).
+- **Source data:** OCCR (Ministry of Justice registry) + Cégközlöny supplements. Primary-source-clean.
+- **API access:** Mentioned but custom — "Database consolidation (API, SOAP), data cleaning" as custom offering. No public PAYG pricing; quote-based.
+- **Tier classification:** Tier 2 — likely enterprise / fixed-cost. Same gating as companyapi.hu.
+
+### Path E — Tier 3 scraping of `e-cegjegyzek.hu`
+
+- Forbidden under DEC-20260428-A. Excluded.
+
+### Path F — National Public Data Portal of Hungary
+
+- Listed at dataportals.org and dateno.io as Hungary's national open-data registry.
+- **Confirmed in research:** No company-register dataset surfaces in search results. The portal aggregates metadata about state-managed registers but does not appear to publish a downloadable bulk dump of the company register itself.
+- **Tier classification:** N/A — no usable dataset.
+
+## 3. Per-field depth
+
+| Field | e-cegjegyzek.hu (free portal) | companyapi.hu (paid) | OPTEN (paid) |
+|---|---|---|---|
+| Legal name | ✓ | ✓ | ✓ |
+| Registration number (cégjegyzékszám) | ✓ | ✓ | ✓ |
+| Tax number | ✓ | ✓ | ✓ |
+| Status | ✓ | ✓ | ✓ |
+| Registered address | ✓ | ✓ | ✓ |
+| Legal form | ✓ | ✓ | ✓ |
+| Incorporation date | basic | ✓ | ✓ |
+| Officers / management | partial | ✓ | ✓ |
+| Owners / shareholders | paid in portal | ✓ | ✓ |
+| Financials | paid in portal | ✓ | ✓ |
+| UBO | paid in portal | partial | ✓ |
+| Risk ratings | — | — | ✓ |
+
+Identity-tuple completeness: full via either commercial wrapper.
+
+## 4. Pricing summary
+
+- Free: e-cegjegyzek.hu basic search (HTML only — not usable for Strale).
+- Tier-2 wrapper: companyapi.hu €42–100/month subscription (no PAYG); OPTEN enterprise.
+- Tier-2 cross-EU candidates: Kyckr (parallel evaluation), Openapi (case 151296).
+
+## 5. Redistribution
+
+- Both companyapi.hu and OPTEN source from MoJ OCCR — primary-source provenance is plausibly clean (verify in any commercial agreement).
+- Per DEC-20260428-A, Tier-2 use requires documented redistribution rights, indemnification, and per-fact primary-source provenance. Both Hungarian-native vendors are more likely to satisfy this than international aggregators.
+- No CC-BY/CC-0 govt open-data license applies — there is no government-published open-data publication of the register to redistribute.
+
+## 6. Freshness
+
+- companyapi.hu and OPTEN both claim near-real-time MoJ sync (registry filing → vendor surface within hours-to-days). Verify in contract.
+- Cégközlöny publishes daily as the official gazette but is event-stream, not state-feed.
+
+## 7. Build effort estimate
+
+- **Tier-2 wrapper integration (companyapi.hu):** **S (2–3 days)** once subscription is contracted. REST API, modern auth model expected.
+- **Tier-2 wrapper integration (OPTEN):** **M (3–7 days)** — SOAP/REST custom integration; quote-and-contract gating slows the cycle.
+- **Bulk-ingest path:** Not available — no open-data publication exists.
+
+## 8. Recommendation
+
+**Stays in gap at v1.** companyapi.hu's €42/month subscription floor is the cheapest entry point, but it's still a fixed-cost commitment under DEC-20260506-G — and at €0.05/call retail (Strale's mid-tier capability price) the break-even is ~840 HU calls per month before the subscription is cost-positive. Defer until either:
+
+1. **Cross-EU aggregator clears.** Kyckr evaluation (`research/kyckr-evaluation`) or Openapi case 151296 — if either covers HU at PAYG economics, HU closes with zero HU-specific work.
+2. **Volume-justified subscription.** Once HU call volume forecasts exceed the break-even, contract companyapi.hu directly.
+
+**Do NOT scrape `e-cegjegyzek.hu`.** Tier 3 is rejected by doctrine.
+
+NAV (sole traders register) is out of scope; revisit only if a HU build session lands and identity-tuple coverage from a wrapper proves insufficient for sole-trader entities.
+
+## Sources
+
+- [European e-Justice Portal — HU business registers](https://e-justice.europa.eu/topics/registers-business-insolvency-land/business-registers-eu-countries/hu_en) — confirms free basic portal access, paid extended access, no API/open-data mention.
+- [companyapi.hu (WellData Kft.)](https://companyapi.hu/) — pricing tiers, field coverage, claimed MoJ primary-source provenance.
+- [OPTEN — Company information services](https://www.opten.hu/ceginformacios-szolgaltatasok?lang=en) — market-leader scope, OCCR + Cégközlöny sourcing, custom API/SOAP available.
+- [Igazságügyi Minisztérium Cégközlöny portal](https://cegportal.im.gov.hu/frontend/cegkozlony) — official gazette surface; event-stream, not registry-state feed.
+- [`e-cegjegyzek.hu`](https://www.e-cegjegyzek.hu/) — official MoJ web portal; free basic search, paid extended, no API.
+- [SmartLegal — How to access Hungarian company business data](http://smartlegal.hu/publication/how-to-access-the-business-data-of-a-hungarian-company) — third-party legal guide consistent with portal-and-wrapper model.

--- a/docs/research/2026-05-07-lu-registry-build-path.md
+++ b/docs/research/2026-05-07-lu-registry-build-path.md
@@ -1,0 +1,103 @@
+# Luxembourg Registry — Build Path Verification Memo
+
+**Date:** 2026-05-07
+**Country:** LU (Luxembourg)
+**Status:** Research only. No code, no manifest, no routing changes in scope.
+**Predecessor:** [2026-05-06 live registry coverage audit](2026-05-06-live-registry-coverage-audit.md), DEC-20260507-A (gap-7).
+
+## 1. Headline classification
+
+**Tier 1 (free) — NOT VIABLE at v1 economics.** No free programmatic API; no open-data publication of the full register on `data.public.lu` or LNDS CKAN catalogue.
+
+**Tier 1 (paid enterprise API) — POSSIBLE, BUT conflicts with DEC-20260506-G (no-fixed-cost).** LBR offers an API for "large professional users" / "fiduciaries / public authorities" / "high-volume usage" — paid model, public documentation limited. Pricing not published; commercial onboarding required. Tier-1 doctrine-clean (direct govt source) but the price-floor risk is real.
+
+**Tier 2 — VIABLE.** Multiple commercial aggregators carry LU coverage with redistribution clauses (Kyckr, BvD/Orbis, Creditsafe, etc.) plus the cross-EU candidates evaluated in parallel spikes (Openapi cohort if LU is in their coverage; Kyckr per the dedicated `research/kyckr-evaluation` spike).
+
+**Recommendation: STAYS IN GAP at v1. Revisit when (a) the parallel Kyckr evaluation finalises, OR (b) revenue justifies a direct LBR API contract, OR (c) a third-party EU-wide aggregator with LU + redistribution-clean ToS lands at PAYG economics.**
+
+## 2. API + data surface findings
+
+### Path A — LBR direct API (paid, enterprise-only)
+
+- **Authority:** Luxembourg Business Registers (LBR), operating the Registre de Commerce et des Sociétés (RCS) and Registre des Bénéficiaires Effectifs (RBE).
+- **Public URL:** `https://www.lbr.lu/`
+- **Web portal (basic searches free):** `https://www.lbr.lu/mjrcs-web-front/`. HTML only. Free basic searches return name + RCS number + legal form + status; document downloads (statutes, annual accounts) free for some, paid for certified extracts. **No JSON/XML API surface on the public portal.** Scraping forbidden under DEC-20260428-A Tier-1 doctrine.
+- **API existence:** Confirmed via [Kyckr Luxembourg Registry guide 2025/2026](https://www.kyckr.com/blog/luxembourg-registry-guide-2025) and [European e-Justice Portal LU page](https://e-justice.europa.eu/topics/registers-business-insolvency-land/business-registers-eu-countries/lu_en): "Large professional users, such as fiduciaries or public authorities, are invited to use API interfaces, designed for machine-to-machine mass data exchanges."
+- **Public documentation:** None located on `lbr.lu`. Kyckr's guide explicitly notes "public documentation is limited."
+- **Pricing:** Not published. Treated as commercial-tier with onboarding, by analogy to similar EU registries (NL KvK B2B, IT InfoCamere). Likely fixed-fee or volume-tiered subscription.
+- **Tier classification:** **Tier 1** — direct govt source. Doctrine-clean if economics work.
+
+### Path B — `data.public.lu` open data portal
+
+- **URL:** `https://data.public.lu/en/`
+- **Search performed (programmatic):** `?q=registre+commerce`. Page returns "2,566 datasets" total but the search-result listing was not extractable from the rendered page; manual inspection during research did not surface a full RCS company-register dump.
+- **What's there for LU companies:** RESA (Recueil électronique des sociétés et associations) is the legal-gazette publication channel for incorporation and filing notices — it is **publication-event-stream**, not a structured registry-state feed. Not suitable as a primary identity provider.
+- **Tier classification:** N/A — no usable dataset identified.
+
+### Path C — LNDS CKAN data catalogue
+
+- **URL:** `https://ckan.data.lnds.lu/`
+- **What's there:** Federation/discovery layer over Luxembourg public-sector data. No RCS company-register dataset surfaced; consistent with the Kyckr guide's "no bulk download" position.
+
+### Path D — Tier 3 scraping of the LBR public portal
+
+- Forbidden under DEC-20260428-A. Excluded.
+
+## 3. Per-field depth (best-case via paid Tier-1 API or Tier-2 vendor)
+
+| Field | LBR portal (free HTML) | LBR API (enterprise) | Tier-2 vendor (typical) |
+|---|---|---|---|
+| Legal name | ✓ | ✓ | ✓ |
+| RCS number | ✓ | ✓ | ✓ |
+| Legal form | ✓ | ✓ | ✓ |
+| Status (active/dissolved) | ✓ | ✓ | ✓ |
+| Registered address | ✓ | ✓ | ✓ |
+| Founding date | ✓ | ✓ | ✓ |
+| Directors / legal representatives | ✓ (in extract) | ✓ | partial |
+| Articles of association | ✓ (download) | ✓ | rare |
+| Financials | ✓ (filed accounts) | ✓ | partial |
+| UBO (RBE) | restricted access post-CJEU Nov 2022 | restricted access | restricted |
+
+UBO/RBE access in the EU was tightened by the CJEU November 2022 ruling; LU implemented "legitimate interest" restrictions. RBE is out of scope for an identity-only v1.
+
+## 4. Pricing
+
+- **Free:** Basic web-portal searches; some document downloads.
+- **Paid:** Certified extracts; API access (price not published, treated as enterprise-tier).
+- **PAYG availability:** None confirmed. Likely fixed-fee subscription model.
+
+## 5. Redistribution
+
+- LBR ToS for the API not located in public sources; commercial agreement likely defines redistribution explicitly.
+- `data.public.lu` content is CC0 by default — but no RCS dataset is published there, so this doesn't help.
+- DEC-20260428-A Tier-2 path: any Tier-2 vendor used must carry documented redistribution rights from LBR; the gap-recovery synthesis flags this as a vendor-due-diligence gate.
+
+## 6. Freshness
+
+- LBR API (if accessed): real-time / near-real-time (registry filings reflected as filed).
+- No bulk-feed cadence to evaluate (no bulk feed exists).
+
+## 7. Build effort estimate
+
+- **Tier-1 paid API path:** **L** (10–20+ days). Commercial onboarding to LBR (KYC, contract, possibly Luxembourg-resident business presence), API integration, schema mapping, and ongoing fixed-cost commitment. The "L" reflects business-side overhead more than engineering — LBR's API-onboarding pace for a non-LU entity is unknown and likely multi-week.
+- **Tier-2 vendor wrapper:** **S–M** (2–5 days) once a vendor is selected and contracted. Engineering pattern matches existing wrappers (CBEAPI for BE, OpenRegister for DE).
+
+## 8. Recommendation
+
+**Stays in gap at v1.** Two cleaner paths exist, and both block on parallel work:
+
+1. **Wait for the Kyckr evaluation** (`research/kyckr-evaluation`). If Kyckr's redistribution + economics clear, LU closes via Tier-2 with no LU-specific work.
+2. **Wait for the Openapi gating decision** (case 151296). Openapi's coverage may include LU at PAYG economics; that would close LU + several other gap countries in one move.
+
+If both fall through, escalate to a direct LBR API contract — but defer until revenue justifies the fixed-cost exposure (DEC-20260506-G).
+
+**Do NOT build via scraping.** Tier 3 is rejected by doctrine.
+
+## Sources
+
+- [Kyckr — Luxembourg Registry Guide 2025/2026](https://www.kyckr.com/blog/luxembourg-registry-guide-2025) — pricing model, API existence, field-level coverage.
+- [European e-Justice Portal — LU business registers](https://e-justice.europa.eu/topics/registers-business-insolvency-land/business-registers-eu-countries/lu_en) — official statement on API for large professional users.
+- [Luxembourg Business Registers official site](https://www.lbr.lu/) and `https://www.lbr.lu/mjrcs-web-front/` — verified public web portal exists; no developer documentation surfaced.
+- [Portail Open Data Luxembourg](https://data.public.lu/en/) — verified no RCS bulk dataset surfaced via `q=registre+commerce`.
+- [LNDS CKAN data catalogue](https://ckan.data.lnds.lu/) — verified federation layer, no LBR/RCS dataset.
+- [Topograph — Extrait RCS Luxembourg](https://www.topograph.co/guides/business-registers-in-luxembourg/extrait-rcs-luxembourg) — third-party guide consistent with Kyckr findings.

--- a/handoff/_general/from-code/2026-05-11-anthropic-cost-audit.md
+++ b/handoff/_general/from-code/2026-05-11-anthropic-cost-audit.md
@@ -1,0 +1,253 @@
+---
+intent: Anthropic API cost-driver audit for the May 2026 ramp (750K → 2.7M tokens/day, May 1 → May 7)
+session_type: read-only audit
+date: 2026-05-11
+---
+
+# Anthropic API cost-driver audit — May 2026 spike
+
+## 1. Summary (top 3 drivers, priority order)
+
+1. **Hourly test-scheduler hammering ~50 Haiku-using capabilities whose `test_suites.external_cost_cents` is still 0.** PR #46 (2026-05-04) cut the scheduler cadence from 24h → 1h. PR #49 and PR #55 cleaned up 5 caps that day (Dilisense × 3, eSortcode, risk-narrative-Sonnet, invoice-extract-Haiku-vision), but PR #49's commit body explicitly defers "Anthropic-Haiku bulk set (~80 caps)". Every active LLM-only capability whose suite cost is 0 is now being executed ~hourly. This is the dominant driver of the 3.6× ramp and accounts for the bulk of the ~2.5M tokens/day observed.
+2. **`POST /v1/suggest` Haiku rerank.** Every call to the public search endpoint sends a 600–1500-token candidate list to Haiku for re-ranking, capped at 1000 output tokens. Production volume unknown from code alone, but suspect this is the second-largest line item — homepage-visible, plausibly high call rate, no prompt caching despite a near-identical system prompt every call.
+3. **Direct `/v1/do` + `/x402/:slug` paid execution of LLM capabilities.** Customer-facing baseline. Small at current customer volume but cleanly scales with usage — and contributes the steady-state component visible pre-May 4 (~750K/day).
+
+## 2. Inventory
+
+### Wrappers (counted once; multiple callers)
+
+| # | File:line | Function | Model | Prompt size | Input shape | `max_tokens` | Cache | Trigger | Retry | Notes |
+|---|-----------|----------|-------|-------------|-------------|--------------|-------|---------|-------|-------|
+| W1 | [browserless-extract.ts:49](apps/api/src/capabilities/lib/browserless-extract.ts#L49) | `extractCompanyFromText` | haiku-4-5 | ~300 chars / ~80 tok | scraped HTML, capped 12000 chars | 800 | no | called by Browserless-tier company-data caps when LLM extraction needed | none | Most country-data caps that go through this path are deactivated or migrated to direct API; small live blast radius. |
+| W2 | [browserless-extract.ts:97](apps/api/src/capabilities/lib/browserless-extract.ts#L97) | `extractCompanyName` | haiku-4-5 | ~120 chars / ~30 tok | natural-language string | 100 | no | called only when input isn't a numeric registry code | none | Cheap call. Skipped on test fixtures (numeric reg codes). |
+| W3 | [name-resolver.ts:76](apps/api/src/capabilities/lib/name-resolver.ts#L76) | name resolver | haiku-4-5 | ~150 tok | NL string | 200 | no | similar pattern: input-conditional | none | Same skip-on-numeric pattern. |
+
+### Per-capability call sites — pure-LLM (no external dep)
+
+Selected examples; full list of 90+ slugs is the grep output in the commit. All use `claude-haiku-4-5-20251001`. Inputs in scheduled-test runs are small fixture strings (~50–500 tokens); customer traffic varies. "Always-LLM" means every successful call hits Haiku.
+
+| # | File:line | Slug | `max_tokens` | Trigger | Always-LLM | Test-suite cost |
+|---|-----------|------|--------------|---------|------------|-----------------|
+| 1 | [address-parse.ts:14](apps/api/src/capabilities/address-parse.ts#L14) | address-parse | 500 | scheduled + paid | yes | unknown (likely 0) |
+| 2 | [agent-trace-analyze.ts:12](apps/api/src/capabilities/agent-trace-analyze.ts#L12) | agent-trace-analyze | 1500 | scheduled + paid | yes | 0 |
+| 3 | [api-docs-generate.ts:20](apps/api/src/capabilities/api-docs-generate.ts#L20) | api-docs-generate | 2000 | scheduled + paid | yes | 0 |
+| 4 | [api-mock-response.ts:23](apps/api/src/capabilities/api-mock-response.ts#L23) | api-mock-response | 1500 | scheduled + paid | yes | 0 |
+| 5 | [blog-post-outline.ts:18](apps/api/src/capabilities/blog-post-outline.ts#L18) | blog-post-outline | 2000 | scheduled + paid | yes | 0 |
+| 6 | [classify-text.ts:19](apps/api/src/capabilities/classify-text.ts#L19) | classify-text | 600 | scheduled + paid | yes | 0 |
+| 7 | [changelog-generate.ts:33](apps/api/src/capabilities/changelog-generate.ts#L33) | changelog-generate | 1500 | scheduled + paid | yes | 0 |
+| 8 | [code-convert.ts:16](apps/api/src/capabilities/code-convert.ts#L16) | code-convert | 3000 | scheduled + paid | yes | 0 |
+| 9 | [code-review.ts:19](apps/api/src/capabilities/code-review.ts#L19) | code-review | 1500 | scheduled + paid | yes | 0 |
+| 10 | [commit-message-generate.ts:14](apps/api/src/capabilities/commit-message-generate.ts#L14) | commit-message-generate | 500 | scheduled + paid | yes | 0 |
+| 11 | [company-industry-classify.ts:46](apps/api/src/capabilities/company-industry-classify.ts#L46) | company-industry-classify | 500 | scheduled + paid | yes | 0 |
+| 12 | [competitor-compare.ts:26](apps/api/src/capabilities/competitor-compare.ts#L26) | competitor-compare | 2000 | scheduled + paid | yes | 0 |
+| 13 | [context-window-optimize.ts:29](apps/api/src/capabilities/context-window-optimize.ts#L29) | context-window-optimize | 1000 | scheduled + paid | yes | 0 |
+| 14 | [crontab-generate.ts:18](apps/api/src/capabilities/crontab-generate.ts#L18) | crontab-generate | 800 | scheduled + paid | yes | 0 |
+| 15 | [curl-to-code.ts:14](apps/api/src/capabilities/curl-to-code.ts#L14) | curl-to-code | 1500 | scheduled + paid | yes | 0 |
+| 16 | [diff-review.ts:34](apps/api/src/capabilities/diff-review.ts#L34) | diff-review | 2000 | scheduled + paid | yes | 0 |
+| 17 | [docstring-generate.ts:14](apps/api/src/capabilities/docstring-generate.ts#L14) | docstring-generate | 2000 | scheduled + paid | yes | 0 |
+| 18 | [dockerfile-generate.ts:16](apps/api/src/capabilities/dockerfile-generate.ts#L16) | dockerfile-generate | 1500 | scheduled + paid | yes | 0 |
+| 19 | [email-draft.ts:18](apps/api/src/capabilities/email-draft.ts#L18) | email-draft | 1000 | scheduled + paid | yes | 0 |
+| 20 | [env-template-generate.ts:76](apps/api/src/capabilities/env-template-generate.ts#L76) | env-template-generate | 1500 | scheduled + paid | yes | 0 |
+| 21 | [error-explain.ts:15](apps/api/src/capabilities/error-explain.ts#L15) | error-explain | 1500 | scheduled + paid | yes | 0 |
+| 22 | [fake-data-generate.ts:20](apps/api/src/capabilities/fake-data-generate.ts#L20) | fake-data-generate | 4000 | scheduled + paid | yes | 0 |
+| 23 | [github-actions-generate.ts:19](apps/api/src/capabilities/github-actions-generate.ts#L19) | github-actions-generate | 2000 | scheduled + paid | yes | 0 |
+| 24 | [github-repo-analyze.ts:60](apps/api/src/capabilities/github-repo-analyze.ts#L60) | github-repo-analyze | 1500 | scheduled + paid | yes | 0 |
+| 25 | [hs-code-lookup.ts:14](apps/api/src/capabilities/hs-code-lookup.ts#L14) | hs-code-lookup | 800 | scheduled + paid | yes | 0 |
+| 26 | [image-to-text.ts:48](apps/api/src/capabilities/image-to-text.ts#L48) | image-to-text | 4000 | scheduled + paid | yes | 0 |
+| 27 | [jsdoc-generate.ts:12](apps/api/src/capabilities/jsdoc-generate.ts#L12) | jsdoc-generate | 2000 | scheduled + paid | yes | 0 |
+| 28 | [job-posting-analyze.ts:36](apps/api/src/capabilities/job-posting-analyze.ts#L36) | job-posting-analyze | 1500 | scheduled + paid | yes | 0 |
+| 29 | [meeting-notes-extract.ts:12](apps/api/src/capabilities/meeting-notes-extract.ts#L12) | meeting-notes-extract | 1500 | scheduled + paid | yes | 0 |
+| 30 | [nginx-config-generate.ts:22](apps/api/src/capabilities/nginx-config-generate.ts#L22) | nginx-config-generate | 2000 | scheduled + paid | yes | 0 |
+| 31 | [openapi-generate.ts:12](apps/api/src/capabilities/openapi-generate.ts#L12) | openapi-generate | 4000 | scheduled + paid | yes | 0 |
+| 32 | [pii-redact.ts:58](apps/api/src/capabilities/pii-redact.ts#L58) | pii-redact | 4000 | scheduled + paid | yes | 0 |
+| 33 | [pr-description-generate.ts:14](apps/api/src/capabilities/pr-description-generate.ts#L14) | pr-description-generate | (n/a) | scheduled + paid | yes | 0 |
+| 34 | [pricing-page-extract.ts:17](apps/api/src/capabilities/pricing-page-extract.ts#L17) | pricing-page-extract | 1500 | scheduled + paid | yes | 0 |
+| 35 | [prompt-compress.ts:16](apps/api/src/capabilities/prompt-compress.ts#L16) | prompt-compress | 4000 | scheduled + paid | yes | 0 |
+| 36 | [prompt-optimize.ts:24](apps/api/src/capabilities/prompt-optimize.ts#L24) | prompt-optimize | 1500 | scheduled + paid | yes | 0 |
+| 37 | [readme-generate.ts:15](apps/api/src/capabilities/readme-generate.ts#L15) | readme-generate | 3000 | scheduled + paid | yes | 0 |
+| 38 | [receipt-categorize.ts:47](apps/api/src/capabilities/receipt-categorize.ts#L47) | receipt-categorize | 1000 | scheduled + paid | yes | 0 |
+| 39 | [regex-explain.ts:14](apps/api/src/capabilities/regex-explain.ts#L14) | regex-explain | 1500 | scheduled + paid | yes | 0 |
+| 40 | [regex-generate.ts:18](apps/api/src/capabilities/regex-generate.ts#L18) | regex-generate | 800 | scheduled + paid | yes | 0 |
+| 41 | [release-notes-generate.ts:14](apps/api/src/capabilities/release-notes-generate.ts#L14) | release-notes-generate | 2000 | scheduled + paid | yes | 0 |
+| 42 | [resume-parse.ts:60](apps/api/src/capabilities/resume-parse.ts#L60) | resume-parse | 2000 | scheduled + paid | yes | 0 |
+| 43 | [schema-migration-generate.ts:17](apps/api/src/capabilities/schema-migration-generate.ts#L17) | schema-migration-generate | (n/a) | scheduled + paid | yes | 0 |
+| 44 | [sentiment-analyze.ts:14](apps/api/src/capabilities/sentiment-analyze.ts#L14) | sentiment-analyze | 600 | scheduled + paid | yes | 0 |
+| 45 | [social-post-generate.ts:44](apps/api/src/capabilities/social-post-generate.ts#L44) | social-post-generate | (n/a) | scheduled + paid | yes | 0 |
+| 46 | [sql-explain.ts:14](apps/api/src/capabilities/sql-explain.ts#L14) | sql-explain | 1500 | scheduled + paid | yes | 0 |
+| 47 | [sql-generate.ts:17](apps/api/src/capabilities/sql-generate.ts#L17) | sql-generate | 1500 | scheduled + paid | yes | 0 |
+| 48 | [sql-optimize.ts:17](apps/api/src/capabilities/sql-optimize.ts#L17) | sql-optimize | 2000 | scheduled + paid | yes | 0 |
+| 49 | [structured-scrape.ts:24](apps/api/src/capabilities/structured-scrape.ts#L24) | structured-scrape | 2000 | scheduled + paid | yes | 0 |
+| 50 | [summarize.ts:17](apps/api/src/capabilities/summarize.ts#L17) | summarize | 1000 | scheduled + paid | yes | 0 |
+| 51 | [test-case-generate.ts:17](apps/api/src/capabilities/test-case-generate.ts#L17) | test-case-generate | 2000 | scheduled + paid | yes | 0 |
+| 52 | [translate.ts:17](apps/api/src/capabilities/translate.ts#L17) | translate | 2000 | scheduled + paid | yes | 0 |
+| 53 | [webhook-test-payload.ts:15](apps/api/src/capabilities/webhook-test-payload.ts#L15) | webhook-test-payload | 2000 | scheduled + paid | yes | 0 |
+
+### Per-capability call sites — heavy-input vision/extraction (paid-only)
+
+| # | File:line | Slug | `max_tokens` | Trigger | Notes |
+|---|-----------|------|--------------|---------|-------|
+| H1 | [annual-report-extract.ts:254](apps/api/src/capabilities/annual-report-extract.ts#L254) | annual-report-extract | 4000 | paid only | **Deactivated** in `auto-register.ts`. No scheduled runs. |
+| H2 | [invoice-extract.ts:140](apps/api/src/capabilities/invoice-extract.ts#L140) | invoice-extract | 2000 | paid only after PR #55 | Suite cost bumped 0 → 1 on 2026-05-04 (PR #55). Scheduler skip flipped. |
+| H3 | [pdf-extract.ts:61](apps/api/src/capabilities/pdf-extract.ts#L61) | pdf-extract | 4000 | scheduled + paid | Vision on PDF bytes — large input shape. Likely still at cost=0. |
+| H4 | [web-extract.ts:106](apps/api/src/capabilities/web-extract.ts#L106) | web-extract | 4000 | scheduled + paid | Scrape + LLM. |
+| H5 | [risk-narrative-generate.ts:234](apps/api/src/capabilities/risk-narrative-generate.ts#L234) | risk-narrative-generate | 1500 | paid only after PR #49 | **Sonnet 4.6**, suite cost bumped 0 → 3 on 2026-05-04 (PR #49). Removed from hourly cycle. |
+
+### Per-capability call sites — country-data and country-conditional LLM
+
+These call LLM only when input requires natural-language resolution; on test runs with numeric registry-code fixtures, the LLM call is bypassed.
+
+| # | File:line | Slug | `max_tokens` | Trigger | LLM-on-test? |
+|---|-----------|------|--------------|---------|--------------|
+| C1 | [brazilian-company-data.ts:33](apps/api/src/capabilities/brazilian-company-data.ts#L33) | brazilian-company-data | 100 | conditional | unlikely |
+| C2 | [cz-company-data.ts:50](apps/api/src/capabilities/cz-company-data.ts#L50) | cz-company-data | 100 | conditional | unlikely |
+| C3 | [danish-company-data.ts:31](apps/api/src/capabilities/danish-company-data.ts#L31) | danish-company-data | 100 | conditional | unlikely |
+| C4 | [estonian-company-data.ts:22](apps/api/src/capabilities/estonian-company-data.ts#L22) | estonian-company-data | 100 | conditional | unlikely |
+| C5 | [finnish-company-data.ts:29](apps/api/src/capabilities/finnish-company-data.ts#L29) | finnish-company-data | 100 | conditional | unlikely |
+| C6 | [french-company-data.ts:24](apps/api/src/capabilities/french-company-data.ts#L24) | french-company-data | 100 | conditional | unlikely |
+| C7 | [norwegian-company-data.ts:17](apps/api/src/capabilities/norwegian-company-data.ts#L17) | norwegian-company-data | 100 | conditional | unlikely |
+| C8 | [uk-company-data.ts:30](apps/api/src/capabilities/uk-company-data.ts#L30) | uk-company-data | 100 | conditional | unlikely |
+| C9 | [us-company-data.ts:20](apps/api/src/capabilities/us-company-data.ts#L20) | us-company-data | 100 | conditional | unlikely |
+| C10 | [website-to-company.ts:108](apps/api/src/capabilities/website-to-company.ts#L108) | website-to-company | 100 | conditional | unlikely |
+
+### Other (non-capability) call sites
+
+| # | File:line | Purpose | Model | `max_tokens` | Trigger | Estimate |
+|---|-----------|---------|-------|--------------|---------|----------|
+| O1 | [lib/suggest.ts:712](apps/api/src/lib/suggest.ts#L712) | `/v1/suggest` rerank | haiku-4-5 | 1000 | every public search | candidate list ~800 tok in, ~600 tok out per call. |
+| O2 | [lib/daily-digest/analyze.ts:127](apps/api/src/lib/daily-digest/analyze.ts#L127) | daily digest analysis | sonnet-4-20250514 | 1500 | 1×/day cron | ~3K in, ~1.2K out. Negligible. |
+
+### Deactivated LLM caps (excluded from inventory totals)
+
+From `auto-register.ts` `DEACTIVATED` map: annual-report-extract, australian-company-data, business-license-check-se, credit-report-summary, patent-search, dutch-company-data, portuguese-company-data, spanish-company-data, austrian-company-data, trustpilot-score, salary-benchmark, employer-review-summary, italian-company-data, eu-court-case-search (+ UK property suite). These do not run scheduled tests.
+
+### False-positives excluded
+
+Grep also matched files that import `Anthropic` or store the constant in lib utility files without actually calling `messages.create`: `lib/credential-health.ts`, `lib/dependency-manifest.ts`, `lib/event-triggers.ts`, `lib/interrupt-sender.ts`, `lib/platform-facts.ts`, `lib/provenance-builder.ts`, `lib/situation-assessment.ts`, `lib/startup-migrations.ts`, `lib/upstream-health-gate.ts`. These reference Anthropic by name only (rosters, classifications, comments).
+
+## 3. Daily token contribution
+
+### Method
+
+`runTests(slug)` is invoked once per scheduled dispatch. It runs every active non-piggyback `test_suite` for that slug; each suite calls the executor once; each executor call → one `messages.create` for the always-LLM caps. Empirically the active test types per cap are typically known_answer + edge_case + negative + known_bad (4); schema_check is dry-run; dependency_health is an auth-less probe.
+
+### Top-of-table contribution per driver
+
+**Driver D1 — scheduled tests, always-LLM caps at cost=0:**
+- Active pure-LLM caps in DEACTIVATED-eligible-minus-suspended set: ~50 (table above, rows 1–53 less ~3 that were since suspended/unhealthy).
+- Hourly dispatches: 24/day per cap.
+- LLM-invoking test types per dispatch: assume 2 (the structurally-passing ones; negative/known_bad often short-circuit on input validation).
+- Tokens per Haiku test call: ~400 input (small fixture + prompt template ~300 tok) + ~600 output (mean of `max_tokens` values 500–4000 × 30–50% realization on JSON output).
+- **D1 total: 50 × 24 × 2 × 1000 ≈ 2.4M tokens/day.**
+
+This is the dominant driver. Lines up with the ~2.5M observed on May 10.
+
+**Driver D2 — `/v1/suggest` rerank:**
+- Per call: ~800 input (candidate descriptions concatenated) + ~600 output (small JSON of indices + reasons).
+- Volume: unknown from code; suspect 100–500 calls/day at current homepage traffic.
+- **D2 total: ~0.05–0.5M tokens/day** (could be larger if traffic is higher than guessed).
+
+**Driver D3 — paid `/v1/do` + `/x402/:slug`:**
+- Per call: capability-shaped; mean ~700 input + ~1000 output for the always-LLM caps.
+- Volume: low at current customer rate but the steady-state May 1 baseline (~750K/day before the scheduler flip) is roughly this plus pre-PR-#46 scheduled tests at 24h cadence (~100K/day).
+- **D3 total: ~600K tokens/day** as the residual pre-ramp baseline.
+
+### Sanity check vs. observed
+
+| Driver | Tokens/day | Share |
+|--------|------------|-------|
+| D1 — scheduled tests at cost=0 | ~2.4M | 95% |
+| D2 — /v1/suggest rerank | ~0.05–0.5M | 2–20% |
+| D3 — paid /v1/do + x402 | ~0.6M (mostly pre-ramp) | embedded in baseline |
+| O2 — daily digest (Sonnet) | ~5K | <1% |
+| Others (conditional country-data, deactivated caps) | ~0 | 0% |
+
+Total bottom-up: ~2.5–3.0M. Observed: ~2.5M on May 10 / ~2.7M peak May 7. Within 2× envelope; passes the sanity gate.
+
+The pre-ramp baseline (~750K/day on May 1) corresponds to: pre-PR-#46 scheduled tests at 24h cadence (~100K) + D3 paid traffic (~600K) + D2 search (~50K). Post-ramp it's: D1 hourly (~2.4M) + D3 (~600K) + D2 (~50K) ≈ 3M, which is a hair above the May 7 peak of 2.7M, consistent with input being smaller than my 400-token estimate or fewer than 2 LLM test types averaging through.
+
+## 4. Ramp attribution
+
+Window: 2026-04-25 → 2026-05-11. Commits on `apps/api/`: 156. Below names every commit class against its ramp effect.
+
+### Pre-ramp baseline (Apr 25–30)
+
+- **2026-04-27** — `16ca790` drops OpenSanctions → single-vendor Dilisense. `f00c088` + `c1100f8` add audit-grade `adverse-media-check`, `sanctions-check`, `pep-check`. Each onboarded; suite cost initially 0. — Adds 3 caps that PR #49 will later move to cost=1.
+- **2026-04-27** — `87456ee`/`3e0544a`/`2b0ee38`/`b4a9a1a`/`d068513`/`a4a84ce`/`22d3597`/`730d5b4`/`af53d40`/`fe831ab`/`4435d39`/`7008caa`/`f5422ca`/`ff687eb`/`17d0f03`/`47f3068`/`9753d4a`/`b8b5d59`/`0b0f52f`/`35ae4a6`/`08c2cd7`/`1a1f836`/`4079c74`/`9b34e6f`/`3a037a9`/`7c3763b` — cert-audit batch. Audit-trail fidelity, hashing, F-AUDIT-XX. No LLM call paths added.
+- **2026-04-28** — deactivation sweep: `5cc120a` (browserless query-token auth), `66fa95a` data_source rewrites, `2a72790` hides deactivated caps from catalog, `9bdc686` parks UK property, `ab95a0e` deactivates italian-company-data + eu-court-case-search, `b5b60d0` deactivates irish-company-data + latvian-company-data. — Reduces LLM-using cap count slightly.
+- **2026-04-29** — `e28f350` upgrades `risk-narrative-generate` Haiku → **Sonnet** per DEC-20260428-B. Suite cost still 0. — Small Sonnet contribution starts.
+- **2026-04-29** — 4 new caps: `7ead04e` (gleif-l2-ubo-lookup), `b1c2998` (fr-bodacc-lookup), `3e07513` (no-bankruptcy-check), `ab61a61` (gleif-l2-children-lookup). None are LLM-backed.
+- **2026-04-29** — `7311319`/`cfd2edb`/`901bd09`/`bd25bc5` migrate IE/LV/LT/SG from Browserless+LLM to direct API. — Removes 4 caps from the LLM-call path.
+
+### The step — 2026-05-01 → 2026-05-04
+
+- **2026-05-01** — `10dc966` wires new compliance caps into KYB Complete + Invoice Verify. `1acc5be` pre-writes 5 gated executors. `617ff5d` suspends 4 pre-deploy caps. — These are configuration; no new LLM calls.
+- **2026-05-02** — `221e12a` web3-assurance v0.1. Doesn't add LLM calls itself.
+- **2026-05-03** — `1311885` (#37) manifest-driven auto-register. — No call-site change.
+- **2026-05-04 11:28 CET** — **`ffa0a8d` (#46) hourly free-only scheduler ships.** Cadence: 24h → 1h (24× amplification). **Primary ramp driver.** PR body acknowledges removing paid caps "with vendor integrations live" but the filter is `external_cost_cents = 0`, which catches every Haiku cap whose suite cost was never set.
+- **2026-05-04 15:44 CET** — `f23a130` (#49) bumps 5 cap suites cost=0 → cost>0 (sanctions-check, pep-check, adverse-media-check, uk-cop-check, risk-narrative-generate). Migration SQL ships in `drizzle/0062_paid_vendor_suite_cost.sql` + `scripts/apply-migrations.ts` block. **But:** `apply-migrations.ts` was a dead file at this point — not on the Dockerfile CMD path, `tsconfig.json rootDir` excluded it from build. UPDATE did not run in prod.
+- **2026-05-04 23:04 CET** — `51ce02d` (#55) bumps invoice-extract suite cost=0 → cost=1. Same migration mechanism. Same dead-file problem.
+- **2026-05-04 evening** — `0b157c2` (#51) + `31e1341` (#52) wire `runStartupMigrations()` into API boot, replacing dead `apply-migrations.ts`. **On the next deploy after this lands, blocks 0062 and 0063 (the PR #49 + PR #55 UPDATEs) finally run.**
+- **2026-05-04** — `58a9b43` (#48) retention DELETE pagination, `7a11e26` (#47) skip-bumper array-binding fix, `87456ee` (#43) Date encoding in spendCapWouldExceed. No LLM impact.
+
+### Equilibrium — 2026-05-05 → 2026-05-11
+
+- **2026-05-05** — PR1 wave 1–3 (`394ef47`/`1bc59dd`/`20c4055`/`063d53a`) deletes the SQS scoring engine. The `source_health` substrate, fixture and canary modes survive; no LLM calls added.
+- **2026-05-05** — `dbab62a` lifecycle cleanup, `b26f20d` Provider-Coverage drift script. No LLM impact.
+- **2026-05-06–07** — `8b46146` german-company-data via OpenRegister Free, `1d67bf2` slovak-company-data, `f90c666` slovenian-company-data. All direct API; not always-LLM. Marginal contribution.
+- **2026-05-06** — `b547385`/`bf06b24`/`e2a94e2`/`4b13d32`/`84ae72d` Browserless v1 pin and chromium diagnostics. No LLM impact.
+- **2026-05-08–10** — P2 doctrine sweep: `6dc5a23`/`0575ff1`/`e25bb64`/`bc46a04`/`e57e00e`/`e668aea`/`9528946`/`c523485`/`a16649b`. Null-safety fixes on output envelopes; no LLM call shape change.
+- **2026-05-09** — `3f5bcfc` deletes dormant seed.ts. No runtime impact.
+- **2026-05-10–11** — `eb67670` worktree janitor; CLAUDE-Md/docs.
+
+### Ramp shape resolution
+
+The chart's "multiplicative ramp" (750K → 2.7M over 6 days) decomposes as:
+- **2026-05-01 to 2026-05-03** (~750K → ~1.1M): drift from new caps onboarded at cost=0 + small risk-narrative Sonnet uplift from the Apr 29 upgrade kicking in as PA flows exercise it.
+- **2026-05-04 morning** (~1.1M → ~2.4M): step from PR #46. This is the dominant single discontinuity.
+- **2026-05-04 evening → 2026-05-05** (~2.4M → ~2.5M, oscillating): PR #51/#52 wire startup-migrations; PR #49 + PR #55 UPDATEs now actually run on next boot; removes pep/sanctions/adverse-media/risk-narrative/uk-cop/invoice-extract from the hourly cycle. Partial offset, not full.
+- **2026-05-06 to 2026-05-11**: equilibrium at ~2.5M ± new-cap drift.
+
+A "step + small decay + small drift" shape can look like a smooth ramp on a 6-day chart with daily granularity, especially when the step partially reverses 24 hours later and is masked by simultaneous new-cap additions.
+
+## 5. Reduction options per driver
+
+### D1 — Scheduled tests hammering Haiku caps at cost=0
+
+The PR #49 deferral is the unblocked path here. The hesitation in PR #49 was "flat 1-cent gives misleading false safety signal" for Haiku caps where per-call cost varies. But the goal of `external_cost_cents` in the scheduler dispatch query is **purely the scheduler-skip flip**, not cost accuracy — the same operational role PR #49 already accepted for uk-cop-check at 1¢. Options:
+
+- **R1.1 — Bulk bump all always-LLM Haiku caps to `external_cost_cents = 1` (trivial).** A single SQL block in `lib/startup-migrations.ts`: `UPDATE test_suites SET external_cost_cents = 1 WHERE active = true AND test_mode = 'live' AND test_type IN ('known_answer','edge_case','negative','known_bad') AND external_cost_cents = 0 AND capability_slug IN (<the ~50 always-LLM Haiku slugs>)`. Estimated saving: ~2.4M tokens/day → ~0. **Trivial complexity. Highest leverage.**
+
+- **R1.2 — Replace LLM-only test runs with fixture-mode tests for the always-LLM caps (moderate).** Keep one canary live test per day per cap (~50 calls/day total) for upstream-health signal; switch the other 3 test types to `test_mode = 'fixture'` reading from a saved response. Estimated saving: ~95% of D1, with better signal for capability-correctness regressions. Moderate complexity (need fixture-capture script + per-cap human review).
+
+- **R1.3 — Move all paid-LLM caps to piggyback-only (structural).** Per CLAUDE.md's "Principle C" piggyback suites receive data exclusively from customer traffic. For always-LLM caps with no free-probe pattern, the only honest quality signal at this stage is observed-from-customer-traffic. Estimated saving: ~95% of D1 + reduces noise. Structural complexity — touches DEC-20260503-B's policy edge.
+
+### D2 — `/v1/suggest` Haiku rerank
+
+- **R2.1 — Enable prompt caching on the system prompt (trivial).** The system prompt is ~600 tokens of fixed instructions + examples — well over the 1024-token cache threshold if you add the catalog context (or just pad the examples). Anthropic prompt caching cuts 90% off cached input tokens after first call. Estimated saving on D2 input: ~85%. Trivial complexity.
+
+- **R2.2 — Skip rerank for high-similarity matches (moderate).** If top embedding similarity is >0.85 and gap to #2 >0.10, return without calling Haiku. Estimated saving: ~30–50% of calls (highly query-dependent). Moderate complexity.
+
+### D3 — Paid /v1/do + x402 baseline
+
+- **R3.1 — Drop `max_tokens` defaults to realistic ceilings (trivial).** Several caps set `max_tokens` at 3000–4000 when typical output is 600–1000 tokens (e.g. `code-convert: 3000`, `pdf-extract: 4000`, `web-extract: 4000`). The model bills only on actual output, so this is not a direct saving — but it caps tail-of-distribution runaways and aligns the post-call cost estimate. **Negligible immediate saving; cleanup-class.**
+
+- **R3.2 — Prompt cache the per-capability system prompts (moderate).** Every always-LLM cap has a per-call constant prompt body. Hoisting these into a `system: [{ type: "text", text: ..., cache_control: { type: "ephemeral" } }]` block enables Anthropic prompt caching. Highest leverage when the same cap is called multiple times within 5 minutes (production traffic clusters). Estimated saving on D3 input: ~50% on the input side for any cap called repeatedly. Moderate complexity (script-edit all 50 caps + verify).
+
+## 6. Open questions
+
+The audit covers code shape, not runtime distribution. The following would require Railway / Anthropic Console / DB access:
+
+- **Actual `external_cost_cents = 0` slug list as of 2026-05-11.** This audit infers ~50 from grep + the PR #49 deferral note. A 30-second prod query gives the truth: `SELECT capability_slug, test_type, external_cost_cents FROM test_suites WHERE active = true AND external_cost_cents = 0`.
+- **Actual hourly dispatch counts.** Scheduler logs include `test-scheduler-poll-start` with `runnable` and `queue_depth`. Sum those over the audit window to get the empirical dispatch rate vs. the 50-cap estimate.
+- **Actual mean output tokens per Haiku call.** The estimate uses 30–50% of `max_tokens`. Anthropic Console > Logs gives the truth per request.
+- **`/v1/suggest` call rate.** Pin D2's range. Cloudflare / Umami / Railway logs.
+- **Whether `pdf-extract` and `web-extract` are actively scheduled.** These have `max_tokens: 4000`. If they are scheduled at cost=0 and inputs are heavy, the D1 estimate is low.
+- **Whether the daily-digest cron is firing.** The Sonnet usage in the Console may or may not match O2's ~5K/day signature.
+
+## 7. Appendix — verification trail
+
+- **Step 1 verification.** `grep -rEn "messages\.create|@anthropic-ai/sdk|new Anthropic\(" apps/api/src/` returned 195 lines covering 95 distinct call sites; all appear in the inventory tables above or in the false-positives footnote. The cross-repo grep for `@anthropic-ai/sdk|new Anthropic\(` outside `apps/api/` produced zero matches; the SDK is not used elsewhere in the monorepo.
+- **Step 2 verification.** Two spot-checks: `address-parse.ts` (small known-shape prompt + `max_tokens: 500`) and `lib/suggest.ts` (large candidate-list prompt + `max_tokens: 1000`) both inspected line-for-line. The 30–50% `max_tokens` realization is an assumption; documented in §6.
+- **Step 3 verification.** Bottom-up estimate 2.5–3.0M vs. observed 2.5–2.7M. Within 2× envelope.
+- **Step 4 verification.** Every commit in `git log --since=2026-04-25 --until=2026-05-12 -- apps/api/` is accounted for either by name or by group ("cert-audit batch", "P2 doctrine sweep", "deactivation sweep") with the LLM-effect classification stated.
+- **Step 5 verification.** This file is the deliverable.

--- a/handoff/_general/from-code/2026-05-11-conditional-llm-bypass-audit.md
+++ b/handoff/_general/from-code/2026-05-11-conditional-llm-bypass-audit.md
@@ -1,0 +1,78 @@
+# Conditional-LLM Bypass Audit (PR #85 follow-up)
+
+Date: 2026-05-11
+Follow-up to: PR #84 (audit), PR #85 (contain + harden)
+
+## Summary
+
+The PR #85 exclusion set (`CONDITIONAL_LLM_CAPABILITIES` in [llm-capability-costs.ts](apps/api/src/lib/llm-capability-costs.ts)) covers 11 capabilities permitted to keep `external_cost_cents = 0` on the assumption that their scheduled-test execution path does not invoke the Anthropic SDK. Tracing each cap's `known_answer.input` fixture through its executor:
+
+- **9 CLEAN** — bypass justification holds; the fixture exercises a non-LLM code path.
+- **2 LEAKY** — the fixture *does* reach a `messages.create` call. Bypass is masking residual leak: `us-company-data` and `website-to-company`.
+- **0 AMBIGUOUS**.
+
+Two of the 9 CLEAN caps have **incorrect bypass justifications** in the source comment (the verdict is still CLEAN, but for a different reason than the comment states): `brazilian-company-data` (the LLM helper function is defined but never reachable from the registered executor) and `container-track` (the fixture is `"test_value"`, not a "well-known carrier prefix" — it triggers the invalid-format early-return path).
+
+Residual Haiku tokens attributable to the 2 LEAKY caps: roughly 1–2% of the pre-PR-#85 daily volume (~30–50K tokens/day vs. the ~2.4M/day that PR #85 closed). Negligible compared to the main fix.
+
+T+48h Anthropic Console interpretation: expected residual ~7–12% of pre-fix daily Haiku tokens, consistent with the audit's 10–15% estimate. The 2 LEAKY caps contribute ~1–2%; the bulk of the residual is `/v1/suggest` rerank + paid `/v1/do` + `/x402` customer traffic + the Sonnet daily-digest cron.
+
+## Per-cap classification
+
+| # | Slug | Bypass comment | Fixture input | SDK called on scheduled test? | Bucket | Notes |
+|---|------|----------------|---------------|------------------------------|--------|-------|
+| 1 | `brazilian-company-data` | "Numeric CNPJ fixture bypasses LLM" | `cnpj: "11222333000181"` (14 digits) | NO | **CLEAN** | `findCnpj` matches at [line 23](apps/api/src/capabilities/brazilian-company-data.ts#L23). `extractCompanyName` is defined at line 29 but **never called** from `registerCapability` — the early-throw at line 97 returns before any LLM path. Effectively dead-code-imported SDK; bypass justified but the cap could even be moved out of the exclusion list once the dead helper is deleted. |
+| 2 | `cz-company-data` | "Numeric IČO fixture bypasses LLM" | `ico: "00177041"` (8 digits) | NO | **CLEAN** | `normalizeIco` + `isValidIcoChecksum` both pass at [line 100](apps/api/src/capabilities/cz-company-data.ts#L100), takes direct ARES API path. LLM only fires at line 107 for non-numeric input. |
+| 3 | `danish-company-data` | "Numeric CVR fixture bypasses LLM" | `cvr_number: "24256790"` (8 digits) | NO | **CLEAN** | `isCvrNumber` matches at [line 116](apps/api/src/capabilities/danish-company-data.ts#L116), takes direct cvrapi.dk path. LLM only fires for non-numeric input via `extractCompanyName`. |
+| 4 | `estonian-company-data` | "Numeric registry-code fixture bypasses LLM" | `registry_code: "17449106"` (8 digits) | NO | **CLEAN** | `findRegCode` matches `/^\d{8}$/` at [line 121](apps/api/src/capabilities/estonian-company-data.ts#L121), takes direct ariregister path. |
+| 5 | `finnish-company-data` | "Y-tunnus fixture bypasses LLM" | `business_id: "0112038-9"` | NO | **CLEAN** | `BIS_RE = /^(\d{7})-?(\d)$/` matches, direct PRH avoindata path. |
+| 6 | `french-company-data` | "Numeric SIREN fixture bypasses LLM" | `siren: "542051180"` (9 digits) | NO | **CLEAN** | `SIREN_RE = /^\d{9}$/` matches at [line 86](apps/api/src/capabilities/french-company-data.ts#L86), direct INSEE/SIRENE path. |
+| 7 | `norwegian-company-data` | "Numeric org-number fixture bypasses LLM" | `org_number: "984851006"` (9 digits) | NO | **CLEAN** | `isOrgNumber` matches, direct brreg path. (Side note: the manifest's `health_check_input.org_number: 556703-7485` is in Swedish format and would fail isOrgNumber — a fixture hygiene bug, but irrelevant to LLM trigger since dependency_health probes don't invoke the executor.) |
+| 8 | `uk-company-data` | "Company-number fixture bypasses LLM" | `company_number: "00445790"` | NO | **CLEAN** | `COMPANY_NUMBER_RE` matches at [line 119](apps/api/src/capabilities/uk-company-data.ts#L119), direct Companies House path. |
+| 9 | **`us-company-data`** | "Numeric CIK fixture bypasses LLM" | **`company: "AAPL"`** (ticker, not CIK) | **YES** | **LEAKY** | `findCik` regex is `/^\d{1,10}$/`. `"AAPL"` contains letters → `findCik` returns null at [line 98](apps/api/src/capabilities/us-company-data.ts#L98) → `extractCompanyName("AAPL")` fires at line 100 → **1 Haiku call per scheduled test**. Then `searchEdgar(name)` is an HTTP-only SEC API call (no further LLM). |
+| 10 | **`website-to-company`** | "Rich-structured-data fixture bypasses LLM" | **`url: "https://equinor.com"`** | **YES (×2)** | **LEAKY** | The bypass comment is wrong about the code shape. `llmExtractCompanyName` at [line 103](apps/api/src/capabilities/website-to-company.ts#L103) is called *whenever* `meta-extract` or `url-to-markdown` returns any non-empty title/site_name (lines 81–82 and 94–95) — i.e. for essentially every real website. The LLM is the *primary* extraction path, with structured data feeding *into* it, not bypassing it. Furthermore, the cap then routes to a country-specific registry (norwegian-company-data for `.com`/`.no` resolution paths) at line 154, passing the LLM-extracted name string, which triggers *another* `extractCompanyName` LLM call inside that downstream cap. **2 Haiku calls per scheduled test.** |
+| 11 | `container-track` | "Well-known carrier prefix fixture bypasses LLM" | `container_number: "test_value"` (gibberish) | NO | **CLEAN** | Verdict correct, **justification wrong**. The fixture is not a Maersk prefix — it's the literal placeholder string `"test_value"`. `validateContainerNumber("test_value")` returns `valid_format: false` (no ISO 6346 match) → early-return at [line 237](apps/api/src/capabilities/container-track.ts#L237) before any Browserless fetch or LLM call. The "carrier-prefix" bypass story would only hold for a real fixture; the current fixture is hygiene-broken. |
+
+## Interpretation for T+48h Anthropic Console check
+
+Rough math for the 2 LEAKY caps' contribution:
+
+- `us-company-data`: 4 active live test types (known_answer, edge_case, negative, known_bad) × 24/day = 96 dispatches/day. Each runs the executor once; the executor makes 1 Haiku call (`extractCompanyName`, max_tokens 100). Per call: ~80 input + ~30 output ≈ 110 tokens. Daily: **96 × 110 ≈ 10,500 tokens/day**.
+- `website-to-company`: same 96 dispatches/day. Each runs the executor once; the executor makes 1 Haiku call (`llmExtractCompanyName`, max_tokens 100) plus 1 downstream Haiku call inside `norwegian-company-data` (via the country-routing). Per dispatch: ~260 tokens. Daily: **96 × 260 ≈ 25,000 tokens/day**.
+- Combined: **~35,000 tokens/day**, or **~1.4%** of the pre-PR-#85 daily volume.
+
+Expected total residual after PR #85 deploy (chat/Petter's T+48h read):
+
+| Component | Estimated tokens/day | Share of pre-fix |
+|-----------|---------------------|------------------|
+| LEAKY conditional caps (this audit) | ~35K | ~1.4% |
+| `/v1/suggest` rerank (no prompt caching) | ~50–500K | ~2–20% |
+| Paid `/v1/do` + `/x402` customer traffic | ~150–250K | ~6–10% |
+| Sonnet daily-digest cron | ~5K | <1% |
+| **Total residual** | **~250K–800K** | **~10–32%** |
+
+The wide range reflects uncertainty about `/v1/suggest` traffic. If T+48h reads **<300K Haiku tokens/day**, attribution is confirmed and the 2 LEAKY caps are negligible. If reads **>500K**, `/v1/suggest` is the swing factor and Phase 2 reductions (prompt caching) become the next leverage point. If reads **>1M**, attribution was wrong and a new audit is warranted.
+
+## Recommended action by bucket
+
+**CLEAN (9):** No action on the cost classification. Three documentation hygiene items, none blocking:
+
+1. `brazilian-company-data` — delete the unused `extractCompanyName` helper + the `@anthropic-ai/sdk` import, then remove the slug from `CONDITIONAL_LLM_CAPABILITIES` (it stops being SDK-importing).
+2. `norwegian-company-data` manifest — fix `health_check_input.org_number` from `556703-7485` (Swedish) to a real 9-digit Norwegian org number. Hygiene only; the auth-less probe doesn't invoke the executor.
+3. `container-track` manifest — replace `container_number: "test_value"` with a real Maersk container (e.g. `MSKU1234564`), AND update the bypass comment in `llm-capability-costs.ts` to match the actual mechanism (invalid-format early-return, not well-known carrier prefix). Note: a real container in the fixture *would* trigger the Browserless + Haiku path, so this hygiene fix would itself reclassify the cap to LEAKY. Decision point: fix the comment OR fix the fixture, not both.
+
+**LEAKY (2):** Promote to `ALWAYS_LLM_CAPABILITY_COSTS`. Two valid paths:
+
+- **Path A (PR #85 mirror):** Bump `us-company-data` and `website-to-company` to `ALWAYS_LLM_CAPABILITY_COSTS` with cost = 1¢ each. Remove from `CONDITIONAL_LLM_CAPABILITIES`. Add a startup-migration block (call it 0065) following the PR #85 / block 0064 pattern. Cleanest, structurally consistent.
+- **Path B (fixture hygiene):** Change `us-company-data` manifest `known_answer.input.company` from `"AAPL"` to a numeric CIK like `"0000320193"` (Apple), and rework `website-to-company`'s LLM-extraction path to actually try structured-data extraction *first* and only fall back to LLM when JSON-LD / meta tags don't surface a name. For `us-company-data` this is trivial; for `website-to-company` it's a meaningful refactor.
+
+Path A is the conservative answer and matches the structural intent of PR #85 (any always-LLM cap → registered cost). Path B is the right long-term shape for the underlying capability but is more work and doesn't generalize beyond these two caps.
+
+Recommend Path A. Sized as a small follow-up PR. Estimated saving: ~35K tokens/day. Implementation complexity: trivial (mirror PR #85's block 0064 with 2 slugs).
+
+## Caveats
+
+- **Other test types (edge_case, negative, known_bad).** The scheduler runs all 4 active live test types per dispatch. Each has its own input fixture, generated by `apps/api/scripts/onboard.ts` at capability-creation time and persisted in the DB `test_suites` table. The manifests on disk only show `known_answer.input` and `health_check_input`. This audit traces the `known_answer.input` path. The other 3 types could in principle have inputs that change the LLM-trigger verdict — particularly for `edge_case`, which often uses variant inputs designed to exercise alternate code paths. Confirming the verdict for those types requires a prod query (`SELECT capability_slug, test_type, input FROM test_suites WHERE capability_slug IN (...)`) — not done in this read-only audit.
+- **Bypass-comment correctness.** The 9 CLEAN verdicts hold even where the per-cap comment in `llm-capability-costs.ts` is inaccurate about *why* (brazilian, container-track). Comment-vs-code drift is a separate hygiene item, not a leak.
+- **Downstream LLM calls via cap-to-cap chaining.** `website-to-company` is the only one in this set that chains. If other capabilities in `ALWAYS_LLM_CAPABILITY_COSTS` are called as sub-routines by anything in `CONDITIONAL_LLM_CAPABILITIES`, the LEAKY classification could propagate further. The audit's grep didn't surface other such chains within the 11 caps, but a general cap-chain audit is a separate undertaking.
+- **Token-rate estimates.** The 1.4% residual figure depends on actual `max_tokens` realization (assumed 30–50% for these short-prompt caps). Anthropic Console > Logs is the ground truth.


### PR DESCRIPTION
While clearing the remote branch graveyard, several branches turned out to hold research that exists **nowhere on main**. Deleting them would have destroyed it, so it lands here first.

**The valuable part:** registry build-path studies for **Bulgaria, Cyprus, Hungary and Luxembourg**, plus the gap-recovery synthesis. That is direct input to "which country do we build next", and right now it is invisible unless you know a five-month-old branch name.

Also rescued: a capability-health blind-spot analysis, DK handler routing, FR director truncation, LT/CH/HR outage triage, rate-limit + orchestration concurrency findings, an SI Openapi WW-Top probe, a US 14-state scout, and two Anthropic cost audits.

Filed per the Report Filing Convention — dated investigation reports to `archive/sessions/`, country research to `docs/research/` beside the existing studies, and the two handoffs to the canonical handoff directory (their branches had them under `apps/api/handoff/`, which is not the real location).

Docs only, no code.