### PR TITLE
fix: stop scoring the harness's own stale fixtures as capability defects

### DIFF
--- a/apps/api/src/lib/fixture-staleness-attribution.test.ts
+++ b/apps/api/src/lib/fixture-staleness-attribution.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression suite for the 2026-08-19 morning check-in finding: the test
+ * harness's own fixture-staleness guard was being scored as a capability
+ * defect.
+ *
+ * The guard (`test-runner.recordStaleFixture`) records `passed: false` with a
+ * message that ends "Not evidence about the capability." Three separate
+ * consumers disagreed with that sentence:
+ *
+ *   1. `classifyTransactionFailure` returned `internal` ("OUR bug until proven
+ *      otherwise"), so the correctness invariant counted it in the denominator
+ *      — despite `recordStaleFixture`'s own docstring asserting it classified
+ *      as `config` and was excluded.
+ *   2. `checkNewFailures` opened a `regression_detected` alert on any
+ *      `passed: false`, whatever the cause. Production fired three for
+ *      `eu-regulation-search` on 2026-08-18 ("was passing (100% over 10
+ *      runs), now failing") while the capability answered correctly.
+ *   3. `SingleTestResult` never declared `failureClassification`, and every
+ *      consumer read it through `(r as any)`. It was therefore `undefined`
+ *      everywhere: 14 of 14 production `infrastructure_alert` events grouped
+ *      as `{"unknown": 6}`.
+ *
+ * Each test below fails against the pre-fix code.
+ */
+import { describe, it, expect } from "vitest";
+import { classifyTransactionFailure } from "./transaction-failure-taxonomy.js";
+import { isCapabilityAttributable, checkNewFailures } from "./meta-monitoring.js";
+import { isEnvironmentalFailure } from "../jobs/invariant-checker.js";
+
+/** Verbatim from production `test_results`, 2026-08-19. */
+const REAL_STALE_REASON =
+  "fixture_refresh_required: baseline captured 2026-03-13T15:41:01.759Z predates " +
+  "the suite's last edit 2026-08-18T13:15:21.316Z and the suite is not free to " +
+  "re-run (external_cost_cents=1). Not evidence about the capability.";
+
+describe("fixture staleness is not a capability fault", () => {
+  it("classifies the real production marker as config, not internal", () => {
+    // Pre-fix: "internal".
+    expect(classifyTransactionFailure(REAL_STALE_REASON)).toBe("config");
+  });
+
+  it("leaves the correctness denominator, as recordStaleFixture's docstring promises", () => {
+    // Pre-fix: false — the docstring was simply untrue.
+    expect(isEnvironmentalFailure(REAL_STALE_REASON)).toBe(true);
+  });
+
+  it("matches on our own prefix rather than the embedded third-party text", () => {
+    // The message embeds timestamps and suite metadata. Classification must
+    // come from our literal marker, so a baseline whose payload happens to
+    // contain caller-ish or upstream-ish words still lands in `config`.
+    const adversarial =
+      "fixture_refresh_required: baseline captured 2026-01-01T00:00:00.000Z predates " +
+      "the suite's last edit and the suite is not free to re-run. " +
+      "Raw: {\"error\":\"not found\",\"status\":503,\"detail\":\"timed out\"}";
+    expect(classifyTransactionFailure(adversarial)).toBe("config");
+  });
+
+  it("does not claim unrelated messages that merely mention fixtures", () => {
+    // The marker is anchored at the start of the string; prose about fixtures
+    // must keep its ordinary classification.
+    expect(classifyTransactionFailure("the fixture_refresh_required flag was set")).not.toBe("config");
+  });
+});
+
+describe("isCapabilityAttributable", () => {
+  it("excuses instrument- and world-shaped verdicts", () => {
+    for (const cls of [
+      "stale_input",
+      "test_infrastructure",
+      "test_design",
+      "upstream_transient",
+      "upstream_changed",
+    ]) {
+      expect(isCapabilityAttributable(cls), cls).toBe(false);
+    }
+  });
+
+  it("keeps genuine capability verdicts attributable", () => {
+    for (const cls of ["capability_bug", "internal", "schema_mismatch"]) {
+      expect(isCapabilityAttributable(cls), cls).toBe(true);
+    }
+  });
+
+  it("treats an unclassified failure as attributable", () => {
+    // Deliberate: silently excusing the unexplained is how a real regression
+    // would go unreported.
+    expect(isCapabilityAttributable(undefined)).toBe(true);
+    expect(isCapabilityAttributable(null)).toBe(true);
+    expect(isCapabilityAttributable("")).toBe(true);
+  });
+});
+
+describe("checkNewFailures", () => {
+  it("opens no regression when every failure is a stale fixture", async () => {
+    // Pre-fix this reached the DB, found prior history and alerted. Post-fix
+    // the batch is empty before any query runs, so the check short-circuits —
+    // which is also why this test needs no database.
+    const res = await checkNewFailures([
+      { capabilitySlug: "eu-regulation-search", passed: false, failureClassification: "stale_input" },
+      { capabilitySlug: "eu-regulation-search", passed: false, failureClassification: "stale_input" },
+    ]);
+    expect(res.passed).toBe(true);
+    expect(res.details).toMatch(/No failures in this batch/);
+  });
+
+  it("still short-circuits when the whole batch passed", async () => {
+    const res = await checkNewFailures([
+      { capabilitySlug: "email-validate", passed: true },
+    ]);
+    expect(res.passed).toBe(true);
+  });
+});

--- a/apps/api/src/lib/meta-monitoring.ts
+++ b/apps/api/src/lib/meta-monitoring.ts
@@ -43,6 +43,28 @@ export interface BatchTestResult {
 // ─── 8A: Post-test-run checks ─────────────────────────────────────────────────
 
 /**
+ * Verdicts that describe the *instrument or the world* rather than the
+ * capability under test. A failure carrying one of these is not evidence the
+ * capability changed behaviour, so it must not open a regression.
+ *
+ * `undefined`/`null` stays attributable on purpose: an unclassified failure is
+ * unexplained, and silently excusing the unexplained is how a real regression
+ * would go unreported.
+ */
+const NON_ATTRIBUTABLE_CLASSIFICATIONS: ReadonlySet<string> = new Set([
+  "stale_input",         // fixture baseline older than its suite — no evidence either way
+  "test_infrastructure", // our own test-budget guard tripped
+  "test_design",         // the fixture asks for something the capability correctly refuses
+  "upstream_transient",  // vendor 5xx/429
+  "upstream_changed",    // vendor altered its contract
+]);
+
+export function isCapabilityAttributable(classification?: string | null): boolean {
+  if (!classification) return true;
+  return !NON_ATTRIBUTABLE_CLASSIFICATIONS.has(classification);
+}
+
+/**
  * Check 1: New failure alert (WARNING)
  * Detects capabilities that were passing in their previous run window
  * and are now failing in this batch (regression).
@@ -56,18 +78,32 @@ export async function checkNewFailures(
   const check = "new_failure_alert";
 
   try {
-    const db = getDb();
     const now = new Date();
 
-    // Only check slugs that failed in this batch
+    // Only check slugs that failed in this batch *for a reason attributable to
+    // the capability*. A stale fixture, an exhausted test budget or an upstream
+    // outage is an absence of evidence, not evidence of a regression — alerting
+    // on it is the crying-wolf failure DQ-12 fixed for the correctness
+    // invariant, arriving here by a different route.
+    //
+    // Observed 2026-08-18: `eu-regulation-search` produced three
+    // "was passing (100% over 10 runs), now failing" alerts while answering
+    // correctly in production. Every one of its failures was the harness's own
+    // `fixture_refresh_required` marker.
     const failedSlugs = [...new Set(
-      batchResults.filter((r) => !r.passed).map((r) => r.capabilitySlug),
+      batchResults
+        .filter((r) => !r.passed && isCapabilityAttributable(r.failureClassification))
+        .map((r) => r.capabilitySlug),
     )];
 
     if (failedSlugs.length === 0) {
       return { check, severity: "warning", passed: true, details: "No failures in this batch" };
     }
 
+    // Opened only once the batch is known to contain something worth querying:
+    // the no-op path must not need a database connection to report "nothing
+    // regressed", which is also what makes this check unit-testable.
+    const db = getDb();
     const regressions: string[] = [];
 
     for (const slug of failedSlugs) {

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -144,6 +144,18 @@ interface SingleTestResult {
   failureReason: string | null;
   responseTimeMs: number;
   remediation?: RemediationResult;
+  /**
+   * The verdict already written to `test_results.failure_classification`,
+   * carried back to the caller so post-run meta-monitoring can group by cause.
+   *
+   * Added 2026-08-19. Every consumer read it as `(r as any).failureClassification`
+   * against an interface that never declared it, so it was `undefined` at every
+   * call site: `checkInfrastructureHealth` bucketed 14 of 14 production
+   * infrastructure alerts as `{"unknown": 6}` and the mass-failure
+   * situation assessment always reported `commonClassification: "unknown"`.
+   * The cast silenced the type error that would have caught this.
+   */
+  failureClassification?: string | null;
 }
 
 // ─── Tier-specific delays ───────────────────────────────────────────────────
@@ -471,8 +483,8 @@ export async function runTests(
   if (results.length > 0 && failed > 5 && failed / results.length > 0.10) {
     const classificationCounts: Record<string, number> = {};
     for (const r of results) {
-      if (!r.passed && (r as any).failureClassification) {
-        const c = String((r as any).failureClassification);
+      if (!r.passed && r.failureClassification) {
+        const c = String(r.failureClassification);
         classificationCounts[c] = (classificationCounts[c] ?? 0) + 1;
       }
     }
@@ -493,7 +505,7 @@ export async function runTests(
     const batchForMeta = results.map((r) => ({
       capabilitySlug: r.capabilitySlug,
       passed: r.passed,
-      failureClassification: (r as any).failureClassification as string | null | undefined,
+      failureClassification: r.failureClassification,
     }));
 
     // Check 1: New failure alert (regressions)
@@ -684,6 +696,7 @@ async function runSingleTest(
       passed: false,
       failureReason,
       responseTimeMs: 0,
+      failureClassification: classification.verdict,
     };
   }
 
@@ -906,6 +919,7 @@ async function runSingleTest(
     passed,
     failureReason,
     responseTimeMs,
+    failureClassification: classification?.verdict ?? null,
   };
 }
 
@@ -996,6 +1010,7 @@ async function runDryRunSchemaTest(
     passed,
     failureReason,
     responseTimeMs,
+    failureClassification: classification?.verdict ?? null,
   };
 }
 
@@ -1149,6 +1164,7 @@ async function runRegressionTest(
       passed: false,
       failureReason,
       responseTimeMs,
+      failureClassification: cls.verdict,
     };
   }
 
@@ -1210,6 +1226,7 @@ async function runRegressionTest(
       passed: false,
       failureReason,
       responseTimeMs,
+      failureClassification: cls.verdict,
     };
   }
 
@@ -1249,6 +1266,7 @@ async function runRegressionTest(
     passed,
     failureReason,
     responseTimeMs,
+    failureClassification: regressionCls?.verdict ?? null,
   };
 }
 
@@ -1370,6 +1388,12 @@ export function isBaselineStale(suite: BaselineStalenessInput, now?: Date): bool
  * (ours to fix, not the capability's logic), so the correctness invariant
  * excludes it from the denominator rather than reporting a code defect.
  */
+/**
+ * The verdict written for a stale fixture. One constant so the persisted row
+ * and the in-memory result returned to meta-monitoring cannot drift apart.
+ */
+const STALE_FIXTURE_CLASSIFICATION = "stale_input";
+
 async function recordStaleFixture(
   suite: typeof testSuites.$inferSelect,
 ): Promise<SingleTestResult> {
@@ -1385,7 +1409,7 @@ async function recordStaleFixture(
     passed: false,
     failureReason,
     responseTimeMs: 0,
-    failureClassification: "stale_input",
+    failureClassification: STALE_FIXTURE_CLASSIFICATION,
   });
 
   return {
@@ -1395,6 +1419,7 @@ async function recordStaleFixture(
     passed: false,
     failureReason,
     responseTimeMs: 0,
+    failureClassification: STALE_FIXTURE_CLASSIFICATION,
   };
 }
 
@@ -1566,6 +1591,7 @@ async function recordQuarantinedRecaptureRefusal(
     passed: false,
     failureReason,
     responseTimeMs: 0,
+    failureClassification: "test_infrastructure",
   };
 }
 

--- a/apps/api/src/lib/transaction-failure-taxonomy.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.ts
@@ -43,6 +43,26 @@ export const CALLER_ATTRIBUTABLE: ReadonlySet<TransactionFailureClass> = new Set
 // generic "is required", so config MUST be checked before caller patterns
 // with a shape only our env errors have. Case-sensitive env-var shape,
 // case-insensitive phrasings.
+/**
+ * The test harness's own fixture-staleness marker, emitted by
+ * `test-runner.recordStaleFixture` when a fixture baseline predates its
+ * suite's last edit and the suite costs money to re-run.
+ *
+ * Classified `config` — harness state on our side — so it joins
+ * `ENVIRONMENTAL_FAILURE_CLASSES` and leaves the correctness denominator.
+ * The result is deliberately recorded `passed: false` (we have no evidence
+ * the capability works), but "no evidence" must never be scored as "evidence
+ * of a defect": the message itself ends "Not evidence about the capability."
+ *
+ * Before 2026-08-19 this fell through to `internal` — "OUR bug until proven
+ * otherwise" — which counted it against the capability's completion rate and
+ * fired false `regression_detected` alerts. `eu-regulation-search` was
+ * reported as regressing from 100% three times on 2026-08-18 while answering
+ * correctly; the taxonomy is the reason. Matched on our own literal prefix,
+ * so no third-party text can reach it.
+ */
+const FIXTURE_STALE_RE = /^fixture_refresh_required:/;
+
 const CONFIG_ENV_RE = /\b[A-Z][A-Z0-9]+(?:_[A-Z0-9]+)*_(?:KEY|TOKEN|SECRET|GUID|URL|PASSWORD)\b/;
 const CONFIG_PHRASE_RE = /not configured|rejected the (?:api )?(?:key|token)|missing credential/i;
 
@@ -223,6 +243,10 @@ export function classifyTransactionFailure(error: string | null | undefined): Tr
   const msg = (error ?? "").trim();
   if (!msg) return "internal";
   if (msg.includes(TOS_REFUSAL_MARKER)) return "tos_policy";
+  // Our own harness marker, claimed before every other pattern: the message
+  // embeds suite metadata and timestamps that must never be pattern-matched
+  // as though they were a capability's error text.
+  if (FIXTURE_STALE_RE.test(msg)) return "config";
   if (CONFIG_ENV_RE.test(msg) || CONFIG_PHRASE_RE.test(msg)) return "config";
   // Before timeout/upstream/caller: these messages quote raw third-party text
   // that can contain any phrase, so they must be claimed by their own


### PR DESCRIPTION
Found during the 2026-08-19 morning check-in, while running the T4.3 exit measurement. `eu-regulation-search` appeared in the "under 90%" list for the first time. It is not broken — every one of its failures is the harness's own fixture-staleness marker, whose message ends **"Not evidence about the capability."**

Three consumers disagreed with that sentence. Each is evidenced from production, not inferred.

### 1. The taxonomy called it our bug

`classifyTransactionFailure` returned `internal` — *"OUR bug until proven otherwise"* — so the correctness invariant counted the guard's own output in its denominator.

`recordStaleFixture`'s docstring already asserted the opposite: *"`transaction-failure-taxonomy` classifies this as `config` … so the correctness invariant excludes it from the denominator rather than reporting a code defect."* The docstring was simply untrue; nothing had ever checked it.

Now matched on our literal `fixture_refresh_required:` prefix, ahead of every other pattern. That ordering is load-bearing: the message embeds suite metadata and timestamps, and pre-fix an adversarial baseline payload containing `"timed out"` classified as **`timeout`** — third-party text really did leak into the verdict. There is a test pinning that.

### 2. It opened false regressions

`checkNewFailures` alerted on any `passed: false`, whatever the cause. Production fired three for `eu-regulation-search` on 2026-08-18:

> `Regression: eu-regulation-search was passing (100% over 10 runs), now failing`

…while the capability answered correctly. Failures whose verdict describes the instrument or the world (`stale_input`, `test_infrastructure`, `test_design`, `upstream_transient`, `upstream_changed`) no longer open one.

An **unclassified** failure stays attributable on purpose — silently excusing the unexplained is how a real regression would go unreported.

### 3. The classification never arrived at all

`SingleTestResult` never declared `failureClassification`, and all four consumers read it through `(r as any)`. It was `undefined` at every call site, and the cast silenced the type error that would have caught it.

Consequence, measured against production:

```
14 of 14 infrastructure_alert events:  classification=unknown, all_groups={"unknown": 6}
```

`checkInfrastructureHealth` exists to name the common cause of a systemic failure. It has never once done so. The mass-failure situation assessment had the same defect (`commonClassification` always `"unknown"`).

The field is now declared and populated at every return site, with one constant shared between the persisted row and the returned result so they cannot drift.

### Also

`getDb()` moved below the early return in `checkNewFailures` — the no-op path no longer opens a connection it does not need, which is what makes the check unit-testable.

### Blast radius

Deliberately checked before assuming the worst: only **1** fixture suite is currently stale (`baseline_older_than_edit = 1` across 138 fixture suites), one capability affected. The initial hypothesis — that a startup migration was invalidating every baseline on each boot — was **wrong**, and re-measuring is what killed it. This is a correctness fix to the instrument, not an incident.

### Tests

9 tests in `apps/api/src/lib/fixture-staleness-attribution.test.ts`, using the verbatim production failure string.

Discrimination verified by reverting all three source files to `origin/main` with the tests in place: **8 of 9 fail**. The 9th is a deliberate over-match guard (prose mentioning fixtures must keep its ordinary class) which correctly passes both ways.

Full suite green: 170 files, 2,138 tests. `tsc --noEmit` clean.

### Not fixed here, deliberately

The `eu-regulation-search` suite is *stuck*: its baseline predates its last edit and `external_cost_cents=1` means it is not free to re-run, so it can never self-heal. This PR stops it being **scored** as a defect; it does not refresh the baseline, which is a production data write and out of scope for an unattended check-in. Flagged in the handoff as the next action.

DEC-20260504-A: regression tests included and proven to fail against the un-fixed state.

Same shape as DQ-12 (invariant counting environmental failures) and E3 (quality floor counting correct refusals), reaching the same place by a third route.