### PR TITLE
docs: 2026-08-19 morning check-in — T4.3 exit measurement, DQ-15, branch sweep

### DIFF
--- a/docs/company/DECISION-QUEUE.md
+++ b/docs/company/DECISION-QUEUE.md
@@ -100,6 +100,33 @@ item 3 leaves one automated check inert; items 1 and 4 are tidying.
 
 ## DECIDED — visible so you can reverse them
 
+**DQ-15** · `decided` · owner Claude · 2026-08-19
+Deleted four dead code branches, and published two research notes that only
+existed on them.
+*What this is:* the morning branch-graveyard sweep. Four July snapshot branches
+held nothing that is not already on the main line, so they are gone; the
+research two of them carried was published first, so nothing was lost.
+*How I checked, and why it matters:* my first pass compared file *paths* and
+reported five documents as missing from the main line. Three of them were not
+missing at all — they had been moved to a different folder months ago, and a
+path comparison cannot see that. Comparing the actual contents found them
+byte-for-byte identical. Only two were genuinely unique, and those are the two
+I published. A path check after a file move is not evidence of absence.
+*What was deleted, all recoverable:* the July screenshot fix snapshot (the main
+line's version is strictly newer), a one-line snapshot, and a snapshot whose
+only unique content was configuration for a system we removed in August. Every
+identifier is recorded in today's handoff.
+*What stays, with reasons:* three branches holding the unfinished Italian
+company-lookup work, because that is live work with a known privacy issue to
+resolve first (DQ-1). One of the three I had expected to delete: its research
+is now published, but it turned out to hold a *different version* of the
+Italian work than the other two — same capability file, three differing
+supporting files — so deleting it would have quietly discarded a variant.
+Also staying: one branch holding a test file not yet on the main line, and the
+two previously-documented keeps.
+*How you'd reverse it:* any deleted branch is restorable from the identifiers
+in today's handoff.
+
 **DQ-13** · `decided` · owner Claude · 2026-08-18
 Switched on payment for the four new growth bundles. They had been on the menu
 for two days without a way to pay for them.

--- a/docs/company/GOALS.md
+++ b/docs/company/GOALS.md
@@ -132,6 +132,18 @@ conversion.
   capability makes a network call. Fixed 2026-08-17 (#305): environmental
   failures leave the denominator and report at Tier 2 instead. Six capabilities
   went quiet; seven still violate and are genuine.
+- **The Codebase Quality Program's exit measurement passed** (T4.3, run
+  2026-08-19 on the clean 24h window it was deferred for). **3 capabilities
+  under 90%** against a ≤5 target, down from 30 at program start, across 210
+  capabilities and 13,779 runs: `uk-gazette-notice-search` 60.0% (vendor API
+  returns 500 to everyone — DQ-14 item 2, Petter to file),
+  `eu-regulation-search` 60.4% (**not a capability fault at all** — every
+  failure was the fixture-staleness guard, fixed in #341) and
+  `canadian-company-data` 88.1%. Cross-checked at 12h/48h/7d: the same three
+  dominate, and the 7d window additionally carries pre-fix rows from the
+  program's own remediation, which is why the clean window was the one
+  specified.
+
 - **The seven that remain are fixture-contract bugs, not broken capabilities.**
   `iso-country-lookup`, `skill-extract`, `company-id-detect`,
   `incoterms-explain`, `dangerous-goods-classify`, `beneficial-ownership-lookup`
@@ -140,10 +152,46 @@ conversion.
   is fixtures asserting a flattened shape against a nested response — verified
   for `iso-country-lookup`, whose six "null" fields all live under `match`. This
   is the next fixture-hygiene batch.
-- **`screenshot-url` has a plain bug, not a quality problem**: 23 of its 25 real
-  failures are `HTTP 400: "waitForSelector" is not allowed` — a parameter *we*
-  send that Browserless rejects. Deterministic, ours, and invisible to the
-  harness.
+- **`screenshot-url`'s `waitForSelector` bug is fixed** (re-checked 2026-08-19).
+  The entry below is kept because the *diagnosis* was right and worth
+  remembering; the defect itself is gone. `screenshot-url.ts` on `main` carries
+  the v1/v2 wait-dialect probe (`toV1WaitFor`, `waitDialectByHost`), and over
+  the last 14 days external traffic shows **one call, completed, no error** —
+  so the fix is confirmed by real traffic, not just by reading the file. The
+  original finding: 23 of its 25 real failures were
+  `HTTP 400: "waitForSelector" is not allowed` — a parameter *we* sent that
+  Browserless rejected. Deterministic, ours, and invisible to the harness.
+
+- **The instrument blamed the capability a third time, by a third route**
+  (found and fixed 2026-08-19, #341). The fixture-staleness guard records
+  `passed: false` with a message ending "Not evidence about the capability" —
+  and then three consumers scored it as exactly that. `classifyTransactionFailure`
+  returned `internal` ("OUR bug until proven otherwise"), so it counted in the
+  correctness denominator, *despite the emitting function's own docstring
+  asserting it was classified `config` and excluded* — the docstring was
+  untrue and nothing had ever checked. `checkNewFailures` opened regressions on
+  it: `eu-regulation-search` was reported "was passing (100% over 10 runs), now
+  failing" three times on 2026-08-18 while answering correctly. And
+  `SingleTestResult` never declared `failureClassification`, so all four
+  consumers read it through `(r as any)` and got `undefined` — which is why
+  **14 of 14 production `infrastructure_alert` events grouped as
+  `{"unknown": 6}`**. A detector built to name the common cause of a systemic
+  failure had never once named one.
+
+  The lesson generalises past this fix: **DQ-12, E3 and this are the same bug
+  three times.** An instrument that knows it lacks evidence must be wired so
+  "no evidence" cannot be scored as "evidence of a defect" — and a comment
+  claiming that wiring exists is not the wiring.
+
+- **The quality floor's "daily" tick is in practice deploy-driven.** Its
+  interval is 24h with a 15-minute startup delay, so in a week of frequent
+  merges it evaluates once per boot: 8 deploys on 2026-08-18 produced 8 ticks,
+  and the 16-hour silence afterwards was simply the absence of a ninth deploy,
+  not an outage. Worth knowing before reading tick cadence as a health signal —
+  it cost most of an hour on 2026-08-19 before the interval constant explained
+  it. The self-throttle ("3 quarantines per run") is therefore per *deploy*,
+  not per day; harmless while decisions are 0, but it is not the documented
+  bound.
 
 ## Active experiments (M1)
 

--- a/handoff/_general/from-code/2026-08-19-checkin-morning.md
+++ b/handoff/_general/from-code/2026-08-19-checkin-morning.md
@@ -1,0 +1,103 @@
+# 2026-08-19 — Morning check-in
+
+Intent: run the daily operations check-in under the Operating Charter (DEC-20260815-A) — dashboard, overnight problems, stale-work sweep, branch graveyard, decision queue, then the highest-leverage work available against M1.
+
+## Headline numbers
+
+From `ceo-dashboard.ts` (canonical path, production read-only):
+
+- **Revenue observed: €52.99** (rolling 7d) · **buyers estimated: 6** (explicitly a lower bound — wallet identity only recorded since 2026-08-15) · **spend estimated €5.66** against the €50/week envelope.
+- **Circuit breakers open: 1** — `us-court-search`, open since 2026-08-17, which is the expected state: it was deliberately switched off in DQ-11 pending a CourtListener key (DQ-14 item 1).
+- **CI on main: green.** Prod served main's tip throughout.
+
+Direction is up. A discrete-week cross-check (external-only) shows the current week already at €30.83 across 464 calls by Wednesday morning, against €39.24 for the whole of the previous week. **I am reporting the dashboard's figure, not that query's** — the ad-hoc SQL lacks the window/population/instrument guards in `lib/metrics`, so it is directional corroboration only, which is also why its absolute numbers differ slightly from GOALS.md's table.
+
+## The one that mattered: the instrument was blaming the capability again (#341, merged, deployed)
+
+Running the **T4.3 exit measurement** (deferred to today specifically for a clean 24h window) surfaced `eu-regulation-search` at 60.4% — a capability that had been at 100% for three straight days and was in no prior failing list.
+
+It is not broken. Every one of its failures is the harness's own fixture-staleness marker, whose message literally ends **"Not evidence about the capability."** Three separate consumers scored it as exactly that:
+
+1. **The taxonomy called it our bug.** `classifyTransactionFailure` returned `internal` — *"OUR bug until proven otherwise"* — so it counted in the correctness denominator. The emitting function's own docstring asserted the opposite: *"classifies this as `config` … so the correctness invariant excludes it."* The docstring was untrue, and nothing had ever checked it.
+2. **It opened false regressions.** Production fired three `regression_detected` alerts on 2026-08-18: *"eu-regulation-search was passing (100% over 10 runs), now failing"* — while the capability answered correctly.
+3. **The classification never arrived anywhere.** `SingleTestResult` never declared `failureClassification`; all four consumers read it via `(r as any)` and got `undefined`. Measured consequence: **14 of 14 production `infrastructure_alert` events grouped as `{"unknown": 6}`**. A detector whose entire job is naming the common cause of a systemic failure has never once named one.
+
+**This is DQ-12 and E3 for the third time, arriving by a third route** — an instrument that knows it has no evidence, scoring "no evidence" as evidence of a defect. Worth stating as a standing rule: a comment claiming the exclusion wiring exists is not the wiring.
+
+Fixed, with 9 tests using the verbatim production failure string. Discrimination proven by reverting all three source files to `origin/main` with the tests in place: **8 of 9 fail**; the 9th is a deliberate over-match guard that correctly passes both ways. Full suite green (170 files, 2,138 tests), `tsc` clean, merged as `f4b3561`, and **prod confirmed serving that commit**.
+
+One detail worth keeping: pre-fix, an adversarial baseline payload containing "timed out" classified as **`timeout`** — third-party text really did leak into the verdict. The fix anchors on our own literal prefix ahead of every other pattern, and a test pins that.
+
+## T4.3: the quality program's exit measurement passes
+
+**3 capabilities under 90%** against a ≤5 target, down from 30 at program start, across 210 capabilities and 13,779 runs:
+
+| capability | rate | verdict |
+|---|---|---|
+| `uk-gazette-notice-search` | 60.0% | vendor API 500s to everyone — DQ-14 item 2, needs Petter |
+| `eu-regulation-search` | 60.4% | **not a capability fault** — the staleness bug above, fixed in #341 |
+| `canadian-company-data` | 88.1% | genuine, marginal |
+
+Cross-checked at 12h/48h/7d. The same three dominate; the 7d window additionally carries pre-fix rows from the program's own remediation, which is exactly why a clean window was specified.
+
+## Two false alarms I talked myself out of — both killed by re-measuring, not by care
+
+Recording these because in both cases the first reading was confident and wrong.
+
+1. **"27 capabilities were delisted overnight."** They were not. `updated_at` had been bumped on 203 of ~340 capabilities within one hour, which looked like a mass quarantine. It is a broad harness writer; the off-rail set is stable at 34 and several entries date from May. No quarantine event exists.
+2. **"The quality floor has been down for 17 hours."** It has not. Its interval is **24h with a 15-minute startup delay**, so ticks are *deploy-driven*: 8 merges on 2026-08-18 produced 8 ticks, and the silence since was simply the absence of a ninth deploy. The unconditional `tick_complete` heartbeat is what made the gap look like a failure. Now recorded in GOALS.md so the next session doesn't spend an hour on it. Side note: the documented self-throttle of "3 quarantines per run" is therefore per *deploy*, not per day — harmless while decisions are 0, but it is not the stated bound.
+
+I also expected the staleness bug to be systemic (a startup migration invalidating every fixture baseline on each boot). **It is not** — `baseline_older_than_edit = 1` across 138 fixture suites. Checking is what killed that hypothesis.
+
+## Stale-work sweep (B2/B2b)
+
+- **Zero open backend PRs at start and at finish.** Both PRs I opened today were merged in the same session.
+- Checkout on `main`, level with origin. Hygiene script clean apart from today's handoff (this file).
+- **Deployed SHA tracked main's tip throughout** — verified before and after each merge.
+- `strale-frontend#5` remains open: a May cleanup PR in the other repo, unrelated to today's work. Flagged rather than merged blind.
+- Leftovers from earlier sessions: a worktree `C:/Users/pette/Projects/strale-wt-checkin` (detached HEAD) and a non-worktree directory `C:/tmp/strale-wt-docs`. Harmless, but they are why I used `-wt-docs2`.
+
+## Branch graveyard (B3): 13 → 8 unmerged
+
+**Deleted (all recoverable from these SHAs):**
+
+| branch | sha | why |
+|---|---|---|
+| `rescue/wip-2026-07-23-fix-screenshot-waitfor-edgar-retry-af2bd66` | `af2bd66a5207b9661533545d4bcc50b3fc376433` | main's `screenshot-url.ts` is strictly newer (7 dialect-probe markers vs 0); its handoff already on main |
+| `rescue/wip-2026-07-16-detached-013108c` | `013108ce2d1b74aa49e18684dfbe7784cfc49065` | one `.gitignore` line |
+| `rescue/wip-2026-07-16` | `d910b64ff0106bb78555ed4fe4ce46a66455baed` | only unique content was `.claude/model-os/*` (removed platform-wide 2026-08-16) and `.agents/skills/*` (rebuilt in #319); all 11 of its `audit-output/` docs byte-identical on main |
+| `rescue/wip-2026-07-16-worktree-agent-a000fba7eea386276-b70a1ff` | `b70a1ffe06fcc2dcc990ef7e229c0dd62ae7d650` | sole unique file was the HVD research doc, landed in #342 first |
+
+**Landed first so deletion was safe (#342):** `se-hvd-api-probe-2026-05-18.md` (Bolagsverket HVD API — including that redistributing personnummer needs a **DPA with Bolagsverket, not just the HVD licence**, which we would otherwise rediscover the hard way) and `eu-coverage-use-case-tier-audit-2026-05-18.md`.
+
+**A methodological correction worth carrying forward.** My first pass compared file *paths* and reported five documents as missing from main. Three were not missing — the Phase-3 sweep had moved `audit-output/` under `archive/sessions/` months ago, and a path check cannot see a move. Content comparison found them byte-identical. **After a file move, a path-based "is it on main" check is not evidence of absence.** Only two were genuinely unique.
+
+**Kept, with reasons:**
+
+- `rescue/wip-2026-07-16-docs-phase-7b-enumeration-edc1d46` — I had queued this for deletion once its research landed. It holds a **different version** of the Italian stakeholders work: same capability file, three *differing* supporting files. Deleting it would have discarded a variant of live DQ-1 work.
+- `rescue/wip-2026-07-16-feat-phase-7a-it-stakeholders-ca1ab4e` and `feat/phase-7a-it-stakeholders` — live DQ-1 work with a known PII hazard (real *codice fiscale* in a fixture) to resolve first.
+- `rescue/stale-2026-08-15-…-6bb5cf4` — holds `guarded-executor.budget.test.ts`, a test file not on main. Assess and land or drop.
+- `archive/retire-solutions-abandoned-2026-05`, `tooling/session-state-marker`, `feat/phase-3-extraction-lv`, `fix/t02-quality-floor-reinstatement-audit` — previously documented keeps.
+
+## Decision queue (C)
+
+Nothing matured into action: **DQ-14 is `your_call` with no deadline** (silence is never approval), and every other open entry is already `decided`. Added **DQ-15** recording today's branch deletions and the path-vs-content correction.
+
+## What's queued for Petter
+
+Unchanged from DQ-14, and none of it blocks anything: CourtListener key · report the Gazette outage to TheGazette · the read-only frontend GitHub token · archive/delete `wow-core`.
+
+Two of today's findings touch that list: the Gazette really is our worst capability at 60.0%, with a written reason, and `us-court-search` is the one open breaker — both waiting on him, neither urgent.
+
+## Next session should pick up
+
+1. **`eu-regulation-search`'s suite is stuck and needs a production write I deliberately did not make.** Its baseline predates its last edit and `external_cost_cents = 1`, so it is not free to re-run and **can never self-heal**. #341 stops it being *scored* as a defect; it does not refresh the baseline. Fixture refresh is platform-acts-alone under DEC-20260812-A, but this check-in runs under a hard read-only-prod rule, so it is the first action for a session that can write.
+2. **The seven fixture-contract bugs** (`iso-country-lookup` et al.) — still the standing fixture-hygiene batch, and the same *shape* as today's bug: fixtures asserting a flattened shape against a nested response.
+3. **E4 is now measurable.** The four growth bundles have been payable since 2026-08-18; the 14-day kill criterion runs to ~2026-09-01. Nothing to decide yet — just don't let the window pass unmeasured.
+4. `rescue/stale-…-6bb5cf4`: land or drop `guarded-executor.budget.test.ts`.
+5. `uk-disqualified-director-check` still has `processes_personal_data = true` with an empty `personal_data_categories` (carried from 2026-08-18; `["name"]` is almost certainly right).
+
+## Merged this session
+
+- **[#341](https://github.com/strale-io/strale/pull/341)** — stop scoring the harness's own stale fixtures as capability defects. `f4b3561`, deployed and verified.
+- **[#342](https://github.com/strale-io/strale/pull/342)** — land two research documents stranded on rescue branches. `f223a86`.


### PR DESCRIPTION
Session record for the daily check-in. Docs only.

**GOALS.md**
- **T4.3 exit measurement, run today** on the clean 24h window it was deferred for: **3 capabilities under 90%** against a ≤5 target, down from 30 at program start, across 210 capabilities and 13,779 runs. Cross-checked at 12h/48h/7d.
- **Corrects the stale `screenshot-url` entry.** The `waitForSelector` bug is fixed — main carries the v1/v2 dialect probe, and 14 days of external traffic shows one call, completed, no error. The diagnosis is kept because it was right; only the claim that it is outstanding was wrong.
- Adds the **third instance of "the instrument blamed the capability"** (fixed in #341) and states the generalisation: DQ-12, E3 and this are the same bug three times. A comment claiming the exclusion wiring exists is not the wiring.
- Records that the quality floor's *"daily"* tick is in practice **deploy-driven** (24h interval, 15-min startup delay). Its cadence is not a health signal — that cost most of an hour this morning before the interval constant explained it. Its documented "3 quarantines per run" throttle is therefore per *deploy*, not per day.

**DECISION-QUEUE.md** — DQ-15: four branch deletions with recoverable SHAs, the two research documents published first (#342) so nothing was lost, and the path-vs-content correction that stopped three false "missing from main" reads.

**Handoff** — full session record, including the two false alarms that re-measurement killed and the one branch I had queued for deletion and kept after finding it held a distinct variant of live DQ-1 work.