### PR TITLE
fix: structured 'not covered' error for Nager.Date 204 empty-body responses

### DIFF
--- a/apps/api/src/capabilities/holiday-calendar.test.ts
+++ b/apps/api/src/capabilities/holiday-calendar.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression tests for the Nager.Date empty-body crash (2026-08-20).
+ *
+ * Nager.Date returns 204 No Content — an empty body with res.ok === true —
+ * for ISO codes it recognizes but has no holiday data for. Thailand ('TH')
+ * was the observed case: all 3 external x402 calls in the 2026-08-19→20
+ * window failed with "Unexpected end of JSON input" because the executor
+ * called res.json() on the empty body. The fix turns a 204 into a structured
+ * "not covered" error, negative-cached so retry loops don't re-hit upstream;
+ * any other unparseable body errors uncached so transient glitches retry.
+ * public-holiday-lookup carried the same crash via its own duplicate fetch;
+ * it now routes through the shared getHolidays().
+ *
+ * fetch is stubbed per test; each test uses a distinct country code because
+ * the module keeps a 24h in-memory cache keyed on country+year.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDirectExecutor } from "./index.js";
+import "./holiday-calendar.js";
+import "./public-holiday-lookup.js";
+
+const calendar = getDirectExecutor("holiday-calendar")!;
+const lookup = getDirectExecutor("public-holiday-lookup")!;
+
+function response(status: number, body: string): Response {
+  return new Response(status === 204 ? null : body, {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const SE_FIXTURE = JSON.stringify([
+  {
+    date: "2026-06-06",
+    localName: "Sveriges nationaldag",
+    name: "National Day of Sweden",
+    fixed: true,
+    global: true,
+    counties: null,
+    types: ["Public"],
+  },
+]);
+
+describe("holiday-calendar", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("204 No Content (the TH case) yields a 'not covered' error, not a JSON parse crash", async () => {
+    fetchMock.mockResolvedValue(response(204, ""));
+    await expect(calendar({ country_code: "TH", year: 2026 })).rejects.toThrow(
+      /Country 'TH' is not covered/
+    );
+    // The outcome is negative-cached: a retry throws the same structured
+    // error without another upstream round trip.
+    await expect(calendar({ country_code: "TH", year: 2026 })).rejects.toThrow(
+      /Country 'TH' is not covered/
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a 200 with an unparseable body yields a structured error", async () => {
+    fetchMock.mockResolvedValue(response(200, "<html>maintenance</html>"));
+    await expect(calendar({ country_code: "MY", year: 2026 })).rejects.toThrow(
+      /unparseable response for 'MY'\/2026/
+    );
+  });
+
+  it("an empty 200 body is a transient error, NOT negative-cached as 'not covered'", async () => {
+    fetchMock.mockResolvedValue(response(200, ""));
+    await expect(calendar({ country_code: "VN", year: 2026 })).rejects.toThrow(
+      /unparseable response for 'VN'\/2026/
+    );
+    // Uncached: the next call must retry upstream.
+    await expect(calendar({ country_code: "VN", year: 2026 })).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("404 still yields the 'not supported' error", async () => {
+    fetchMock.mockResolvedValue(response(404, ""));
+    await expect(calendar({ country_code: "XX", year: 2026 })).rejects.toThrow(
+      /Country 'XX' not supported/
+    );
+  });
+
+  it("a 200 with holiday data still returns the documented output shape", async () => {
+    fetchMock.mockResolvedValue(response(200, SE_FIXTURE));
+    const r = await calendar({ country_code: "SE", year: 2026 });
+    expect(r.output.country_code).toBe("SE");
+    expect(r.output.year).toBe(2026);
+    expect(r.output.total_holidays).toBe(1);
+    expect(r.output.holidays[0]).toEqual({
+      date: "2026-06-06",
+      name: "National Day of Sweden",
+      local_name: "Sveriges nationaldag",
+      type: "Public",
+      fixed: true,
+      global: true,
+      counties: null,
+    });
+    expect(r.provenance.source).toBe("nager.date");
+  });
+});
+
+describe("public-holiday-lookup (shares getHolidays)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("204 No Content yields the 'not covered' error instead of the pre-fix parse crash", async () => {
+    fetchMock.mockResolvedValue(response(204, ""));
+    await expect(lookup({ country_code: "LA", year: 2026 })).rejects.toThrow(
+      /Country 'LA' is not covered/
+    );
+  });
+
+  it("a 200 with holiday data still returns the documented output shape", async () => {
+    fetchMock.mockResolvedValue(response(200, SE_FIXTURE));
+    const r = await lookup({ country_code: "SE", year: 2027 });
+    expect(r.output.country_code).toBe("SE");
+    expect(r.output.total_holidays).toBe(1);
+    expect(r.output.holidays[0]).toEqual({
+      date: "2026-06-06",
+      name: "National Day of Sweden",
+      local_name: "Sveriges nationaldag",
+      type: "Public",
+      fixed: true,
+      global: true,
+    });
+    expect(r.output).toHaveProperty("next_upcoming");
+    expect(r.provenance.source).toBe("date.nager.at");
+  });
+});

--- a/apps/api/src/capabilities/holiday-calendar.ts
+++ b/apps/api/src/capabilities/holiday-calendar.ts
@@ -3,14 +3,27 @@ import { registerCapability, type CapabilityInput } from "./index.js";
 // Nager.Date API — free, no key needed
 const NAGER_API = "https://date.nager.at/api/v3";
 
-// Cache holidays per country+year (holidays don't change mid-year)
-const holidayCache = new Map<string, { data: any[]; cachedAt: number }>();
+// Cache holidays per country+year (holidays don't change mid-year).
+// `data: null` negative-caches a country Nager.Date has no data for, so
+// agents retry-looping on an uncovered country don't re-hit upstream.
+const holidayCache = new Map<string, { data: any[] | null; cachedAt: number }>();
 const CACHE_TTL = 24 * 60 * 60 * 1000; // 24h
+
+// Wording is deliberately distinct from the 404 branch's "not supported":
+// 404 = the code isn't a recognized ISO country (fix your input);
+// "not covered" = real country, but Nager.Date has no data for it.
+function notCoveredError(countryCode: string): Error {
+  return new Error(
+    `Country '${countryCode}' is not covered by the Nager.Date holiday data source. ` +
+    `Covered countries: https://date.nager.at/api/v3/AvailableCountries`
+  );
+}
 
 export async function getHolidays(countryCode: string, year: number): Promise<any[]> {
   const key = `${countryCode}-${year}`;
   const cached = holidayCache.get(key);
   if (cached && Date.now() - cached.cachedAt < CACHE_TTL) {
+    if (cached.data === null) throw notCoveredError(countryCode);
     return cached.data;
   }
 
@@ -27,7 +40,24 @@ export async function getHolidays(countryCode: string, year: number): Promise<an
     throw new Error(`Nager.Date API error: HTTP ${res.status}`);
   }
 
-  const data = (await res.json()) as any[];
+  // Nager.Date signals recognized-but-no-data with 204 No Content (res.ok
+  // true, empty body) — e.g. 'TH'. Parsing that body would throw
+  // "Unexpected end of JSON input". An empty 200 is NOT proof of
+  // non-coverage (could be a transient upstream glitch), so only a real 204
+  // is negative-cached; anything else unparseable errors uncached and the
+  // next call retries.
+  if (res.status === 204) {
+    holidayCache.set(key, { data: null, cachedAt: Date.now() });
+    throw notCoveredError(countryCode);
+  }
+
+  const text = await res.text();
+  let data: any[];
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error(`Nager.Date API returned an unparseable response for '${countryCode}'/${year}.`);
+  }
   holidayCache.set(key, { data, cachedAt: Date.now() });
   return data;
 }

--- a/apps/api/src/capabilities/public-holiday-lookup.ts
+++ b/apps/api/src/capabilities/public-holiday-lookup.ts
@@ -1,4 +1,5 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
+import { getHolidays } from "./holiday-calendar.js";
 
 // Public holiday lookup via Nager.Date API — free, no key required
 // https://date.nager.at/api/v3/PublicHolidays/{year}/{countryCode}
@@ -34,32 +35,16 @@ registerCapability("public-holiday-lookup", async (input: CapabilityInput) => {
     throw new Error("'year' must be a valid year between 1900 and 2100.");
   }
 
-  const url = `https://date.nager.at/api/v3/PublicHolidays/${year}/${countryCode}`;
-  const response = await fetch(url, {
-    headers: { Accept: "application/json" },
-    signal: AbortSignal.timeout(10000),
-  });
-
-  if (response.status === 404) {
-    throw new Error(
-      `No public holiday data found for country '${countryCode}' and year ${year}. Verify the country code is supported by Nager.Date API.`,
-    );
-  }
-  if (!response.ok) {
-    throw new Error(`Nager.Date API returned HTTP ${response.status}`);
-  }
-
-  const data = (await response.json()) as Array<{
+  // Shared Nager.Date integration — brings the 24h cache, the 204/empty-body
+  // "not covered" handling, and the JSON.parse guard along with it.
+  const data: Array<{
     date: string;
     localName: string;
     name: string;
-    countryCode: string;
     fixed: boolean;
     global: boolean;
-    counties: string[] | null;
-    launchYear: number | null;
     types: string[];
-  }>;
+  }> = await getHolidays(countryCode, year);
 
   // Format holidays
   const holidays = data.map((h) => ({

--- a/manifests/holiday-calendar.yaml
+++ b/manifests/holiday-calendar.yaml
@@ -1,8 +1,9 @@
 slug: holiday-calendar
 name: Holiday Calendar
 description: >-
-  Get public holidays for any country and year. Returns holiday names, dates, types
-  (public/bank/optional), and whether they are fixed or variable. Covers 100+ countries.
+  Get public holidays by country and year for the 200+ countries covered by
+  Nager.Date. Returns holiday names, dates, types (public/bank/optional), and
+  whether they are fixed or variable.
 category: data-extraction
 cost_class: free_unlimited
 quota_window: none
@@ -63,10 +64,14 @@ output_field_reliability:
   country_code: guaranteed
   year: guaranteed
 limitations:
-  - title: Coverage varies by country
-    text: Nager.Date covers 100+ countries but some smaller nations may not be supported
+  - title: Not all countries are covered
+    text: >-
+      Nager.Date covers 200+ countries but has notable gaps, including Thailand,
+      India, Malaysia, Pakistan, the UAE, and Saudi Arabia (verified 2026-08-20).
+      Uncovered countries return a structured "not covered" error. Machine-readable
+      coverage list: https://date.nager.at/api/v3/AvailableCountries
     category: coverage
-    severity: info
+    severity: warning
   - title: Regional/local holidays may not be included
     text: Only national/federal holidays included — regional and local holidays may be missing
     category: coverage

--- a/manifests/public-holiday-lookup.yaml
+++ b/manifests/public-holiday-lookup.yaml
@@ -3,7 +3,7 @@
 
 slug: public-holiday-lookup
 name: Public Holiday Lookup
-description: Get public holidays for any country and year. Uses Nager.Date API. Returns holiday dates, names, and next upcoming.
+description: Get public holidays by country and year for the 200+ countries covered by Nager.Date. Returns holiday dates, names, and next upcoming.
 category: data-extraction
 cost_class: free_unlimited
 quota_window: none
@@ -174,3 +174,11 @@ limitations:
     category: coverage
     severity: info
     workaround: For regional holidays (e.g., German Bundesländer), check the specific state's official holiday calendar
+  - title: Not all countries are covered
+    text: >-
+      Nager.Date covers 200+ countries but has notable gaps, including Thailand,
+      India, Malaysia, Pakistan, the UAE, and Saudi Arabia (verified 2026-08-20).
+      Uncovered countries return a structured "not covered" error. Machine-readable
+      coverage list: https://date.nager.at/api/v3/AvailableCountries
+    category: coverage
+    severity: warning


### PR DESCRIPTION
## Summary
- Nager.Date returns **204 No Content** (empty body, `res.ok` true) for countries it has no holiday data for. `holiday-calendar` and `public-holiday-lookup` both called `res.json()` on it and crashed with a raw `Unexpected end of JSON input` — all 3 external x402 calls for Thailand in the 2026-08-19→20 window failed this way.
- `getHolidays()` now throws a structured "not covered" error citing Nager's machine-readable coverage endpoint, negative-cached 24h (only on a true 204; empty/unparseable 200s error uncached so transient glitches retry). `public-holiday-lookup`'s duplicate raw Nager fetch — same latent crash — now routes through the shared `getHolidays()`.
- Manifests claimed "any country" coverage; both now state verified coverage (200+ countries, gaps include TH, IN, MY, PK, AE, SA — verified against `AvailableCountries` 2026-08-20) with a `warning`-severity limitation.

## Verification
- `npx tsc --noEmit --project tsconfig.json` — clean
- `vitest run holiday-calendar.test.ts` — 7/7 pass; regression tests verified **fail-before/pass-after** against the pre-fix executor (3 fail on old code)
- `smoke-test.ts` — ✅ both slugs; `validate-capability.ts` — pass (holiday-calendar has one pre-existing ✗: `dataClassification` null, untouched by this PR)
- `checkReadiness` — `ready: true`, zero issues, both slugs
- Live local run: TH → structured "not covered" error; SE → 16 holidays

## Reviewer findings (technical + product passes)
- **MEDIUM (technical, addressed):** empty-200 was initially negative-cached like a 204 — a transient upstream glitch could have poisoned a covered country for 24h across all three consumers (incl. business-day-check). Now only a true 204 is negative-cached.
- **MEDIUM (technical, flagged — no code change):** the "not covered" refusal counts as a *failure* under the armed quality floor because the failure taxonomy has no refusal category (known gap). This PR doesn't worsen metrics (crash-failure → refusal-failure, same count), but if uncovered-country traffic grows, these capabilities could drift toward quarantine for behaving correctly. The eventual taxonomy fix should pick these up.
- **MEDIUM (product, addressed):** manifests promised "any country" — a paying agent couldn't have known TH was uncovered. Fixed in both YAMLs.
- **LOW (addressed):** error now cites the machine-readable `AvailableCountries` API instead of an HTML page; comment documents the deliberate 404 "not supported" vs 204 "not covered" wording split.
- Pre-existing, out of scope: `business-day-check` silently degrades to weekend-only when holiday data is unavailable; `public-holiday-lookup` interpolates non-2-letter input into the URL path (fixed host, bounded impact).

## Deploy notes (DEC-20260504-C)
- No deploy-pipeline dependency: pure request-handler code on the auto-register import graph. Post-deploy verification = prod call for TH must return the structured "not covered" error.
- Manifest description/limitation text lives in the DB and has **no boot-time sync** — `sync-manifest-text-to-db.ts` must run post-deploy with write credentials, or the catalog keeps the old "any country" text.

## Test plan
- Merge, wait for Railway deploy (`GET /health` shows commit SHA)
- Call `holiday-calendar` with `{"country_code":"TH","year":2026}` on prod → expect structured "not covered" error, not a JSON parse crash
- Call with `{"country_code":"SE","year":2026}` → expect 16 holidays

🤖 Generated with [Claude Code](https://claude.com/claude-code)