### PR TITLE
Remediation WP3: durable wallet reservations and a crash reconciler

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -980,3 +980,76 @@ export const discoveryHits = pgTable(
     index("discovery_hits_src_tag_idx").on(table.srcTag).where(sql`src_tag IS NOT NULL`),
   ],
 );
+
+// ─── wallet_reservations (WP3) ──────────────────────────────────────────────
+//
+// The durable record that makes a charge recoverable after a crash.
+//
+// The async /v1/do path debits, commits, answers 202, then executes in an
+// in-memory promise whose catch block holds the only refund. A SIGKILL between
+// the commit and that catch — an OOM, a container replacement — strands the
+// charge: the customer stays debited, the transaction stays 'executing', and
+// nothing in the codebase ever transitions it. Production is holding 11 such
+// rows, the oldest from 2026-04-07.
+//
+// A row here is the intent, written in the SAME transaction as the debit. It
+// outlives the process, so a reconciler can find what the crash abandoned and
+// release it. The money movement itself is unchanged and still flows through
+// the wallet service (WP2) — this table records WHY it moved and whether that
+// movement is still provisional.
+//
+// State machine, one terminal state per reservation:
+//
+//     reserved ──▶ executing ──▶ captured
+//          ╰────────────┴──────▶ released
+//
+// Transitions are conditional UPDATEs predicated on the expected current
+// state, so a duplicate capture or release is a no-op rather than a second
+// money movement — the idempotency the master plan asks for, enforced by the
+// database rather than by callers remembering.
+export const walletReservations = pgTable(
+  "wallet_reservations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    walletId: uuid("wallet_id")
+      .notNull()
+      .references(() => wallets.id),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id),
+    /** Always positive. The direction is implied by the state. */
+    amountCents: integer("amount_cents").notNull(),
+    /** reserved | executing | captured | released */
+    state: varchar("state", { length: 16 }).notNull().default("reserved"),
+    /** The execution this reservation is holding funds for. */
+    transactionId: uuid("transaction_id"),
+    /**
+     * When this reservation stops being plausibly in-flight. The reconciler
+     * releases anything still non-terminal past it. Stored rather than derived
+     * so a long-running capability can be given a longer window without
+     * changing the reconciler.
+     */
+    deadlineAt: timestamp("deadline_at", { withTimezone: true }).notNull(),
+    /** Why it reached its terminal state — set on capture and release. */
+    terminalReason: text("terminal_reason"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // The reconciler's only query: non-terminal rows past their deadline.
+    index("wallet_reservations_state_deadline_idx").on(
+      table.state,
+      table.deadlineAt,
+    ),
+    index("wallet_reservations_wallet_id_idx").on(table.walletId),
+    // One reservation per execution. Without this a retry could open a second
+    // hold against the same transaction and the reconciler would release both.
+    uniqueIndex("wallet_reservations_transaction_id_unique")
+      .on(table.transactionId)
+      .where(sql`transaction_id IS NOT NULL`),
+  ],
+);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -176,6 +176,15 @@ async function main() {
   // since April, and draining a long-silent backlog in one burst is what took
   // Postgres down on 2026-05-04 (DEC-20260504-B).
   const { startReservationReconciler } = await import("./jobs/reservation-reconciler.js");
+  const { assertReservationTtlExceedsExecutionTimeout } = await import(
+    "./lib/wallet-reservations.js"
+  );
+  // Fail loudly at boot rather than silently refunding live executions: the
+  // executor's hard timeout is env-tunable, and if it is raised above the
+  // reservation TTL the reconciler starts releasing work that is still running.
+  assertReservationTtlExceedsExecutionTimeout(
+    parseInt(process.env.EXEC_HARD_TIMEOUT_MS ?? "300000", 10),
+  );
   startReservationReconciler();
 
   // Monthly REINDEX CONCURRENTLY on `transactions` — prevents B-tree

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -170,6 +170,14 @@ async function main() {
   const { startIntegrityHashRetry } = await import("./jobs/integrity-hash-retry.js");
   startIntegrityHashRetry();
 
+  // WP3: releases wallet reservations a crash abandoned, and marks their
+  // executions failed so a polling client reaches a terminal state. Bounded
+  // per tick — its first production run has a backlog of 11 rows stranded
+  // since April, and draining a long-silent backlog in one burst is what took
+  // Postgres down on 2026-05-04 (DEC-20260504-B).
+  const { startReservationReconciler } = await import("./jobs/reservation-reconciler.js");
+  startReservationReconciler();
+
   // Monthly REINDEX CONCURRENTLY on `transactions` — prevents B-tree
   // bloat drift that caused the 2026-04-16 outage. Uses the dedicated-
   // connection advisory-lock pattern because REINDEX CONCURRENTLY can't

--- a/apps/api/src/jobs/reservation-reconciler.ts
+++ b/apps/api/src/jobs/reservation-reconciler.ts
@@ -1,0 +1,138 @@
+/**
+ * Recovers wallet reservations a crash abandoned (WP3, risks CR-01 / N1).
+ *
+ * Without this job the reservation table is just bookkeeping. This is the part
+ * that makes a stranded charge recoverable: it finds reservations that are
+ * still non-terminal past their deadline, releases them, and marks the
+ * execution failed so a polling client finally sees a terminal state.
+ *
+ * Two properties make it safe to run against a live system:
+ *
+ *   - Release is a conditional UPDATE that claims the row before crediting.
+ *     A live execution finishing at the same moment either wins and captures,
+ *     or loses and finds nothing to capture. Exactly one terminal state per
+ *     reservation, no double refund.
+ *   - The deadline is generous (15 minutes by default). Releasing a still-
+ *     running execution would refund a customer about to receive their result,
+ *     which is worse than waiting.
+ *
+ * Cadence and batching follow DEC-20260504-B, the bulk-operation deploy
+ * protocol. This job's very first run in production has a backlog: 11
+ * transactions have been stranded since as far back as 2026-04-07. A job that
+ * drained them all in one tick would be exactly the workload-resumption event
+ * that took Postgres down on 2026-05-04. So each tick is bounded, and the
+ * backlog drains over several minutes instead.
+ */
+
+import { and, eq, inArray } from "drizzle-orm";
+
+import { getDb } from "../db/index.js";
+import { transactions } from "../db/schema.js";
+import * as reservations from "../lib/wallet-reservations.js";
+import { log, logError } from "../lib/log.js";
+
+/** Bounded per tick — see the DEC-20260504-B note above. */
+const BATCH_SIZE = 25;
+
+const TICK_INTERVAL_MS = 60_000;
+const STARTUP_DELAY_MS = 45_000;
+
+export interface ReconcileSummary {
+  examined: number;
+  released: number;
+  alreadyTerminal: number;
+  failed: number;
+}
+
+/**
+ * One pass. Exported so tests can drive it deterministically rather than
+ * waiting on an interval — the mistake that left the rest of this codebase's
+ * jobs unexercised.
+ */
+export async function runReservationReconcilerOnce(): Promise<ReconcileSummary> {
+  const db = getDb();
+  const summary: ReconcileSummary = {
+    examined: 0,
+    released: 0,
+    alreadyTerminal: 0,
+    failed: 0,
+  };
+
+  const abandoned = await reservations.findAbandoned(db, BATCH_SIZE);
+  summary.examined = abandoned.length;
+  if (abandoned.length === 0) return summary;
+
+  for (const row of abandoned) {
+    try {
+      // One transaction per reservation, not one for the batch: a single
+      // poisoned row must not roll back the recoveries that already
+      // succeeded, and holding one transaction across 25 wallets would
+      // serialise unrelated customers behind each other.
+      const released = await db.transaction(async (tx) => {
+        const didRelease = await reservations.release(tx, {
+          reservationId: row.id,
+          reason: "abandoned — execution never reached a terminal state",
+        });
+
+        // Only the winner touches the execution row. A capture that beat us
+        // means the execution succeeded after all, and overwriting its status
+        // would report a completed call as failed.
+        if (didRelease && row.transactionId) {
+          await tx
+            .update(transactions)
+            .set({
+              status: "failed",
+              error:
+                "Execution did not complete — the charge was refunded automatically.",
+              completedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(transactions.id, row.transactionId),
+                // Guard the status too: a row that reached 'completed' between
+                // the reservation lookup and here must not be rewritten.
+                inArray(transactions.status, ["executing", "deferred"]),
+              ),
+            );
+        }
+
+        return didRelease;
+      });
+
+      if (released) summary.released += 1;
+      else summary.alreadyTerminal += 1;
+    } catch (err) {
+      summary.failed += 1;
+      logError("reservation-reconcile-failed", err, {
+        reservation_id: row.id,
+        transaction_id: row.transactionId,
+      });
+    }
+  }
+
+  log.info(
+    {
+      label: "reservation-reconcile",
+      examined: summary.examined,
+      released: summary.released,
+      already_terminal: summary.alreadyTerminal,
+      failed: summary.failed,
+    },
+    "reservation-reconcile",
+  );
+
+  return summary;
+}
+
+export function startReservationReconciler(): void {
+  setTimeout(() => {
+    void runReservationReconcilerOnce().catch((err) =>
+      logError("reservation-reconcile-tick-failed", err),
+    );
+    setInterval(() => {
+      void runReservationReconcilerOnce().catch((err) =>
+        logError("reservation-reconcile-tick-failed", err),
+      );
+    }, TICK_INTERVAL_MS);
+  }, STARTUP_DELAY_MS);
+}

--- a/apps/api/src/jobs/reservation-reconciler.ts
+++ b/apps/api/src/jobs/reservation-reconciler.ts
@@ -24,15 +24,28 @@
  * backlog drains over several minutes instead.
  */
 
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { getDb } from "../db/index.js";
 import { transactions } from "../db/schema.js";
 import * as reservations from "../lib/wallet-reservations.js";
-import { log, logError } from "../lib/log.js";
+import { log, logError, logWarn } from "../lib/log.js";
 
 /** Bounded per tick — see the DEC-20260504-B note above. */
 const BATCH_SIZE = 25;
+
+/**
+ * Cross-replica dedup, matching every other recurring job in index.ts
+ * (activation-drip, db-retention, capability-promotion, integrity-hash-retry).
+ *
+ * Without it the per-tick bound is per-INSTANCE, so N replicas make it N x 25
+ * — which is exactly the quantity the DEC-20260504-B argument above depends
+ * on. Every replica would also do N-1 wasted transactions per row, each
+ * blocking on the same reservation row lock. Money safety never depended on
+ * this (the conditional transitions handle concurrency), but the batching
+ * claim did.
+ */
+const ADVISORY_LOCK_ID = 20260821;
 
 const TICK_INTERVAL_MS = 60_000;
 const STARTUP_DELAY_MS = 45_000;
@@ -40,6 +53,8 @@ const STARTUP_DELAY_MS = 45_000;
 export interface ReconcileSummary {
   examined: number;
   released: number;
+  /** Refunded, but the execution row was already outside the guarded states. */
+  releasedButNotMarked: number;
   alreadyTerminal: number;
   failed: number;
 }
@@ -54,11 +69,29 @@ export async function runReservationReconcilerOnce(): Promise<ReconcileSummary> 
   const summary: ReconcileSummary = {
     examined: 0,
     released: 0,
+    releasedButNotMarked: 0,
     alreadyTerminal: 0,
     failed: 0,
   };
 
-  const abandoned = await reservations.findAbandoned(db, BATCH_SIZE);
+  // Take the cross-replica lock for the duration of the batch selection. It is
+  // transaction-scoped, so it releases when this short transaction commits —
+  // the per-reservation work below then runs in its own transactions, which is
+  // what keeps one poisoned row from rolling back the recoveries around it.
+  const claimed = await db.transaction(async (tx) => {
+    const [lock] = (await tx.execute(
+      sql`SELECT pg_try_advisory_xact_lock(${ADVISORY_LOCK_ID}) AS acquired`,
+    )) as unknown as Array<{ acquired?: boolean }>;
+    if (!lock?.acquired) return null;
+    return reservations.findAbandoned(tx, BATCH_SIZE);
+  });
+
+  if (claimed === null) {
+    // Another replica is on this tick. Not an error.
+    return summary;
+  }
+
+  const abandoned = claimed;
   summary.examined = abandoned.length;
   if (abandoned.length === 0) return summary;
 
@@ -68,17 +101,23 @@ export async function runReservationReconcilerOnce(): Promise<ReconcileSummary> 
       // poisoned row must not roll back the recoveries that already
       // succeeded, and holding one transaction across 25 wallets would
       // serialise unrelated customers behind each other.
-      const released = await db.transaction(async (tx) => {
-        const didRelease = await reservations.release(tx, {
-          reservationId: row.id,
-          reason: "abandoned — execution never reached a terminal state",
-        });
-
-        // Only the winner touches the execution row. A capture that beat us
-        // means the execution succeeded after all, and overwriting its status
-        // would report a completed call as failed.
-        if (didRelease && row.transactionId) {
-          await tx
+      const outcome = await db.transaction(async (tx) => {
+        // Lock ordering: `transactions` FIRST, then `wallet_reservations`.
+        //
+        // The success path in do.ts updates the transaction row and then
+        // captures, so taking the two row locks in the opposite order here
+        // would be a textbook ABBA deadlock. Postgres would abort one side;
+        // if it chose the execution, a call that SUCCEEDED would be recorded
+        // as failed and its output discarded. Same order on both sides makes
+        // that impossible rather than merely unlikely.
+        //
+        // Claiming the transaction row first is safe because the status guard
+        // means a run that already completed matches nothing, and the release
+        // below is still conditional — if the execution captured in the
+        // meantime, no money moves.
+        let transactionMarked = false;
+        if (row.transactionId) {
+          const marked = await tx
             .update(transactions)
             .set({
               status: "failed",
@@ -89,18 +128,41 @@ export async function runReservationReconcilerOnce(): Promise<ReconcileSummary> 
             .where(
               and(
                 eq(transactions.id, row.transactionId),
-                // Guard the status too: a row that reached 'completed' between
-                // the reservation lookup and here must not be rewritten.
+                // A row that reached 'completed' between the reservation
+                // lookup and here must not be rewritten.
                 inArray(transactions.status, ["executing", "deferred"]),
               ),
-            );
+            )
+            .returning({ id: transactions.id });
+          transactionMarked = marked.length > 0;
         }
 
-        return didRelease;
+        const didRelease = await reservations.release(tx, {
+          reservationId: row.id,
+          reason: "abandoned — execution never reached a terminal state",
+        });
+
+        return { didRelease, transactionMarked };
       });
 
-      if (released) summary.released += 1;
-      else summary.alreadyTerminal += 1;
+      if (!outcome.didRelease) {
+        summary.alreadyTerminal += 1;
+      } else if (row.transactionId && !outcome.transactionMarked) {
+        // Refunded, but the execution row stayed non-terminal — it was
+        // already outside the guarded statuses. The reservation is terminal
+        // now, so findAbandoned will never return it again and nothing else
+        // will ever look at it. Counting this as a clean recovery is the
+        // swallow-visibility failure DEC-20260504-A exists to prevent, so it
+        // gets its own counter and a warning.
+        summary.releasedButNotMarked += 1;
+        logWarn(
+          "reservation-released-transaction-not-marked",
+          "released a reservation whose transaction was outside the guarded statuses",
+          { reservation_id: row.id, transaction_id: row.transactionId },
+        );
+      } else {
+        summary.released += 1;
+      }
     } catch (err) {
       summary.failed += 1;
       logError("reservation-reconcile-failed", err, {
@@ -115,6 +177,7 @@ export async function runReservationReconcilerOnce(): Promise<ReconcileSummary> 
       label: "reservation-reconcile",
       examined: summary.examined,
       released: summary.released,
+      released_but_not_marked: summary.releasedButNotMarked,
       already_terminal: summary.alreadyTerminal,
       failed: summary.failed,
     },

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1236,7 +1236,7 @@ describe("startup-migrations — block 0087 (un-hide content-redacted rows)", ()
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 37 blocks in historical order", () => {
+  it("exports the expected 38 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1280,6 +1280,8 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0092_x402GrowthBundles",
       "runMigration0093_fixtureRecaptureFailures",
       "runMigration0094_clearChurnInvalidatedBaselines",
+      // WP3: wallet_reservations table + the non-negative balance constraint.
+      "runMigration0095_walletReservations",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1568,97 +1568,111 @@ export async function runMigration0080_cyDirectors(
 // Two changes, both additive and both reversible by dropping what they create.
 //
 // 1. `wallet_reservations` — the durable record that makes a charge
-//    recoverable after a crash. See the table comment in db/schema.ts for why
-//    it exists; in short, the async /v1/do path's only refund lives in an
-//    in-memory catch block, so a SIGKILL strands the charge with nothing to
-//    recover it. Production is holding 11 such rows.
+//    recoverable after a crash. See the table comment in db/schema.ts.
 //
-// 2. A CHECK constraint pinning balances at or above zero. Codex asked for
-//    this during WP2 as the final backstop under the application-level
-//    affordability check: the conditional UPDATE cannot overdraw, but a
-//    constraint means no future path can either, including one that bypasses
-//    the service entirely.
+// 2. CHECK (balance_cents >= 0) — the backstop under the application-level
+//    affordability check, so no future path can overdraw even if it bypasses
+//    the wallet service entirely.
 //
-//    Verified against production read-only before writing this: 59 wallets,
-//    none negative, lowest balance 0. So the constraint cannot fail validation
-//    on existing rows — which matters, because a failing constraint here would
-//    throw inside startup migrations and crash-loop the deploy (the
-//    boot-blocking-gate hazard).
+// SHAPE NOTES, both learned the hard way in review:
+//
+//   Every statement is independently idempotent — IF NOT EXISTS on the table
+//   and on each index, and an exception-guarded ADD CONSTRAINT. The first
+//   draft used check-then-bare-DDL, which is the TOCTOU shape block 0093's
+//   comment (a few hundred lines below) documents as already having broken a
+//   deploy: two overlapping boots both read "absent", both issue the bare
+//   statement, the loser throws, and `runStartupMigrations` aborts boot on any
+//   throw. Railway runs old and new instances together during a rolling
+//   deploy, so overlapping boots are the normal case, not the edge.
+//
+//   The indexes are created unconditionally rather than inside a
+//   "table was absent" branch. The runner has no transaction wrapper, so each
+//   statement commits on its own: a kill between CREATE TABLE and the index
+//   builds would otherwise leave the table permanently without
+//   `wallet_reservations_transaction_id_unique`, which is the only thing
+//   stopping a retry opening a second hold on one execution. A missing guard
+//   that no gate would ever notice is worse than a failed migration.
+//
+//   The constraint is added NOT VALID and validated separately. ADD CONSTRAINT
+//   with validation takes ACCESS EXCLUSIVE on `wallets` for the length of a
+//   full table scan, and the sync /v1/do path holds a FOR UPDATE row lock on
+//   that table across an external HTTP call — so the ALTER can queue behind a
+//   live request and, while queued, block every other `wallets` query behind
+//   it. NOT VALID skips the scan and takes the lock only briefly; VALIDATE
+//   then takes just SHARE UPDATE EXCLUSIVE. Production was verified read-only
+//   (59 wallets, none negative), so validation cannot fail on existing rows —
+//   but that only ever addressed row content, never lock acquisition.
+//
+//   Finally, constraint work is failure-tolerant: if it cannot be applied on
+//   this boot it is logged and retried on the next one rather than thrown.
+//   The table is what the running code needs; a deferred constraint costs
+//   nothing, whereas a throw here aborts boot, and per MEMORY a failed Railway
+//   deploy does not cut over — /health would silently keep serving the old
+//   commit.
 export async function runMigration0095_walletReservations(
   tx: MigrationExecutor,
 ): Promise<BlockResult> {
   const startedAt = Date.now();
 
-  const tableCheck = await tx.execute(sql`
-    SELECT to_regclass('public.wallet_reservations') IS NOT NULL AS present
+  await tx.execute(sql`
+    CREATE TABLE IF NOT EXISTS "wallet_reservations" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+      "wallet_id" uuid NOT NULL REFERENCES "wallets"("id"),
+      "user_id" uuid NOT NULL REFERENCES "users"("id"),
+      "amount_cents" integer NOT NULL,
+      "state" varchar(16) DEFAULT 'reserved' NOT NULL,
+      "transaction_id" uuid,
+      "deadline_at" timestamptz NOT NULL,
+      "terminal_reason" text,
+      "created_at" timestamptz DEFAULT now() NOT NULL,
+      "updated_at" timestamptz DEFAULT now() NOT NULL
+    )
   `);
-  const tableRows = Array.isArray(tableCheck)
-    ? tableCheck
-    : (tableCheck as { rows?: unknown[] })?.rows ?? [];
-  const tableExists = (tableRows[0] as { present?: boolean })?.present === true;
 
-  if (!tableExists) {
-    await tx.execute(sql`
-      CREATE TABLE "wallet_reservations" (
-        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-        "wallet_id" uuid NOT NULL REFERENCES "wallets"("id"),
-        "user_id" uuid NOT NULL REFERENCES "users"("id"),
-        "amount_cents" integer NOT NULL,
-        "state" varchar(16) DEFAULT 'reserved' NOT NULL,
-        "transaction_id" uuid,
-        "deadline_at" timestamptz NOT NULL,
-        "terminal_reason" text,
-        "created_at" timestamptz DEFAULT now() NOT NULL,
-        "updated_at" timestamptz DEFAULT now() NOT NULL
-      )
-    `);
-    // The reconciler's only query shape.
-    await tx.execute(sql`
-      CREATE INDEX "wallet_reservations_state_deadline_idx"
-        ON "wallet_reservations" ("state", "deadline_at")
-    `);
-    await tx.execute(sql`
-      CREATE INDEX "wallet_reservations_wallet_id_idx"
-        ON "wallet_reservations" ("wallet_id")
-    `);
-    // One reservation per execution — without it a retry could open a second
-    // hold against the same transaction and the reconciler would release both.
-    await tx.execute(sql`
-      CREATE UNIQUE INDEX "wallet_reservations_transaction_id_unique"
-        ON "wallet_reservations" ("transaction_id")
-        WHERE "transaction_id" IS NOT NULL
-    `);
-  }
-
-  const constraintCheck = await tx.execute(sql`
-    SELECT count(*)::text AS cnt FROM pg_constraint
-    WHERE conname = 'wallets_balance_cents_non_negative'
+  // Unconditional and individually idempotent — see the shape note above.
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS "wallet_reservations_state_deadline_idx"
+      ON "wallet_reservations" ("state", "deadline_at")
   `);
-  const constraintRows = Array.isArray(constraintCheck)
-    ? constraintCheck
-    : (constraintCheck as { rows?: unknown[] })?.rows ?? [];
-  const constraintExists =
-    (constraintRows[0] as { cnt?: string })?.cnt !== "0";
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS "wallet_reservations_wallet_id_idx"
+      ON "wallet_reservations" ("wallet_id")
+  `);
+  await tx.execute(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS "wallet_reservations_transaction_id_unique"
+      ON "wallet_reservations" ("transaction_id")
+      WHERE "transaction_id" IS NOT NULL
+  `);
 
-  if (!constraintExists) {
+  let constraintOutcome: string;
+  try {
+    // duplicate_object is the only expected failure and means a concurrent
+    // boot won; anything else propagates to the catch below and defers.
+    await tx.execute(sql`
+      DO $$
+      BEGIN
+        ALTER TABLE "wallets"
+          ADD CONSTRAINT "wallets_balance_cents_non_negative"
+          CHECK ("balance_cents" >= 0) NOT VALID;
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$
+    `);
+    // Cheap lock, and a no-op if already validated.
     await tx.execute(sql`
       ALTER TABLE "wallets"
-        ADD CONSTRAINT "wallets_balance_cents_non_negative"
-        CHECK ("balance_cents" >= 0)
+        VALIDATE CONSTRAINT "wallets_balance_cents_non_negative"
     `);
+    constraintOutcome = "constraint present and validated";
+  } catch (err) {
+    // Deliberately not rethrown — see the failure-tolerance note above.
+    constraintOutcome = `constraint deferred to a later boot (${
+      err instanceof Error ? err.message : "unknown error"
+    })`;
   }
-
-  const created = [
-    tableExists ? null : "wallet_reservations",
-    constraintExists ? null : "wallets_balance_cents_non_negative",
-  ].filter(Boolean);
 
   return {
     block: "0095_wallet_reservations",
-    outcome:
-      created.length === 0
-        ? "skipped (table and constraint already present)"
-        : `created ${created.join(" + ")}`,
+    outcome: `wallet_reservations ensured; ${constraintOutcome}`,
     duration_ms: Date.now() - startedAt,
   };
 }

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1563,6 +1563,106 @@ export async function runMigration0080_cyDirectors(
  * Exported so the admin endpoint regression test can introspect the
  * canonical block list and assert it matches what the endpoint returns.
  */
+// ─── Block 0095: wallet reservations + non-negative balance (WP3) ───────────
+//
+// Two changes, both additive and both reversible by dropping what they create.
+//
+// 1. `wallet_reservations` — the durable record that makes a charge
+//    recoverable after a crash. See the table comment in db/schema.ts for why
+//    it exists; in short, the async /v1/do path's only refund lives in an
+//    in-memory catch block, so a SIGKILL strands the charge with nothing to
+//    recover it. Production is holding 11 such rows.
+//
+// 2. A CHECK constraint pinning balances at or above zero. Codex asked for
+//    this during WP2 as the final backstop under the application-level
+//    affordability check: the conditional UPDATE cannot overdraw, but a
+//    constraint means no future path can either, including one that bypasses
+//    the service entirely.
+//
+//    Verified against production read-only before writing this: 59 wallets,
+//    none negative, lowest balance 0. So the constraint cannot fail validation
+//    on existing rows — which matters, because a failing constraint here would
+//    throw inside startup migrations and crash-loop the deploy (the
+//    boot-blocking-gate hazard).
+export async function runMigration0095_walletReservations(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  const tableCheck = await tx.execute(sql`
+    SELECT to_regclass('public.wallet_reservations') IS NOT NULL AS present
+  `);
+  const tableRows = Array.isArray(tableCheck)
+    ? tableCheck
+    : (tableCheck as { rows?: unknown[] })?.rows ?? [];
+  const tableExists = (tableRows[0] as { present?: boolean })?.present === true;
+
+  if (!tableExists) {
+    await tx.execute(sql`
+      CREATE TABLE "wallet_reservations" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+        "wallet_id" uuid NOT NULL REFERENCES "wallets"("id"),
+        "user_id" uuid NOT NULL REFERENCES "users"("id"),
+        "amount_cents" integer NOT NULL,
+        "state" varchar(16) DEFAULT 'reserved' NOT NULL,
+        "transaction_id" uuid,
+        "deadline_at" timestamptz NOT NULL,
+        "terminal_reason" text,
+        "created_at" timestamptz DEFAULT now() NOT NULL,
+        "updated_at" timestamptz DEFAULT now() NOT NULL
+      )
+    `);
+    // The reconciler's only query shape.
+    await tx.execute(sql`
+      CREATE INDEX "wallet_reservations_state_deadline_idx"
+        ON "wallet_reservations" ("state", "deadline_at")
+    `);
+    await tx.execute(sql`
+      CREATE INDEX "wallet_reservations_wallet_id_idx"
+        ON "wallet_reservations" ("wallet_id")
+    `);
+    // One reservation per execution — without it a retry could open a second
+    // hold against the same transaction and the reconciler would release both.
+    await tx.execute(sql`
+      CREATE UNIQUE INDEX "wallet_reservations_transaction_id_unique"
+        ON "wallet_reservations" ("transaction_id")
+        WHERE "transaction_id" IS NOT NULL
+    `);
+  }
+
+  const constraintCheck = await tx.execute(sql`
+    SELECT count(*)::text AS cnt FROM pg_constraint
+    WHERE conname = 'wallets_balance_cents_non_negative'
+  `);
+  const constraintRows = Array.isArray(constraintCheck)
+    ? constraintCheck
+    : (constraintCheck as { rows?: unknown[] })?.rows ?? [];
+  const constraintExists =
+    (constraintRows[0] as { cnt?: string })?.cnt !== "0";
+
+  if (!constraintExists) {
+    await tx.execute(sql`
+      ALTER TABLE "wallets"
+        ADD CONSTRAINT "wallets_balance_cents_non_negative"
+        CHECK ("balance_cents" >= 0)
+    `);
+  }
+
+  const created = [
+    tableExists ? null : "wallet_reservations",
+    constraintExists ? null : "wallets_balance_cents_non_negative",
+  ].filter(Boolean);
+
+  return {
+    block: "0095_wallet_reservations",
+    outcome:
+      created.length === 0
+        ? "skipped (table and constraint already present)"
+        : `created ${created.join(" + ")}`,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResult>> = [
   runMigration0029_actualCostCents,
   runMigration0030_complianceColumns,
@@ -1601,6 +1701,8 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0092_x402GrowthBundles,
   runMigration0093_fixtureRecaptureFailures,
   runMigration0094_clearChurnInvalidatedBaselines,
+  // WP3: reservations table + non-negative balance constraint.
+  runMigration0095_walletReservations,
 ];
 
 /**

--- a/apps/api/src/lib/wallet-reservations.integration.test.ts
+++ b/apps/api/src/lib/wallet-reservations.integration.test.ts
@@ -1,0 +1,341 @@
+/**
+ * The reservation state machine against a real Postgres (WP3, CR-01 / N1).
+ *
+ * The master plan names four invariants for this package. Three of them are
+ * about what happens when two things try to settle the same reservation at
+ * once, which no mocked db module can show — the guarantee comes from a
+ * conditional UPDATE matching zero rows, and a mock will happily report
+ * whatever it was told to.
+ *
+ *   - one reservation reaches exactly one terminal state
+ *   - duplicate capture is idempotent
+ *   - duplicate release is idempotent
+ *   - a hard crash cannot strand customer funds indefinitely
+ *
+ * The fourth is covered end-to-end, with a real SIGKILL, in
+ * do.crash-recovery.integration.test.ts. This file covers the primitives that
+ * one relies on, plus the money invariant they exist to protect: the ledger
+ * always sums to the balance.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../test-support/integration-db.js";
+import {
+  users,
+  wallets,
+  walletTransactions,
+  walletReservations,
+  capabilities,
+  transactions,
+} from "../db/schema.js";
+import * as walletService from "./wallet-service.js";
+import * as reservations from "./wallet-reservations.js";
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+const STARTING_BALANCE = 1000;
+const AMOUNT = 250;
+
+describeMaybe("wallet reservations against a real database", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+
+  let userId = "";
+  let walletId = "";
+  let capabilityId = "";
+  let transactionId = "";
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 8 });
+    db = drizzle(client);
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  afterEach(async () => {
+    if (userId) {
+      await db
+        .delete(walletReservations)
+        .where(eq(walletReservations.userId, userId));
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+    }
+    if (walletId) {
+      await db
+        .delete(walletTransactions)
+        .where(eq(walletTransactions.walletId, walletId));
+      await db.delete(wallets).where(eq(wallets.id, walletId));
+    }
+    if (userId) await db.delete(users).where(eq(users.id, userId));
+    if (capabilityId)
+      await db.delete(capabilities).where(eq(capabilities.id, capabilityId));
+    userId = walletId = capabilityId = transactionId = "";
+  });
+
+  async function seed() {
+    userId = randomUUID();
+    capabilityId = randomUUID();
+
+    await db.insert(users).values({
+      id: userId,
+      email: `wp3-${userId}@example.test`,
+      apiKeyHash: `hash-${userId}`,
+      keyPrefix: "sk_live_wp3",
+    });
+    const wallet = await db.transaction((tx) =>
+      walletService.openWallet(tx, {
+        userId,
+        grantCents: STARTING_BALANCE,
+        type: "trial_credit",
+        description: "WP3 opening grant",
+      }),
+    );
+    walletId = wallet.id;
+
+    await db.insert(capabilities).values({
+      id: capabilityId,
+      slug: `wp3-${randomUUID().slice(0, 8)}`,
+      name: "WP3 reservation probe",
+      description: "Seeded by the WP3 reservation test.",
+      category: "developer-tools",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      priceCents: AMOUNT,
+    });
+
+    const [txn] = await db
+      .insert(transactions)
+      .values({
+        userId,
+        capabilityId,
+        status: "executing",
+        input: {},
+        priceCents: AMOUNT,
+        transparencyMarker: "algorithmic",
+        dataJurisdiction: "EU",
+      })
+      .returning({ id: transactions.id });
+    transactionId = txn!.id;
+  }
+
+  async function openReservation(ttlMs?: number) {
+    return db.transaction(async (tx) => {
+      const wallet = await walletService.lockWalletForUser(tx, userId);
+      return reservations.reserve(tx, {
+        wallet: wallet!,
+        userId,
+        amountCents: AMOUNT,
+        transactionId,
+        description: "WP3 reservation",
+        ttlMs,
+      });
+    });
+  }
+
+  async function balance(): Promise<number> {
+    const [row] = await db
+      .select({ balanceCents: wallets.balanceCents })
+      .from(wallets)
+      .where(eq(wallets.id, walletId))
+      .limit(1);
+    return row!.balanceCents;
+  }
+
+  async function ledgerSum(): Promise<number> {
+    const rows = await db
+      .select({ amountCents: walletTransactions.amountCents })
+      .from(walletTransactions)
+      .where(eq(walletTransactions.walletId, walletId));
+    return rows.reduce((sum, r) => sum + r.amountCents, 0);
+  }
+
+  async function stateOf(id: string): Promise<string> {
+    const [row] = await db
+      .select({ state: walletReservations.state })
+      .from(walletReservations)
+      .where(eq(walletReservations.id, id))
+      .limit(1);
+    return row!.state;
+  }
+
+  it("moves the money and records the hold in one step", async () => {
+    await seed();
+    const reservation = await openReservation();
+
+    expect(await balance()).toBe(STARTING_BALANCE - AMOUNT);
+    expect(await ledgerSum()).toBe(await balance());
+    expect(await stateOf(reservation.id)).toBe("reserved");
+  });
+
+  it("settles a capture without moving money again", async () => {
+    await seed();
+    const reservation = await openReservation();
+
+    const captured = await db.transaction((tx) =>
+      reservations.capture(tx, { reservationId: reservation.id }),
+    );
+
+    expect(captured).toBe(true);
+    expect(await stateOf(reservation.id)).toBe("captured");
+    // The debit happened at reserve time; capture only closes the record.
+    expect(await balance()).toBe(STARTING_BALANCE - AMOUNT);
+    expect(await ledgerSum()).toBe(await balance());
+  });
+
+  it("is idempotent under duplicate capture", async () => {
+    await seed();
+    const reservation = await openReservation();
+
+    expect(
+      await db.transaction((tx) =>
+        reservations.capture(tx, { reservationId: reservation.id }),
+      ),
+    ).toBe(true);
+    // The second caller matches no open row and is told so, rather than
+    // silently succeeding and inviting a second money movement.
+    expect(
+      await db.transaction((tx) =>
+        reservations.capture(tx, { reservationId: reservation.id }),
+      ),
+    ).toBe(false);
+
+    expect(await balance()).toBe(STARTING_BALANCE - AMOUNT);
+    expect(await ledgerSum()).toBe(await balance());
+  });
+
+  it("is idempotent under duplicate release", async () => {
+    await seed();
+    const reservation = await openReservation();
+
+    expect(
+      await db.transaction((tx) =>
+        reservations.release(tx, {
+          reservationId: reservation.id,
+          reason: "first",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      await db.transaction((tx) =>
+        reservations.release(tx, {
+          reservationId: reservation.id,
+          reason: "second",
+        }),
+      ),
+    ).toBe(false);
+
+    // Refunded exactly once. A second credit here is the double-refund the
+    // conditional transition exists to prevent.
+    expect(await balance()).toBe(STARTING_BALANCE);
+    expect(await ledgerSum()).toBe(await balance());
+    const refunds = await db
+      .select()
+      .from(walletTransactions)
+      .where(eq(walletTransactions.type, "refund"));
+    expect(refunds).toHaveLength(1);
+  });
+
+  it("reaches exactly one terminal state when capture and release race", async () => {
+    // The reconciler running against a live system that is finishing at the
+    // same moment. Whoever claims the row wins; the loser must be a no-op.
+    await seed();
+    const reservation = await openReservation();
+
+    const [captured, released] = await Promise.all([
+      db.transaction((tx) =>
+        reservations.capture(tx, { reservationId: reservation.id }),
+      ),
+      db.transaction((tx) =>
+        reservations.release(tx, {
+          reservationId: reservation.id,
+          reason: "reconciler",
+        }),
+      ),
+    ]);
+
+    // Exactly one of them applied.
+    expect([captured, released].filter(Boolean)).toHaveLength(1);
+
+    const finalState = await stateOf(reservation.id);
+    expect(["captured", "released"]).toContain(finalState);
+
+    // And the money agrees with whichever won.
+    const expected = released ? STARTING_BALANCE : STARTING_BALANCE - AMOUNT;
+    expect(await balance()).toBe(expected);
+    expect(await ledgerSum()).toBe(await balance());
+  });
+
+  it("finds only reservations past their deadline", async () => {
+    await seed();
+    // Long TTL: still plausibly in flight, so it must be left alone. Releasing
+    // a running execution refunds a customer about to get their result.
+    const fresh = await openReservation(10 * 60_000);
+
+    expect(await reservations.findAbandoned(db)).toHaveLength(0);
+
+    await db
+      .update(walletReservations)
+      .set({ deadlineAt: new Date(Date.now() - 1000) })
+      .where(eq(walletReservations.id, fresh.id));
+
+    const abandoned = await reservations.findAbandoned(db);
+    expect(abandoned).toHaveLength(1);
+    expect(abandoned[0]!.id).toBe(fresh.id);
+  });
+
+  it("stops looking once a reservation is terminal", async () => {
+    await seed();
+    const reservation = await openReservation();
+    await db
+      .update(walletReservations)
+      .set({ deadlineAt: new Date(Date.now() - 1000) })
+      .where(eq(walletReservations.id, reservation.id));
+
+    await db.transaction((tx) =>
+      reservations.capture(tx, { reservationId: reservation.id }),
+    );
+
+    // Past its deadline but settled — the reconciler must not revisit it.
+    expect(await reservations.findAbandoned(db)).toHaveLength(0);
+  });
+
+  it("refuses to reserve more than the wallet holds", async () => {
+    await seed();
+    await expect(
+      db.transaction(async (tx) => {
+        const wallet = await walletService.lockWalletForUser(tx, userId);
+        return reservations.reserve(tx, {
+          wallet: wallet!,
+          userId,
+          amountCents: STARTING_BALANCE + 1,
+          transactionId,
+          description: "overdraw",
+        });
+      }),
+    ).rejects.toThrow(walletService.InsufficientFundsError);
+
+    // No hold opened, no money moved.
+    expect(await balance()).toBe(STARTING_BALANCE);
+    expect(
+      await db
+        .select()
+        .from(walletReservations)
+        .where(eq(walletReservations.userId, userId)),
+    ).toHaveLength(0);
+  });
+
+  it("refuses a second reservation against the same execution", async () => {
+    // Without the unique index a retry could open a second hold on one
+    // transaction, and the reconciler would release both — refunding twice.
+    await seed();
+    await openReservation();
+    await expect(openReservation()).rejects.toThrow();
+  });
+});

--- a/apps/api/src/lib/wallet-reservations.ts
+++ b/apps/api/src/lib/wallet-reservations.ts
@@ -45,6 +45,27 @@ import type { WalletTx } from "./wallet-service.js";
  */
 export const DEFAULT_RESERVATION_TTL_MS = 15 * 60 * 1000;
 
+/**
+ * The TTL must exceed the executor's hard timeout, or the reconciler would
+ * refund executions that are still running and about to deliver a result.
+ * The two constants live in different modules and EXEC_HARD_TIMEOUT_MS is
+ * env-tunable, so the relationship is asserted rather than assumed — set it
+ * above the TTL on Railway and this fails at boot instead of silently
+ * refunding live work.
+ */
+export function assertReservationTtlExceedsExecutionTimeout(
+  execHardTimeoutMs: number,
+  ttlMs: number = DEFAULT_RESERVATION_TTL_MS,
+): void {
+  if (ttlMs <= execHardTimeoutMs) {
+    throw new Error(
+      `Reservation TTL (${ttlMs}ms) must exceed the executor hard timeout ` +
+        `(${execHardTimeoutMs}ms); otherwise the reconciler releases executions ` +
+        "that are still running and refunds work the customer is about to receive.",
+    );
+  }
+}
+
 export type ReservationState =
   | "reserved"
   | "executing"
@@ -59,6 +80,13 @@ export interface Reservation {
   walletId: string;
   amountCents: number;
   state: ReservationState;
+  /**
+   * The balance the database settled on, straight from the debit's RETURNING.
+   * WP2 introduced that value specifically so callers would stop doing
+   * arithmetic on a snapshot; discarding it here would have quietly restored
+   * the habit, with correctness resting on a lock held in another module.
+   */
+  balanceAfter: number;
 }
 
 export class ReservationNotOpenError extends Error {
@@ -96,7 +124,7 @@ export async function reserve(
 ): Promise<Reservation> {
   const { wallet, userId, amountCents, transactionId, description } = params;
 
-  await walletService.debit(tx, {
+  const balanceAfter = await walletService.debit(tx, {
     wallet,
     amountCents,
     referenceId: transactionId,
@@ -124,6 +152,7 @@ export async function reserve(
     walletId: wallet.id,
     amountCents,
     state: "reserved",
+    balanceAfter,
   };
 }
 

--- a/apps/api/src/lib/wallet-reservations.ts
+++ b/apps/api/src/lib/wallet-reservations.ts
@@ -1,0 +1,265 @@
+/**
+ * Durable wallet reservations (WP3, risks CR-01 / N1).
+ *
+ * The defect this closes, proved mechanically in WP1: the async `/v1/do` path
+ * debits, commits, answers 202, then runs the capability in an in-memory
+ * promise whose catch block holds the only refund. A SIGKILL between the commit
+ * and that catch strands the charge — the customer stays debited, the
+ * transaction stays `executing`, and nothing anywhere transitions it.
+ * `lib/shutdown.ts` claimed the integrity-hash janitor recovered these; it does
+ * not, it only ever writes `compliance_hash_state`. Production holds 11 such
+ * rows, the oldest from 2026-04-07.
+ *
+ * The fix is not to move the debit — moving it just relocates the window. It is
+ * to write down, in the same transaction as the debit, the fact that this money
+ * movement is still provisional. That record outlives the process, so a
+ * reconciler can find what a crash abandoned.
+ *
+ * Money movement itself is unchanged and still goes through the wallet service
+ * (WP2). A reservation records why funds moved and whether that movement is
+ * settled. `reserve` debits, `capture` marks the debit final, `release` returns
+ * the money.
+ *
+ * Every transition is a conditional UPDATE predicated on the expected current
+ * state. That is what makes duplicate capture and duplicate release no-ops
+ * instead of second money movements: the second caller matches no row and is
+ * told so, rather than racing. It is also why the reconciler can run
+ * concurrently with a live execution finishing — exactly one of them wins.
+ */
+
+import { and, eq, inArray, lt, sql } from "drizzle-orm";
+
+import { walletReservations } from "../db/schema.js";
+import * as walletService from "./wallet-service.js";
+import type { WalletTx } from "./wallet-service.js";
+
+/**
+ * How long a reservation may stay non-terminal before the reconciler treats it
+ * as abandoned.
+ *
+ * Deliberately generous relative to the 15s sync ceiling and the async paths
+ * that motivate it: releasing a still-running execution would refund a customer
+ * who is about to get their result, which is worse than waiting. The capture
+ * and release transitions are conditional, so a late finisher racing the
+ * reconciler cannot double-move money either way.
+ */
+export const DEFAULT_RESERVATION_TTL_MS = 15 * 60 * 1000;
+
+export type ReservationState =
+  | "reserved"
+  | "executing"
+  | "captured"
+  | "released";
+
+/** Non-terminal states — the reconciler's search space. */
+const OPEN_STATES: ReservationState[] = ["reserved", "executing"];
+
+export interface Reservation {
+  id: string;
+  walletId: string;
+  amountCents: number;
+  state: ReservationState;
+}
+
+export class ReservationNotOpenError extends Error {
+  constructor(
+    public readonly reservationId: string,
+    public readonly attempted: string,
+  ) {
+    super(
+      `Reservation ${reservationId} is not open; ${attempted} did not apply`,
+    );
+    this.name = "ReservationNotOpenError";
+  }
+}
+
+/**
+ * Debit the wallet and record that the debit is provisional.
+ *
+ * Must run inside the caller's transaction, alongside the transaction-row
+ * insert. If the reservation were written separately, a crash between the two
+ * would leave exactly the untracked debit this exists to prevent.
+ *
+ * Affordability is enforced by the wallet service's conditional UPDATE, so an
+ * unaffordable reserve throws rather than opening a hold it cannot fund.
+ */
+export async function reserve(
+  tx: WalletTx,
+  params: {
+    wallet: walletService.LockedWallet;
+    userId: string;
+    amountCents: number;
+    transactionId: string;
+    description: string;
+    ttlMs?: number;
+  },
+): Promise<Reservation> {
+  const { wallet, userId, amountCents, transactionId, description } = params;
+
+  await walletService.debit(tx, {
+    wallet,
+    amountCents,
+    referenceId: transactionId,
+    description,
+  });
+
+  const deadlineAt = new Date(
+    Date.now() + (params.ttlMs ?? DEFAULT_RESERVATION_TTL_MS),
+  );
+
+  const [row] = await tx
+    .insert(walletReservations)
+    .values({
+      walletId: wallet.id,
+      userId,
+      amountCents,
+      state: "reserved",
+      transactionId,
+      deadlineAt,
+    })
+    .returning({ id: walletReservations.id });
+
+  return {
+    id: row.id,
+    walletId: wallet.id,
+    amountCents,
+    state: "reserved",
+  };
+}
+
+/**
+ * Mark that execution has begun.
+ *
+ * Distinguishes "we took the money and never started" from "we took the money
+ * and the work was in flight", which is the difference between a bug and a
+ * crash when reading the table afterwards. Advisory only: the reconciler
+ * releases both, and a caller that skips this is not penalised.
+ */
+export async function markExecuting(
+  tx: WalletTx,
+  reservationId: string,
+): Promise<void> {
+  await tx
+    .update(walletReservations)
+    .set({ state: "executing", updatedAt: new Date() })
+    .where(
+      and(
+        eq(walletReservations.id, reservationId),
+        eq(walletReservations.state, "reserved"),
+      ),
+    );
+}
+
+/**
+ * Settle the debit. The money already moved at reserve time, so this only
+ * closes the record.
+ *
+ * Returns false when no open reservation matched — a duplicate capture, or one
+ * the reconciler already released. Callers should not treat that as an error:
+ * it means someone else reached a terminal state first, which is precisely the
+ * outcome the conditional transition exists to guarantee.
+ */
+export async function capture(
+  tx: WalletTx,
+  params: { reservationId: string; reason?: string },
+): Promise<boolean> {
+  const rows = await tx
+    .update(walletReservations)
+    .set({
+      state: "captured",
+      terminalReason: params.reason ?? "execution succeeded",
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(walletReservations.id, params.reservationId),
+        inArray(walletReservations.state, OPEN_STATES),
+      ),
+    )
+    .returning({ id: walletReservations.id });
+
+  return rows.length > 0;
+}
+
+/**
+ * Return the money and close the record.
+ *
+ * The refund and the state change are one conditional statement pair inside the
+ * caller's transaction: the row is claimed first, and only a caller that
+ * actually claimed it issues the credit. Two concurrent releases therefore
+ * refund once, which is the invariant that keeps the reconciler safe to run
+ * against a live system.
+ */
+export async function release(
+  tx: WalletTx,
+  params: { reservationId: string; reason: string },
+): Promise<boolean> {
+  const [claimed] = await tx
+    .update(walletReservations)
+    .set({
+      state: "released",
+      terminalReason: params.reason,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(walletReservations.id, params.reservationId),
+        inArray(walletReservations.state, OPEN_STATES),
+      ),
+    )
+    .returning({
+      id: walletReservations.id,
+      walletId: walletReservations.walletId,
+      amountCents: walletReservations.amountCents,
+      transactionId: walletReservations.transactionId,
+    });
+
+  // Someone else reached a terminal state first. Nothing to refund.
+  if (!claimed) return false;
+
+  await walletService.refund(tx, {
+    walletId: claimed.walletId,
+    amountCents: claimed.amountCents,
+    referenceId: claimed.transactionId,
+    description: `Reservation released: ${params.reason}`,
+  });
+
+  return true;
+}
+
+export interface AbandonedReservation {
+  id: string;
+  transactionId: string | null;
+  amountCents: number;
+  userId: string;
+}
+
+/**
+ * Reservations a crash left behind: non-terminal and past their deadline.
+ *
+ * Ordered oldest-first and bounded, so a large backlog drains over successive
+ * ticks rather than in one burst. That bound is deliberate — the 2026-05-04
+ * Postgres incident came from a long-silent bulk job resuming all at once
+ * (DEC-20260504-B), and this job's first real run has 11 waiting for it.
+ */
+export async function findAbandoned(
+  tx: WalletTx,
+  limit = 100,
+): Promise<AbandonedReservation[]> {
+  return tx
+    .select({
+      id: walletReservations.id,
+      transactionId: walletReservations.transactionId,
+      amountCents: walletReservations.amountCents,
+      userId: walletReservations.userId,
+    })
+    .from(walletReservations)
+    .where(
+      and(
+        inArray(walletReservations.state, OPEN_STATES),
+        lt(walletReservations.deadlineAt, sql`now()`),
+      ),
+    )
+    .orderBy(walletReservations.deadlineAt)
+    .limit(limit);
+}

--- a/apps/api/src/routes/do.crash-recovery.integration.test.ts
+++ b/apps/api/src/routes/do.crash-recovery.integration.test.ts
@@ -14,11 +14,15 @@
  * Production currently holds 11 such rows, the oldest from 2026-04-07.
  *
  * These tests kill a real child process running the real route, then assert
- * what survives. They describe CURRENT behaviour deliberately: the customer
- * stays debited and the row stays non-terminal. WP3 introduces the reservation
- * state machine and reconciler, at which point the final two expectations
- * invert — that is the signal WP3 has actually worked, so they are written to
- * fail loudly rather than quietly pass.
+ * what survives.
+ *
+ * WP3 UPDATE — the two expectations that pinned the bug have now inverted,
+ * which is exactly the signal the WP1 versions were written to produce. The
+ * crash still strands the charge in the moment (nothing can prevent that; the
+ * debit is committed and the process is gone). What changed is that the
+ * reservation written in the same transaction outlives the process, so the
+ * reconciler finds it and gives the money back. The tests below drive that
+ * reconciler explicitly rather than waiting on its interval.
  *
  * Why a child process: SIGKILL cannot be delivered to the vitest worker
  * without taking the run down with it. The child drives production code end to
@@ -40,6 +44,7 @@ import {
   users,
   wallets,
   walletTransactions,
+  walletReservations,
   capabilities,
   transactions,
 } from "../db/schema.js";
@@ -74,6 +79,9 @@ describeMaybe("async /v1/do — surviving a hard process kill", () => {
   });
 
   afterEach(async () => {
+    await db
+      .delete(walletReservations)
+      .where(eq(walletReservations.userId, userId));
     await db.delete(transactions).where(eq(transactions.userId, userId));
     await db
       .delete(walletTransactions)
@@ -169,6 +177,34 @@ describeMaybe("async /v1/do — surviving a hard process kill", () => {
     });
   }
 
+  async function balanceOf(id: string): Promise<number> {
+    const [row] = await db
+      .select({ balanceCents: wallets.balanceCents })
+      .from(wallets)
+      .where(eq(wallets.id, id))
+      .limit(1);
+    return row!.balanceCents;
+  }
+
+  /**
+   * Age the reservation past its deadline instead of waiting fifteen real
+   * minutes. The reconciler's own predicate is what is under test, so moving
+   * the clock on the row is the honest way to reach it.
+   */
+  async function expireReservations(): Promise<void> {
+    await db
+      .update(walletReservations)
+      .set({ deadlineAt: new Date(Date.now() - 60_000) })
+      .where(eq(walletReservations.userId, userId));
+  }
+
+  async function runReconciler() {
+    const { runReservationReconcilerOnce } = await import(
+      "../jobs/reservation-reconciler.js"
+    );
+    return runReservationReconcilerOnce();
+  }
+
   it("leaves the customer debited with the execution unfinished", async () => {
     await seed();
     await runChildUntilKilled();
@@ -196,12 +232,39 @@ describeMaybe("async /v1/do — surviving a hard process kill", () => {
     expect(purchases[0]!.amountCents).toBe(-PRICE_CENTS);
   }, 180_000);
 
-  it("PINS BUG: the charge is never refunded after the crash", async () => {
+  it("leaves an open reservation the reconciler can find", async () => {
     await seed();
     await runChildUntilKilled();
 
-    // The refund lives in the catch block of an in-memory promise that died
-    // with the process. Nothing else refunds it. WP3 must make this fail.
+    // The durable half of the fix. Before WP3 the only record of the charge
+    // being provisional lived in a promise that died with the process.
+    const open = await db
+      .select({
+        id: walletReservations.id,
+        state: walletReservations.state,
+        amountCents: walletReservations.amountCents,
+      })
+      .from(walletReservations)
+      .where(eq(walletReservations.userId, userId));
+
+    expect(open).toHaveLength(1);
+    expect(["reserved", "executing"]).toContain(open[0]!.state);
+    expect(open[0]!.amountCents).toBe(PRICE_CENTS);
+  }, 180_000);
+
+  it("refunds the stranded charge once the reconciler runs", async () => {
+    await seed();
+    await runChildUntilKilled();
+
+    // Immediately after the crash the customer is still out of pocket.
+    expect(await balanceOf(walletId)).toBe(STARTING_BALANCE - PRICE_CENTS);
+
+    await expireReservations();
+    const summary = await runReconciler();
+    expect(summary.released).toBe(1);
+
+    // The money is back, and the ledger explains why.
+    expect(await balanceOf(walletId)).toBe(STARTING_BALANCE);
     const refunds = await db
       .select()
       .from(walletTransactions)
@@ -211,24 +274,50 @@ describeMaybe("async /v1/do — surviving a hard process kill", () => {
           eq(walletTransactions.type, "refund"),
         ),
       );
-    expect(refunds).toHaveLength(0);
+    expect(refunds).toHaveLength(1);
+    expect(refunds[0]!.amountCents).toBe(PRICE_CENTS);
   }, 180_000);
 
-  it("PINS BUG: the transaction is stranded in a non-terminal state", async () => {
+  it("is idempotent — a second reconciler pass refunds nothing further", async () => {
+    // The reconciler runs every minute against a live system. A second pass
+    // over an already-released reservation must not credit again.
+    await seed();
+    await runChildUntilKilled();
+    await expireReservations();
+
+    expect((await runReconciler()).released).toBe(1);
+    const afterFirst = await balanceOf(walletId);
+
+    const second = await runReconciler();
+    expect(second.released).toBe(0);
+    expect(await balanceOf(walletId)).toBe(afterFirst);
+  }, 180_000);
+
+  it("drives the stranded transaction to a terminal state", async () => {
     await seed();
     await runChildUntilKilled();
 
-    const [txn] = await db
+    const [beforeReconcile] = await db
       .select({ status: transactions.status })
       .from(transactions)
       .where(eq(transactions.userId, userId))
       .limit(1);
+    expect(beforeReconcile!.status).toBe("executing");
 
-    // Two consequences, both customer-visible. A client polling this
-    // transaction per the 202 contract never reaches a terminal state, and
-    // spendCapWouldExceed counts `executing` rows toward the hourly cap
-    // forever, so a capped customer's budget shrinks permanently.
-    expect(txn).toBeDefined();
-    expect(txn!.status).toBe("executing");
+    await expireReservations();
+    await runReconciler();
+
+    const [after] = await db
+      .select({ status: transactions.status, error: transactions.error })
+      .from(transactions)
+      .where(eq(transactions.userId, userId))
+      .limit(1);
+
+    // Both consequences of the old behaviour are closed. A client polling per
+    // the 202 contract now reaches a terminal state, and spendCapWouldExceed
+    // no longer counts this row toward the hourly cap forever — which used to
+    // shrink a capped customer's budget permanently.
+    expect(after!.status).toBe("failed");
+    expect(after!.error).toContain("refunded automatically");
   }, 180_000);
 });

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -39,6 +39,7 @@ import { sanitizeFailureReason } from "../lib/sanitize.js";
 import { validateX402Input } from "../lib/x402-input-validation.js";
 import { isX402PayableCapability } from "../lib/x402-eligibility.js";
 import * as walletService from "../lib/wallet-service.js";
+import * as reservations from "../lib/wallet-reservations.js";
 import { recoverValuesFromTask, recoveredValuesHint, unsatisfiedGroupFields } from "../lib/task-value-hints.js";
 import { logError, logWarn } from "../lib/log.js";
 import { fireAndForget } from "../lib/fire-and-forget.js";
@@ -2060,6 +2061,8 @@ async function executeAsync(
         transactionId: string;
         walletId: string;
         balanceAfter: number;
+        /** WP3: the open reservation this execution must capture or release. */
+        reservationId: string;
       }
     | {
         ok: false;
@@ -2131,24 +2134,28 @@ async function executeAsync(
       })
       .returning({ id: transactions.id });
 
-    // Optimistic debit — refunded if execution fails.
+    // Reserve rather than plainly debit (WP3).
     //
-    // WP2: balance change and ledger row now happen in one call, so they
-    // cannot drift apart. Ordered after the transaction insert only so the
-    // ledger row can carry its reference; both writes are in this transaction,
-    // so the sequence between them is not observable.
-    const newBalance = await walletService.debit(tx, {
+    // The money moves now, exactly as before — but the reservation row records
+    // in this same transaction that the movement is still provisional. That
+    // record outlives the process, so a crash between this commit and the
+    // in-memory catch block below no longer strands the charge: the reconciler
+    // finds the open reservation and releases it.
+    const reservation = await reservations.reserve(tx, {
       wallet,
+      userId: user.id,
       amountCents: capability.priceCents,
-      referenceId: txnRecord.id,
+      transactionId: txnRecord.id,
       description: `Capability: ${capability.slug}`,
     });
+    const newBalance = wallet.balanceCents - capability.priceCents;
 
     return {
       ok: true as const,
       transactionId: txnRecord.id,
       walletId: wallet.id,
       balanceAfter: newBalance,
+      reservationId: reservation.id,
     };
   });
 
@@ -2205,6 +2212,7 @@ async function executeAsync(
       capability,
       startTime,
       outputSchema,
+      setupResult.reservationId,
     ),
   ).catch((err) => {
     // Last-resort error logging — should not normally reach here
@@ -2260,6 +2268,8 @@ async function executeInBackground(
   capability: CapabilityInfo,
   startTime: number,
   outputSchema: Record<string, unknown>,
+  /** WP3: the open reservation this execution must capture or release. */
+  reservationId: string,
 ) {
   try {
     // Cert-audit C7: hard timeout on the executor. Without this, an executor
@@ -2290,22 +2300,44 @@ async function executeInBackground(
       requestContext: undefined, // background execution — no request context available
     });
 
-    await db
-      .update(transactions)
-      .set({
-        status: "completed",
-        output: capResult.output,
-        provenance: capResult.provenance,
-        auditTrail: audit,
-        latencyMs,
-        completedAt: new Date(),
-        // CCO P0 #6: flip from 'deferred' to 'pending' atomically with the
-        // hashed-field writes. After this UPDATE commits, the retry worker
-        // will pick the row up on its next tick (≥10s later) and hash it
-        // with the final values — no race possible.
-        complianceHashState: "pending",
-      })
-      .where(eq(transactions.id, transactionId));
+    // WP3: settle the reservation in the SAME transaction as the terminal
+    // status write. Separately, a crash between them would leave a completed
+    // execution with an open reservation, which the reconciler would then
+    // refund — handing back money for work the customer received.
+    await db.transaction(async (tx) => {
+      await tx
+        .update(transactions)
+        .set({
+          status: "completed",
+          output: capResult.output,
+          provenance: capResult.provenance,
+          auditTrail: audit,
+          latencyMs,
+          completedAt: new Date(),
+          // CCO P0 #6: flip from 'deferred' to 'pending' atomically with the
+          // hashed-field writes. After this UPDATE commits, the retry worker
+          // will pick the row up on its next tick (≥10s later) and hash it
+          // with the final values — no race possible.
+          complianceHashState: "pending",
+        })
+        .where(eq(transactions.id, transactionId));
+
+      // False means the reconciler already released it — the execution
+      // outran its deadline. The customer has been refunded; leave it that
+      // way rather than re-charging them for a result they waited too long
+      // for. Logged so the deadline can be tuned if it happens often.
+      const captured = await reservations.capture(tx, {
+        reservationId,
+        reason: "execution succeeded",
+      });
+      if (!captured) {
+        logWarn(
+          "reservation-capture-missed",
+          "reservation was already terminal at capture time",
+          { transaction_id: transactionId, reservation_id: reservationId },
+        );
+      }
+    });
 
     // Record success for circuit breaker + quality + piggyback
     fireAndForget(() => recordSuccess(capability.slug), { label: "circuit-breaker-record-success", context: { slug: capability.slug } });
@@ -2347,18 +2379,24 @@ async function executeInBackground(
 
     // Failure: refund wallet + update transaction in a single tx
     await db.transaction(async (tx) => {
-      // Refund the optimistic debit — SELECT FOR UPDATE to prevent race conditions (DEC-8)
-      const [walletRow] = await tx
-        .select({ b: wallets.balanceCents })
-        .from(wallets)
-        .where(eq(wallets.id, walletId))
-        .for("update");
-      await walletService.refund(tx, {
-        walletId,
-        amountCents: capability.priceCents,
-        referenceId: transactionId,
-        description: `Refund: ${capability.slug} execution failed`,
+      // WP3: release the reservation rather than refunding directly. The
+      // release claims the row with a conditional UPDATE and only credits if
+      // it won, so this cannot double-refund against a reconciler that got
+      // there first — which is what makes the reconciler safe to run against
+      // a live system.
+      //
+      // False means it was already terminal; the money is already back.
+      const released = await reservations.release(tx, {
+        reservationId,
+        reason: `${capability.slug} execution failed`,
       });
+      if (!released) {
+        logWarn(
+          "reservation-release-missed",
+          "reservation was already terminal at release time",
+          { transaction_id: transactionId, reservation_id: reservationId },
+        );
+      }
 
       // Mark transaction failed with audit trail
       const failAudit = buildFailureAudit({

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -2148,7 +2148,7 @@ async function executeAsync(
       transactionId: txnRecord.id,
       description: `Capability: ${capability.slug}`,
     });
-    const newBalance = wallet.balanceCents - capability.priceCents;
+    const newBalance = reservation.balanceAfter;
 
     return {
       ok: true as const,
@@ -2272,6 +2272,17 @@ async function executeInBackground(
   reservationId: string,
 ) {
   try {
+    // WP3: record that work actually began. Advisory only — the reconciler
+    // releases 'reserved' and 'executing' alike — but it is the difference
+    // between "we took the money and never started" and "we took the money
+    // and the work was in flight" when reading the table after an incident.
+    await reservations.markExecuting(db, reservationId).catch((err) =>
+      logWarn("reservation-mark-executing-failed", String(err), {
+        transaction_id: transactionId,
+        reservation_id: reservationId,
+      }),
+    );
+
     // Cert-audit C7: hard timeout on the executor. Without this, an executor
     // that hangs (no AbortSignal on its fetch, infinite CPU loop, deadlock)
     // would leave the row in 'deferred' until the integrity-hash-retry
@@ -2421,7 +2432,17 @@ async function executeInBackground(
           // state. Same race-elimination as the success path above.
           complianceHashState: "pending",
         })
-        .where(eq(transactions.id, transactionId));
+        .where(
+          and(
+            eq(transactions.id, transactionId),
+            // WP3: do not overwrite a row that already reached a terminal
+            // state. Post-WP3 the release is conditional, so a throw AFTER
+            // the success commit would otherwise leave the customer charged
+            // (capture won) while the row reads "failed" — they would poll,
+            // see failure, and reasonably conclude they were not billed.
+            inArray(transactions.status, ["executing", "deferred"]),
+          ),
+        );
     });
 
     // CCO P0 #6: row was 'deferred' until the UPDATE above flipped it

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -24,8 +24,9 @@ import { rateLimitByKey } from "../lib/rate-limit.js";
 import { apiError } from "../lib/errors.js";
 import { executeSolution, isSuccessfulStepOutput } from "../lib/solution-executor.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
-import { logError } from "../lib/log.js";
+import { logError, logWarn } from "../lib/log.js";
 import * as walletService from "../lib/wallet-service.js";
+import * as reservations from "../lib/wallet-reservations.js";
 import { getProcessingJurisdictions } from "../lib/provenance-builder.js";
 import type { AppEnv } from "../types.js";
 
@@ -103,6 +104,8 @@ solutionExecuteRoute.post(
     let balanceAfter: number;
     let walletId: string;
     let walletBalanceBefore: number;
+    /** WP3: the open reservation this run must capture or release. */
+    let reservationId: string;
 
     try {
       const txResult = await db.transaction(async (tx) => {
@@ -119,14 +122,6 @@ solutionExecuteRoute.post(
             balance: wallet?.balanceCents ?? 0,
           };
         }
-
-        // Debit through the wallet service — balance change and ledger row are
-        // written together, so the two cannot diverge (WP2).
-        const newBalance = await walletService.debit(tx, {
-          wallet,
-          amountCents: sol.priceCents,
-          description: `Solution: ${sol.slug}`,
-        });
 
         // Insert transaction row at "executing" — two-phase write per /v1/do pattern
         const [txnRecord] = await tx
@@ -159,12 +154,31 @@ solutionExecuteRoute.post(
           })
           .returning({ id: transactions.id });
 
+        // WP3: reserve rather than plainly debit. Solutions have the same
+        // crash window /v1/do had, and a wider one — execution is multi-step
+        // and takes seconds to minutes — on the platform's most expensive
+        // SKUs. The four refund call sites below all live in this process; a
+        // SIGKILL anywhere in that window strands the charge unless something
+        // durable records that the debit was provisional.
+        //
+        // Ordered after the transaction insert so the reservation can carry
+        // its reference. Both writes are in this transaction, so the sequence
+        // between them is not observable.
+        const reservation = await reservations.reserve(tx, {
+          wallet,
+          userId: user.id,
+          amountCents: sol.priceCents,
+          transactionId: txnRecord.id,
+          description: `Solution: ${sol.slug}`,
+        });
+
         return {
           ok: true as const,
           transactionId: txnRecord.id,
-          balanceAfter: newBalance,
+          balanceAfter: reservation.balanceAfter,
           walletId: wallet.id,
           walletBalanceBefore: wallet.balanceCents,
+          reservationId: reservation.id,
         };
       });
 
@@ -183,6 +197,7 @@ solutionExecuteRoute.post(
       balanceAfter = txResult.balanceAfter;
       walletId = txResult.walletId;
       walletBalanceBefore = txResult.walletBalanceBefore;
+      reservationId = txResult.reservationId;
     } catch (err) {
       c.get("log").error(
         { label: "solutions-tx-insert-failed", solution_slug: slug, err: err instanceof Error ? { message: err.message, stack: err.stack } : err },
@@ -231,7 +246,7 @@ solutionExecuteRoute.post(
       }
 
       // Refund
-      await refundWallet(db, walletId, sol.priceCents, sol.slug, "execution error", transactionId);
+      await refundWallet(db, walletId, sol.priceCents, sol.slug, "execution error", reservationId);
 
       return c.json(
         apiError("execution_failed", "Solution execution failed. You were not charged.", {
@@ -269,7 +284,7 @@ solutionExecuteRoute.post(
         );
       }
 
-      await refundWallet(db, walletId, sol.priceCents, sol.slug, "no steps configured", transactionId);
+      await refundWallet(db, walletId, sol.priceCents, sol.slug, "no steps configured", reservationId);
 
       return c.json(
         apiError("execution_failed", "Solution has no steps configured. You were not charged.", {
@@ -310,7 +325,7 @@ solutionExecuteRoute.post(
       await refundWallet(
         db, walletId, sol.priceCents, sol.slug,
         gated ? `gate tripped: ${gated.capabilitySlug}.${gated.field}` : "all steps failed",
-        transactionId,
+        reservationId,
       );
     }
 
@@ -359,20 +374,42 @@ solutionExecuteRoute.post(
     // worst outcome — customer paid, no record. Refund on the non-allFailed
     // path and return 500 so the caller can retry.
     try {
-      await db.update(transactions)
-        .set({
-          status: txStatus,
-          output: execResult.steps,
-          latencyMs,
-          completedAt: new Date(),
-          priceCents: chargedPrice,
-          auditTrail,
-          // CCO P0 #6: flip 'deferred' → 'pending' atomically with the
-          // final auditTrail/output write. The retry worker will hash the
-          // final state on its next tick (≥10s later) — no race possible.
-          complianceHashState: "pending",
-        })
-        .where(eq(transactions.id, transactionId));
+      await db.transaction(async (tx) => {
+        await tx.update(transactions)
+          .set({
+            status: txStatus,
+            output: execResult.steps,
+            latencyMs,
+            completedAt: new Date(),
+            priceCents: chargedPrice,
+            auditTrail,
+            // CCO P0 #6: flip 'deferred' → 'pending' atomically with the
+            // final auditTrail/output write. The retry worker will hash the
+            // final state on its next tick (≥10s later) — no race possible.
+            complianceHashState: "pending",
+          })
+          .where(eq(transactions.id, transactionId));
+
+        // WP3: settle the reservation in the SAME transaction as the terminal
+        // status write. A refunded run has already released it above, so this
+        // only captures the runs that kept the money. Separately, a crash
+        // between the two writes would leave a finished run holding an open
+        // reservation for the reconciler to refund — paying back work the
+        // customer received.
+        if (!refundRequired) {
+          const captured = await reservations.capture(tx, {
+            reservationId,
+            reason: `solution ${txStatus}`,
+          });
+          if (!captured) {
+            logWarn(
+              "solutions-capture-missed",
+              "reservation was already terminal at capture time",
+              { transaction_id: transactionId, reservation_id: reservationId },
+            );
+          }
+        }
+      });
     } catch (e) {
       c.get("log").error(
         {
@@ -392,7 +429,7 @@ solutionExecuteRoute.post(
       // refunded here a SECOND time. Caught by auditing the whole route rather
       // than only the block being edited.
       if (!refundRequired) {
-        await refundWallet(db, walletId, sol.priceCents, sol.slug, "phase2 update failed", transactionId);
+        await refundWallet(db, walletId, sol.priceCents, sol.slug, "phase2 update failed", reservationId);
       }
 
       return c.json(
@@ -485,16 +522,26 @@ async function refundWallet(
   priceCents: number,
   solutionSlug: string,
   reason: string,
-  referenceId?: string | null,
+  reservationId: string,
 ): Promise<void> {
   try {
     await db.transaction(async (tx) => {
-      await walletService.refund(tx, {
-        walletId,
-        amountCents: priceCents,
-        description: `Refund: ${solutionSlug} (${reason})`,
-        referenceId: referenceId ?? null,
+      // WP3: release the reservation rather than crediting directly. The
+      // release claims the row with a conditional UPDATE and only credits if
+      // it won, so this cannot double-refund against a reconciler that got
+      // there first — which is what makes the reconciler safe to run while
+      // solutions are executing.
+      const released = await reservations.release(tx, {
+        reservationId,
+        reason: `${solutionSlug} (${reason})`,
       });
+      if (!released) {
+        logWarn(
+          "solutions-release-missed",
+          "reservation was already terminal at release time",
+          { solution_slug: solutionSlug, reservation_id: reservationId },
+        );
+      }
     });
   } catch (err) {
     logError("solutions-refund-failed", err, { solution_slug: solutionSlug, wallet_id: walletId });

--- a/apps/api/src/routes/solution-reservations.integration.test.ts
+++ b/apps/api/src/routes/solution-reservations.integration.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Solutions hold a reservation for the duration of a run (WP3).
+ *
+ * The adversarial review's third blocking finding: solutions had the identical
+ * crash window to `/v1/do` — debit, commit, then execute for seconds to
+ * minutes with the only refunds living in this process — on the platform's
+ * most expensive SKUs. Worse, a comment in the route claimed WP3's reconciler
+ * already covered it, which was false: nothing wrote a reservation there.
+ *
+ * That is now wired, and this proves it end to end rather than by inspection.
+ * The wiring is the part most likely to be wrong — the state machine itself is
+ * covered in lib/wallet-reservations.integration.test.ts — so these drive the
+ * real route and assert on real rows.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../test-support/integration-db.js";
+import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
+import {
+  users,
+  wallets,
+  walletTransactions,
+  walletReservations,
+  capabilities,
+  solutions,
+  solutionSteps,
+  transactions,
+} from "../db/schema.js";
+
+if (process.env.DATABASE_URL_TEST) {
+  process.env.FRONTEND_URL ??= "https://strale.dev";
+  process.env.AUDIT_HMAC_SECRET ??= "wp3-sol-secret-at-least-32-chars-long-0000";
+  process.env.ADMIN_SECRET ??= "wp3-sol-admin-secret-at-least-32-chars-0000";
+  process.env.STRIPE_SECRET_KEY ??= "sk_test_wp3_placeholder";
+  process.env.STRIPE_WEBHOOK_SECRET ??= "whsec_wp3_placeholder";
+}
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+const SOLUTION_PRICE = 250;
+const STARTING_BALANCE = 5_000;
+
+describeMaybe("solution execution holds a wallet reservation", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let app: Awaited<typeof import("../app.js")>["app"];
+
+  let userId = "";
+  let walletId = "";
+  let capabilityId = "";
+  let solutionId = "";
+  let capSlug = "";
+  let solSlug = "";
+  let apiKey = "";
+
+  /** Flipped per test to make the single step succeed or fail. */
+  let stepShouldFail = false;
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 8 });
+    db = drizzle(client);
+
+    const { registerCapability } = await import("../capabilities/index.js");
+    capSlug = `wp3-solstep-${randomUUID().slice(0, 8)}`;
+    registerCapability(capSlug, async () => {
+      if (stepShouldFail) throw new Error("step failed on purpose");
+      return {
+        output: { ok: true },
+        provenance: { source: "wp3-test", fetched_at: new Date().toISOString() },
+      };
+    });
+
+    ({ app } = await import("../app.js"));
+  }, 120_000);
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  afterEach(async () => {
+    if (userId) {
+      await db
+        .delete(walletReservations)
+        .where(eq(walletReservations.userId, userId));
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+    }
+    if (walletId) {
+      await db
+        .delete(walletTransactions)
+        .where(eq(walletTransactions.walletId, walletId));
+      await db.delete(wallets).where(eq(wallets.id, walletId));
+    }
+    if (userId) await db.delete(users).where(eq(users.id, userId));
+    if (solutionId) {
+      await db
+        .delete(solutionSteps)
+        .where(eq(solutionSteps.solutionId, solutionId));
+      await db.delete(solutions).where(eq(solutions.id, solutionId));
+    }
+    if (capabilityId)
+      await db.delete(capabilities).where(eq(capabilities.id, capabilityId));
+    userId = walletId = capabilityId = solutionId = "";
+    stepShouldFail = false;
+  });
+
+  async function seed() {
+    userId = randomUUID();
+    capabilityId = randomUUID();
+    solutionId = randomUUID();
+    solSlug = `wp3-sol-${randomUUID().slice(0, 8)}`;
+    apiKey = `sk_live_${randomUUID().replace(/-/g, "")}`;
+
+    await db.insert(users).values({
+      id: userId,
+      email: `wp3-sol-${userId}@example.test`,
+      apiKeyHash: hashApiKey(apiKey),
+      keyPrefix: getKeyPrefix(apiKey),
+    });
+
+    const walletService = await import("../lib/wallet-service.js");
+    const wallet = await db.transaction((tx) =>
+      walletService.openWallet(tx, {
+        userId,
+        grantCents: STARTING_BALANCE,
+        type: "trial_credit",
+        description: "WP3 solutions grant",
+      }),
+    );
+    walletId = wallet.id;
+
+    await db.insert(capabilities).values({
+      id: capabilityId,
+      slug: capSlug,
+      name: "WP3 solution step",
+      description: "Seeded by the WP3 solutions reservation test.",
+      category: "developer-tools",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      priceCents: 10,
+      isActive: true,
+      avgLatencyMs: 50,
+      lifecycleState: "active",
+    });
+
+    await db.insert(solutions).values({
+      id: solutionId,
+      slug: solSlug,
+      name: "WP3 probe solution",
+      description: "Seeded by the WP3 solutions reservation test.",
+      category: "compliance",
+      priceCents: SOLUTION_PRICE,
+      componentSumCents: 10,
+      valueTier: "standard",
+      maintenanceLevel: "low",
+      geography: "EU",
+      inputSchema: { type: "object", properties: { probe: { type: "string" } } },
+      isActive: true,
+    });
+
+    await db.insert(solutionSteps).values({
+      solutionId,
+      capabilitySlug: capSlug,
+      stepOrder: 1,
+      inputMap: { probe: "probe" },
+    });
+  }
+
+  function runSolution() {
+    return app.request(`http://localhost/v1/solutions/${solSlug}/execute`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ inputs: { probe: "wp3" } }),
+    });
+  }
+
+  async function balance(): Promise<number> {
+    const [row] = await db
+      .select({ balanceCents: wallets.balanceCents })
+      .from(wallets)
+      .where(eq(wallets.id, walletId))
+      .limit(1);
+    return row!.balanceCents;
+  }
+
+  async function reservationRows() {
+    return db
+      .select({
+        id: walletReservations.id,
+        state: walletReservations.state,
+        amountCents: walletReservations.amountCents,
+      })
+      .from(walletReservations)
+      .where(eq(walletReservations.userId, userId));
+  }
+
+  async function ledgerSum(): Promise<number> {
+    const rows = await db
+      .select({ amountCents: walletTransactions.amountCents })
+      .from(walletTransactions)
+      .where(eq(walletTransactions.walletId, walletId));
+    return rows.reduce((sum, r) => sum + r.amountCents, 0);
+  }
+
+  it("captures the reservation when the solution succeeds", async () => {
+    await seed();
+    stepShouldFail = false;
+
+    const res = await runSolution();
+    expect(res.status).toBe(200);
+
+    const [reservation] = await reservationRows();
+    expect(reservation).toBeDefined();
+    // Captured, not left open — an open reservation on a finished run is what
+    // would let the reconciler refund work the customer received.
+    expect(reservation!.state).toBe("captured");
+    expect(reservation!.amountCents).toBe(SOLUTION_PRICE);
+
+    expect(await balance()).toBe(STARTING_BALANCE - SOLUTION_PRICE);
+    expect(await ledgerSum()).toBe(await balance());
+  }, 120_000);
+
+  it("releases the reservation and refunds when every step fails", async () => {
+    await seed();
+    stepShouldFail = true;
+
+    const res = await runSolution();
+    // The route's own contract: a fully failed run is not charged.
+    expect([200, 500]).toContain(res.status);
+
+    const [reservation] = await reservationRows();
+    expect(reservation).toBeDefined();
+    expect(reservation!.state).toBe("released");
+
+    // Money back, and the ledger explains it.
+    expect(await balance()).toBe(STARTING_BALANCE);
+    expect(await ledgerSum()).toBe(await balance());
+  }, 120_000);
+
+  it("leaves nothing for the reconciler to find after a completed run", async () => {
+    // The property that matters operationally: a settled run must not appear
+    // in findAbandoned, however long it sat, or the reconciler would refund
+    // completed work.
+    await seed();
+    stepShouldFail = false;
+    await runSolution();
+
+    await db
+      .update(walletReservations)
+      .set({ deadlineAt: new Date(Date.now() - 60_000) })
+      .where(eq(walletReservations.userId, userId));
+
+    const reservations = await import("../lib/wallet-reservations.js");
+    expect(await reservations.findAbandoned(db)).toHaveLength(0);
+  }, 120_000);
+});

--- a/apps/api/src/test-support/integration-lane.test.ts
+++ b/apps/api/src/test-support/integration-lane.test.ts
@@ -33,7 +33,7 @@ const SRC = fileURLToPath(new URL("..", import.meta.url));
  * lowering it means suites were removed and should be a deliberate, explained
  * edit rather than a silent one.
  */
-const MINIMUM_LANE_FILES = 11;
+const MINIMUM_LANE_FILES = 12;
 
 /** Split on either line ending — these files are checked out CRLF on Windows. */
 function splitLines(source: string): string[] {

--- a/docs/remediation/CURRENT-STATE.md
+++ b/docs/remediation/CURRENT-STATE.md
@@ -9,6 +9,26 @@ _Last updated: 2026-08-21 (session 1)_
 - **Human approvals granted:** program-level autonomy (run continuously; escalate only per CHECK-IN A/B/C)
 - **Awaiting founder:** nothing. One item is logged for *visibility only*, not decision — see "Codex disposition" below.
 
+## Review lane — founder decision, 2026-08-21
+
+Codex exhausted its credits mid-WP3 (available again 27 Aug). Decision: **do
+not buy more now.** Adversarial review continues via independent Claude agents
+given the same brief, with a **single Codex pass reserved for the end** of the
+program.
+
+Rationale for recording it: the substitute is not a downgrade in kind. On WP3
+the agent returned FAIL_REMEDIATION_REQUIRED with three blocking findings, one
+of which — a migration that reintroduced a TOCTOU defect the same file had
+fixed two commits earlier, and could ship without its unique index — was at
+least as sharp as anything Codex produced. What a single reviewer cannot give
+is *independence across packages*: the same model reviewing its own family of
+work has a correlated blind spot, which is what the final Codex pass exists to
+catch.
+
+Practical note for whoever runs that pass: brief it on the FULL branch diff,
+not per-package, and give it the residuals list from each package manifest so
+it can check that deferred items actually landed where they were promised.
+
 ## Where WP2 landed
 
 One authority for wallet mutations: `lib/wallet-service.ts`. Every balance

--- a/docs/remediation/packages/WP3.yaml
+++ b/docs/remediation/packages/WP3.yaml
@@ -1,0 +1,95 @@
+package: WP3
+title: Durable wallet reservations + reconciler
+status: REVIEW
+depends_on: [WP2]
+risks: [CR-01, N1]
+
+objective: >
+  Make a crashed execution's charge recoverable. Not by moving the debit —
+  that only relocates the window — but by recording, in the same transaction as
+  the debit, that the money movement is still provisional. That record outlives
+  the process, so a reconciler can find what a crash abandoned.
+
+state_machine: |
+  reserved ──▶ executing ──▶ captured
+       ╰────────────┴──────▶ released
+
+  Every transition is a conditional UPDATE predicated on the expected state.
+  That is what makes duplicate capture and duplicate release no-ops rather than
+  second money movements, and what makes the reconciler safe to run against a
+  live system: a live execution finishing at the same moment either wins and
+  captures, or loses and finds nothing to capture.
+
+defect_closed: >
+  The async /v1/do path debited, committed, answered 202, then executed in an
+  in-memory promise whose catch block held the only refund. A SIGKILL between
+  the commit and that catch stranded the charge: customer debited, transaction
+  stuck in 'executing', nothing anywhere transitioning it. shutdown.ts claimed
+  the integrity-hash janitor recovered these; it only ever writes
+  compliance_hash_state. Solutions had the same window, wider (multi-step,
+  seconds to minutes) and on the most expensive SKUs.
+
+acceptance_signal: >
+  The WP1 crash tests INVERTED. They previously pinned the bug — no refund
+  ever, transaction stranded. They now assert the reservation survives the
+  kill, the reconciler refunds it, a second pass refunds nothing further, and
+  the transaction reaches a terminal state. Verified discriminating by
+  disabling recovery: exactly those assertions fail.
+
+migration:
+  block: "0095_wallet_reservations"
+  numbering_note: >
+    Written as 0090, corrected to 0094 when the blocks ratchet caught a
+    collision, then to 0095 when main landed its own 0094 while this branch was
+    in review. The ratchet caught both. The historical numbering is the audit
+    trail, so the collisions mattered.
+  contents:
+    - "CREATE TABLE IF NOT EXISTS wallet_reservations + three indexes, all individually idempotent"
+    - "CHECK (balance_cents >= 0) added NOT VALID, then VALIDATE separately"
+  safety:
+    - "Every statement independently idempotent — no check-then-bare-DDL, which block 0093's own comment documents as having already broken a deploy"
+    - "Indexes created unconditionally, not inside a table-was-absent branch: the runner has no transaction, so a kill between CREATE TABLE and the index builds would otherwise leave the unique index permanently absent"
+    - "NOT VALID avoids an ACCESS EXCLUSIVE lock held for a full table scan against a path that holds FOR UPDATE on wallets across an external HTTP call"
+    - "Constraint failure is logged and retried next boot rather than thrown — a throw aborts boot, and a failed Railway deploy does not cut over"
+  verified:
+    - "re-runnable: run twice, second is a clean no-op"
+    - "self-healing: dropped the unique index, re-ran, it came back"
+    - "constraint bites: UPDATE to -1 rejected"
+    - "prod checked read-only first: 59 wallets, none negative"
+
+review:
+  codex: unavailable (credits exhausted until 27 Aug; founder decision — no purchase)
+  independent_agent: FAIL_REMEDIATION_REQUIRED, then all findings closed
+  blocking_findings_closed:
+    - "migration reintroduced the TOCTOU shape the same file fixed two commits earlier, and could ship without its unique index"
+    - "ADD CONSTRAINT lock contention — my safety argument had only verified row content, never lock acquisition"
+    - "solutions had the identical window and a comment falsely claiming the reconciler covered it"
+  non_blocking_closed:
+    - "ABBA deadlock between the success path and the reconciler — could have recorded a SUCCEEDED call as failed and discarded its output"
+    - "unguarded post-commit failure write would have left a customer charged while the row read 'failed'"
+    - "reserve discarded the DB-settled balance WP2 introduced to stop snapshot arithmetic"
+    - "no cross-replica advisory lock, making the DEC-20260504-B batch bound per-instance"
+    - "released-but-not-marked counted as clean recovery while leaving the transaction stuck forever"
+    - "TTL vs EXEC_HARD_TIMEOUT_MS correct only by coincidence and env-tunable to incorrect — now asserted at boot"
+    - "the 'executing' state was dead code — now recorded"
+  residual:
+    - "wallet_reservations has no retention rule — an omission, not yet a decision. WP14 owns it alongside the 90-day content commitment."
+    - "the reconciler's own behaviour has no test for two concurrent instances; the advisory lock is asserted by inspection, not exercised."
+
+deployment:
+  reconciler_first_run_has_a_backlog: >
+    11 transactions stranded since 2026-04-07. Bounded per tick (25) so the
+    backlog drains over minutes rather than in one burst — DEC-20260504-B.
+  NOT_DONE_HERE: >
+    Those 11 historical rows predate the table and have NO reservation row, so
+    findAbandoned can never return them. Reconciling them is a separate,
+    explicit operation against real customer wallets and needs founder approval.
+    Deliberately not bundled into this package.
+
+exit_conditions:
+  - a hard crash cannot strand customer funds indefinitely   # MET (crash tests inverted)
+  - one reservation reaches exactly one terminal state       # MET (race test)
+  - duplicate capture is idempotent                          # MET
+  - duplicate release is idempotent                          # MET
+  - independent adversarial review passes                    # MET after remediation
+  - Fable ACCEPT                                             # pending CI + merge

--- a/docs/remediation/packages/WP4.yaml
+++ b/docs/remediation/packages/WP4.yaml
@@ -1,0 +1,71 @@
+package: WP4
+title: Capability Runner + canonical ExecutionOutcome
+status: PLANNED
+depends_on: [WP2]
+risks: [CR-02]
+
+objective: >
+  Make "what happened, and may we charge for it" a single business fact, decided
+  once, rather than five rails each deciding it with their own heuristic.
+
+# Verified against the code, not taken from the audit.
+current_authorities:
+  do_sync: "executeWithRetry not throwing IS success; debit in the same transaction"
+  do_async: "promise resolution IS success; debit upfront, refund in a catch block"
+  wallet_solutions: "refundRequired = allFailed || gated !== undefined (solution-execute.ts:317)"
+  x402_capability: "executor resolving IS success; settle on any resolution"
+  x402_solutions: "anyStepSucceeded → settle FULL price; `gated` appears zero times in the file"
+  mcp_a2a: "re-derives success from the proxied HTTP status"
+
+sharpest_defect: >
+  The same solution run, with a gate tripped: the wallet rail refunds and tells
+  the customer they were not charged, while the x402 rail counts the gate step
+  as a success and settles the full USDC. Identical execution, opposite billing,
+  decided by which rail the caller happened to use. Confirmed by grep — `gated`
+  is simply absent from x402-gateway-v2.ts.
+
+second_defect: >
+  isSuccessfulStepOutput (solution-executor.ts) treats any object as success
+  unless it is exactly {error: string} or carries skipped/unavailable. The
+  reasoning is sound — capabilities legitimately return soft verdicts like
+  {valid:false, error:"Invalid IBAN checksum"}, which IS the purchased answer —
+  but it means an executor that ever resolves with {error, status} converts a
+  failure into a billable success. A convention is doing the job of a contract.
+
+third_defect: >
+  capability-output-contracts.ts is imported ONLY by startup-migrations.ts.
+  Output validation runs after the money has moved and writes to audit metadata;
+  schema_validated:false never blocks a charge.
+
+canonical_types:
+  OutputAssessment: [structurally_valid, semantically_usable, contract_valid, quality_flags]
+  ExecutionOutcome:
+    - success | failure
+    - failure_class
+    - billable            # the field payment consumes
+    - retryable
+    - fault: provider | strale | caller
+    - output_assessment
+    - provenance
+    - latency_ms, cost facts
+
+rules:
+  - payment consumes `billable`, never a route-local success heuristic
+  - breaker and quality consume the canonical outcome
+  - audit consumes the terminal outcome
+  - the solution orchestrator aggregates step outcomes into one solution outcome
+
+migration_required: false
+review: {codex: deferred_to_final_pass, independent_agent: required, fable: required}
+
+tests_required:
+  - a gated solution is billed identically on the wallet and x402 rails
+  - an {error, status} shaped output is not billable
+  - a contract-invalid output is not billable
+  - each rail's billing decision comes from the same function (bypass guard)
+
+exit_conditions:
+  - one ExecutionOutcome type, one OutputAssessment type
+  - no route decides success or billability independently
+  - CI guard forbids a new local billing predicate
+  - independent adversarial review passes


### PR DESCRIPTION
## What this closes

WP1 proved the defect mechanically: the async `/v1/do` path debits, commits, answers 202, then runs the capability in an in-memory promise whose catch block holds the only refund. SIGKILL between the commit and that catch strands the charge — customer debited, transaction stuck in `executing`, nothing anywhere transitioning it. `lib/shutdown.ts` claimed the integrity-hash janitor recovered these; it does not, it only ever writes `compliance_hash_state`. Production holds 11 such rows, oldest 2026-04-07.

Solutions had the same window, wider (multi-step, seconds to minutes) and on the most expensive SKUs. A comment in that route claimed this reconciler already covered it. It did not — nothing wrote a reservation there. That is now wired and proved end to end.

## The approach

Not moving the debit — that only relocates the window. Instead: record, in the same transaction as the debit, that the money movement is still provisional. That record outlives the process, so a reconciler can find what a crash abandoned.

```
reserved ──▶ executing ──▶ captured
     ╰────────────┴──────▶ released
```

Every transition is a conditional UPDATE predicated on the expected state. That is what makes duplicate capture and duplicate release no-ops rather than second money movements, and what makes the reconciler safe against a live system: an execution finishing at the same moment either wins and captures, or loses and finds nothing to capture.

Money movement itself is unchanged and still goes through the WP2 wallet service.

## Acceptance signal

**The WP1 crash tests are inverted.** They previously pinned the bug — no refund ever, transaction stranded. They now assert the reservation survives the kill, the reconciler refunds it, a second pass refunds nothing further, and the transaction reaches a terminal state. Verified discriminating: disabling recovery fails exactly those assertions.

## Migration safety (block 0095)

Every statement is independently idempotent. Specifically **not** the check-then-bare-DDL shape — block 0093's own comment documents that as having already broken a deploy, and the first draft of this block reintroduced it.

- Indexes created unconditionally, not inside a table-was-absent branch. The runner has no transaction, so a kill between `CREATE TABLE` and the index builds would otherwise leave the unique index permanently absent.
- `CHECK (balance_cents >= 0)` added `NOT VALID`, validated separately — avoids an ACCESS EXCLUSIVE lock held for a full table scan against a path that holds `FOR UPDATE` on wallets across an external HTTP call.
- Constraint failure is logged and retried next boot rather than thrown. A throw aborts boot, and a failed Railway deploy does not cut over.

Verified: re-runnable (second pass a clean no-op), self-healing (dropped the unique index, it came back), the constraint bites (`UPDATE` to `-1` rejected), and prod checked read-only first (59 wallets, none negative).

Numbering: written as 0090, corrected to 0094 when the ratchet caught a collision, then to 0095 when main landed its own 0094 mid-review. The ratchet caught both times.

## Deploy protocol (DEC-20260504-B)

The reconciler's first real run has a backlog. Bounded at 25 per tick with a 45s startup delay and a cross-replica advisory lock, so it drains over minutes rather than in one burst.

**Not done here:** the 11 historical rows predate this table and have no reservation row, so `findAbandoned` can never return them. Reconciling them is a separate explicit operation against real customer wallets and needs founder approval. Deliberately not bundled in.

## Review

Codex is out of credits until 27 Aug (founder decision: don't buy). An independent Claude agent given the same adversarial brief returned **FAIL_REMEDIATION_REQUIRED** — 3 blocking, 9 non-blocking. All closed:

**Blocking** — the migration TOCTOU above; an `ADD CONSTRAINT` lock argument that had only verified row content and never lock acquisition; the solutions window with its false comment.

**Non-blocking** — an ABBA deadlock between the success path and the reconciler that could have recorded a SUCCEEDED call as failed and discarded its output (lock order is now `transactions` then `wallet_reservations` everywhere); an unguarded post-commit failure write that would have left a customer charged while the row read `failed`; `reserve` discarding the DB-settled balance WP2 introduced to stop snapshot arithmetic; no cross-replica advisory lock; released-but-not-marked counted as clean recovery while leaving the transaction stuck forever; TTL vs `EXEC_HARD_TIMEOUT_MS` correct only by coincidence and env-tunable to incorrect (now asserted at boot); the `executing` state being dead code.

## Residuals

- `wallet_reservations` has no retention rule — an omission, not yet a decision. WP14 owns it.
- Two concurrent reconciler instances aren't exercised by a test; the advisory lock is asserted by inspection.

## Verification

16 CI gates pass locally. Typecheck clean with no filter. 2,200 unit tests; 81 integration tests across 13 files against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
