### PR TITLE
Remediation WP4: one canonical ExecutionOutcome for billability

### DIFF
--- a/apps/api/src/lib/execution-outcome.guard.test.ts
+++ b/apps/api/src/lib/execution-outcome.guard.test.ts
@@ -1,0 +1,158 @@
+/**
+ * WP4 bypass guard: no rail may decide billability on its own.
+ *
+ * WP2 shipped the same shape for wallet mutations and it earned its keep — it
+ * caught a runbook telling an operator to run bare `UPDATE wallets`. The failure
+ * this one guards against is quieter and was live for months: five rails each
+ * answered "may we charge for this?" with their own predicate, and two of them
+ * disagreed about a gated solution. Nobody chose that. It accumulated.
+ *
+ * A unit test proves the shared function is right today. Only a guard keeps a
+ * sixth answer from appearing next quarter.
+ *
+ * Two checks, deliberately different in kind:
+ *
+ *   1. A denylist of the specific predicates WP4 retired. Precise, zero false
+ *      positives, and catches a literal revert.
+ *   2. A shape check: in a rail file, an identifier that names a billing
+ *      decision must be assigned from the canonical module. Catches the case
+ *      the denylist cannot — a NEW predicate under a NEW name.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const API_SRC = join(import.meta.dirname, "..");
+
+/**
+ * The files that move money. A rail added later and not listed here is the
+ * obvious hole, so the list is asserted against the settlement/debit call sites
+ * rather than maintained by hand — see the last test.
+ */
+const RAIL_FILES = [
+  "routes/do.ts",
+  "routes/solution-execute.ts",
+  "routes/x402-gateway-v2.ts",
+];
+
+const CANONICAL = "lib/execution-outcome.ts";
+
+function read(rel: string): string {
+  return readFileSync(join(API_SRC, rel), "utf8");
+}
+
+/** Strip comments so prose describing a retired predicate is not a violation. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+describe("no rail decides billability on its own", () => {
+  it.each(RAIL_FILES)("%s reads the canonical outcome", (rel) => {
+    expect(read(rel)).toMatch(/from "\.\.\/lib\/execution-outcome\.js"/);
+  });
+
+  it.each([
+    // routes/x402-gateway-v2.ts settled full price on this while the wallet
+    // rail refunded — the defect that motivated the package.
+    ["anyStepSucceeded", /\banyStepSucceeded\b/],
+    // The wallet rail's local rule, now folded into aggregateSolutionOutcome.
+    ["refundRequired = allFailed ||", /refundRequired\s*=\s*allFailed\s*\|\|/],
+    // The predecessor that counted skipped steps as billable successes.
+    ["step_count - errors.length", /step_count\s*-\s*errors\.length/],
+  ])("no rail reintroduces `%s`", (_label, pattern) => {
+    for (const rel of RAIL_FILES) {
+      expect(stripComments(read(rel)), `${rel} reintroduced a retired predicate`)
+        .not.toMatch(pattern);
+    }
+  });
+
+  it("the superseded step predicate is not imported by any rail", () => {
+    // isSuccessfulStepOutput still exists and its own suite still pins its
+    // behaviour — it is the historical record of the H-1 refinement. It just
+    // may not be a billing authority any more.
+    for (const rel of RAIL_FILES) {
+      expect(read(rel), `${rel} still imports the superseded predicate`)
+        .not.toMatch(/\bisSuccessfulStepOutput\b/);
+    }
+  });
+
+  it("a billing-decision identifier is assigned from the canonical module", () => {
+    // The check the denylist cannot do: catch a NEW predicate under a NEW name.
+    // Any `const shouldCharge = …` / `let billable = …` in a rail must derive
+    // from an ExecutionOutcome, not from a hand-rolled expression.
+    const NAMES = /\b(?:const|let|var)\s+(billable|shouldCharge|shouldSettle|shouldRefund|refundRequired|chargeable|isBillable)\s*=\s*([^;]+);/g;
+    const CANONICAL_SOURCE = /\boutcome\b|aggregateSolutionOutcome|outcomeFrom|\.billable\b/;
+
+    const violations: string[] = [];
+    for (const rel of RAIL_FILES) {
+      const src = stripComments(read(rel));
+      for (const match of src.matchAll(NAMES)) {
+        const [, name, expression] = match;
+        if (!CANONICAL_SOURCE.test(expression)) {
+          violations.push(`${rel}: \`${name} = ${expression.trim().slice(0, 60)}\``);
+        }
+      }
+    }
+
+    expect(
+      violations,
+      "a rail computed a billing decision without reading the canonical outcome; " +
+        `decide it in ${CANONICAL} instead`,
+    ).toEqual([]);
+  });
+
+  it("RAIL_FILES still covers every file that settles or debits", () => {
+    // The guard's own blind spot: a new rail nobody added to the list above.
+    // Rather than trust the list, re-derive it. Money leaves the platform
+    // through a wallet debit or an x402 settlement; any file doing either and
+    // not listed here is unguarded.
+    const MONEY = /walletService\.debit\(|settleX402Payment\(/;
+    const candidates = ["routes", "lib", "jobs"].flatMap((dir) =>
+      readdirRecursive(join(API_SRC, dir))
+        .filter((f) => f.endsWith(".ts") && !f.includes(".test."))
+        .filter((f) => MONEY.test(readFileSync(f, "utf8")))
+        .map((f) => f.slice(API_SRC.length + 1).replace(/\\/g, "/")),
+    );
+
+    // The canonical module and the wallet/reservation authorities themselves
+    // move money by definition; they are the authority, not a rail consuming it.
+    const EXEMPT = new Set([
+      "lib/wallet-service.ts",
+      "lib/wallet-reservations.ts",
+      "lib/execution-outcome.ts",
+      // Defines settleX402Payment. It performs the settlement a rail decides
+      // on; it does not decide. WP4 deleted the one function here that DID
+      // decide — verifyX402Payment, which settled before execution.
+      "lib/x402-gateway.ts",
+    ]);
+
+    const unguarded = candidates.filter(
+      (f) => !RAIL_FILES.includes(f) && !EXEMPT.has(f),
+    );
+
+    expect(
+      unguarded,
+      "a file debits a wallet or settles x402 but is not covered by this guard",
+    ).toEqual([]);
+  });
+});
+
+function readdirRecursive(dir: string): string[] {
+  const { readdirSync, statSync } = require("node:fs") as typeof import("node:fs");
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...readdirRecursive(full));
+    else out.push(full);
+  }
+  return out;
+}

--- a/apps/api/src/lib/execution-outcome.guard.test.ts
+++ b/apps/api/src/lib/execution-outcome.guard.test.ts
@@ -10,26 +10,33 @@
  * A unit test proves the shared function is right today. Only a guard keeps a
  * sixth answer from appearing next quarter.
  *
- * Two checks, deliberately different in kind:
+ * ── What the first version of this guard got wrong ──────────────────────────
  *
- *   1. A denylist of the specific predicates WP4 retired. Precise, zero false
- *      positives, and catches a literal revert.
- *   2. A shape check: in a rail file, an identifier that names a billing
- *      decision must be assigned from the canonical module. Catches the case
- *      the denylist cannot — a NEW predicate under a NEW name.
+ * It was green while an entire rail was unwired. Three holes, all found by
+ * adversarial review rather than by the guard itself, all closed below:
+ *
+ *   1. The import check was FILE-scoped. One handler importing the module
+ *      satisfied it, so x402-gateway-v2.ts passed while its capability handler
+ *      settled on any resolution 250 lines from the solutions handler that did
+ *      the importing. The check is now handler-scoped.
+ *   2. The name denylist listed seven identifiers, so `const mustRefund = …`
+ *      walked past it — and its "canonical source" test was satisfied by the
+ *      bare substring `outcome`, so `const refundRequired = outcome ? local : true`
+ *      passed too.
+ *   3. The "derived" rail list did not derive the rails. Its regex matched
+ *      `walletService.debit(` and `settleX402Payment(`, neither of which
+ *      appears in routes/solution-execute.ts — that rail moves money through
+ *      `reservations.reserve/capture/release`, one indirection inside the
+ *      exempt wallet-reservations.ts. The list it claimed to derive was in
+ *      fact hand-maintained.
  */
 
 import { describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const API_SRC = join(import.meta.dirname, "..");
 
-/**
- * The files that move money. A rail added later and not listed here is the
- * obvious hole, so the list is asserted against the settlement/debit call sites
- * rather than maintained by hand — see the last test.
- */
 const RAIL_FILES = [
   "routes/do.ts",
   "routes/solution-execute.ts",
@@ -37,6 +44,22 @@ const RAIL_FILES = [
 ];
 
 const CANONICAL = "lib/execution-outcome.ts";
+
+/**
+ * Money leaves the platform through one of these.
+ *
+ * Note `reservations.capture(` rather than `reserve(`. A WP3 reservation is
+ * PROVISIONAL by design — reserve happens before execution, and the decision to
+ * keep the money is capture. Keying on reserve flagged `executeAsync`, which
+ * reserves in one function and assesses in the background executor, which is
+ * the architecture working rather than a defect.
+ */
+const MOVES_MONEY =
+  /walletService\.debit\(|\bdebit\(|settleX402Payment\(|reservations\.capture\(/;
+
+/** Evidence that the enclosing handler asked the canonical module first. */
+const CONSULTS_BILLABILITY =
+  /assertBillableOutput\(|\.billable\b|aggregateSolutionOutcome\(|outcomeFrom\w*\(/;
 
 function read(rel: string): string {
   return readFileSync(join(API_SRC, rel), "utf8");
@@ -49,10 +72,77 @@ function stripComments(src: string): string {
     .replace(/(^|[^:])\/\/.*$/gm, "$1");
 }
 
+/**
+ * Split a source file into handler-sized regions.
+ *
+ * Deliberately crude — a top-level function, route registration, or arrow
+ * binding starts a new region. It only has to be fine-grained enough that a
+ * money call and its billability consult must be neighbours, which is the
+ * property a file-level check cannot express at all.
+ */
+function handlerRegions(
+  src: string,
+): Array<{ name: string; line: number; body: string }> {
+  const lines = src.split("\n");
+  const BOUNDARY =
+    /^(?:export\s+)?(?:async\s+)?function\s+(\w+)|^(?:export\s+)?const\s+(\w+)\s*=\s*(?:async\s*)?\(|^\w+\.(?:on|post|get|put|all)\(/;
+
+  const regions: Array<{ name: string; line: number; body: string }> = [];
+  let current = { name: "<module>", line: 1, body: [] as string[] };
+
+  lines.forEach((line, i) => {
+    const m = BOUNDARY.exec(line);
+    if (m) {
+      regions.push({ ...current, body: current.body.join("\n") });
+      current = {
+        name: m[1] ?? m[2] ?? line.trim().slice(0, 40),
+        line: i + 1,
+        body: [],
+      };
+    }
+    current.body.push(line);
+  });
+  regions.push({ ...current, body: current.body.join("\n") });
+  return regions;
+}
+
+function readdirRecursive(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...readdirRecursive(full));
+    else out.push(full);
+  }
+  return out;
+}
+
 describe("no rail decides billability on its own", () => {
   it.each(RAIL_FILES)("%s reads the canonical outcome", (rel) => {
     expect(read(rel)).toMatch(/from "\.\.\/lib\/execution-outcome\.js"/);
   });
+
+  it.each(RAIL_FILES)(
+    "%s consults billability in EVERY handler that moves money",
+    (rel) => {
+      // Hole 1. This is the assertion that would have caught an entire rail
+      // being left unwired, which the file-level check above cannot.
+      const violations = handlerRegions(stripComments(read(rel)))
+        .filter((region) => MOVES_MONEY.test(region.body))
+        .filter((region) => !CONSULTS_BILLABILITY.test(region.body))
+        .map((region) => `${rel}:${region.line} (${region.name})`);
+
+      expect(
+        violations,
+        `a handler moves money without consulting the canonical outcome; decide it in ${CANONICAL}`,
+      ).toEqual([]);
+    },
+  );
 
   it.each([
     // routes/x402-gateway-v2.ts settled full price on this while the wallet
@@ -80,20 +170,46 @@ describe("no rail decides billability on its own", () => {
   });
 
   it("a billing-decision identifier is assigned from the canonical module", () => {
-    // The check the denylist cannot do: catch a NEW predicate under a NEW name.
-    // Any `const shouldCharge = …` / `let billable = …` in a rail must derive
-    // from an ExecutionOutcome, not from a hand-rolled expression.
-    const NAMES = /\b(?:const|let|var)\s+(billable|shouldCharge|shouldSettle|shouldRefund|refundRequired|chargeable|isBillable)\s*=\s*([^;]+);/g;
-    const CANONICAL_SOURCE = /\boutcome\b|aggregateSolutionOutcome|outcomeFrom|\.billable\b/;
+    // Hole 2. Widened from a seven-name list that `const mustRefund = …` or
+    // `const noCharge = …` walked straight past: ANY identifier whose name is
+    // about charging, billing, refunding or settling.
+    const NAMES =
+      /\b(?:const|let|var)\s+(\w*(?:[Bb]illable|[Cc]harge|[Rr]efund|[Ss]ettle)\w*)\s*=\s*([^;]+);/g;
+    // And tightened: the bare substring `outcome` used to satisfy this, so
+    // `const refundRequired = outcome ? localPredicate : true;` passed while
+    // reintroducing the defect. The expression must actually READ the decision.
+    const CANONICAL_SOURCE =
+      /\.billable\b|aggregateSolutionOutcome\(|outcomeFrom\w*\(|assertBillableOutput\(/;
 
     const violations: string[] = [];
     for (const rel of RAIL_FILES) {
       const src = stripComments(read(rel));
+
+      // Names already shown to derive from the canonical outcome. A decision
+      // may be computed in steps — `refundRequired = !outcome.billable` and
+      // then `chargedPrice = refundRequired ? 0 : price` — and the second step
+      // is validated by the first. Without this the guard demands every
+      // downstream expression re-read `.billable`, which is noise, not safety.
+      const derived = new Set<string>();
+
       for (const match of src.matchAll(NAMES)) {
         const [, name, expression] = match;
-        if (!CANONICAL_SOURCE.test(expression)) {
-          violations.push(`${rel}: \`${name} = ${expression.trim().slice(0, 60)}\``);
+
+        // `const settled = await settleX402Payment(…)` holds the RESULT of
+        // moving money, not a decision about whether to. Matching it conflates
+        // the act with the choice.
+        if (MOVES_MONEY.test(expression)) continue;
+
+        const derivesFromValidated = [...derived].some((d) =>
+          new RegExp(`\\b${d}\\b`).test(expression),
+        );
+
+        if (CANONICAL_SOURCE.test(expression) || derivesFromValidated) {
+          derived.add(name);
+          continue;
         }
+
+        violations.push(`${rel}: \`${name} = ${expression.trim().slice(0, 60)}\``);
       }
     }
 
@@ -105,11 +221,15 @@ describe("no rail decides billability on its own", () => {
   });
 
   it("RAIL_FILES still covers every file that settles or debits", () => {
-    // The guard's own blind spot: a new rail nobody added to the list above.
-    // Rather than trust the list, re-derive it. Money leaves the platform
-    // through a wallet debit or an x402 settlement; any file doing either and
-    // not listed here is unguarded.
-    const MONEY = /walletService\.debit\(|settleX402Payment\(/;
+    // Hole 3. The original regex matched neither of the ways
+    // routes/solution-execute.ts actually moves money, so this "derivation"
+    // silently agreed with a hand-written list. It now covers the post-WP3
+    // reservation pattern — the natural way a new rail would be built — and a
+    // bare `debit(` from a direct import rather than the `walletService.`
+    // namespace.
+    const MONEY =
+      /walletService\.debit\(|\bdebit\(|settleX402Payment\(|reservations\.(reserve|capture|release)\(/;
+
     const candidates = ["routes", "lib", "jobs"].flatMap((dir) =>
       readdirRecursive(join(API_SRC, dir))
         .filter((f) => f.endsWith(".ts") && !f.includes(".test."))
@@ -117,16 +237,18 @@ describe("no rail decides billability on its own", () => {
         .map((f) => f.slice(API_SRC.length + 1).replace(/\\/g, "/")),
     );
 
-    // The canonical module and the wallet/reservation authorities themselves
-    // move money by definition; they are the authority, not a rail consuming it.
+    // These MOVE money by definition — they are the authority a rail consumes,
+    // not a rail deciding anything.
     const EXEMPT = new Set([
       "lib/wallet-service.ts",
       "lib/wallet-reservations.ts",
       "lib/execution-outcome.ts",
-      // Defines settleX402Payment. It performs the settlement a rail decides
-      // on; it does not decide. WP4 deleted the one function here that DID
+      // Defines settleX402Payment. WP4 deleted the one function here that DID
       // decide — verifyX402Payment, which settled before execution.
       "lib/x402-gateway.ts",
+      // The WP3 reconciler releases abandoned reservations. It refunds; it
+      // never charges, so there is no billability question for it to answer.
+      "jobs/reservation-reconciler.ts",
     ]);
 
     const unguarded = candidates.filter(
@@ -139,20 +261,3 @@ describe("no rail decides billability on its own", () => {
     ).toEqual([]);
   });
 });
-
-function readdirRecursive(dir: string): string[] {
-  const { readdirSync, statSync } = require("node:fs") as typeof import("node:fs");
-  const out: string[] = [];
-  let entries: string[];
-  try {
-    entries = readdirSync(dir);
-  } catch {
-    return out;
-  }
-  for (const entry of entries) {
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) out.push(...readdirRecursive(full));
-    else out.push(full);
-  }
-  return out;
-}

--- a/apps/api/src/lib/execution-outcome.test.ts
+++ b/apps/api/src/lib/execution-outcome.test.ts
@@ -1,0 +1,242 @@
+/**
+ * WP4 acceptance tests for the canonical outcome.
+ *
+ * The first describe block is the package's whole reason for existing: it
+ * asserts the two rails agree. It is written against the shared function rather
+ * than against either route so that it keeps meaning after the routes are
+ * rewired — if someone reintroduces a rail-local billing predicate, the guard
+ * test below catches that, and this one keeps proving what the shared answer
+ * should be.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregateSolutionOutcome,
+  assessOutput,
+  outcomeFromError,
+  outcomeFromGate,
+  outcomeFromOutput,
+  transactionStatusFor,
+} from "./execution-outcome.js";
+import {
+  BudgetExhaustedError,
+  CapabilityInvocationRefusedError,
+  CapabilityNotClassifiedError,
+} from "../capabilities/guarded-executor.js";
+
+const okStep = outcomeFromOutput("x", { answer: 1 });
+const failStep = outcomeFromOutput("x", { error: "upstream 503" });
+
+describe("the two rails bill a gated solution identically", () => {
+  // Before WP4: routes/solution-execute.ts refunded in full
+  // (`refundRequired = allFailed || gated !== undefined`) while
+  // routes/x402-gateway-v2.ts settled in full (`anyStepSucceeded`, and the gate
+  // step IS a successful output). Same run, opposite billing.
+  const gate = { capabilitySlug: "site-availability", field: "reachable" };
+
+  it("is not billable even when steps behind the gate succeeded", () => {
+    const outcome = aggregateSolutionOutcome([okStep, okStep, okStep], gate);
+
+    expect(outcome.billable).toBe(false);
+    expect(outcome.failure_class).toBe("gate_tripped");
+    expect(outcome.steps_succeeded).toBe(3);
+  });
+
+  it("gives one answer, so no rail can reach a different one", () => {
+    // The property that actually matters: billability is a function of the
+    // execution, not of the caller's payment method. Any rail passing the same
+    // steps gets the same boolean.
+    const walletView = aggregateSolutionOutcome([okStep, okStep], gate);
+    const x402View = aggregateSolutionOutcome([okStep, okStep], gate);
+
+    expect(x402View.billable).toBe(walletView.billable);
+    expect(x402View.failure_class).toBe(walletView.failure_class);
+  });
+
+  it("still bills a partially-successful run with no gate", () => {
+    // The correction must not swing the other way: a bundle that answered is
+    // charged, with the shortfall disclosed rather than priced per step.
+    const outcome = aggregateSolutionOutcome([okStep, failStep]);
+    expect(outcome.billable).toBe(true);
+    expect(outcome.steps_succeeded).toBe(1);
+  });
+
+  it("bills nothing when no step produced usable output", () => {
+    const outcome = aggregateSolutionOutcome([failStep, failStep]);
+    expect(outcome.billable).toBe(false);
+    expect(transactionStatusFor(outcome)).toBe("failed");
+  });
+});
+
+describe("an {error, status} shaped output is not billable", () => {
+  // The second defect: isSuccessfulStepOutput matched EXACTLY {error: string},
+  // so an executor resolving with an error plus transport metadata converted a
+  // failure into a billable success on the strength of a second key.
+  it("treats error + status as the failure it is", () => {
+    const outcome = outcomeFromOutput("x", { error: "not found", status: 404 });
+    expect(outcome.billable).toBe(false);
+    expect(outcome.output_assessment?.semantically_usable).toBe(false);
+  });
+
+  it.each(["statusCode", "code", "http_status"])(
+    "also covers error + numeric %s",
+    (key) => {
+      const outcome = outcomeFromOutput("x", { error: "boom", [key]: 500 });
+      expect(outcome.billable).toBe(false);
+    },
+  );
+
+  it.each(["statusCode", "code", "http_status"])(
+    "but a non-numeric %s is a verdict, and stays billable",
+    (key) => {
+      const outcome = outcomeFromOutput("x", { error: "boom", [key]: "degraded" });
+      expect(outcome.billable).toBe(true);
+    },
+  );
+
+  it("does NOT unbill an uptime check reporting a site down", () => {
+    // {status:"down", error:"timeout"} is the deliverable. Keying the widening
+    // on the KEY NAME rather than a numeric value would have turned this
+    // correct answer into an unbilled failure — caught because the pre-existing
+    // solution-executor suite already pinned it.
+    const outcome = outcomeFromOutput("uptime-check", {
+      status: "down",
+      error: "timeout",
+    });
+    expect(outcome.billable).toBe(true);
+  });
+
+  it("does NOT swallow a soft verdict that carries an error string", () => {
+    // The line that keeps the correction honest. {valid:false, error:"..."} is
+    // the purchased answer — a true negative from a check that ran. Billing it
+    // as a failure would refund correct work and, through the shared quality
+    // signal, eventually delist a capability for being right.
+    const outcome = outcomeFromOutput("x", {
+      valid: false,
+      error: "Invalid IBAN checksum",
+    });
+    expect(outcome.billable).toBe(true);
+    expect(outcome.success).toBe(true);
+  });
+
+  it("treats skipped and unavailable as unbillable, and skipped as unretryable", () => {
+    const skipped = outcomeFromOutput("x", { skipped: true, reason: "no input" });
+    expect(skipped.billable).toBe(false);
+    // Its inputs were starved by an earlier failure; retrying it alone is noise.
+    expect(skipped.retryable).toBe(false);
+    expect(skipped.counts_against_capability).toBe(false);
+
+    const unavailable = outcomeFromOutput("x", { unavailable: true });
+    expect(unavailable.billable).toBe(false);
+    expect(unavailable.fault).toBe("strale");
+  });
+
+  it.each([null, undefined, "a string", 42, []])(
+    "refuses to bill a structurally invalid output (%s)",
+    (value) => {
+      const outcome = outcomeFromOutput("x", value);
+      expect(outcome.billable).toBe(false);
+      expect(outcome.output_assessment?.structurally_valid).toBe(false);
+    },
+  );
+});
+
+describe("contract validation informs quality without blocking the charge", () => {
+  // The third defect was that capability-output-contracts.ts was imported only
+  // by startup-migrations.ts, so output validation never reached a billing
+  // decision at all. It reaches one now — as a recorded observation.
+  // company-id-detect guarantees BOTH `input` and `detected`. Chosen over
+  // iso-country-lookup, whose only guaranteed field is `query` because its
+  // response shape is bimodal — a reminder that most fields in this table are
+  // deliberately `common`, so `contract_valid: false` is rare by design.
+  it("reports a contract violation on a slug that declares one", () => {
+    const assessment = assessOutput("company-id-detect", { input: "5593957979" });
+    expect(assessment.contract_valid).toBe(false);
+    expect(assessment.quality_flags.join()).toMatch(/contract_missing:detected/);
+  });
+
+  it("passes a contract-satisfying output", () => {
+    const assessment = assessOutput("company-id-detect", {
+      input: "5593957979",
+      detected: { country: "SE" },
+    });
+    expect(assessment.contract_valid).toBe(true);
+  });
+
+  it("does not treat a `common` field's absence as a violation", () => {
+    // iso-country-lookup returns EITHER `match` or `matches`; demanding both
+    // would recreate the harness false-alarm this table was written to fix.
+    expect(assessOutput("iso-country-lookup", { query: "Sweden" }).contract_valid).toBe(true);
+  });
+
+  it("reports null — never false — when no contract is declared", () => {
+    // Absence of a contract is not a violation. Most slugs have none, so a
+    // false here would make the majority of the catalog look non-compliant.
+    expect(assessOutput("slug-with-no-contract", { a: 1 }).contract_valid).toBe(null);
+  });
+
+  it("does not block billing on a contract violation", () => {
+    // Deliberate: the table exists to correct declarations that drifted away
+    // from working executors. Refusing the charge would hand money back on the
+    // strength of a declaration we already know to be the unreliable side.
+    const outcome = outcomeFromOutput("company-id-detect", { input: "5593957979" });
+    expect(outcome.billable).toBe(true);
+    expect(outcome.output_assessment?.contract_valid).toBe(false);
+  });
+});
+
+describe("a refusal is not a capability fault", () => {
+  it.each([
+    ["refused", new CapabilityInvocationRefusedError("x", "test-reason"), "capability_refused", "caller"],
+    ["budget", new BudgetExhaustedError("x", "daily", 1, 1), "budget_exhausted", "strale"],
+    ["unclassified", new CapabilityNotClassifiedError("x"), "not_classified", "strale"],
+  ])("%s: unbillable, not retryable, not counted", (_label, err, cls, fault) => {
+    const outcome = outcomeFromError(err);
+    expect(outcome.failure_class).toBe(cls);
+    expect(outcome.billable).toBe(false);
+    expect(outcome.retryable).toBe(false);
+    expect(outcome.fault).toBe(fault);
+    // The taxonomy gap that let the armed quality floor delist capabilities
+    // for correctly refusing bad input.
+    expect(outcome.counts_against_capability).toBe(false);
+  });
+});
+
+describe("error classification drives retry and blame", () => {
+  it.each([
+    "Request timed out after 15000ms",
+    "The operation was aborted",
+    "fetch failed: ECONNRESET",
+    "connect ECONNREFUSED 10.0.0.1:443",
+    "getaddrinfo ENOTFOUND registry.example",
+    "socket hang up",
+    "Upstream returned 503 Service Unavailable",
+  ])("treats %s as retryable provider unavailability", (message) => {
+    const outcome = outcomeFromError(new Error(message));
+    expect(outcome.failure_class).toBe("provider_unavailable");
+    expect(outcome.retryable).toBe(true);
+    expect(outcome.fault).toBe("provider");
+  });
+
+  it("treats a definitive rejection as non-retryable", () => {
+    const outcome = outcomeFromError(new Error("Upstream returned 400 Bad Request"));
+    expect(outcome.failure_class).toBe("provider_rejected");
+    expect(outcome.retryable).toBe(false);
+  });
+
+  it("never bills a thrown error, whatever its class", () => {
+    for (const e of [new Error("x"), "a string", null, { weird: true }]) {
+      expect(outcomeFromError(e).billable).toBe(false);
+    }
+  });
+});
+
+describe("gate outcome", () => {
+  it("does not blame the gate capability for answering", () => {
+    const outcome = outcomeFromGate({ capabilitySlug: "s", field: "f" });
+    expect(outcome.billable).toBe(false);
+    expect(outcome.counts_against_capability).toBe(false);
+    expect(outcome.error_message).toBe("gate tripped: s.f");
+  });
+});

--- a/apps/api/src/lib/execution-outcome.test.ts
+++ b/apps/api/src/lib/execution-outcome.test.ts
@@ -188,9 +188,33 @@ describe("contract validation informs quality without blocking the charge", () =
 
 describe("a refusal is not a capability fault", () => {
   it.each([
-    ["refused", new CapabilityInvocationRefusedError("x", "test-reason"), "capability_refused", "caller"],
-    ["budget", new BudgetExhaustedError("x", "daily", 1, 1), "budget_exhausted", "strale"],
-    ["unclassified", new CapabilityNotClassifiedError("x"), "not_classified", "strale"],
+    // Constructed with the REAL signatures. Review finding: the first version
+    // passed the wrong arity to all three, and tsconfig excludes *.test.ts so
+    // `tsc --noEmit` never caught it. The assertions held via `instanceof`, so
+    // it was not a false green — but it did not exercise the shapes production
+    // throws, which is the only reason to build them at all.
+    [
+      "refused",
+      new CapabilityInvocationRefusedError("x", "paid_external", "scheduled_test"),
+      "capability_refused",
+      "caller",
+    ],
+    [
+      "budget",
+      new BudgetExhaustedError(
+        "x",
+        { slug: "x", cost_class: "paid_external", quota_window: "daily", quota_cap: 10 } as never,
+        { kind: "scheduled_test" } as never,
+      ),
+      "budget_exhausted",
+      "strale",
+    ],
+    [
+      "unclassified",
+      new CapabilityNotClassifiedError("x", { kind: "scheduled_test" } as never),
+      "not_classified",
+      "strale",
+    ],
   ])("%s: unbillable, not retryable, not counted", (_label, err, cls, fault) => {
     const outcome = outcomeFromError(err);
     expect(outcome.failure_class).toBe(cls);

--- a/apps/api/src/lib/execution-outcome.ts
+++ b/apps/api/src/lib/execution-outcome.ts
@@ -408,3 +408,43 @@ export function aggregateSolutionOutcome(
 export function transactionStatusFor(outcome: ExecutionOutcome): "completed" | "failed" {
   return outcome.success ? "completed" : "failed";
 }
+
+/**
+ * Thrown when an executor resolved with something that is not the purchased
+ * answer.
+ *
+ * The capability rails are written around "resolved means succeeded", with the
+ * charge and the audit write immediately after resolution and every failure
+ * path already living in the surrounding catch block. Rather than restructure
+ * four call sites around a new return value — which is where a money bug would
+ * hide — the unusable case is raised as an error, so it takes the failure path
+ * that is already proven: no debit on the sync rail, reservation released on
+ * the async rail, transaction marked failed on both.
+ */
+export class UnbillableOutputError extends Error {
+  constructor(
+    public readonly slug: string,
+    public readonly assessment: OutputAssessment,
+  ) {
+    super(
+      assessment.quality_flags.includes("executor_error_marker")
+        ? "Capability returned an error marker rather than output"
+        : "Capability returned no usable output",
+    );
+    this.name = "UnbillableOutputError";
+  }
+}
+
+/**
+ * Gate the capability rails on the same assessment the solution rails use.
+ *
+ * Note what this does NOT reject: a soft verdict, an uptime check reporting a
+ * site down, or an output that violates its declared contract. Those are all
+ * billable — see the header, and `outcomeFromOutput`.
+ */
+export function assertBillableOutput(slug: string, output: unknown): void {
+  const outcome = outcomeFromOutput(slug, output);
+  if (!outcome.billable) {
+    throw new UnbillableOutputError(slug, outcome.output_assessment!);
+  }
+}

--- a/apps/api/src/lib/execution-outcome.ts
+++ b/apps/api/src/lib/execution-outcome.ts
@@ -1,0 +1,410 @@
+/**
+ * The canonical answer to "what happened, and may we charge for it" (WP4, CR-02).
+ *
+ * Before this module, five rails each decided that question their own way:
+ *
+ *   /v1/do sync      — `executeWithRetry` not throwing IS success
+ *   /v1/do async     — promise resolution IS success
+ *   wallet solutions — `refundRequired = allFailed || gated !== undefined`
+ *   x402 capability  — the executor resolving IS success
+ *   x402 solutions   — `anyStepSucceeded` → settle FULL price
+ *
+ * The sharpest consequence, confirmed by grep rather than inference: the token
+ * `gated` appears twelve times in routes/solution-execute.ts and zero times in
+ * routes/x402-gateway-v2.ts. So one solution run with a gate tripped refunds
+ * the wallet customer in full while charging the x402 customer in full — same
+ * execution, opposite billing, decided by which rail the caller happened to
+ * use. Nobody chose that. It is what happens when a business fact has five
+ * authorities.
+ *
+ * So: billability is decided here, once, and payment consumes `billable`.
+ * A rail may still decide *how* to collect (refund a wallet, decline to settle
+ * USDC) — that is genuinely rail-specific. It may not decide *whether*.
+ *
+ * ── Two rules that look like bugs and are not ────────────────────────────────
+ *
+ * A soft verdict is billable. `{valid:false, error:"Invalid IBAN checksum"}` is
+ * the answer the customer paid for; the check ran and returned a true negative.
+ * Treating it as a failure would refund correct work, and — because the same
+ * signal feeds the breaker and the quality floor — would eventually delist a
+ * capability for being right.
+ *
+ * A refusal is not a fault. When the guarded executor refuses an invocation it
+ * has protected budget or upheld a classification rule; it has not broken. Such
+ * an outcome is not billable, not retryable, and attributed to the caller, and
+ * it must not count against the capability. This is the failure-taxonomy gap
+ * that let the armed quality floor delist capabilities for refusing bad input.
+ */
+
+import {
+  BudgetExhaustedError,
+  CapabilityInvocationRefusedError,
+  CapabilityNotClassifiedError,
+} from "../capabilities/guarded-executor.js";
+import { CAPABILITY_OUTPUT_CONTRACTS } from "./capability-output-contracts.js";
+
+/**
+ * Why an execution did not produce a billable answer.
+ *
+ * The distinctions that earn a member are the ones some consumer acts on
+ * differently: payment, retry, the breaker, the quality floor, or the audit
+ * trail. Anything finer belongs in the error message.
+ */
+export type FailureClass =
+  /** Upstream unreachable, timed out, or returned 5xx. Provider's fault, worth retrying. */
+  | "provider_unavailable"
+  /** Upstream reachable and rejected our request — 4xx, malformed response, quota. */
+  | "provider_rejected"
+  /** The caller's input could not address a real question. */
+  | "caller_input_invalid"
+  /** The guarded executor declined. Correct behaviour, not a fault. */
+  | "capability_refused"
+  /** Cost guard hit its ceiling. Strale's own limit, not a capability defect. */
+  | "budget_exhausted"
+  /** Capability is not cost-classified — a Strale configuration gap. */
+  | "not_classified"
+  /** A gate step reported the bundle cannot do what it was sold for. */
+  | "gate_tripped"
+  /** The executor resolved, but with something that is not the purchased answer. */
+  | "output_unusable"
+  /** Strale's own code broke. */
+  | "internal_error";
+
+/** Who is answerable. Drives the breaker and the quality floor, not billing. */
+export type Fault = "provider" | "strale" | "caller";
+
+/**
+ * What we can say about the value an executor handed back.
+ *
+ * Deliberately three independent axes rather than one boolean. They disagree in
+ * practice, and the disagreements are the interesting cases: a soft verdict is
+ * structurally valid, semantically usable, and may be contract-invalid; an
+ * `{error, status}` object is structurally valid and NOT semantically usable.
+ * Collapsing them is how a convention ends up doing a contract's job.
+ */
+export interface OutputAssessment {
+  /** An object at all — not null, not a primitive, not an array. */
+  structurally_valid: boolean;
+  /** Real capability output: not an error marker, not skipped, not unavailable. */
+  semantically_usable: boolean;
+  /**
+   * Checked against the capability's declared output contract.
+   * `null` means no contract is declared for this slug — most of them — and
+   * must never be read as failure. Absence of a contract is not a violation.
+   */
+  contract_valid: boolean | null;
+  /** Non-fatal observations, for audit and quality. Never consulted for billing. */
+  quality_flags: string[];
+}
+
+export interface ExecutionOutcome {
+  success: boolean;
+  failure_class: FailureClass | null;
+  /** The one field payment reads. Nothing else may decide this. */
+  billable: boolean;
+  retryable: boolean;
+  fault: Fault | null;
+  output_assessment: OutputAssessment | null;
+  /** Whether this outcome should count against the capability's health. */
+  counts_against_capability: boolean;
+  error_message: string | null;
+}
+
+/**
+ * The executor's own failure marker is EXACTLY `{error: string}` — a single
+ * key, written in the executor catch block. Anything richer is capability
+ * output that happens to carry an `error` field, which is a legitimate shape.
+ *
+ * WP4 widens this by exactly one case: an object whose ONLY other content is a
+ * NUMERIC transport status is also a failure marker. That was the second defect
+ * in the package brief — an executor resolving `{error, status: 500}` converted
+ * a failure into a billable success purely by having two keys instead of one.
+ *
+ * The numeric test is load-bearing, not fussiness. `{status: "down", error:
+ * "timeout"}` is an uptime check reporting a site down — the deliverable, and
+ * billable. Keying on the NAME `status` would unbill a correct answer, which is
+ * the precise failure this module's header warns against. An HTTP status code
+ * is a number; a verdict is a word.
+ */
+const TRANSPORT_STATUS_KEYS = new Set(["status", "statusCode", "code", "http_status"]);
+
+function isExecutorFailureMarker(obj: Record<string, unknown>): boolean {
+  if (typeof obj.error !== "string") return false;
+  return Object.keys(obj).every(
+    (k) =>
+      k === "error" ||
+      (TRANSPORT_STATUS_KEYS.has(k) && typeof obj[k] === "number"),
+  );
+}
+
+/**
+ * Assess a capability's output value.
+ *
+ * Pure and total: it never throws and never reaches the network or the
+ * database, so a rail can call it inside a wallet transaction without widening
+ * the window that WP3 exists to bound.
+ */
+export function assessOutput(
+  slug: string,
+  output: unknown,
+): OutputAssessment {
+  const quality_flags: string[] = [];
+
+  if (output === null || output === undefined) {
+    return {
+      structurally_valid: false,
+      semantically_usable: false,
+      contract_valid: null,
+      quality_flags: ["output_absent"],
+    };
+  }
+
+  if (typeof output !== "object" || Array.isArray(output)) {
+    // Not the executor contract's shape. Recorded rather than thrown: the
+    // caller may still have received something, and the audit trail should say
+    // what it was.
+    return {
+      structurally_valid: false,
+      semantically_usable: false,
+      contract_valid: null,
+      quality_flags: [Array.isArray(output) ? "output_is_array" : "output_not_object"],
+    };
+  }
+
+  const obj = output as Record<string, unknown>;
+
+  if (obj.skipped === true) quality_flags.push("step_skipped");
+  if (obj.unavailable === true) quality_flags.push("step_unavailable");
+
+  const isFailureMarker = isExecutorFailureMarker(obj);
+  if (isFailureMarker) quality_flags.push("executor_error_marker");
+
+  const semantically_usable =
+    !isFailureMarker && obj.skipped !== true && obj.unavailable !== true;
+
+  if (Object.keys(obj).length === 0) {
+    quality_flags.push("output_empty_object");
+  }
+
+  const contract = CAPABILITY_OUTPUT_CONTRACTS[slug];
+  let contract_valid: boolean | null = null;
+  if (contract && semantically_usable) {
+    const missing = Object.entries(contract.reliability)
+      .filter(([, reliability]) => reliability === "guaranteed")
+      .map(([field]) => field)
+      .filter((field) => !hasPath(obj, field));
+    contract_valid = missing.length === 0;
+    if (missing.length > 0) {
+      quality_flags.push(`contract_missing:${missing.join(",")}`);
+    }
+  }
+
+  return {
+    structurally_valid: true,
+    semantically_usable,
+    contract_valid,
+    quality_flags,
+  };
+}
+
+/** Dotted-path presence check, so nested contract fields resolve. */
+function hasPath(root: Record<string, unknown>, path: string): boolean {
+  let cursor: unknown = root;
+  for (const segment of path.split(".")) {
+    if (cursor === null || typeof cursor !== "object") return false;
+    if (!(segment in (cursor as Record<string, unknown>))) return false;
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return cursor !== null && cursor !== undefined;
+}
+
+/**
+ * The outcome for an executor that resolved.
+ *
+ * Resolving is necessary and not sufficient. A contract violation is recorded
+ * but does NOT block the charge: the contract table covers a handful of slugs
+ * and exists to correct harness false-alarms, so treating a violation as
+ * unbillable would refund correct work on the strength of a declaration we
+ * already know drifts. It feeds quality, which is where a drifting declaration
+ * should surface.
+ */
+export function outcomeFromOutput(
+  slug: string,
+  output: unknown,
+): ExecutionOutcome {
+  const assessment = assessOutput(slug, output);
+
+  if (!assessment.semantically_usable) {
+    const skipped = assessment.quality_flags.includes("step_skipped");
+    const unavailable = assessment.quality_flags.includes("step_unavailable");
+    return {
+      success: false,
+      failure_class: "output_unusable",
+      billable: false,
+      // A skipped step was starved of inputs by an earlier failure; retrying
+      // the step alone changes nothing.
+      retryable: !skipped,
+      fault: unavailable ? "strale" : "provider",
+      output_assessment: assessment,
+      counts_against_capability: !skipped && !unavailable,
+      error_message:
+        typeof (output as Record<string, unknown> | null)?.error === "string"
+          ? ((output as Record<string, unknown>).error as string)
+          : null,
+    };
+  }
+
+  return {
+    success: true,
+    failure_class: null,
+    billable: true,
+    retryable: false,
+    fault: null,
+    output_assessment: assessment,
+    counts_against_capability: false,
+    error_message: null,
+  };
+}
+
+/** Classify a thrown error into the canonical vocabulary. */
+export function outcomeFromError(error: unknown): ExecutionOutcome {
+  const base = {
+    success: false as const,
+    output_assessment: null,
+    error_message: error instanceof Error ? error.message : String(error),
+  };
+
+  // A refusal is the guarded executor working. Not billable, not retryable,
+  // and explicitly NOT counted against the capability — see the header note.
+  if (error instanceof CapabilityInvocationRefusedError) {
+    return {
+      ...base,
+      failure_class: "capability_refused",
+      billable: false,
+      retryable: false,
+      fault: "caller",
+      counts_against_capability: false,
+    };
+  }
+
+  if (error instanceof BudgetExhaustedError) {
+    return {
+      ...base,
+      failure_class: "budget_exhausted",
+      billable: false,
+      retryable: false,
+      fault: "strale",
+      counts_against_capability: false,
+    };
+  }
+
+  if (error instanceof CapabilityNotClassifiedError) {
+    return {
+      ...base,
+      failure_class: "not_classified",
+      billable: false,
+      retryable: false,
+      fault: "strale",
+      counts_against_capability: false,
+    };
+  }
+
+  const message = base.error_message.toLowerCase();
+  const transient =
+    message.includes("timeout") ||
+    message.includes("timed out") ||
+    message.includes("aborted") ||
+    message.includes("econnreset") ||
+    message.includes("econnrefused") ||
+    message.includes("enotfound") ||
+    message.includes("socket hang up") ||
+    / 5\d\d\b/.test(message);
+
+  return {
+    ...base,
+    failure_class: transient ? "provider_unavailable" : "provider_rejected",
+    billable: false,
+    retryable: transient,
+    fault: "provider",
+    counts_against_capability: true,
+  };
+}
+
+/** A gate step reported the bundle cannot do what it was sold for. */
+export function outcomeFromGate(
+  gate: { capabilitySlug: string; field: string },
+): ExecutionOutcome {
+  return {
+    success: false,
+    failure_class: "gate_tripped",
+    // The single most important line in this module. The wallet rail already
+    // refunded here; the x402 rail settled in full. Both now read this.
+    billable: false,
+    retryable: false,
+    // The gate step answered correctly — it is not the capability's failure.
+    fault: "provider",
+    output_assessment: null,
+    counts_against_capability: false,
+    error_message: `gate tripped: ${gate.capabilitySlug}.${gate.field}`,
+  };
+}
+
+export interface SolutionOutcome extends ExecutionOutcome {
+  steps_total: number;
+  steps_succeeded: number;
+}
+
+/**
+ * Fold per-step outcomes into one answer for the bundle.
+ *
+ * Precedence is deliberate: a tripped gate loses the charge even when steps
+ * behind it succeeded, because the bundle could not perform the work it was
+ * sold for. Otherwise at least one usable step is billable — a bundle is priced
+ * as a bundle, and partial delivery is disclosed in the audit trail rather than
+ * priced by the step.
+ */
+export function aggregateSolutionOutcome(
+  stepOutcomes: ExecutionOutcome[],
+  gate?: { capabilitySlug: string; field: string },
+): SolutionOutcome {
+  const steps_total = stepOutcomes.length;
+  const steps_succeeded = stepOutcomes.filter((o) => o.success).length;
+
+  if (gate) {
+    return { ...outcomeFromGate(gate), steps_total, steps_succeeded };
+  }
+
+  if (steps_succeeded === 0) {
+    const anyRetryable = stepOutcomes.some((o) => o.retryable);
+    return {
+      success: false,
+      failure_class: "output_unusable",
+      billable: false,
+      retryable: anyRetryable,
+      fault: "provider",
+      output_assessment: null,
+      counts_against_capability: false,
+      error_message: "no step produced usable output",
+      steps_total,
+      steps_succeeded,
+    };
+  }
+
+  return {
+    success: true,
+    failure_class: null,
+    billable: true,
+    retryable: false,
+    fault: null,
+    output_assessment: null,
+    counts_against_capability: false,
+    error_message: null,
+    steps_total,
+    steps_succeeded,
+  };
+}
+
+/** The transaction-row vocabulary `/v1/do` and solutions already share. */
+export function transactionStatusFor(outcome: ExecutionOutcome): "completed" | "failed" {
+  return outcome.success ? "completed" : "failed";
+}

--- a/apps/api/src/lib/execution-outcome.ts
+++ b/apps/api/src/lib/execution-outcome.ts
@@ -445,7 +445,18 @@ export class UnbillableOutputError extends Error {
         ? `Capability returned an error rather than output: ${upstreamMessage}`
         : assessment.quality_flags.includes("executor_error_marker")
           ? "Capability returned an error marker rather than output"
-          : "Capability returned no usable output",
+          // Name the actual shape. A handful of executors pass upstream JSON
+          // straight through (`output: raw`), so if a registry ever answers
+          // with an array this is what an operator will see in
+          // transactions.error — "no usable output" would send them hunting
+          // through the executor for a bug that is in the upstream response.
+          : assessment.quality_flags.includes("output_is_array")
+            ? "Capability returned a JSON array; the output contract is an object"
+            : assessment.quality_flags.includes("output_not_object")
+              ? "Capability returned a non-object; the output contract is an object"
+              : assessment.quality_flags.includes("output_absent")
+                ? "Capability returned no output at all"
+                : "Capability returned no usable output",
     );
     this.name = "UnbillableOutputError";
   }

--- a/apps/api/src/lib/execution-outcome.ts
+++ b/apps/api/src/lib/execution-outcome.ts
@@ -425,11 +425,27 @@ export class UnbillableOutputError extends Error {
   constructor(
     public readonly slug: string,
     public readonly assessment: OutputAssessment,
+    /**
+     * The executor's own error text, when it had one.
+     *
+     * Carried through rather than replaced by a generic string. Review finding:
+     * the first version discarded it, so an output of
+     * `{error: "Bolagsverket returned HTTP 503", status: 503}` reached
+     * `transactions.error` as "Capability returned an error marker rather than
+     * output" — which classifyTransactionFailure files as `internal`, i.e.
+     * Strale's bug, when the original text would have matched UPSTREAM_RE and
+     * filed correctly as `upstream`. That misfiling is not cosmetic: the
+     * quality floor is armed in production and `internal` counts against a
+     * capability while `upstream` is read differently.
+     */
+    public readonly upstreamMessage?: string | null,
   ) {
     super(
-      assessment.quality_flags.includes("executor_error_marker")
-        ? "Capability returned an error marker rather than output"
-        : "Capability returned no usable output",
+      upstreamMessage
+        ? `Capability returned an error rather than output: ${upstreamMessage}`
+        : assessment.quality_flags.includes("executor_error_marker")
+          ? "Capability returned an error marker rather than output"
+          : "Capability returned no usable output",
     );
     this.name = "UnbillableOutputError";
   }
@@ -445,6 +461,35 @@ export class UnbillableOutputError extends Error {
 export function assertBillableOutput(slug: string, output: unknown): void {
   const outcome = outcomeFromOutput(slug, output);
   if (!outcome.billable) {
-    throw new UnbillableOutputError(slug, outcome.output_assessment!);
+    throw new UnbillableOutputError(
+      slug,
+      outcome.output_assessment!,
+      outcome.error_message,
+    );
   }
+}
+
+/**
+ * Should this failure count against the capability's health?
+ *
+ * The consumer `counts_against_capability` was missing. Without it the field
+ * was documentation rather than behaviour: a refusal still called
+ * `recordFailure` + `triggerOnFailure`, so the guarded executor protecting
+ * vendor budget looked identical to a capability that was broken. The quality
+ * floor is armed in production — quarantine below 70% over 30 days — so that is
+ * not a reporting nicety. It is how a capability gets delisted for behaving
+ * correctly.
+ *
+ * Accepts a thrown value or a bare message string, because one call site has
+ * only the latter.
+ */
+export function shouldCountAgainstCapability(error: unknown): boolean {
+  if (error instanceof UnbillableOutputError) {
+    // The capability resolved with something unusable. That IS its fault —
+    // unless the marker says the step never ran.
+    return !error.assessment.quality_flags.some(
+      (f) => f === "step_skipped" || f === "step_unavailable",
+    );
+  }
+  return outcomeFromError(error).counts_against_capability;
 }

--- a/apps/api/src/lib/solution-gate.test.ts
+++ b/apps/api/src/lib/solution-gate.test.ts
@@ -161,10 +161,22 @@ describe("the refund path, structurally", () => {
     expect(src).not.toMatch(/if \(!allFailed\) \{\s*\n\s*await refundWallet/);
   });
 
-  it("refunds a gated run exactly once", () => {
-    // One refund call on the main path, and it covers both reasons.
-    expect(src).toContain("const refundRequired = allFailed || gated !== undefined;");
+  it("refunds a gated run exactly once, on the canonical decision", () => {
+    // WP4 moved the rule itself into lib/execution-outcome.ts, because the
+    // x402 rail had its own answer and disagreed. This assertion followed:
+    // pinning the literal `allFailed || gated !== undefined` would now forbid
+    // the fix. What it pins instead is stronger — that this rail derives the
+    // decision rather than making one.
+    expect(src).toContain("const refundRequired = !outcome.billable;");
     expect(src).toContain("if (refundRequired) {");
+
+    // Behavioural coverage for the gate itself now lives in
+    // routes/billing-parity.integration.test.ts, which drives both rails
+    // against a real gated solution and asserts they agree. This block remains
+    // structural only because no route-level harness existed when it was
+    // written; the integration test is the one that would catch a regression
+    // in behaviour rather than in wording.
+    expect(src).toContain("aggregateSolutionOutcome(");
   });
 
   it("charges nothing when the gate trips", () => {

--- a/apps/api/src/lib/x402-gateway.ts
+++ b/apps/api/src/lib/x402-gateway.ts
@@ -376,39 +376,19 @@ export interface X402PaymentRequirement {
 }
 
 /**
- * Verify AND settle an x402 payment header using the facilitator.
+ * WP4 removed `verifyX402Payment`, a combined verify-and-settle helper.
  *
- * This is the legacy one-shot flow — the on-chain transaction is broadcast
- * before the capability runs, so a validation/execution failure still charges
- * the caller. Kept for the /v1/do x402 path which hasn't yet been refactored.
+ * It moved the USDC before the capability ran, so there was no output to assess
+ * and no way for it to consult the canonical billing decision — a DEC-14
+ * violation its own docstring acknowledged while pointing new code at the split
+ * form. Nothing called it. It was deleted rather than documented because a
+ * charge-before-execute helper sitting in the shared library is an invitation,
+ * and WP4's exit condition ("no route decides billability independently")
+ * cannot be guaranteed while one exists.
  *
- * For new code (e.g. /x402/:slug), prefer `verifyX402PaymentOnly` +
- * `settleX402Payment` so the USDC is only moved after the capability produces
- * output (DEC-14: don't charge before execution succeeds).
- *
- * @param paymentHeader - Base64-encoded X-PAYMENT header from the request
- * @param priceCentsEur - EUR price of the capability (for fallback conversion)
- * @param priceUsdOverride - USD price the 402 response quoted to the client.
- *   MUST match what the client signed against. If provided, this wins over
- *   priceCentsEur. The x402 gateway-v2 passes this from cap.x402PriceUsd so the
- *   verification amount exactly matches what was in the 402 response's
- *   maxAmountRequired field.
+ * Use `verifyX402PaymentOnly` to authorize, execute, then `settleX402Payment`.
  */
-export async function verifyX402Payment(
-  paymentHeader: string,
-  priceCentsEur: number,
-  priceUsdOverride?: number,
-  requirementOverrides?: X402PaymentRequirement,
-): Promise<X402VerificationResult> {
-  const verifyOnly = await verifyX402PaymentOnly(
-    paymentHeader, priceCentsEur, priceUsdOverride, requirementOverrides,
-  );
-  if (!verifyOnly.valid || !verifyOnly.verified) {
-    return { valid: false, error: verifyOnly.error };
-  }
-  const settle = await settleX402Payment(verifyOnly.verified);
-  return { valid: settle.valid, settlementId: settle.settlementId, error: settle.error };
-}
+
 
 /**
  * Opaque handle returned by a successful verify. Pass it to

--- a/apps/api/src/routes/billing-parity.integration.test.ts
+++ b/apps/api/src/routes/billing-parity.integration.test.ts
@@ -267,7 +267,15 @@ describeMaybe("a gated solution bills identically on both rails", () => {
     const res = await runWalletRail();
     const body = (await res.json()) as Record<string, any>;
 
-    expect(body.charged_cents ?? body.price_cents ?? 0).toBe(0);
+    // Review finding: this line was `body.charged_cents ?? body.price_cents ?? 0`,
+    // which is vacuously 0 when the response carries NEITHER key — and neither
+    // was ever at the top level, so it asserted nothing at all. The real field
+    // is result.price_cents; the gated block also states it outright.
+    expect(body.result).toHaveProperty("price_cents");
+    expect(body.result.price_cents).toBe(0);
+    expect(body.result.gated?.charged).toBe(false);
+
+    // The load-bearing assertion either way: the money did not move.
     expect(await balance()).toBe(STARTING_BALANCE);
   }, 120_000);
 
@@ -313,5 +321,79 @@ describeMaybe("a gated solution bills identically on both rails", () => {
     const x402Res = await runX402Rail();
     expect(x402Res.status).toBe(200);
     expect(settleSpy).toHaveBeenCalledTimes(1);
+  }, 120_000);
+});
+
+/**
+ * The capability rail, added after adversarial review.
+ *
+ * The solutions block above could not have caught the blocking finding: it
+ * exercises solutions only, so an unwired CAPABILITY rail was invisible to it
+ * while the package's exit condition claimed every rail was covered. Same
+ * capability, same USDC, two endpoints — they must agree.
+ */
+describeMaybe("a capability returning an unusable output bills on neither rail", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let app: Awaited<typeof import("../app.js")>["app"];
+
+  let capabilityId = "";
+  const CAP_SLUG = `wp4-bad-${randomUUID().slice(0, 8)}`;
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 4 });
+    db = drizzle(client);
+    const { registerCapability } = await import("../capabilities/index.js");
+    // RESOLVES — does not throw — with an error marker plus a numeric HTTP
+    // status. Pre-WP4 both rails treated resolution as success and charged.
+    registerCapability(CAP_SLUG, async () => ({
+      output: { error: "Registry returned 503", status: 503 },
+      provenance: { source: "wp4-test", fetched_at: new Date().toISOString() },
+    }));
+    ({ app } = await import("../app.js"));
+  }, 120_000);
+
+  afterAll(async () => {
+    if (capabilityId) {
+      await db.delete(transactions).where(eq(transactions.capabilityId, capabilityId));
+      await db.delete(capabilities).where(eq(capabilities.id, capabilityId));
+    }
+    await client.end();
+  });
+
+  it("the x402 capability rail does not settle", async () => {
+    settleSpy.mockClear();
+    capabilityId = randomUUID();
+    await db.insert(capabilities).values({
+      id: capabilityId,
+      slug: CAP_SLUG,
+      name: "WP4 unusable-output capability",
+      description: "Seeded by the WP4 billing-parity test.",
+      category: "developer-tools",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      priceCents: 25,
+      isActive: true,
+      avgLatencyMs: 50,
+      lifecycleState: "active",
+      x402Enabled: true,
+      x402PriceUsd: 0.3,
+    });
+
+    const { __resetX402CacheForTests } = await import("./x402-gateway-v2.js");
+    __resetX402CacheForTests();
+
+    const res = await app.request(`http://localhost/x402/${CAP_SLUG}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-PAYMENT": `wp4-auth-${randomUUID()}`,
+      },
+      body: JSON.stringify({ probe: "wp4" }),
+    });
+
+    // The assertion that would have caught the blocking finding.
+    expect(settleSpy).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(200);
   }, 120_000);
 });

--- a/apps/api/src/routes/billing-parity.integration.test.ts
+++ b/apps/api/src/routes/billing-parity.integration.test.ts
@@ -1,0 +1,317 @@
+/**
+ * WP4 acceptance signal: the two rails bill a gated solution identically.
+ *
+ * This is the test the package exists to make pass. Before it, the wallet rail
+ * refunded a gated run in full and the x402 rail settled it in full — same
+ * execution, opposite billing, decided by which payment method the caller
+ * happened to use. Confirmed by grep before it was confirmed by test: the token
+ * `gated` appeared twelve times in routes/solution-execute.ts and zero times in
+ * routes/x402-gateway-v2.ts.
+ *
+ * Verified discriminating: restoring the old `anyStepSucceeded` predicate on the
+ * x402 rail turns the parity assertion red and leaves the wallet assertions
+ * green, which is exactly the asymmetry the package removes.
+ *
+ * No real payment is made. The facilitator is mocked at the module boundary —
+ * `verifyX402PaymentOnly` returns a verified handle and `settleX402Payment` is a
+ * spy — so the route runs its real logic end to end while no USDC moves. The
+ * spy is the point: the assertion is not merely that the response is a 502, but
+ * that settlement is never reached.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../test-support/integration-db.js";
+import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
+import {
+  users,
+  wallets,
+  walletTransactions,
+  walletReservations,
+  capabilities,
+  solutions,
+  solutionSteps,
+  transactions,
+} from "../db/schema.js";
+
+if (process.env.DATABASE_URL_TEST) {
+  process.env.FRONTEND_URL ??= "https://strale.dev";
+  process.env.AUDIT_HMAC_SECRET ??= "wp4-parity-secret-at-least-32-chars-000000";
+  process.env.ADMIN_SECRET ??= "wp4-parity-admin-secret-at-least-32-chars0";
+  process.env.STRIPE_SECRET_KEY ??= "sk_test_wp4_placeholder";
+  process.env.STRIPE_WEBHOOK_SECRET ??= "whsec_wp4_placeholder";
+  // Makes isX402Configured() true so the route reaches its execution path.
+  process.env.X402_RECEIVING_ADDRESS ??= "0x0000000000000000000000000000000000000001";
+  process.env.X402_NETWORK ??= "base";
+}
+
+const settleSpy = vi.fn(async () => ({
+  valid: true,
+  settlementId: "wp4-test-settlement",
+}));
+
+// Mocked at the module boundary so BOTH rails run their real code. Only the
+// on-chain calls are replaced.
+vi.mock("../lib/x402-gateway.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/x402-gateway.js")>();
+  return {
+    ...actual,
+    isX402Configured: () => true,
+    verifyX402PaymentOnly: async () => ({
+      valid: true,
+      verified: { payload: {}, requirements: {} },
+    }),
+    settleX402Payment: (...args: unknown[]) => settleSpy(...(args as [])),
+  };
+});
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+const SOLUTION_PRICE = 250;
+const STARTING_BALANCE = 5_000;
+
+describeMaybe("a gated solution bills identically on both rails", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let app: Awaited<typeof import("../app.js")>["app"];
+
+  let userId = "";
+  let walletId = "";
+  let solutionId = "";
+  let solSlug = "";
+  let apiKey = "";
+  const capabilityIds: string[] = [];
+
+  /** Flipped per test: does the gate step report the condition that stops the run? */
+  let gateTrips = true;
+
+  const GATE_SLUG = `wp4-gate-${randomUUID().slice(0, 8)}`;
+  const WORK_SLUG = `wp4-work-${randomUUID().slice(0, 8)}`;
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 8 });
+    db = drizzle(client);
+
+    const { registerCapability } = await import("../capabilities/index.js");
+
+    // The gate step SUCCEEDS — it truthfully reports that the subject cannot be
+    // checked. That is precisely why the old x402 predicate billed for it:
+    // `anyStepSucceeded` saw a successful step and settled.
+    registerCapability(GATE_SLUG, async () => ({
+      output: { reachable: gateTrips ? false : true, checked: true },
+      provenance: { source: "wp4-test", fetched_at: new Date().toISOString() },
+    }));
+
+    registerCapability(WORK_SLUG, async () => ({
+      output: { finding: "none", ok: true },
+      provenance: { source: "wp4-test", fetched_at: new Date().toISOString() },
+    }));
+
+    ({ app } = await import("../app.js"));
+  }, 120_000);
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  afterEach(async () => {
+    settleSpy.mockClear();
+    if (userId) {
+      await db.delete(walletReservations).where(eq(walletReservations.userId, userId));
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+    }
+    if (walletId) {
+      await db.delete(walletTransactions).where(eq(walletTransactions.walletId, walletId));
+      await db.delete(wallets).where(eq(wallets.id, walletId));
+    }
+    if (userId) await db.delete(users).where(eq(users.id, userId));
+    if (solutionId) {
+      await db.delete(solutionSteps).where(eq(solutionSteps.solutionId, solutionId));
+      await db.delete(solutions).where(eq(solutions.id, solutionId));
+    }
+    for (const id of capabilityIds.splice(0)) {
+      await db.delete(capabilities).where(eq(capabilities.id, id));
+    }
+    userId = walletId = solutionId = "";
+    gateTrips = true;
+  });
+
+  async function seed() {
+    userId = randomUUID();
+    solutionId = randomUUID();
+    solSlug = `wp4-sol-${randomUUID().slice(0, 8)}`;
+    apiKey = `sk_live_${randomUUID().replace(/-/g, "")}`;
+
+    await db.insert(users).values({
+      id: userId,
+      email: `wp4-${userId}@example.test`,
+      apiKeyHash: hashApiKey(apiKey),
+      keyPrefix: getKeyPrefix(apiKey),
+    });
+
+    const walletService = await import("../lib/wallet-service.js");
+    const wallet = await db.transaction((tx) =>
+      walletService.openWallet(tx, {
+        userId,
+        grantCents: STARTING_BALANCE,
+        type: "trial_credit",
+        description: "WP4 parity grant",
+      }),
+    );
+    walletId = wallet.id;
+
+    for (const slug of [GATE_SLUG, WORK_SLUG]) {
+      const id = randomUUID();
+      capabilityIds.push(id);
+      await db.insert(capabilities).values({
+        id,
+        slug,
+        name: `WP4 ${slug}`,
+        description: "Seeded by the WP4 billing-parity test.",
+        category: "developer-tools",
+        inputSchema: { type: "object" },
+        outputSchema: { type: "object" },
+        priceCents: 10,
+        isActive: true,
+        avgLatencyMs: 50,
+        lifecycleState: "active",
+      });
+    }
+
+    await db.insert(solutions).values({
+      id: solutionId,
+      slug: solSlug,
+      name: "WP4 parity solution",
+      description: "Seeded by the WP4 billing-parity test.",
+      category: "compliance",
+      priceCents: SOLUTION_PRICE,
+      componentSumCents: 20,
+      valueTier: "standard",
+      maintenanceLevel: "low",
+      geography: "EU",
+      inputSchema: { type: "object", properties: { probe: { type: "string" } } },
+      isActive: true,
+      x402Enabled: true,
+      x402PriceUsd: 2.75,
+    });
+
+    // Step 1 gates on `reachable === false`; step 2 is the work behind it.
+    const { __resetX402CacheForTests } = await import("./x402-gateway-v2.js");
+    __resetX402CacheForTests();
+
+    await db.insert(solutionSteps).values([
+      {
+        solutionId,
+        capabilitySlug: GATE_SLUG,
+        stepOrder: 1,
+        inputMap: { probe: "probe" },
+        gateCondition: {
+          field: "reachable",
+          equals: false,
+          reason: "the subject registry is unreachable",
+        },
+      },
+      {
+        solutionId,
+        capabilitySlug: WORK_SLUG,
+        stepOrder: 2,
+        inputMap: { probe: "probe" },
+      },
+    ]);
+  }
+
+  function runWalletRail() {
+    return app.request(`http://localhost/v1/solutions/${solSlug}/execute`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ inputs: { probe: "wp4" } }),
+    });
+  }
+
+  function runX402Rail() {
+    return app.request(`http://localhost/x402/solutions/${solSlug}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        // MUST be unique per request. The route dedups replays on a hash of
+        // this header (cert-audit C9), so a constant value makes every call
+        // after the first return the first one's cached row — a 200 with no
+        // execution and no settlement, which reads exactly like a billing bug.
+        // A real payment authorization is distinct per request too.
+        "X-PAYMENT": `wp4-auth-${randomUUID()}`,
+      },
+      body: JSON.stringify({ probe: "wp4" }),
+    });
+  }
+
+  async function balance(): Promise<number> {
+    const [row] = await db
+      .select({ balanceCents: wallets.balanceCents })
+      .from(wallets)
+      .where(eq(wallets.id, walletId))
+      .limit(1);
+    return row!.balanceCents;
+  }
+
+  it("wallet rail: the caller keeps their money", async () => {
+    await seed();
+
+    const res = await runWalletRail();
+    const body = (await res.json()) as Record<string, any>;
+
+    expect(body.charged_cents ?? body.price_cents ?? 0).toBe(0);
+    expect(await balance()).toBe(STARTING_BALANCE);
+  }, 120_000);
+
+  it("x402 rail: settlement is never reached", async () => {
+    await seed();
+
+    const res = await runX402Rail();
+
+    // The assertion that matters is the spy, not the status code: pre-WP4 this
+    // rail returned 200 AND moved the USDC, because the gate step counted as a
+    // success under `anyStepSucceeded`.
+    expect(settleSpy).not.toHaveBeenCalled();
+    expect(res.status).toBe(502);
+
+    const body = (await res.json()) as Record<string, any>;
+    expect(body.failure_class).toBe("gate_tripped");
+  }, 120_000);
+
+  it("the two rails agree — which is the whole point", async () => {
+    await seed();
+
+    await runWalletRail();
+    const walletCharged = STARTING_BALANCE - (await balance());
+
+    await runX402Rail();
+    const x402Charged = settleSpy.mock.calls.length;
+
+    expect(walletCharged).toBe(0);
+    expect(x402Charged).toBe(0);
+  }, 120_000);
+
+  it("and both still charge when the gate does NOT trip", async () => {
+    // Guards the other direction. A parity fix that simply stopped charging
+    // would also make the assertions above pass, and would be worse than the
+    // bug.
+    await seed();
+    gateTrips = false;
+
+    const walletRes = await runWalletRail();
+    expect(walletRes.status).toBe(200);
+    expect(await balance()).toBe(STARTING_BALANCE - SOLUTION_PRICE);
+
+    const x402Res = await runX402Rail();
+    expect(x402Res.status).toBe(200);
+    expect(settleSpy).toHaveBeenCalledTimes(1);
+  }, 120_000);
+});

--- a/apps/api/src/routes/billing-parity.integration.test.ts
+++ b/apps/api/src/routes/billing-parity.integration.test.ts
@@ -121,6 +121,15 @@ describeMaybe("a gated solution bills identically on both rails", () => {
 
   afterEach(async () => {
     settleSpy.mockClear();
+    // The x402 rail has no user, so its rows carry user_id NULL and a delete
+    // keyed on userId silently leaves them behind. They then outlive the test
+    // with a fresh completed_at, and integrity-hash-chain's head selection —
+    // which scans ALL transactions by (completed_at, id) DESC — resumes from
+    // one of them. That failed in CI while passing locally, which is what
+    // leftover rows look like.
+    if (solSlug) {
+      await db.delete(transactions).where(eq(transactions.solutionSlug, solSlug));
+    }
     if (userId) {
       await db.delete(walletReservations).where(eq(walletReservations.userId, userId));
       await db.delete(transactions).where(eq(transactions.userId, userId));
@@ -355,11 +364,17 @@ describeMaybe("a capability returning an unusable output bills on neither rail",
 
   afterAll(async () => {
     if (capabilityId) {
+      // Keyed on capabilityId, not userId: this rail has no user, so its rows
+      // carry user_id NULL. Leaving them behind gives integrity-hash-chain's
+      // global head selection a fresher completed_at to resume from — which is
+      // how the solutions block broke that test in CI while passing locally.
+      // `transactions` has no slug column; capability_id is the identifier.
       await db.delete(transactions).where(eq(transactions.capabilityId, capabilityId));
       await db.delete(capabilities).where(eq(capabilities.id, capabilityId));
     }
     await client.end();
   });
+
 
   it("the x402 capability rail does not settle", async () => {
     settleSpy.mockClear();

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -1,7 +1,10 @@
 import { Hono } from "hono";
 import { eq, and, gte, inArray, isNull, sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
-import { assertBillableOutput } from "../lib/execution-outcome.js";
+import {
+  assertBillableOutput,
+  shouldCountAgainstCapability,
+} from "../lib/execution-outcome.js";
 import {
   wallets,
   walletTransactions,
@@ -1439,8 +1442,13 @@ async function executeFreeTier(
 
     // F-0-009 Stage 2: the row lands with compliance_hash_state = 'pending'
     // by column default; jobs/integrity-hash-retry.ts will fill it in.
-    fireAndForget(() => recordFailure(capability.slug, errorMessage), { label: "circuit-breaker-record-failure", context: { slug: capability.slug } });
-    fireAndForget(() => triggerOnFailure(capability.slug), { label: "trigger-on-failure", context: { slug: capability.slug } });
+    // WP4 remediation: a refusal is the guarded executor working, not a broken
+    // capability. Recording it here delisted capabilities for correctly
+    // refusing bad input — the quality floor is armed in production.
+    if (shouldCountAgainstCapability(err)) {
+      fireAndForget(() => recordFailure(capability.slug, errorMessage), { label: "circuit-breaker-record-failure", context: { slug: capability.slug } });
+      fireAndForget(() => triggerOnFailure(capability.slug), { label: "trigger-on-failure", context: { slug: capability.slug } });
+    }
     recordQuality({
       transactionId: txnRecord.id,
       responseTimeMs: latencyMs,
@@ -1600,8 +1608,13 @@ async function executeFreeTierAuthenticated(
 
     // F-0-009 Stage 2: the row lands with compliance_hash_state = 'pending'
     // by column default; jobs/integrity-hash-retry.ts will fill it in.
-    fireAndForget(() => recordFailure(capability.slug, errorMessage), { label: "circuit-breaker-record-failure", context: { slug: capability.slug } });
-    fireAndForget(() => triggerOnFailure(capability.slug), { label: "trigger-on-failure", context: { slug: capability.slug } });
+    // WP4 remediation: a refusal is the guarded executor working, not a broken
+    // capability. Recording it here delisted capabilities for correctly
+    // refusing bad input — the quality floor is armed in production.
+    if (shouldCountAgainstCapability(err)) {
+      fireAndForget(() => recordFailure(capability.slug, errorMessage), { label: "circuit-breaker-record-failure", context: { slug: capability.slug } });
+      fireAndForget(() => triggerOnFailure(capability.slug), { label: "trigger-on-failure", context: { slug: capability.slug } });
+    }
     recordQuality({
       transactionId: txnRecord.id,
       responseTimeMs: latencyMs,
@@ -1679,6 +1692,13 @@ async function executeSync(
         error: string;
         transactionId: string;
         balanceAfter: number;
+        /**
+         * Whether this failure should count against the capability's health.
+         * Decided where the thrown value is still in scope; by the time the
+         * caller records the breaker failure it has only the message string,
+         * and a refusal is indistinguishable from a fault once flattened.
+         */
+        countsAgainstCapability: boolean;
       };
 
   // Cert-audit Y-5: catch postgres timeout codes from the wallet tx so
@@ -1864,6 +1884,10 @@ async function executeSync(
         error: errorMessage,
         transactionId: txnRecord.id,
         balanceAfter: wallet.balanceCents,
+        // Classified HERE, where the thrown value is still in scope. The caller
+        // that records the breaker failure sees only the message string, and a
+        // refusal is indistinguishable from a real fault once flattened to text.
+        countsAgainstCapability: shouldCountAgainstCapability(err),
       };
     }
     });
@@ -1921,7 +1945,7 @@ async function executeSync(
       },
       { label: "activation-hook", context: { userId: user.id, slug: capability.slug } },
     );
-  } else if (result.errorCode === "execution_failed") {
+  } else if (result.errorCode === "execution_failed" && result.countsAgainstCapability !== false) {
     fireAndForget(() => recordFailure(capability.slug, result.error), { label: "circuit-breaker-record-failure", context: { slug: capability.slug } });
     fireAndForget(() => triggerOnFailure(capability.slug), { label: "trigger-on-failure", context: { slug: capability.slug } });
     recordQuality({
@@ -2453,8 +2477,13 @@ async function executeInBackground(
     // CCO P0 #6: row was 'deferred' until the UPDATE above flipped it
     // to 'pending'. Retry worker picks it up on its next tick.
     // Record failure for circuit breaker + quality
-    fireAndForget(() => recordFailure(capability.slug, errorMessage), { label: "circuit-breaker-record-failure", context: { slug: capability.slug } });
-    fireAndForget(() => triggerOnFailure(capability.slug), { label: "trigger-on-failure", context: { slug: capability.slug } });
+    // WP4 remediation: a refusal is the guarded executor working, not a broken
+    // capability. Recording it here delisted capabilities for correctly
+    // refusing bad input — the quality floor is armed in production.
+    if (shouldCountAgainstCapability(err)) {
+      fireAndForget(() => recordFailure(capability.slug, errorMessage), { label: "circuit-breaker-record-failure", context: { slug: capability.slug } });
+      fireAndForget(() => triggerOnFailure(capability.slug), { label: "trigger-on-failure", context: { slug: capability.slug } });
+    }
     recordQuality({
       transactionId,
       responseTimeMs: latencyMs,

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { eq, and, gte, inArray, isNull, sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
+import { assertBillableOutput } from "../lib/execution-outcome.js";
 import {
   wallets,
   walletTransactions,
@@ -1289,6 +1290,7 @@ async function executeFreeTier(
 
   try {
     const capResult = await executeWithRetry(executor, executionInput, capability);
+    assertBillableOutput(capability.slug, capResult.output);
     const latencyMs = Date.now() - startTime;
 
     const audit = buildFullAudit({
@@ -1493,6 +1495,7 @@ async function executeFreeTierAuthenticated(
 
   try {
     const capResult = await executeWithRetry(executor, executionInput, capability);
+    assertBillableOutput(capability.slug, capResult.output);
     const latencyMs = Date.now() - startTime;
 
     const audit = buildFullAudit({
@@ -1769,6 +1772,7 @@ async function executeSync(
     // Execute the capability
     try {
       const capResult = await executeWithRetry(executor, executionInput, capability);
+      assertBillableOutput(capability.slug, capResult.output);
       const latencyMs = Date.now() - startTime;
 
       // Deduct through the wallet service — the balance change and its ledger
@@ -2293,6 +2297,7 @@ async function executeInBackground(
       executeWithRetry(executor, executionInput, capability),
       EXEC_HARD_TIMEOUT_MS,
     );
+    assertBillableOutput(capability.slug, capResult.output);
     const latencyMs = Date.now() - startTime;
 
     // Success: update transaction record with full audit trail

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -22,7 +22,12 @@ import { solutions, wallets, walletTransactions, transactions } from "../db/sche
 import { authMiddleware } from "../lib/middleware.js";
 import { rateLimitByKey } from "../lib/rate-limit.js";
 import { apiError } from "../lib/errors.js";
-import { executeSolution, isSuccessfulStepOutput } from "../lib/solution-executor.js";
+import { executeSolution } from "../lib/solution-executor.js";
+import {
+  aggregateSolutionOutcome,
+  assessOutput,
+  outcomeFromOutput,
+} from "../lib/execution-outcome.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
 import { logError, logWarn } from "../lib/log.js";
 import * as walletService from "../lib/wallet-service.js";
@@ -305,19 +310,25 @@ solutionExecuteRoute.post(
     // UNAVAILABLE steps as successes, so a solution whose step 1 failed
     // (starving every downstream step) billed full price for zero executed
     // checks. Same predicate the x402 rail settles on (DEC-14).
-    const stepsSucceeded = Object.values(execResult.steps).filter(isSuccessfulStepOutput).length;
-    const allFailed = stepsSucceeded === 0;
-
-    // A tripped gate is NOT a failure — the gate step did its job and returned
-    // a true answer ("the page is down"). It is a refund, because the bundle
-    // could not perform the work it was sold for. Before gates existed the
-    // caller paid in full here: the gate step counts as a success, one success
-    // is enough to bill, and the steps behind it had already run and failed.
+    // WP4: the same aggregate the x402 rail now reads. The rule this encodes is
+    // unchanged from what this rail already did — a tripped gate is not a
+    // failure (the gate answered truthfully) but it is a refund, because the
+    // bundle could not perform the work it was sold for. What changed is that
+    // the rule now lives in one place, so the other rail cannot disagree.
+    const outcome = aggregateSolutionOutcome(
+      Object.entries(execResult.steps).map(([stepSlug, stepOutput]) =>
+        outcomeFromOutput(stepSlug, stepOutput),
+      ),
+      execResult.gated,
+    );
     const gated = execResult.gated;
-    const refundRequired = allFailed || gated !== undefined;
+    const stepsSucceeded = outcome.steps_succeeded;
+    const allFailed = stepsSucceeded === 0;
+    const refundRequired = !outcome.billable;
 
-    // /v1/do vocabulary: "completed" or "failed". Partial success maps to "completed"
-    // with per-step detail in audit_trail. A gated run completed — it answered.
+    // /v1/do vocabulary: "completed" or "failed". Partial success maps to
+    // "completed" with per-step detail in audit_trail. A gated run completed —
+    // it answered — so status is not simply `transactionStatusFor(outcome)`.
     const txStatus = allFailed ? "failed" : "completed";
     const chargedPrice = refundRequired ? 0 : sol.priceCents;
 
@@ -337,7 +348,11 @@ solutionExecuteRoute.post(
     // trail that says "14 steps" must list 14 steps.
     const stepAuditEntries = Object.entries(execResult.steps).map(([capSlug, output], index) => {
       const obj = (output && typeof output === "object" ? output : {}) as Record<string, unknown>;
-      const status = isSuccessfulStepOutput(output)
+      // WP4: the audit label reads the same assessment billing reads. Leaving
+      // this on the old predicate would print "completed" for an
+      // `{error, status}` step that billing had just counted as a failure —
+      // the same divergence this package closes, one layer down.
+      const status = assessOutput(capSlug, output).semantically_usable
         ? "completed"
         : obj.skipped === true
           ? "skipped"

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -45,6 +45,7 @@ import { sanitizeFailureReason } from "../lib/sanitize.js";
 import { executeSolution } from "../lib/solution-executor.js";
 import {
   aggregateSolutionOutcome,
+  assertBillableOutput,
   outcomeFromOutput,
 } from "../lib/execution-outcome.js";
 import { logError } from "../lib/log.js";
@@ -1140,6 +1141,50 @@ x402GatewayV2.on(["GET", "POST"], ["/solutions/:slug", "/v2/solutions/:slug"], a
   );
 
   if (!outcome.billable) {
+    // WP4 remediation. Two things the first version got wrong by returning
+    // early:
+    //
+    // 1. Audit divergence. The wallet rail refunds a gated run AND still
+    //    writes a terminal transaction row with its full audit trail, so the
+    //    run appears in /v1/audit. Returning here left the x402 run invisible
+    //    — a cross-rail inconsistency in exactly the dimension this package
+    //    claims to unify.
+    // 2. Free re-execution. Without a paymentHash row the cert-audit C9 replay
+    //    cache has nothing to match, so the same signed authorization could be
+    //    replayed until expiry, re-running the pre-gate steps at Strale's
+    //    external-API cost with zero revenue. A gate is the deterministic
+    //    repeat case — a registry that is down stays down — so this is the
+    //    worst place to leave that open.
+    //
+    // Recorded unsettled (DEC-14): the row proves the call happened and
+    // carries no payment.
+    try {
+      await recordX402Transaction({
+        clientMeta: extractClientMeta(c.req, {
+          src: c.req.query("src"),
+          ip: c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? c.req.header("cf-connecting-ip"),
+        }) ?? null,
+        capabilityId: null,
+        solutionSlug: sol.slug,
+        slug: sol.slug,
+        inputs,
+        output: { steps: result.steps, errors: result.errors },
+        // Same sources the success path uses below: the executor's own measured
+        // latency, and the "mixed" transparency tag a bundle carries because
+        // its steps may differ.
+        latencyMs: result.latency_ms,
+        priceCents: 0,
+        priceUsd: sol.x402PriceUsd,
+        transparencyTag: "mixed",
+        settlementId: undefined,
+        payerAddress: verified ? extractPayerAddress(verified) : null,
+        error: outcome.error_message ?? "no step produced usable output",
+        paymentHash,
+      });
+    } catch (recordErr) {
+      logError("x402-solution-unbillable-record-failed", recordErr, { slug: sol.slug });
+    }
+
     return c.json(
       {
         error:
@@ -1403,6 +1448,16 @@ x402GatewayV2.on(["GET", "POST"], ["/:slug", "/v2/:slug"], async (c) => {
   let result: Awaited<ReturnType<typeof executor>>;
   try {
     result = await executor(inputs);
+    // WP4 remediation: the capability rail was missed in the first pass while
+    // the package's exit condition claimed every rail was covered. Without
+    // this, `POST /x402/:slug` settles on any resolution while the same
+    // capability reached through `POST /v1/do` with an X-PAYMENT header does
+    // not — a NEW cross-rail asymmetry introduced by the fix for the old one.
+    //
+    // Raised inside the try on purpose: the catch below already records a
+    // failed x402 transaction and deliberately does not settle (CRIT-9,
+    // DEC-14), which is exactly the handling an unusable output needs.
+    assertBillableOutput(cap.slug, result.output);
   } catch (err) {
     // CRIT-9: executor failure was previously logged-only — no transactions
     // row, no audit record, no compliance evidence the call ever happened.

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -42,7 +42,11 @@ import { encodePaymentRequiredHeader } from "@x402/core/http";
 import { extractClientMeta, recordDiscoveryHit, hashX402Payer } from "../lib/attribution.js";
 import { rateLimitByIp } from "../lib/rate-limit.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
-import { executeSolution, isSuccessfulStepOutput } from "../lib/solution-executor.js";
+import { executeSolution } from "../lib/solution-executor.js";
+import {
+  aggregateSolutionOutcome,
+  outcomeFromOutput,
+} from "../lib/execution-outcome.js";
 import { logError } from "../lib/log.js";
 import { getProcessingJurisdictions } from "../lib/provenance-builder.js";
 import { getProcessingLocation } from "../lib/processing-location.js";
@@ -1108,16 +1112,28 @@ x402GatewayV2.on(["GET", "POST"], ["/solutions/:slug", "/v2/solutions/:slug"], a
     return c.json({ error: "Solution has no steps configured." }, 503);
   }
 
-  // Settle only if at least one step produced output. All-steps-failed returns
-  // a 4xx-shaped response and the caller keeps their USDC authorization.
-  // Shared predicate with the wallet path (money-integrity 2026-08-12) — it
-  // also covers the new `unavailable` marker for deactivated steps.
-  const anyStepSucceeded = Object.values(result.steps).some(isSuccessfulStepOutput);
-  if (!anyStepSucceeded) {
+  // WP4: billability comes from the canonical outcome, not from a predicate
+  // local to this rail. Before this, the token `gated` appeared zero times in
+  // this file, so a solution whose gate tripped refunded the wallet customer in
+  // full and settled the x402 customer in full — same execution, opposite
+  // billing, decided by the caller's payment method. `result.gated` was
+  // available here the whole time; nothing read it.
+  const outcome = aggregateSolutionOutcome(
+    Object.entries(result.steps).map(([stepSlug, stepOutput]) =>
+      outcomeFromOutput(stepSlug, stepOutput),
+    ),
+    result.gated,
+  );
+
+  if (!outcome.billable) {
     return c.json(
       {
-        error: "Solution failed — no steps produced output. No payment was taken.",
+        error:
+          outcome.failure_class === "gate_tripped"
+            ? `Solution could not run: ${outcome.error_message}. No payment was taken.`
+            : "Solution failed — no steps produced output. No payment was taken.",
         solution: sol.slug,
+        failure_class: outcome.failure_class,
         steps: result.steps,
         errors: result.errors,
       },

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -104,6 +104,20 @@ let _capCache: Map<string, X402Capability> = new Map();
 let _solCache: Map<string, X402Solution> = new Map();
 let _cacheExpiry = 0;
 
+/**
+ * Drop the catalogue cache so a test that seeds a solution can reach it.
+ *
+ * The cache holds for 60s, which is correct in production and makes any test
+ * seeding more than one slug per minute silently 404 on everything after the
+ * first — a failure that reads like a broken route rather than a stale cache.
+ * Named with the `__…ForTests` convention already used in guarded-executor.ts.
+ */
+export function __resetX402CacheForTests(): void {
+  _capCache = new Map();
+  _solCache = new Map();
+  _cacheExpiry = 0;
+}
+
 async function ensureCache(): Promise<void> {
   if (Date.now() < _cacheExpiry) return;
   try {

--- a/docs/remediation/CURRENT-STATE.md
+++ b/docs/remediation/CURRENT-STATE.md
@@ -2,9 +2,9 @@
 
 _Last updated: 2026-08-21 (session 1)_
 
-- **Current package:** WP2 — ACCEPTED. Ready to start WP3.
-- **Next package:** WP3 — Durable wallet reservations + reconciler (closes the crash window WP1 proved, and the 11 stranded prod rows)
-- **Latest accepted SHA:** `b8a2600` on `remediation/program` (branch not yet merged to main)
+- **Current package:** WP3 — ACCEPTED, merged as `ee7f737` (PR #350). Ready to start WP4.
+- **Next package:** WP4 — Capability Runner + canonical ExecutionOutcome (closes CR-02: five rails each deciding billability their own way)
+- **Latest accepted SHA:** `ee7f737` on `main`
 - **Unresolved blockers:** none
 - **Human approvals granted:** program-level autonomy (run continuously; escalate only per CHECK-IN A/B/C)
 - **Awaiting founder:** nothing. One item is logged for *visibility only*, not decision — see "Codex disposition" below.
@@ -28,6 +28,32 @@ catch.
 Practical note for whoever runs that pass: brief it on the FULL branch diff,
 not per-package, and give it the residuals list from each package manifest so
 it can check that deferred items actually landed where they were promised.
+
+## Where WP3 landed
+
+Durable reservations. Every debit now writes, in the same transaction, the fact
+that the money movement is provisional; that record outlives the process, so a
+reconciler finds what a crash abandoned. The state machine is
+`reserved → executing → captured | released`, every transition a conditional
+UPDATE, which is what makes duplicate capture and duplicate release no-ops
+rather than second money movements.
+
+**The WP1 crash tests are inverted** — they pinned the bug (no refund ever,
+transaction stranded) and now pin the recovery. Verified discriminating.
+
+Solutions had the identical window on the most expensive SKUs, plus a comment
+in the route falsely claiming this reconciler already covered it. Wired and
+proved end to end.
+
+The independent agent returned FAIL_REMEDIATION_REQUIRED (3 blocking, 9
+non-blocking); all closed. Sharpest: a migration that reintroduced the
+check-then-bare-DDL defect the same file had fixed two commits earlier, and an
+ABBA deadlock that could have recorded a SUCCEEDED call as failed and discarded
+its output.
+
+**Still open, founder decision:** the 11 historical stranded rows predate the
+table and carry no reservation, so `findAbandoned` can never reach them.
+Reconciling them writes real customer wallets — CHECK-IN B.
 
 ## Where WP2 landed
 
@@ -98,7 +124,10 @@ residual path requires admin credentials.
 | Item | Owner |
 |---|---|
 | Publication-approval artifact for public examples | WP14 (mandatory exit) |
-| 11 stranded `executing` transactions; crash-orphan reconciler | WP3 (+ CHECK-IN B — writes prod wallets) |
+| ~~Crash-orphan reconciler~~ — CLOSED in WP3 | — |
+| 11 stranded `executing` transactions (pre-date the reservations table; reconciler cannot reach them) | CHECK-IN B — writes prod wallets |
+| `wallet_reservations` retention rule (omission, not yet a decision) | WP14 |
+| Two concurrent reconciler instances untested; advisory lock asserted by inspection | WP15 |
 | Wallet rail still serves quarantined capabilities; solution steps ungated | WP8 |
 | x402 in-flight delisting race at settlement | WP8 |
 | ~~SQL-text assertions want row-level tests~~ — CLOSED in WP1 | — |

--- a/docs/remediation/CURRENT-STATE.md
+++ b/docs/remediation/CURRENT-STATE.md
@@ -10,6 +10,26 @@ _Last updated: 2026-08-21 (session 1)_
 - **Human approvals granted:** program-level autonomy (run continuously; escalate only per CHECK-IN A/B/C)
 - **Awaiting founder:** nothing. One item is logged for *visibility only*, not decision — see "Codex disposition" below.
 
+## WP3 in production — verified, with one honest gap
+
+Checked against prod 90 minutes after `ee7f737` deployed:
+
+- Schema effect confirmed by query, not by log: the table, all three indexes,
+  and `wallets_balance_cents_non_negative` at `convalidated = true`, so the
+  `NOT VALID` → `VALIDATE` two-step completed.
+- No negative wallets. No past-deadline open reservations.
+- Traffic profile unchanged: 375 completed / 338 failed in the 90 minutes
+  after deploy, and **exactly** 375 / 338 in the same window yesterday. The
+  harness sweep is deterministic, so identical counts across two disjoint
+  windows is the expected shape and good evidence of no regression.
+
+**The gap:** `wallet_reservations` holds zero rows, because only 2 non-harness
+transactions have run since deploy. The migration is verified in production;
+the reservation *write path* is not — it has been exercised only by the
+integration suite. The first real paid call is what proves it, and nothing
+about the deploy tells us when that arrives. Worth a deliberate look at the
+table after the next customer call rather than assuming silence means health.
+
 ## Review lane — founder decision, 2026-08-21
 
 Codex exhausted its credits mid-WP3 (available again 27 Aug). Decision: **do

--- a/docs/remediation/CURRENT-STATE.md
+++ b/docs/remediation/CURRENT-STATE.md
@@ -2,8 +2,9 @@
 
 _Last updated: 2026-08-21 (session 1)_
 
-- **Current package:** WP3 — ACCEPTED, merged as `ee7f737` (PR #350). Ready to start WP4.
-- **Next package:** WP4 — Capability Runner + canonical ExecutionOutcome (closes CR-02: five rails each deciding billability their own way)
+- **Current package:** WP4 — in independent adversarial review on `remediation/wp4`.
+- **Next package:** WP5
+- **WP3:** ACCEPTED, merged as `ee7f737` (PR #350), verified live in production — table, all three indexes, and the CHECK constraint reached `validated=true`.
 - **Latest accepted SHA:** `ee7f737` on `main`
 - **Unresolved blockers:** none
 - **Human approvals granted:** program-level autonomy (run continuously; escalate only per CHECK-IN A/B/C)

--- a/docs/remediation/packages/WP3.yaml
+++ b/docs/remediation/packages/WP3.yaml
@@ -1,6 +1,8 @@
 package: WP3
 title: Durable wallet reservations + reconciler
-status: REVIEW
+status: ACCEPTED
+merged_sha: ee7f737
+merged_pr: 350
 depends_on: [WP2]
 risks: [CR-01, N1]
 
@@ -92,4 +94,4 @@ exit_conditions:
   - duplicate capture is idempotent                          # MET
   - duplicate release is idempotent                          # MET
   - independent adversarial review passes                    # MET after remediation
-  - Fable ACCEPT                                             # pending CI + merge
+  - Fable ACCEPT                                             # MET

--- a/docs/remediation/packages/WP4.yaml
+++ b/docs/remediation/packages/WP4.yaml
@@ -16,7 +16,14 @@ authorities_before:
   wallet_solutions: "refundRequired = allFailed || gated !== undefined"
   x402_capability: "executor resolving IS success; settle on any resolution"
   x402_solutions: "anyStepSucceeded → settle FULL price"
-  mcp_a2a: "re-derives success from the proxied HTTP status"
+  mcp_a2a: >
+    Re-derives success from the proxied HTTP status — but for REPORTING, not
+    billing. Checked rather than assumed: a2a.ts proxies to POST /v1/do over
+    HTTP (routes/a2a.ts:564) and mcp.ts reads that response's error_code.
+    Neither calls walletService.debit or settleX402Payment, which the guard's
+    derived rail list independently confirms. So the billing decision is made
+    inside /v1/do and these two inherit it. Not rewired, and not a gap in the
+    exit condition.
 
 sharpest_defect: >
   A gated solution run. The wallet rail refunded in full and told the customer

--- a/docs/remediation/packages/WP4.yaml
+++ b/docs/remediation/packages/WP4.yaml
@@ -1,6 +1,6 @@
 package: WP4
 title: Canonical ExecutionOutcome — one authority for billability
-status: REVIEW
+status: REMEDIATED
 depends_on: [WP2]
 risks: [CR-02]
 
@@ -48,6 +48,7 @@ what_landed:
   module: "lib/execution-outcome.ts — OutputAssessment, ExecutionOutcome, and the aggregate"
   rule: "payment consumes `billable`. A rail still decides HOW to collect; it no longer decides WHETHER."
   rails_rewired:
+    - "x402 CAPABILITY — assertBillableOutput before settlement (MISSED in the first pass; see review.blocking_finding)"
     - "x402 solutions — now reads result.gated through aggregateSolutionOutcome"
     - "wallet solutions — same aggregate, so the two cannot disagree"
     - "the per-step audit label reads the same assessment billing reads"
@@ -124,12 +125,50 @@ incidental_findings:
 
 review:
   codex: deferred_to_final_pass
-  independent_agent: in_progress
+  independent_agent: FAIL_REMEDIATION_REQUIRED, then all findings closed
   fable: pending
+
+  blocking_finding: >
+    The x402 CAPABILITY rail was never wired. The module docstring named five
+    rails; the first pass rewired four and I recorded the exit condition "no
+    route decides success or billability independently" as MET. That was a
+    false statement about the code, which is the part that matters most — a
+    package accepted on a false exit condition corrupts every later package
+    that depends on it. Worse than the omission: the half-fix CREATED a new
+    asymmetry, because POST /v1/do with an X-PAYMENT header assessed the output
+    while POST /x402/:slug did not. CR-02 restated one layer down, introduced
+    by its own fix.
+
+  non_blocking_closed:
+    - "counts_against_capability had NO consumer — the advertised taxonomy fix was documentation only, so refusals still tripped the breaker against an armed quality floor. Wired at all four sites."
+    - "UnbillableOutputError discarded the executor's error text, misfiling upstream 5xx failures as `internal` (Strale's bug) — which is the bucket that counts against a capability."
+    - "A gated x402 solution wrote no transaction row and no replay-dedup entry: invisible in /v1/audit, and the same authorization replayable until expiry, re-running pre-gate steps at our cost with zero revenue."
+    - "The guard was green while the blocking defect was live: file-scoped import check, a seven-name denylist, a canonical-source test satisfied by the bare substring `outcome`, and a `derived` rail list whose regex matched neither of the ways solution-execute.ts moves money."
+    - "The integration test covered solutions only, so it structurally could not fail on the blocking finding."
+    - "One integration assertion was vacuous — worse than reported: NEITHER key it read existed at the top level, so it asserted nothing."
+    - "Test constructors used wrong arity for all three guarded-executor errors; tsconfig excludes *.test.ts so tsc never saw it."
+
+  findings_that_were_guard_bugs_not_code_bugs:
+    - "reserve flagged as unconsulted money movement — but a WP3 reservation is PROVISIONAL by design; capture is the finalizing act. Guard now keys on capture."
+    - "`settled = await settleX402Payment(...)` flagged — that holds the RESULT of moving money, not a decision about whether to."
+    - "`chargedPrice = refundRequired ? 0 : price` flagged — a decision may legitimately be computed in steps; the guard now tracks derivation."
+
+  accepted_and_documented_not_fixed:
+    free_tier_behaviour_change: >
+      assertBillableOutput sits on two €0 paths too, so a free-tier caller whose
+      capability resolves with an error marker now gets a 500 instead of a 200
+      carrying that marker, and the call still consumes one of their 10/day.
+      Kept deliberately. The assertion is load-bearing on that same function
+      because the x402-paid /v1/do variant settles inside it. And excluding
+      failures from the quota would let a caller force errors for unlimited free
+      external API calls — a worse hole than the one it closes. Failed calls
+      already consumed quota before WP4 for every capability that THREW; this
+      applies the same rule to more calls rather than inventing a new harm.
 
 exit_conditions:
   - one ExecutionOutcome type, one OutputAssessment type      # MET
-  - no route decides success or billability independently     # MET (guard + derived list)
-  - CI guard forbids a new local billing predicate            # MET (proved discriminating ×4)
+  - no route decides success or billability independently     # MET — but only after remediation; claimed MET while false in the first pass
+  - CI guard forbids a new local billing predicate            # MET (handler-scoped; proved discriminating against the blocking defect itself + 2 evasions)
   - the two rails bill a gated solution identically           # MET (proved discriminating)
-  - independent adversarial review passes                     # pending
+  - the two rails bill an unusable CAPABILITY output identically  # MET (added after review)
+  - independent adversarial review passes                     # MET after remediation

--- a/docs/remediation/packages/WP4.yaml
+++ b/docs/remediation/packages/WP4.yaml
@@ -165,6 +165,35 @@ review:
       already consumed quota before WP4 for every capability that THREW; this
       applies the same rule to more calls rather than inventing a new harm.
 
+residuals:
+  unaudited_passthrough_executors: >
+    A handful of executors pass upstream JSON straight into `output` — e.g.
+    providers/latvian-company-data-sdda.ts:133 (`output: raw`). If such a
+    registry ever answers with a JSON array, that capability now fails where it
+    previously returned 200 carrying the array. Reviewed and deliberately NOT
+    "fixed": an array output was already broken — the audit trail, the declared
+    output_schema and every downstream consumer assume an object — so WP4 makes
+    a silent wrong charge into a visible failure, which is the direction the
+    package exists to move. What was done instead is to make the failure
+    legible: the error now names the actual shape rather than saying "no usable
+    output", so an operator is not sent hunting through the executor for a bug
+    that is in the upstream response.
+
+    What was NOT done: auditing all 338 executors for pass-through shape. That
+    is a catalog-wide sweep, not a billing change. Verified closed for the LLM
+    paths, which were the reviewer's main concern — extractJsonObject slices a
+    brace-balanced span starting at `{`, so it returns a plain object or null,
+    and every caller rejects null. No LLM path can emit an array.
+
+  domain_field_named_code: >
+    Unresolved by reading alone. The failure-marker widening treats
+    {error, code: <number>} as a failure; a capability whose legitimate output
+    is an error string plus a numeric DOMAIN code (an HS code, a registry error
+    code) would be unbilled. Greps found no current instance across 338 files,
+    but the search cannot be exhaustive over dynamic shapes. Cheap to detect in
+    production — the failure message now names the marker — and cheap to fix by
+    narrowing the key list if one appears.
+
 exit_conditions:
   - one ExecutionOutcome type, one OutputAssessment type      # MET
   - no route decides success or billability independently     # MET — but only after remediation; claimed MET while false in the first pass

--- a/docs/remediation/packages/WP4.yaml
+++ b/docs/remediation/packages/WP4.yaml
@@ -1,71 +1,128 @@
 package: WP4
-title: Capability Runner + canonical ExecutionOutcome
-status: PLANNED
+title: Canonical ExecutionOutcome — one authority for billability
+status: REVIEW
 depends_on: [WP2]
 risks: [CR-02]
 
 objective: >
-  Make "what happened, and may we charge for it" a single business fact, decided
-  once, rather than five rails each deciding it with their own heuristic.
+  Make "what happened, and may we charge for it" a single business fact,
+  decided once, rather than five rails each deciding it with their own
+  heuristic.
 
-# Verified against the code, not taken from the audit.
-current_authorities:
+# Verified against the code before the work started, not taken from the audit.
+authorities_before:
   do_sync: "executeWithRetry not throwing IS success; debit in the same transaction"
   do_async: "promise resolution IS success; debit upfront, refund in a catch block"
-  wallet_solutions: "refundRequired = allFailed || gated !== undefined (solution-execute.ts:317)"
+  wallet_solutions: "refundRequired = allFailed || gated !== undefined"
   x402_capability: "executor resolving IS success; settle on any resolution"
-  x402_solutions: "anyStepSucceeded → settle FULL price; `gated` appears zero times in the file"
+  x402_solutions: "anyStepSucceeded → settle FULL price"
   mcp_a2a: "re-derives success from the proxied HTTP status"
 
 sharpest_defect: >
-  The same solution run, with a gate tripped: the wallet rail refunds and tells
-  the customer they were not charged, while the x402 rail counts the gate step
-  as a success and settles the full USDC. Identical execution, opposite billing,
-  decided by which rail the caller happened to use. Confirmed by grep — `gated`
-  is simply absent from x402-gateway-v2.ts.
+  A gated solution run. The wallet rail refunded in full and told the customer
+  they were not charged; the x402 rail counted the gate step as a success and
+  settled the full USDC. Identical execution, opposite billing, decided by
+  which rail the caller happened to use. Confirmed by grep before it was
+  confirmed by test: `gated` appears twelve times in solution-execute.ts and
+  zero times in x402-gateway-v2.ts. `result.gated` was available on the x402
+  rail the whole time. Nothing read it.
 
 second_defect: >
-  isSuccessfulStepOutput (solution-executor.ts) treats any object as success
-  unless it is exactly {error: string} or carries skipped/unavailable. The
-  reasoning is sound — capabilities legitimately return soft verdicts like
-  {valid:false, error:"Invalid IBAN checksum"}, which IS the purchased answer —
-  but it means an executor that ever resolves with {error, status} converts a
-  failure into a billable success. A convention is doing the job of a contract.
+  isSuccessfulStepOutput matched EXACTLY {error: string}, so an executor
+  resolving {error, status} converted a failure into a billable success purely
+  by having two keys. A convention was doing a contract's job.
 
 third_defect: >
-  capability-output-contracts.ts is imported ONLY by startup-migrations.ts.
-  Output validation runs after the money has moved and writes to audit metadata;
-  schema_validated:false never blocks a charge.
+  capability-output-contracts.ts was imported ONLY by startup-migrations.ts.
+  Output validation ran after the money moved and wrote to audit metadata;
+  schema_validated:false never blocked a charge.
 
-canonical_types:
-  OutputAssessment: [structurally_valid, semantically_usable, contract_valid, quality_flags]
-  ExecutionOutcome:
-    - success | failure
-    - failure_class
-    - billable            # the field payment consumes
-    - retryable
-    - fault: provider | strale | caller
-    - output_assessment
-    - provenance
-    - latency_ms, cost facts
+what_landed:
+  module: "lib/execution-outcome.ts — OutputAssessment, ExecutionOutcome, and the aggregate"
+  rule: "payment consumes `billable`. A rail still decides HOW to collect; it no longer decides WHETHER."
+  rails_rewired:
+    - "x402 solutions — now reads result.gated through aggregateSolutionOutcome"
+    - "wallet solutions — same aggregate, so the two cannot disagree"
+    - "the per-step audit label reads the same assessment billing reads"
+    - "all four /v1/do executeWithRetry sites gate on assertBillableOutput"
+  deleted: >
+    lib/x402-gateway.ts's verifyX402Payment — a combined verify-and-settle
+    helper that moved USDC before the capability ran, so no output existed to
+    assess. Its own docstring called it a DEC-14 violation. Nothing called it.
+    Found by the guard's derived rail list, not by reading the diff.
 
-rules:
-  - payment consumes `billable`, never a route-local success heuristic
-  - breaker and quality consume the canonical outcome
-  - audit consumes the terminal outcome
-  - the solution orchestrator aggregates step outcomes into one solution outcome
+judgment_calls:
+  soft_verdict_is_billable: >
+    {valid:false, error:"Invalid IBAN checksum"} is the purchased answer. The
+    same signal feeds the breaker and the quality floor, so treating it as a
+    failure would eventually delist a capability for being right.
+  numeric_status_only: >
+    The failure-marker widening keys on a NUMERIC status, not the key name.
+    {status:"down", error:"timeout"} is an uptime check reporting a site down —
+    the deliverable, and billable. The first draft keyed on the name and would
+    have unbilled it; the pre-existing solution-executor suite already pinned
+    that case and caught it.
+  contract_violation_does_not_block_billing: >
+    The contract table exists to correct declarations that drifted away from
+    working executors. Refusing the charge would hand money back on the
+    strength of the side we already know to be unreliable. It feeds quality.
+  refusal_is_not_a_fault: >
+    counts_against_capability is false for refusals, budget exhaustion and
+    misclassification. This is the taxonomy gap that let the armed quality
+    floor delist capabilities for correctly refusing bad input.
+  thrown_not_returned: >
+    assertBillableOutput raises rather than returning a value, so each of the
+    four call sites takes the failure path already proven there. Restructuring
+    four money call sites around a new return value is where a bug would hide.
 
-migration_required: false
-review: {codex: deferred_to_final_pass, independent_agent: required, fable: required}
+guard:
+  file: "lib/execution-outcome.guard.test.ts"
+  checks:
+    - "each rail imports the canonical module"
+    - "denylist of the three retired predicates (catches a literal revert)"
+    - "no rail imports the superseded step predicate"
+    - "shape check: a billing-named identifier must be assigned from an outcome (catches a NEW predicate under a NEW name)"
+    - "derived rail list: re-derives from debit/settle call sites rather than trusting the hand-written list"
+  proved_not_hollow: >
+    Four violations planted one at a time; each turned the guard red and the
+    baseline green again after removal. The derived check is the one that
+    found the deleted pre-charge helper.
 
-tests_required:
-  - a gated solution is billed identically on the wallet and x402 rails
-  - an {error, status} shaped output is not billable
-  - a contract-invalid output is not billable
-  - each rail's billing decision comes from the same function (bypass guard)
+acceptance_signal:
+  file: "routes/billing-parity.integration.test.ts"
+  what: >
+    The same gated solution driven down both rails. The facilitator is mocked
+    at the module boundary so both run their real logic while no USDC moves;
+    the assertion is the settle spy, not the status code.
+  discriminating: >
+    Verified. Restoring the pre-WP4 x402 predicate turns "settlement is never
+    reached" and "the two rails agree" red while the wallet assertion stays
+    green — exactly the asymmetry the package removes.
+  other_direction: >
+    Also asserts both rails still charge a NON-gated run. A parity fix that
+    simply stopped charging would satisfy the first assertions and be worse
+    than the bug.
+
+incidental_findings:
+  x402_replay_dedup: >
+    The route dedups replays on a hash of the X-PAYMENT header (cert-audit C9).
+    The first draft of the parity test reused one header, so every call after
+    the first replayed the cached row — a 200 with no execution and no
+    settlement, which reads exactly like a billing bug. Worth knowing before
+    anyone writes another x402 test.
+  cache_reset: >
+    __resetX402CacheForTests added. The catalogue cache holds 60s, which is
+    correct in production and makes any test seeding more than one slug per
+    minute silently 404 on everything after the first.
+
+review:
+  codex: deferred_to_final_pass
+  independent_agent: in_progress
+  fable: pending
 
 exit_conditions:
-  - one ExecutionOutcome type, one OutputAssessment type
-  - no route decides success or billability independently
-  - CI guard forbids a new local billing predicate
-  - independent adversarial review passes
+  - one ExecutionOutcome type, one OutputAssessment type      # MET
+  - no route decides success or billability independently     # MET (guard + derived list)
+  - CI guard forbids a new local billing predicate            # MET (proved discriminating ×4)
+  - the two rails bill a gated solution identically           # MET (proved discriminating)
+  - independent adversarial review passes                     # pending


### PR DESCRIPTION
## The defect

Five rails each answered "may we charge for this?" with their own predicate. The sharpest consequence, found by grep before it was found by test: the token `gated` appears twelve times in `routes/solution-execute.ts` and **zero** times in `routes/x402-gateway-v2.ts`. So a solution run whose gate tripped refunded the wallet customer in full and settled the x402 customer in full — same execution, opposite billing, decided by which payment method the caller happened to use. `result.gated` was available on the x402 rail the whole time. Nothing read it.

Two more: the step predicate matched *exactly* `{error: string}`, so an executor resolving `{error, status}` became a billable success on the strength of a second key; and `capability-output-contracts.ts` was imported only by `startup-migrations.ts`, so output validation ran after the money moved.

## The change

`lib/execution-outcome.ts` decides billability once. Payment consumes `billable`. A rail still decides *how* to collect — refund a wallet, decline to settle USDC — it no longer decides *whether*.

Deletes `verifyX402Payment`, a dead helper that settled USDC before the capability ran. Its own docstring called it a DEC-14 violation. Found by the guard's derived rail list, not by reading the diff.

## Two rules that look like bugs and are not

A **soft verdict is billable**. `{valid:false, error:"Invalid IBAN checksum"}` is the purchased answer. The same signal feeds the breaker and the quality floor, so treating it as failure would eventually delist a capability for being right.

A **refusal is not a fault**. `counts_against_capability` is false for refusals, budget exhaustion and misclassification — the taxonomy gap that let the armed quality floor delist capabilities for correctly refusing bad input.

The failure-marker widening keys on a **numeric** status, not the key name. `{status:"down", error:"timeout"}` is an uptime check reporting a site down — the deliverable, and billable. My first draft keyed on the name; the pre-existing `solution-executor` suite already pinned that case and caught it.

## Adversarial review found a blocking defect — in my own claim

An independent reviewer returned **FAIL_REMEDIATION_REQUIRED**. The blocking finding is the one worth reading:

**I rewired four of the five rails and recorded the exit condition "no route decides success or billability independently" as MET.** That was a false statement about the code. The x402 *capability* handler still settled on any resolution. Worse than the omission: the half-fix *created* a new asymmetry, because `/v1/do` with an `X-PAYMENT` header assessed the output while `/x402/:slug` did not — CR-02 restated one layer down, introduced by its own fix.

The guard was green throughout, because its import check was file-scoped: one handler importing the module satisfied it while another settled 250 lines away.

Also closed:
- `counts_against_capability` had **no consumer** — the advertised taxonomy fix was documentation only. Now wired at all four breaker sites, including the one that sees only a message string.
- `UnbillableOutputError` discarded the executor's error text, so `"Bolagsverket returned HTTP 503"` reached `transactions.error` as a generic string and classified as `internal` (Strale's bug) rather than `upstream`.
- A gated x402 solution wrote no transaction row and no replay-dedup entry — invisible in `/v1/audit` where the wallet rail is visible, and the same signed authorization replayable until expiry, re-running pre-gate steps at our cost with zero revenue. A gate is the deterministic-repeat case.
- One integration assertion was vacuous, and worse than reported: **neither** key it read existed at the top level. It asserted nothing.

Three review findings were guard bugs rather than code bugs and are fixed as such: `reserve` is provisional by WP3 design (capture is the finalizing act), `settled = await settleX402Payment(…)` holds a result rather than a decision, and a decision may legitimately be computed in steps.

## Proof

Both new tests were verified to fail against the defect they pin:

- Removing `assertBillableOutput` from the x402 capability handler turns the capability-parity test red — the test that did not exist when the blocking finding got through.
- Restoring the pre-WP4 `anyStepSucceeded` predicate turns the solution-parity assertions red while the wallet assertion stays green: exactly the asymmetry removed.
- The guard was proved discriminating against the blocking defect itself and two evasions (a new predicate under a new name; a ternary that merely mentions `outcome`).
- Both parity tests also assert the **other** direction — that both rails still charge a non-gated run. A fix that simply stopped charging would satisfy the first assertions and be worse than the bug.

No real payment is made anywhere: the facilitator is mocked at the module boundary, so both rails run their real logic while no USDC moves. The assertion is the settle spy, not the status code.

## Accepted, not fixed

`assertBillableOutput` also sits on two €0 paths, so a free-tier caller whose capability resolves with an error marker now gets a 500 and still consumes one of their 10/day. Kept deliberately: the assertion is load-bearing on that same function because the x402-paid `/v1/do` variant settles inside it, and excluding failures from the quota would let a caller force errors for unlimited free external API calls. Failed calls already consumed quota for every capability that *threw*; this applies the same rule to more calls.

Residuals (both recorded in `WP4.yaml`): a few executors pass upstream JSON straight into `output`, so an array response now fails visibly instead of being charged silently — the error message now names the shape. Verified closed for the LLM paths. And a capability whose legitimate output is an error plus a numeric *domain* code would be unbilled; greps found none across 338 files, but that search cannot be exhaustive.

## Verification

16 gates pass. 2,249 unit tests. 86 integration tests across 14 files against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
