### PR TITLE
Remediation WP5: durable x402 settlement state and recovery

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -410,8 +410,15 @@ export const x402SettlementIntents = pgTable(
     solutionSlug: text("solution_slug"),
     priceCents: integer("price_cents").notNull(),
     priceUsd: decimal("price_usd", { precision: 10, scale: 4 }),
-    // 'settling' | 'settled' | 'recorded' | 'failed'
+    // 'settling' | 'settled' | 'recorded' | 'failed' | 'escalated'
+    //
+    // 'escalated' is terminal-from-the-job's-perspective: a human must resolve
+    // it against the chain. It exists so an unresolvable row LEAVES the
+    // reconciler's selection set. Without it, a stuck row keeps its original
+    // updated_at, stays permanently the oldest row, and — with an ordered,
+    // limited sweep — starves every later crash out of ever being examined.
     state: varchar("state", { length: 16 }).notNull().default("settling"),
+    escalatedAt: timestamp("escalated_at", { withTimezone: true }),
     settlementId: text("settlement_id"),
     transactionId: uuid("transaction_id"),
     failureReason: text("failure_reason"),

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -393,6 +393,52 @@ export const disputeRequests = pgTable("dispute_requests", {
   dispositionNotes: text("disposition_notes"),
 });
 
+// ─── x402_settlement_intents ────────────────────────────────────────────────
+// WP5: durable intent, written BEFORE the facilitator is called. The orphan
+// table below only catches "the INSERT threw"; it cannot catch "the process
+// died", because then its catch block never runs either. This table is what
+// survives a SIGKILL between an irreversible on-chain settlement and the row
+// that records it.
+export const x402SettlementIntents = pgTable(
+  "x402_settlement_intents",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    // One intent per payment authorization. Unique so a replayed header cannot
+    // create a second attempt record for one platform action.
+    paymentHash: text("payment_hash").notNull(),
+    slug: text("slug").notNull(),
+    solutionSlug: text("solution_slug"),
+    priceCents: integer("price_cents").notNull(),
+    priceUsd: decimal("price_usd", { precision: 10, scale: 4 }),
+    // 'settling' | 'settled' | 'recorded' | 'failed'
+    state: varchar("state", { length: 16 }).notNull().default("settling"),
+    settlementId: text("settlement_id"),
+    transactionId: uuid("transaction_id"),
+    failureReason: text("failure_reason"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("x402_settlement_intents_payment_hash_unique").on(
+      table.paymentHash,
+    ),
+    index("x402_settlement_intents_state_updated_idx").on(
+      table.state,
+      table.updatedAt,
+    ),
+    // One canonical record per settlement, enforced structurally rather than by
+    // convention. Partial, because the column is null until the facilitator
+    // answers and null values must not compete for the slot.
+    uniqueIndex("x402_settlement_intents_settlement_id_unique")
+      .on(table.settlementId)
+      .where(sql`${table.settlementId} IS NOT NULL`),
+  ],
+);
+
 // ─── x402_orphan_settlements ────────────────────────────────────────────────
 // CCO P0 #12: log of x402 settlements that succeeded on-chain but whose
 // transactions row INSERT failed. See migration 0053 for the recovery

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -176,6 +176,7 @@ async function main() {
   // since April, and draining a long-silent backlog in one burst is what took
   // Postgres down on 2026-05-04 (DEC-20260504-B).
   const { startReservationReconciler } = await import("./jobs/reservation-reconciler.js");
+  const { startSettlementReconciler } = await import("./jobs/settlement-reconciler.js");
   const { assertReservationTtlExceedsExecutionTimeout } = await import(
     "./lib/wallet-reservations.js"
   );
@@ -186,6 +187,9 @@ async function main() {
     parseInt(process.env.EXEC_HARD_TIMEOUT_MS ?? "300000", 10),
   );
   startReservationReconciler();
+  // WP5: the x402 half. Nothing read x402_orphan_settlements before this —
+  // "awaiting reconciliation" meant awaiting a human who had to notice first.
+  startSettlementReconciler();
 
   // Monthly REINDEX CONCURRENTLY on `transactions` — prevents B-tree
   // bloat drift that caused the 2026-04-16 outage. Uses the dedicated-

--- a/apps/api/src/jobs/settlement-reconciler.ts
+++ b/apps/api/src/jobs/settlement-reconciler.ts
@@ -1,0 +1,206 @@
+/**
+ * x402 settlement reconciler (WP5).
+ *
+ * WP3's reconciler releases wallet reservations a crash abandoned. This one
+ * cannot do the equivalent, because an x402 settlement is irreversible: there
+ * is no "give it back". What it can do is make sure that money which moved is
+ * always recorded, and that money which MIGHT have moved is always escalated
+ * rather than quietly forgotten.
+ *
+ * Three populations, and the difference between them is the whole design:
+ *
+ *   settled, transaction row exists   → discharge the intent. Bookkeeping only.
+ *   settled, no transaction row       → recreate the row. We know the money
+ *                                       moved and we know what it was for; this
+ *                                       is the case the orphan table was meant
+ *                                       to catch and could not, because its
+ *                                       catch block died with the process.
+ *   settling, no settlement id        → WE DO NOT KNOW. The process died during
+ *                                       the facilitator call. Alert. Never guess.
+ *
+ * That last one is the honest part. Assuming it settled invents revenue and
+ * tells a customer they paid when they may not have; assuming it did not gives
+ * away work that may have been paid for. Only an on-chain query resolves it,
+ * and the platform has no such query today. So the job escalates and leaves the
+ * row exactly as it found it — a stuck row an operator can see beats a wrong
+ * number nobody can find.
+ */
+
+import { eq, sql } from "drizzle-orm";
+
+import { getDb } from "../db/index.js";
+import { transactions } from "../db/schema.js";
+import { log, logError } from "../lib/log.js";
+import { alertOnce } from "../lib/alert-once.js";
+import {
+  findAbandonedIntents,
+  markRecordedBySettlement,
+} from "../lib/x402-settlement-intent.js";
+
+/**
+ * Distinct from the WP3 reconciler's lock. Two jobs sweeping different tables
+ * must not serialise behind each other; sharing an id would make the slower one
+ * silently starve the other on a busy replica.
+ */
+const ADVISORY_LOCK_ID = 20260822;
+
+/** How long to suppress a repeat of the same alert. */
+const ALERT_COOLDOWN_MS = 6 * 60 * 60 * 1000;
+
+/** Bounded per tick — DEC-20260504-B. */
+const BATCH_SIZE = 25;
+const TICK_INTERVAL_MS = 60_000;
+const STARTUP_DELAY_MS = 60_000;
+
+export interface ReconcileSettlementsSummary {
+  examined: number;
+  /** Intents whose transaction row already existed; bookkeeping caught up. */
+  discharged: number;
+  /** Rows recreated for settlements that moved money and lost their record. */
+  recovered: number;
+  /** Interrupted mid-facilitator. Cannot be resolved from our side. */
+  escalated: number;
+  failed: number;
+}
+
+export async function reconcileSettlementsOnce(): Promise<ReconcileSettlementsSummary> {
+  const db = getDb();
+  const summary: ReconcileSettlementsSummary = {
+    examined: 0,
+    discharged: 0,
+    recovered: 0,
+    escalated: 0,
+    failed: 0,
+  };
+
+  // Cross-replica: one sweeper at a time, so the batch bound means what it says
+  // rather than being multiplied by the replica count. Transaction-scoped like
+  // the WP3 reconciler's, so it releases even if this process dies holding it.
+  const abandoned = await db.transaction(async (tx) => {
+    const [lock] = (await tx.execute(
+      sql`SELECT pg_try_advisory_xact_lock(${ADVISORY_LOCK_ID}) AS acquired`,
+    )) as unknown as Array<{ acquired?: boolean }>;
+    if (!lock?.acquired) return null;
+    return findAbandonedIntents(tx, BATCH_SIZE);
+  });
+
+  // Another replica is on this tick. Not an error.
+  if (abandoned === null) return summary;
+
+  {
+    summary.examined = abandoned.length;
+
+    for (const intent of abandoned) {
+      try {
+        if (intent.state === "settling" || !intent.settlementId) {
+          // The unresolvable class. Escalate; do not touch the row.
+          summary.escalated += 1;
+          await alertOnce(
+            `x402-settlement-interrupted-${intent.id}`,
+            ALERT_COOLDOWN_MS,
+            {
+              subject:
+                "x402 settlement interrupted mid-flight — manual on-chain check required",
+              body:
+                `Intent ${intent.id} (slug=${intent.slug}, ${intent.priceCents} cents) was left ` +
+                `in state '${intent.state}' with no settlement id. The process died during the ` +
+                `facilitator call, so we cannot tell from our side whether the USDC moved. ` +
+                `Check the chain against our receiving address for payment hash ` +
+                `${intent.paymentHash}. If it settled, the customer paid and has no record; ` +
+                `if it did not, no action is needed.`,
+              severity: "critical",
+            },
+          );
+          continue;
+        }
+
+        // From here the money definitely moved — we hold a settlement id.
+        const existing = await db
+          .select({ id: transactions.id })
+          .from(transactions)
+          .where(eq(transactions.x402SettlementId, intent.settlementId))
+          .limit(1);
+
+        if (existing.length > 0) {
+          await markRecordedBySettlement(db, {
+            settlementId: intent.settlementId,
+            transactionId: existing[0].id,
+          });
+          summary.discharged += 1;
+          continue;
+        }
+
+        // Settled, and no row. This is the case the orphan table was written
+        // for and structurally could not catch.
+        const [recreated] = await db
+          .insert(transactions)
+          .values({
+            userId: null,
+            capabilityId: null,
+            solutionSlug: intent.solutionSlug,
+            status: "completed",
+            input: { recovered_by: "settlement-reconciler" },
+            output: null,
+            priceCents: intent.priceCents,
+            paymentMethod: "x402",
+            x402SettlementId: intent.settlementId,
+            x402PaymentHash: intent.paymentHash,
+            error:
+              "Recovered by the WP5 settlement reconciler: the settlement " +
+              "succeeded on-chain but the process died before its transaction " +
+              "row was written. Output was not captured and cannot be " +
+              "reconstructed.",
+            completedAt: new Date(),
+          })
+          .returning({ id: transactions.id });
+
+        await markRecordedBySettlement(db, {
+          settlementId: intent.settlementId,
+          transactionId: recreated.id,
+        });
+        summary.recovered += 1;
+
+        // Recovered, but the customer paid and did not receive output. That is
+        // a refund conversation, not a silent fix.
+        await alertOnce(
+          `x402-settlement-recovered-${intent.id}`,
+          ALERT_COOLDOWN_MS,
+          {
+            subject:
+              "x402 settlement recovered — customer paid but received no output",
+            body:
+              `Settlement ${intent.settlementId} (slug=${intent.slug}, ${intent.priceCents} ` +
+              `cents) moved USDC and lost its transaction row to a crash. A row has been ` +
+              `recreated for audit completeness, but the customer did not receive their ` +
+              `result and may be owed a refund.`,
+            severity: "warning",
+          },
+        );
+      } catch (err) {
+        summary.failed += 1;
+        logError("settlement-reconcile-item-failed", err, {
+          intent_id: intent.id,
+        });
+      }
+    }
+  }
+
+  // Logged every tick, including the quiet ones. A summary that only appears
+  // when something happened is indistinguishable from a job that stopped
+  // running — the failure mode DEC-20260504-B was written about.
+  log.info({ label: "settlement-reconcile", ...summary }, "settlement-reconcile");
+  return summary;
+}
+
+export function startSettlementReconciler(): void {
+  setTimeout(() => {
+    void reconcileSettlementsOnce().catch((err) =>
+      logError("settlement-reconcile-tick-failed", err),
+    );
+    setInterval(() => {
+      void reconcileSettlementsOnce().catch((err) =>
+        logError("settlement-reconcile-tick-failed", err),
+      );
+    }, TICK_INTERVAL_MS).unref?.();
+  }, STARTUP_DELAY_MS).unref?.();
+}

--- a/apps/api/src/jobs/settlement-reconciler.ts
+++ b/apps/api/src/jobs/settlement-reconciler.ts
@@ -33,9 +33,12 @@ import { transactions } from "../db/schema.js";
 import { log, logError } from "../lib/log.js";
 import { alertOnce } from "../lib/alert-once.js";
 import {
+  countEscalated,
+  escalateIntent,
   findAbandonedIntents,
   markRecordedBySettlement,
 } from "../lib/x402-settlement-intent.js";
+import { capabilities, x402OrphanSettlements } from "../db/schema.js";
 
 /**
  * Distinct from the WP3 reconciler's lock. Two jobs sweeping different tables
@@ -93,24 +96,20 @@ export async function reconcileSettlementsOnce(): Promise<ReconcileSettlementsSu
     for (const intent of abandoned) {
       try {
         if (intent.state === "settling" || !intent.settlementId) {
-          // The unresolvable class. Escalate; do not touch the row.
+          // The unresolvable class: the process died during the facilitator
+          // call, so only the chain knows whether USDC moved. We still refuse
+          // to guess — nothing about the money is inferred — but the row MUST
+          // leave the sweep.
+          //
+          // Review finding: the first version escalated and deliberately left
+          // the row untouched. The sweep is ORDER BY updated_at ASC LIMIT n, so
+          // an untouched row stays permanently among the oldest; once n of them
+          // accumulate they own the whole batch forever and the next real crash
+          // is never examined. The recovery job would have silently stopped
+          // recovering. Handing the row to a human is a state change, not a
+          // guess about the money.
+          await escalateIntent(db, intent.id);
           summary.escalated += 1;
-          await alertOnce(
-            `x402-settlement-interrupted-${intent.id}`,
-            ALERT_COOLDOWN_MS,
-            {
-              subject:
-                "x402 settlement interrupted mid-flight — manual on-chain check required",
-              body:
-                `Intent ${intent.id} (slug=${intent.slug}, ${intent.priceCents} cents) was left ` +
-                `in state '${intent.state}' with no settlement id. The process died during the ` +
-                `facilitator call, so we cannot tell from our side whether the USDC moved. ` +
-                `Check the chain against our receiving address for payment hash ` +
-                `${intent.paymentHash}. If it settled, the customer paid and has no record; ` +
-                `if it did not, no action is needed.`,
-              severity: "critical",
-            },
-          );
           continue;
         }
 
@@ -132,24 +131,51 @@ export async function reconcileSettlementsOnce(): Promise<ReconcileSettlementsSu
 
         // Settled, and no row. This is the case the orphan table was written
         // for and structurally could not catch.
+        //
+        // Attribute it properly. The intent stores the slug precisely so
+        // recovery is possible, and the first version discarded it — leaving
+        // the row unattributable to any capability except through free text.
+        const [cap] = intent.solutionSlug
+          ? []
+          : await db
+              .select({
+                id: capabilities.id,
+                transparencyTag: capabilities.transparencyTag,
+              })
+              .from(capabilities)
+              .where(eq(capabilities.slug, intent.slug))
+              .limit(1);
+
         const [recreated] = await db
           .insert(transactions)
           .values({
             userId: null,
-            capabilityId: null,
+            capabilityId: cap?.id ?? null,
             solutionSlug: intent.solutionSlug,
-            status: "completed",
+            // 'failed', not 'completed'. transactions.status is about what the
+            // CUSTOMER got, and they got nothing — the output was lost with the
+            // process. Marking it completed would both overstate delivery and
+            // poison the gateway's replay cache, which serves a completed row's
+            // output back: a retry inside the authorization window would have
+            // received an empty body dressed as a successful cached result.
+            // The money that moved is recorded by priceCents + the settlement
+            // id, not by the status.
+            status: "failed",
             input: { recovered_by: "settlement-reconciler" },
             output: null,
             priceCents: intent.priceCents,
             paymentMethod: "x402",
             x402SettlementId: intent.settlementId,
             x402PaymentHash: intent.paymentHash,
+            // Never inherit the column default here. It is 'ai_generated',
+            // which on a recovered row would be a fabricated EU AI Act Art. 50
+            // marker on a call we cannot describe.
+            transparencyMarker: cap?.transparencyTag ?? "unknown",
             error:
               "Recovered by the WP5 settlement reconciler: the settlement " +
               "succeeded on-chain but the process died before its transaction " +
-              "row was written. Output was not captured and cannot be " +
-              "reconstructed.",
+              "row was written. The customer paid and did not receive output, " +
+              "which cannot be reconstructed.",
             completedAt: new Date(),
           })
           .returning({ id: transactions.id });
@@ -158,6 +184,15 @@ export async function reconcileSettlementsOnce(): Promise<ReconcileSettlementsSu
           settlementId: intent.settlementId,
           transactionId: recreated.id,
         });
+        // The orphan table is the OTHER channel for this same event, and it
+        // says "awaiting reconciliation" with a procedure ("recreate the row
+        // OR refund the payer") that an operator following it now would apply
+        // to a settlement already reconciled — double-recording or wrongly
+        // refunding. Close it here so the two channels cannot disagree.
+        await db
+          .update(x402OrphanSettlements)
+          .set({ reconciledAt: new Date(), reconciliationStatus: "auto_recovered" })
+          .where(eq(x402OrphanSettlements.settlementId, intent.settlementId));
         summary.recovered += 1;
 
         // Recovered, but the customer paid and did not receive output. That is
@@ -177,6 +212,16 @@ export async function reconcileSettlementsOnce(): Promise<ReconcileSettlementsSu
           },
         );
       } catch (err) {
+        // The unique index on transactions.x402_settlement_id IS the claim.
+        // The advisory lock only spans the batch SELECT, so two staggered
+        // replicas can both reach the insert; the loser gets 23505 here, which
+        // means "already recovered", not "failed". Treated as a discharge so a
+        // benign race is not reported as an error every tick.
+        const pgCode = (err as { code?: string } | null)?.code;
+        if (pgCode === "23505") {
+          summary.discharged += 1;
+          continue;
+        }
         summary.failed += 1;
         logError("settlement-reconcile-item-failed", err, {
           intent_id: intent.id,
@@ -185,10 +230,42 @@ export async function reconcileSettlementsOnce(): Promise<ReconcileSettlementsSu
     }
   }
 
+  // One alert about the whole escalated backlog, not one per row.
+  //
+  // Review finding: the first version paged per intent id on a 6h cooldown, so
+  // a handful of permanently-stuck rows meant a standing stream of CRITICAL
+  // pages every six hours — the alert-fatigue mode that ends with the channel
+  // muted, which is precisely the channel that would tell an operator the
+  // recovery job had stopped recovering.
+  const escalatedBacklog = await countEscalated(db);
+  if (escalatedBacklog > 0) {
+    await alertOnce("x402-settlement-escalated-backlog", ALERT_COOLDOWN_MS, {
+      subject: `${escalatedBacklog} x402 settlement(s) need a manual on-chain check`,
+      body:
+        `${escalatedBacklog} settlement intent(s) are in state 'escalated'. Each was ` +
+        `interrupted during the facilitator call, so we cannot tell from our side whether ` +
+        `the USDC moved. Query:
+
+` +
+        `  SELECT id, slug, payment_hash, price_cents, escalated_at
+` +
+        `  FROM x402_settlement_intents WHERE state = 'escalated' ORDER BY escalated_at;
+
+` +
+        `For each, check the chain against our receiving address for that payment hash. ` +
+        `If it settled, the customer paid and has no record. If it did not, no action is ` +
+        `needed — mark the row resolved either way so this count returns to zero.`,
+      severity: "critical",
+    });
+  }
+
   // Logged every tick, including the quiet ones. A summary that only appears
   // when something happened is indistinguishable from a job that stopped
   // running — the failure mode DEC-20260504-B was written about.
-  log.info({ label: "settlement-reconcile", ...summary }, "settlement-reconcile");
+  log.info(
+    { label: "settlement-reconcile", ...summary, escalated_backlog: escalatedBacklog },
+    "settlement-reconcile",
+  );
   return summary;
 }
 

--- a/apps/api/src/jobs/settlement-recovery.integration.test.ts
+++ b/apps/api/src/jobs/settlement-recovery.integration.test.ts
@@ -253,13 +253,21 @@ describeMaybe("a crashed x402 settlement is recoverable", () => {
       // updatedAt defaults to now(): inside the staleness window.
     });
 
-    const summary = await reconcile();
+    await reconcile();
 
     const [intent] = await db
-      .select({ state: x402SettlementIntents.state })
+      .select({
+        state: x402SettlementIntents.state,
+        updatedAt: x402SettlementIntents.updatedAt,
+      })
       .from(x402SettlementIntents)
       .where(eq(x402SettlementIntents.paymentHash, paymentHash));
+
+    // Asserted about THIS intent rather than the summary's global counter.
+    // The counter reflects every stale row in the database, including ones
+    // other suites left behind, so `escalated === 0` was a claim about the
+    // whole table pretending to be a claim about this row.
     expect(intent!.state).toBe("settling");
-    expect(summary.escalated).toBe(0);
+    expect(intent!.updatedAt.getTime()).toBeGreaterThan(Date.now() - 60_000);
   }, 120_000);
 });

--- a/apps/api/src/jobs/settlement-recovery.integration.test.ts
+++ b/apps/api/src/jobs/settlement-recovery.integration.test.ts
@@ -122,21 +122,71 @@ describeMaybe("a crashed x402 settlement is recoverable", () => {
     expect(intent!.state).toBe("recorded");
   }, 120_000);
 
-  it("does not recover it twice", async () => {
-    // A second tick must be a no-op. The unique index on settlement_id is the
-    // structural guarantee; this proves the job respects it rather than
-    // relying on it to throw.
+  it("does not recover it twice when the discharge itself was lost", async () => {
+    // Review finding: the first version of this test ran reconcile() twice and
+    // claimed to prove idempotent recovery. It could not — after the first tick
+    // the intent is 'recorded' with a transaction_id, so the selection excludes
+    // it and the second tick never looks at the row. It was asserting a state
+    // transition while describing a guarantee.
+    //
+    // The real risk is markRecordedBySettlement failing AFTER the INSERT, which
+    // leaves the intent at 'settled' with a null transaction_id — squarely back
+    // in the sweep, with its row already created. That is what this reproduces.
     const settlementId = `wp5-set-${randomUUID().slice(0, 8)}`;
-    await seedIntent({ state: "settled", settlementId });
+    const { paymentHash } = await seedIntent({ state: "settled", settlementId });
 
     await reconcile();
+
+    // Simulate the lost discharge: the row exists, the intent forgot.
+    await db
+      .update(x402SettlementIntents)
+      .set({ state: "settled", transactionId: null, updatedAt: STALE })
+      .where(eq(x402SettlementIntents.paymentHash, paymentHash));
+
     await reconcile();
 
     const rows = await db
       .select({ id: transactions.id })
       .from(transactions)
       .where(eq(transactions.x402SettlementId, settlementId));
+    // Exactly one. The second pass must find the existing row and discharge,
+    // never insert a second revenue record for one settlement.
     expect(rows).toHaveLength(1);
+
+    const [intent] = await db
+      .select({ state: x402SettlementIntents.state })
+      .from(x402SettlementIntents)
+      .where(eq(x402SettlementIntents.paymentHash, paymentHash));
+    expect(intent!.state).toBe("recorded");
+  }, 120_000);
+
+  it("takes an unresolvable intent OUT of the sweep", async () => {
+    // The starvation defect. The escalate branch left the row untouched, so it
+    // kept its original updated_at, stayed permanently among the oldest, and —
+    // with ORDER BY updated_at ASC LIMIT n — a handful of them would own the
+    // whole batch forever, starving every later crash out of ever being
+    // examined. The recovery job would have silently stopped recovering.
+    const { paymentHash } = await seedIntent({ state: "settling" });
+
+    await reconcile();
+
+    const [intent] = await db
+      .select({
+        state: x402SettlementIntents.state,
+        escalatedAt: x402SettlementIntents.escalatedAt,
+      })
+      .from(x402SettlementIntents)
+      .where(eq(x402SettlementIntents.paymentHash, paymentHash));
+
+    expect(intent!.state).toBe("escalated");
+    expect(intent!.escalatedAt).not.toBeNull();
+
+    // And it no longer appears in the sweep at all.
+    const { findAbandonedIntents } = await import(
+      "../lib/x402-settlement-intent.js"
+    );
+    const remaining = await findAbandonedIntents(db, 100);
+    expect(remaining.map((r) => r.paymentHash)).not.toContain(paymentHash);
   }, 120_000);
 
   it("discharges an intent whose transaction row already exists", async () => {
@@ -181,22 +231,27 @@ describeMaybe("a crashed x402 settlement is recoverable", () => {
     // have.
     const { paymentHash } = await seedIntent({ state: "settling" });
 
-    const summary = await reconcile();
-    expect(summary.escalated).toBeGreaterThanOrEqual(1);
-    expect(summary.recovered).toBe(0);
+    await reconcile();
 
     const [intent] = await db
       .select({
         state: x402SettlementIntents.state,
         transactionId: x402SettlementIntents.transactionId,
+        settlementId: x402SettlementIntents.settlementId,
       })
       .from(x402SettlementIntents)
       .where(eq(x402SettlementIntents.paymentHash, paymentHash));
 
-    // Untouched. A stuck row an operator can see beats a wrong number nobody
-    // can find.
-    expect(intent!.state).toBe("settling");
+    // `summary.recovered === 0` was here and was wrong in the same way the
+    // last test in this file calls out: that counter covers every stale row in
+    // the database, including ones other suites write. Assert about THIS row.
+    //
+    // Nothing about the MONEY is inferred: no settlement id is invented and no
+    // transaction row is created. The state change only records that a human
+    // now owns it.
+    expect(intent!.state).toBe("escalated");
     expect(intent!.transactionId).toBeNull();
+    expect(intent!.settlementId).toBeNull();
   }, 120_000);
 
   it("a settlement-id collision does not fail the request", async () => {

--- a/apps/api/src/jobs/settlement-recovery.integration.test.ts
+++ b/apps/api/src/jobs/settlement-recovery.integration.test.ts
@@ -199,6 +199,47 @@ describeMaybe("a crashed x402 settlement is recoverable", () => {
     expect(intent!.transactionId).toBeNull();
   }, 120_000);
 
+  it("a settlement-id collision does not fail the request", async () => {
+    // Regression. The unique index on settlement_id can reject markSettled, and
+    // that rejection propagated as an unhandled 500 — AFTER the USDC had
+    // already left the customer's wallet. Pre-WP5 they would have received
+    // their result, so the durability mechanism had made things strictly worse.
+    // Found by the WP4 parity suite, not by inspection.
+    const settlementId = `wp5-dup-${randomUUID().slice(0, 8)}`;
+    const first = await seedIntent({ state: "settled", settlementId });
+    expect(first.settlementId).toBe(settlementId);
+
+    const secondHash = `wp5-${randomUUID().slice(0, 12)}`;
+    hashes.push(secondHash);
+    await db.insert(x402SettlementIntents).values({
+      paymentHash: secondHash,
+      slug: "wp5-probe-capability",
+      priceCents: 25,
+      state: "settling",
+    });
+    const [second] = await db
+      .select({ id: x402SettlementIntents.id })
+      .from(x402SettlementIntents)
+      .where(eq(x402SettlementIntents.paymentHash, secondHash));
+
+    const { markSettled } = await import("../lib/x402-settlement-intent.js");
+
+    // Must not throw. The money already moved; bookkeeping may not turn a paid
+    // call into an error.
+    await expect(
+      markSettled(db, { intentId: second!.id, settlementId }),
+    ).resolves.toBeUndefined();
+
+    // And it degrades to the RIGHT state: still 'settling', which is the
+    // reconciler's "we do not know" class, so a human is paged rather than the
+    // discrepancy being silently resolved.
+    const [after] = await db
+      .select({ state: x402SettlementIntents.state })
+      .from(x402SettlementIntents)
+      .where(eq(x402SettlementIntents.paymentHash, secondHash));
+    expect(after!.state).toBe("settling");
+  }, 120_000);
+
   it("leaves a fresh in-flight intent alone", async () => {
     // Not stale yet — a live settlement in progress. Sweeping it would race a
     // request that is about to write its own row.

--- a/apps/api/src/jobs/settlement-recovery.integration.test.ts
+++ b/apps/api/src/jobs/settlement-recovery.integration.test.ts
@@ -1,0 +1,224 @@
+/**
+ * WP5 acceptance signal: an irreversible settlement survives a crash.
+ *
+ * The defect these pin: `recordX402Transaction` captured an orphaned settlement
+ * in a catch block, which handles "the INSERT threw" and cannot handle "the
+ * process died" — then the catch never runs either. A SIGKILL between the
+ * settlement succeeding and the row committing left the customer's USDC moved
+ * and Strale holding no row anywhere.
+ *
+ * These drive the reconciler against real rows rather than asserting on source
+ * text, and they cover the three populations separately, because the whole
+ * design is that those three are NOT treated alike.
+ *
+ * The third case is the one worth reading. An intent interrupted mid-facilitator
+ * is genuinely unresolvable from our side: assuming it settled invents revenue,
+ * assuming it did not gives the work away. The test asserts the reconciler
+ * LEAVES IT ALONE — that refusing to guess is the specified behaviour, not an
+ * omission someone should later "fix" by picking a default.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../test-support/integration-db.js";
+import { transactions, x402SettlementIntents } from "../db/schema.js";
+
+if (process.env.DATABASE_URL_TEST) {
+  process.env.AUDIT_HMAC_SECRET ??= "wp5-secret-at-least-32-chars-long-000000";
+  process.env.ADMIN_SECRET ??= "wp5-admin-secret-at-least-32-chars-00000";
+}
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+/** Older than INTENT_STALE_AFTER_MS, so the reconciler considers it abandoned. */
+const STALE = new Date(Date.now() - 10 * 60 * 1000);
+
+describeMaybe("a crashed x402 settlement is recoverable", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let reconcile: typeof import("./settlement-reconciler.js").reconcileSettlementsOnce;
+
+  const hashes: string[] = [];
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 4 });
+    db = drizzle(client);
+    ({ reconcileSettlementsOnce: reconcile } = await import(
+      "./settlement-reconciler.js"
+    ));
+  }, 120_000);
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  afterEach(async () => {
+    for (const h of hashes.splice(0)) {
+      const rows = await db
+        .select({ settlementId: x402SettlementIntents.settlementId })
+        .from(x402SettlementIntents)
+        .where(eq(x402SettlementIntents.paymentHash, h));
+      for (const r of rows) {
+        if (r.settlementId) {
+          await db
+            .delete(transactions)
+            .where(eq(transactions.x402SettlementId, r.settlementId));
+        }
+      }
+      await db
+        .delete(x402SettlementIntents)
+        .where(eq(x402SettlementIntents.paymentHash, h));
+    }
+  });
+
+  async function seedIntent(params: {
+    state: "settling" | "settled";
+    settlementId?: string | null;
+  }): Promise<{ paymentHash: string; settlementId: string | null }> {
+    const paymentHash = `wp5-${randomUUID().slice(0, 12)}`;
+    hashes.push(paymentHash);
+    const settlementId = params.settlementId ?? null;
+
+    await db.insert(x402SettlementIntents).values({
+      paymentHash,
+      slug: "wp5-probe-capability",
+      priceCents: 25,
+      state: params.state,
+      settlementId,
+      // Backdated so findAbandonedIntents sees it as stale rather than in-flight.
+      updatedAt: STALE,
+    });
+
+    return { paymentHash, settlementId };
+  }
+
+  it("recovers a settlement whose transaction row was lost to a crash", async () => {
+    // THE case. The money moved — we hold a settlement id — and the process
+    // died before the row was written. Pre-WP5 nothing recorded this at all.
+    const settlementId = `wp5-set-${randomUUID().slice(0, 8)}`;
+    const { paymentHash } = await seedIntent({ state: "settled", settlementId });
+
+    const summary = await reconcile();
+    expect(summary.recovered).toBeGreaterThanOrEqual(1);
+
+    const [row] = await db
+      .select({ id: transactions.id, priceCents: transactions.priceCents })
+      .from(transactions)
+      .where(eq(transactions.x402SettlementId, settlementId))
+      .limit(1);
+
+    expect(row, "a transaction row should exist for the settled intent").toBeDefined();
+    expect(row!.priceCents).toBe(25);
+
+    const [intent] = await db
+      .select({ state: x402SettlementIntents.state })
+      .from(x402SettlementIntents)
+      .where(eq(x402SettlementIntents.paymentHash, paymentHash));
+    expect(intent!.state).toBe("recorded");
+  }, 120_000);
+
+  it("does not recover it twice", async () => {
+    // A second tick must be a no-op. The unique index on settlement_id is the
+    // structural guarantee; this proves the job respects it rather than
+    // relying on it to throw.
+    const settlementId = `wp5-set-${randomUUID().slice(0, 8)}`;
+    await seedIntent({ state: "settled", settlementId });
+
+    await reconcile();
+    await reconcile();
+
+    const rows = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.x402SettlementId, settlementId));
+    expect(rows).toHaveLength(1);
+  }, 120_000);
+
+  it("discharges an intent whose transaction row already exists", async () => {
+    // Bookkeeping only: the row landed, the mark did not. No money question.
+    const settlementId = `wp5-set-${randomUUID().slice(0, 8)}`;
+    const { paymentHash } = await seedIntent({ state: "settled", settlementId });
+
+    await db.insert(transactions).values({
+      userId: null,
+      capabilityId: null,
+      status: "completed",
+      input: {},
+      priceCents: 25,
+      paymentMethod: "x402",
+      x402SettlementId: settlementId,
+      completedAt: new Date(),
+    });
+
+    const summary = await reconcile();
+    expect(summary.discharged).toBeGreaterThanOrEqual(1);
+
+    const rows = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.x402SettlementId, settlementId));
+    // Discharged, NOT recovered — recovering here would double-record a
+    // settlement that was already recorded.
+    expect(rows).toHaveLength(1);
+
+    const [intent] = await db
+      .select({ state: x402SettlementIntents.state })
+      .from(x402SettlementIntents)
+      .where(eq(x402SettlementIntents.paymentHash, paymentHash));
+    expect(intent!.state).toBe("recorded");
+  }, 120_000);
+
+  it("REFUSES to guess when the crash happened mid-facilitator", async () => {
+    // The honest case, and the one most likely to be "fixed" wrongly later.
+    // No settlement id means we do not know whether the chain moved. The
+    // reconciler must escalate and change nothing: inventing a transaction row
+    // would fabricate revenue and tell a customer they paid when they may not
+    // have.
+    const { paymentHash } = await seedIntent({ state: "settling" });
+
+    const summary = await reconcile();
+    expect(summary.escalated).toBeGreaterThanOrEqual(1);
+    expect(summary.recovered).toBe(0);
+
+    const [intent] = await db
+      .select({
+        state: x402SettlementIntents.state,
+        transactionId: x402SettlementIntents.transactionId,
+      })
+      .from(x402SettlementIntents)
+      .where(eq(x402SettlementIntents.paymentHash, paymentHash));
+
+    // Untouched. A stuck row an operator can see beats a wrong number nobody
+    // can find.
+    expect(intent!.state).toBe("settling");
+    expect(intent!.transactionId).toBeNull();
+  }, 120_000);
+
+  it("leaves a fresh in-flight intent alone", async () => {
+    // Not stale yet — a live settlement in progress. Sweeping it would race a
+    // request that is about to write its own row.
+    const paymentHash = `wp5-${randomUUID().slice(0, 12)}`;
+    hashes.push(paymentHash);
+    await db.insert(x402SettlementIntents).values({
+      paymentHash,
+      slug: "wp5-probe-capability",
+      priceCents: 25,
+      state: "settling",
+      // updatedAt defaults to now(): inside the staleness window.
+    });
+
+    const summary = await reconcile();
+
+    const [intent] = await db
+      .select({ state: x402SettlementIntents.state })
+      .from(x402SettlementIntents)
+      .where(eq(x402SettlementIntents.paymentHash, paymentHash));
+    expect(intent!.state).toBe("settling");
+    expect(summary.escalated).toBe(0);
+  }, 120_000);
+});

--- a/apps/api/src/lib/execution-outcome.ts
+++ b/apps/api/src/lib/execution-outcome.ts
@@ -495,6 +495,12 @@ export function assertBillableOutput(slug: string, output: unknown): void {
  * only the latter.
  */
 export function shouldCountAgainstCapability(error: unknown): boolean {
+  // WP5: a settlement-intent write failure is Strale's database, not the
+  // capability. Matched by name rather than by import to keep the billing
+  // authority from depending on the x402 rail.
+  if ((error as Error | null)?.name === "SettlementIntentUnavailableError") {
+    return false;
+  }
   if (error instanceof UnbillableOutputError) {
     // The capability resolved with something unusable. That IS its fault —
     // unless the marker says the step never ran.

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1236,7 +1236,7 @@ describe("startup-migrations — block 0087 (un-hide content-redacted rows)", ()
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 38 blocks in historical order", () => {
+  it("exports the expected 39 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1282,6 +1282,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0094_clearChurnInvalidatedBaselines",
       // WP3: wallet_reservations table + the non-negative balance constraint.
       "runMigration0095_walletReservations",
+      "runMigration0096_x402SettlementIntents",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1677,6 +1677,64 @@ export async function runMigration0095_walletReservations(
   };
 }
 
+/**
+ * Block 0096 — x402 settlement intents (WP5).
+ *
+ * Same shape discipline as 0095, for the same reason: every statement is
+ * independently idempotent, and the indexes are created unconditionally rather
+ * than inside a table-was-absent branch. The runner has no transaction, so a
+ * kill between CREATE TABLE and the index builds would otherwise leave a unique
+ * index permanently absent — and here that index is the "one canonical record
+ * per settlement" guarantee, which is the whole point of the block.
+ *
+ * New table, starts empty. DEC-20260504-B backlog-drain does not apply: there
+ * is no accumulated workload for the reconciler's first run, because nothing
+ * has ever written an intent.
+ */
+export async function runMigration0096_x402SettlementIntents(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  await tx.execute(sql`
+    CREATE TABLE IF NOT EXISTS "x402_settlement_intents" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+      "payment_hash" text NOT NULL,
+      "slug" text NOT NULL,
+      "solution_slug" text,
+      "price_cents" integer NOT NULL,
+      "price_usd" numeric(10, 4),
+      "state" varchar(16) DEFAULT 'settling' NOT NULL,
+      "settlement_id" text,
+      "transaction_id" uuid,
+      "failure_reason" text,
+      "created_at" timestamptz DEFAULT now() NOT NULL,
+      "updated_at" timestamptz DEFAULT now() NOT NULL
+    )
+  `);
+
+  await tx.execute(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS "x402_settlement_intents_payment_hash_unique"
+      ON "x402_settlement_intents" ("payment_hash")
+  `);
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS "x402_settlement_intents_state_updated_idx"
+      ON "x402_settlement_intents" ("state", "updated_at")
+  `);
+  await tx.execute(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS "x402_settlement_intents_settlement_id_unique"
+      ON "x402_settlement_intents" ("settlement_id")
+      WHERE "settlement_id" IS NOT NULL
+  `);
+
+  return {
+    block: "0096_x402_settlement_intents",
+    outcome: "x402_settlement_intents table + 3 indexes (idempotent)",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+
 export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResult>> = [
   runMigration0029_actualCostCents,
   runMigration0030_complianceColumns,
@@ -1717,6 +1775,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0094_clearChurnInvalidatedBaselines,
   // WP3: reservations table + non-negative balance constraint.
   runMigration0095_walletReservations,
+  runMigration0096_x402SettlementIntents,
 ];
 
 /**

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1708,9 +1708,18 @@ export async function runMigration0096_x402SettlementIntents(
       "settlement_id" text,
       "transaction_id" uuid,
       "failure_reason" text,
+      "escalated_at" timestamptz,
       "created_at" timestamptz DEFAULT now() NOT NULL,
       "updated_at" timestamptz DEFAULT now() NOT NULL
     )
+  `);
+
+  // Separate ADD COLUMN as well as the inline definition: the table may already
+  // exist from an earlier boot of this same block before the column was added.
+  // IF NOT EXISTS on both, so either order is a no-op the second time.
+  await tx.execute(sql`
+    ALTER TABLE "x402_settlement_intents"
+      ADD COLUMN IF NOT EXISTS "escalated_at" timestamptz
   `);
 
   await tx.execute(sql`
@@ -1727,9 +1736,22 @@ export async function runMigration0096_x402SettlementIntents(
       WHERE "settlement_id" IS NOT NULL
   `);
 
+  // One canonical record per settlement, on the table that actually holds the
+  // revenue. Review finding: WP5 named this defect on `transactions` and then
+  // only constrained the intents table, leaving duplicate prevention resting on
+  // the unrelated payment-hash index — a different guarantee that happens to
+  // work only because the recovery path populates that column too.
+  await tx.execute(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS "transactions_x402_settlement_id_unique"
+      ON "transactions" ("x402_settlement_id")
+      WHERE "x402_settlement_id" IS NOT NULL
+  `);
+
   return {
     block: "0096_x402_settlement_intents",
-    outcome: "x402_settlement_intents table + 3 indexes (idempotent)",
+    outcome:
+      "x402_settlement_intents table + 3 indexes, escalated_at column, " +
+      "and the transactions.x402_settlement_id unique index (idempotent)",
     duration_ms: Date.now() - startedAt,
   };
 }

--- a/apps/api/src/lib/x402-gateway.ts
+++ b/apps/api/src/lib/x402-gateway.ts
@@ -16,6 +16,7 @@
  */
 
 import { HTTPFacilitatorClient } from "@x402/core/server";
+import { createHash } from "node:crypto";
 import { parsePaymentPayload } from "@x402/core/schemas";
 import { createFacilitatorConfig } from "@coinbase/x402";
 import { log, logError } from "./log.js";
@@ -662,4 +663,17 @@ export function extractPaymentHeader(headers: Headers): string | null {
 export function encodePaymentResponseHeader(settlementId: string): string {
   const payload = { success: true, transaction: settlementId, network: NETWORK };
   return Buffer.from(JSON.stringify(payload)).toString("base64");
+}
+
+/**
+ * Stable identifier for one payment authorization.
+ *
+ * Moved here in WP5 from routes/x402-gateway-v2.ts, where it was private. Both
+ * the wildcard gateway and the /v1/do x402 path need it now — the gateway to
+ * dedup replays, /v1/do to key its settlement intent — and two copies of a
+ * hashing rule is how the two rails would silently stop agreeing about what
+ * "the same payment" means.
+ */
+export function hashPaymentHeader(header: string): string {
+  return createHash("sha256").update(header).digest("hex").slice(0, 32);
 }

--- a/apps/api/src/lib/x402-settlement-intent.ts
+++ b/apps/api/src/lib/x402-settlement-intent.ts
@@ -36,7 +36,38 @@
 import { and, eq, isNull, lt, sql } from "drizzle-orm";
 
 import { x402SettlementIntents } from "../db/schema.js";
+import { logError } from "./log.js";
 import type { WalletTx } from "./wallet-service.js";
+
+/**
+ * Bookkeeping after the money has moved must never fail the request.
+ *
+ * Found by an existing test rather than by inspection: the unique index on
+ * settlement_id can reject `markSettled`, and that rejection propagated as an
+ * unhandled 500 — AFTER the USDC had already left the customer's wallet. Before
+ * WP5 they would have received their result. A durability mechanism that turns
+ * a successful paid call into an error has made things worse, not better.
+ *
+ * Swallowing here is safe precisely because of what it degrades TO: an intent
+ * stuck at 'settling' is the reconciler's "we do not know" class, which gets
+ * escalated to a human rather than silently resolved. The failure becomes a
+ * page instead of a 500.
+ *
+ * Logged loudly, per DEC-20260504-A's swallow-visibility rule — a swallowed
+ * error that produces a clean-looking summary is the failure mode that protocol
+ * exists to prevent.
+ */
+async function bestEffort(
+  label: string,
+  context: Record<string, unknown>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    logError(label, err, context);
+  }
+}
 
 export type SettlementIntentState =
   | "settling"
@@ -116,6 +147,10 @@ export async function markSettled(
   db: WalletTx,
   params: { intentId: string; settlementId: string },
 ): Promise<void> {
+  await bestEffort(
+    "x402-intent-mark-settled-failed",
+    { intent_id: params.intentId, settlement_id: params.settlementId },
+    async () => {
   await db
     .update(x402SettlementIntents)
     .set({
@@ -129,6 +164,8 @@ export async function markSettled(
         eq(x402SettlementIntents.state, "settling"),
       ),
     );
+    },
+  );
 }
 
 /**
@@ -142,6 +179,10 @@ export async function markFailed(
   db: WalletTx,
   params: { intentId: string; reason: string },
 ): Promise<void> {
+  await bestEffort(
+    "x402-intent-mark-failed-failed",
+    { intent_id: params.intentId },
+    async () => {
   await db
     .update(x402SettlementIntents)
     .set({
@@ -155,6 +196,8 @@ export async function markFailed(
         eq(x402SettlementIntents.state, "settling"),
       ),
     );
+    },
+  );
 }
 
 /**

--- a/apps/api/src/lib/x402-settlement-intent.ts
+++ b/apps/api/src/lib/x402-settlement-intent.ts
@@ -35,7 +35,7 @@
 
 import { and, eq, isNull, lt, sql } from "drizzle-orm";
 
-import { x402SettlementIntents } from "../db/schema.js";
+import { x402OrphanSettlements, x402SettlementIntents } from "../db/schema.js";
 import { logError } from "./log.js";
 import type { WalletTx } from "./wallet-service.js";
 
@@ -60,12 +60,41 @@ import type { WalletTx } from "./wallet-service.js";
 async function bestEffort(
   label: string,
   context: Record<string, unknown>,
-  fn: () => Promise<void>,
-): Promise<void> {
+  fn: () => Promise<number>,
+): Promise<number> {
   try {
-    await fn();
+    return await fn();
   } catch (err) {
     logError(label, err, context);
+    return 0;
+  }
+}
+
+/**
+ * A conditional UPDATE that matches nothing is not an exception.
+ *
+ * Review finding, and the sharper half of the swallow problem: `bestEffort`
+ * only catches THROWS. Every transition here is guarded on the prior state, so
+ * a guard miss is a zero-row UPDATE — no error, no log, no counter, nothing.
+ * The safety argument above ("it degrades to a state the reconciler escalates")
+ * holds for the throw case and is FALSE for this one, where the row can be left
+ * describing a different settlement while looking fully resolved.
+ *
+ * So every transition reports whether it applied, and a no-op is logged as the
+ * anomaly it is. DEC-20260504-A's swallow-visibility rule, applied to the case
+ * that produces no error to swallow.
+ */
+function reportNoOp(
+  label: string,
+  applied: number,
+  context: Record<string, unknown>,
+): void {
+  if (applied === 0) {
+    logError(
+      label,
+      new Error("conditional state transition matched no row"),
+      context,
+    );
   }
 }
 
@@ -73,7 +102,19 @@ export type SettlementIntentState =
   | "settling"
   | "settled"
   | "recorded"
-  | "failed";
+  | "failed"
+  /**
+   * Handed to a human. Terminal from the job's perspective.
+   *
+   * Exists because of a starvation defect found in review: the reconciler
+   * escalated unresolvable rows and deliberately left them untouched, but the
+   * sweep is `ORDER BY updated_at ASC LIMIT n`. An untouched row keeps its
+   * original timestamp, so it stays permanently among the oldest — and once n
+   * of them accumulate they occupy the whole batch forever, and the next real
+   * crash is never examined. The recovery job would have silently stopped
+   * recovering, which is the failure WP5 exists to prevent.
+   */
+  | "escalated";
 
 /**
  * How long an intent may sit non-terminal before the reconciler treats it as
@@ -86,9 +127,33 @@ export type SettlementIntentState =
  */
 export const INTENT_STALE_AFTER_MS = 5 * 60 * 1000;
 
+/**
+ * The intent could not be written, so the settlement cannot be made durable.
+ *
+ * Its own class so the failure is attributable. It is raised BEFORE any money
+ * moves, which makes failing the request the safe choice — but the capability
+ * has already executed successfully by then, and without a distinct type the
+ * generic catch fires recordFailure + triggerOnFailure against a quality floor
+ * that is armed in production. A database blip on Strale's side would delist a
+ * capability that did its job.
+ */
+export class SettlementIntentUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super(
+      "Could not record a durable settlement intent; the payment was not " +
+        "taken. This is a Strale-side failure, not a capability failure.",
+    );
+    this.name = "SettlementIntentUnavailableError";
+    this.cause = cause;
+  }
+}
+
 export interface SettlementIntent {
   id: string;
   paymentHash: string;
+  /** State AFTER the upsert — 'settling' for a fresh intent. */
+  state: string;
+  settlementId: string | null;
 }
 
 /**
@@ -118,6 +183,7 @@ export async function openIntent(
     priceUsd?: number | null;
   },
 ): Promise<SettlementIntent> {
+  try {
   const [row] = await db
     .insert(x402SettlementIntents)
     .values({
@@ -137,9 +203,38 @@ export async function openIntent(
     .returning({
       id: x402SettlementIntents.id,
       paymentHash: x402SettlementIntents.paymentHash,
+      state: x402SettlementIntents.state,
+      settlementId: x402SettlementIntents.settlementId,
     });
 
+  // A conflict on a NON-'settling' intent means this authorization already
+  // reached the facilitator once. The caller is about to settle it again, and
+  // this row cannot represent two settlements — its uniqueness on payment_hash
+  // caps the durable record at one. Surfaced rather than swallowed; markSettled's
+  // zero-row path is what actually preserves the second settlement.
+  if (row.state !== "settling") {
+    logError(
+      "x402-intent-reopened-on-terminal-state",
+      new Error(
+        `Intent for this payment hash is already in state '${row.state}'; a ` +
+          "second settlement is about to be attempted against one authorization",
+      ),
+      {
+        intent_id: row.id,
+        existing_state: row.state,
+        existing_settlement_id: row.settlementId,
+      },
+    );
+  }
+
   return row;
+  } catch (err) {
+    // Deliberately NOT best-effort: this runs before the facilitator, so
+    // failing the request costs nothing but a retry, while proceeding without
+    // durability reinstates the exact defect WP5 exists to close.
+    if (err instanceof SettlementIntentUnavailableError) throw err;
+    throw new SettlementIntentUnavailableError(err);
+  }
 }
 
 /** The facilitator answered. Record which way, and the settlement id if any. */
@@ -147,11 +242,11 @@ export async function markSettled(
   db: WalletTx,
   params: { intentId: string; settlementId: string },
 ): Promise<void> {
-  await bestEffort(
+  const applied = await bestEffort(
     "x402-intent-mark-settled-failed",
     { intent_id: params.intentId, settlement_id: params.settlementId },
     async () => {
-  await db
+  const rows = await db
     .update(x402SettlementIntents)
     .set({
       state: "settled",
@@ -163,9 +258,41 @@ export async function markSettled(
         eq(x402SettlementIntents.id, params.intentId),
         eq(x402SettlementIntents.state, "settling"),
       ),
-    );
+    )
+    .returning({ id: x402SettlementIntents.id });
+  return rows.length;
     },
   );
+
+  // The settlement id could not be attached to its intent, so it now exists
+  // ONLY on-chain. Preserve it in the orphan table — that table's whole purpose
+  // is "a settlement we could not record normally" — otherwise a second
+  // settlement against one authorization vanishes without trace.
+  if (applied === 0) {
+    reportNoOp("x402-intent-mark-settled-noop", applied, {
+      intent_id: params.intentId,
+      settlement_id: params.settlementId,
+    });
+    await bestEffort(
+      "x402-intent-orphan-capture-failed",
+      { settlement_id: params.settlementId },
+      async () => {
+        await db.insert(x402OrphanSettlements).values({
+          settlementId: params.settlementId,
+          capabilitySlug: null,
+          solutionSlug: null,
+          payerAddress: null,
+          priceUsd: "0.0000",
+          priceCents: 0,
+          rawArgs: { intent_id: params.intentId, source: "mark-settled-noop" },
+          failureReason:
+            "Settlement succeeded but its intent was no longer in 'settling'; " +
+            "the settlement id had nowhere else to live.",
+        });
+        return 1;
+      },
+    );
+  }
 }
 
 /**
@@ -179,11 +306,11 @@ export async function markFailed(
   db: WalletTx,
   params: { intentId: string; reason: string },
 ): Promise<void> {
-  await bestEffort(
+  const applied = await bestEffort(
     "x402-intent-mark-failed-failed",
     { intent_id: params.intentId },
     async () => {
-  await db
+  const rows = await db
     .update(x402SettlementIntents)
     .set({
       state: "failed",
@@ -195,9 +322,14 @@ export async function markFailed(
         eq(x402SettlementIntents.id, params.intentId),
         eq(x402SettlementIntents.state, "settling"),
       ),
-    );
+    )
+    .returning({ id: x402SettlementIntents.id });
+  return rows.length;
     },
   );
+  reportNoOp("x402-intent-mark-failed-noop", applied, {
+    intent_id: params.intentId,
+  });
 }
 
 /**
@@ -296,7 +428,7 @@ export async function markRecordedBySettlement(
   db: WalletTx,
   params: { settlementId: string; transactionId: string },
 ): Promise<void> {
-  await db
+  const rows = await db
     .update(x402SettlementIntents)
     .set({
       state: "recorded",
@@ -308,5 +440,44 @@ export async function markRecordedBySettlement(
         eq(x402SettlementIntents.settlementId, params.settlementId),
         eq(x402SettlementIntents.state, "settled"),
       ),
-    );
+    )
+    .returning({ id: x402SettlementIntents.id });
+
+  reportNoOp("x402-intent-mark-recorded-noop", rows.length, {
+    settlement_id: params.settlementId,
+    transaction_id: params.transactionId,
+  });
+}
+
+/**
+ * Hand an unresolvable intent to a human and take it OUT of the sweep.
+ *
+ * The transition is what fixes the starvation: an escalated row no longer
+ * matches the selection, so it cannot occupy a slot in an ordered, limited
+ * batch forever. It stays in the table, fully visible, with the timestamp of
+ * when it was handed over.
+ */
+export async function escalateIntent(
+  db: WalletTx,
+  intentId: string,
+): Promise<boolean> {
+  const rows = await db
+    .update(x402SettlementIntents)
+    .set({ state: "escalated", escalatedAt: new Date(), updatedAt: new Date() })
+    .where(
+      and(
+        eq(x402SettlementIntents.id, intentId),
+        sql`${x402SettlementIntents.state} IN ('settling', 'settled')`,
+      ),
+    )
+    .returning({ id: x402SettlementIntents.id });
+  return rows.length > 0;
+}
+
+/** How many intents are sitting with a human. Drives one aggregate alert. */
+export async function countEscalated(db: WalletTx): Promise<number> {
+  const rows = (await db.execute(
+    sql`SELECT count(*)::int AS c FROM x402_settlement_intents WHERE state = 'escalated'`,
+  )) as unknown as Array<{ c: number }>;
+  return rows[0]?.c ?? 0;
 }

--- a/apps/api/src/lib/x402-settlement-intent.ts
+++ b/apps/api/src/lib/x402-settlement-intent.ts
@@ -1,0 +1,269 @@
+/**
+ * Durable intent for x402 settlements (WP5, risk CR-01).
+ *
+ * WP3 made a crashed wallet debit recoverable. This is the harder half: a
+ * settlement moves USDC on-chain and cannot be undone, so there is no
+ * equivalent of "release the reservation and give it back".
+ *
+ * The defect. `recordX402Transaction` captures an orphaned settlement in a
+ * catch block (routes/x402-gateway-v2.ts). That handles "the INSERT threw". It
+ * cannot handle "the process died between the settlement succeeding and the
+ * INSERT committing", because then the catch never runs either. A SIGKILL in
+ * that window means the customer's USDC moved irreversibly and Strale holds no
+ * row anywhere — not in `transactions`, not in `x402_orphan_settlements`. The
+ * only remaining evidence is on the chain.
+ *
+ * An in-process catch block is not a recovery mechanism. That was the WP3
+ * lesson, and it had not been applied to the one rail where the money movement
+ * is irreversible.
+ *
+ * So: write down what we are ABOUT to do, before doing it. The row outlives the
+ * process, so a reconciler can ask "what happened to this?" instead of nobody
+ * ever knowing it was attempted.
+ *
+ *   settling ──▶ settled ──▶ recorded
+ *        ╰─────▶ failed
+ *
+ * ── What this deliberately does NOT do ──────────────────────────────────────
+ *
+ * It does not decide, on its own, whether an interrupted settlement moved money.
+ * A crash DURING the facilitator call leaves genuine ambiguity that only an
+ * on-chain query can resolve. Assuming "settled" invents revenue; assuming "not
+ * settled" gives the work away. The reconciler alerts and leaves the row alone.
+ * Money code should refuse to guess, and say so loudly.
+ */
+
+import { and, eq, isNull, lt, sql } from "drizzle-orm";
+
+import { x402SettlementIntents } from "../db/schema.js";
+import type { WalletTx } from "./wallet-service.js";
+
+export type SettlementIntentState =
+  | "settling"
+  | "settled"
+  | "recorded"
+  | "failed";
+
+/**
+ * How long an intent may sit non-terminal before the reconciler treats it as
+ * abandoned.
+ *
+ * Short relative to the wallet TTL: a facilitator call is seconds, not minutes,
+ * and unlike a wallet reservation there is no live execution that a premature
+ * sweep could disturb. The reconciler never reverses money, so the cost of
+ * looking early is a query, not a wrong refund.
+ */
+export const INTENT_STALE_AFTER_MS = 5 * 60 * 1000;
+
+export interface SettlementIntent {
+  id: string;
+  paymentHash: string;
+}
+
+/**
+ * Record that a settlement is about to be attempted.
+ *
+ * Committed BEFORE the facilitator is called — that ordering is the entire
+ * point, and a caller that writes it afterwards has reintroduced the defect
+ * with extra steps.
+ *
+ * Idempotent on `paymentHash`: a replayed payment header must not create a
+ * second intent, or the reconciler would later see two attempts where the
+ * platform made one.
+ */
+export async function openIntent(
+  db: WalletTx,
+  params: {
+    paymentHash: string;
+    slug: string;
+    solutionSlug?: string | null;
+    priceCents: number;
+    /**
+     * Optional: the /v1/do rail's CapabilityInfo does not carry the USD price.
+     * The intent exists to make a settlement recoverable, and priceCents plus
+     * the slug are enough for that; the USD figure is convenience for an
+     * operator reading the row.
+     */
+    priceUsd?: number | null;
+  },
+): Promise<SettlementIntent> {
+  const [row] = await db
+    .insert(x402SettlementIntents)
+    .values({
+      paymentHash: params.paymentHash,
+      slug: params.slug,
+      solutionSlug: params.solutionSlug ?? null,
+      priceCents: params.priceCents,
+      priceUsd: params.priceUsd != null ? params.priceUsd.toFixed(4) : null,
+      state: "settling",
+    })
+    .onConflictDoUpdate({
+      target: x402SettlementIntents.paymentHash,
+      // A no-op update rather than DO NOTHING: DO NOTHING returns no row, and
+      // the caller needs the id of the existing intent to close it out.
+      set: { updatedAt: new Date() },
+    })
+    .returning({
+      id: x402SettlementIntents.id,
+      paymentHash: x402SettlementIntents.paymentHash,
+    });
+
+  return row;
+}
+
+/** The facilitator answered. Record which way, and the settlement id if any. */
+export async function markSettled(
+  db: WalletTx,
+  params: { intentId: string; settlementId: string },
+): Promise<void> {
+  await db
+    .update(x402SettlementIntents)
+    .set({
+      state: "settled",
+      settlementId: params.settlementId,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(x402SettlementIntents.id, params.intentId),
+        eq(x402SettlementIntents.state, "settling"),
+      ),
+    );
+}
+
+/**
+ * The facilitator declined. No money moved, so there is nothing to reconcile.
+ *
+ * Recorded rather than deleted: a burst of failed intents is the signal that
+ * the facilitator is unhealthy, and deleting them would erase exactly the
+ * evidence an operator needs.
+ */
+export async function markFailed(
+  db: WalletTx,
+  params: { intentId: string; reason: string },
+): Promise<void> {
+  await db
+    .update(x402SettlementIntents)
+    .set({
+      state: "failed",
+      failureReason: params.reason.slice(0, 500),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(x402SettlementIntents.id, params.intentId),
+        eq(x402SettlementIntents.state, "settling"),
+      ),
+    );
+}
+
+/**
+ * The transaction row exists. The intent is fully discharged.
+ *
+ * Conditional on `settled` so a duplicate call is a no-op rather than a second
+ * transition, for the same reason every WP3 transition is conditional.
+ */
+export async function markRecorded(
+  db: WalletTx,
+  params: { intentId: string; transactionId: string },
+): Promise<void> {
+  await db
+    .update(x402SettlementIntents)
+    .set({
+      state: "recorded",
+      transactionId: params.transactionId,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(x402SettlementIntents.id, params.intentId),
+        eq(x402SettlementIntents.state, "settled"),
+      ),
+    );
+}
+
+export interface AbandonedIntent {
+  id: string;
+  state: SettlementIntentState;
+  paymentHash: string;
+  settlementId: string | null;
+  slug: string;
+  solutionSlug: string | null;
+  priceCents: number;
+}
+
+/**
+ * Intents a crash left behind: non-terminal and past the staleness window.
+ *
+ * Two very different populations come back from this, and the reconciler must
+ * treat them differently:
+ *
+ *   state='settled'  — the money moved and we know it. Recoverable: the
+ *                      transaction row can be recreated from what we stored.
+ *   state='settling' — we do not know whether the chain moved. NOT recoverable
+ *                      from our side. Alert; never guess.
+ *
+ * Bounded and oldest-first, per DEC-20260504-B: the first real run of a job
+ * like this is a workload-resumption event, not a routine tick.
+ */
+export async function findAbandonedIntents(
+  db: WalletTx,
+  limit = 50,
+): Promise<AbandonedIntent[]> {
+  return db
+    .select({
+      id: x402SettlementIntents.id,
+      state: x402SettlementIntents.state,
+      paymentHash: x402SettlementIntents.paymentHash,
+      settlementId: x402SettlementIntents.settlementId,
+      slug: x402SettlementIntents.slug,
+      solutionSlug: x402SettlementIntents.solutionSlug,
+      priceCents: x402SettlementIntents.priceCents,
+    })
+    .from(x402SettlementIntents)
+    .where(
+      and(
+        sql`${x402SettlementIntents.state} IN ('settling', 'settled')`,
+        lt(
+          x402SettlementIntents.updatedAt,
+          sql`now() - ${sql.raw(`interval '${Math.floor(INTENT_STALE_AFTER_MS / 1000)} seconds'`)}`,
+        ),
+        isNull(x402SettlementIntents.transactionId),
+      ),
+    )
+    .orderBy(x402SettlementIntents.updatedAt)
+    .limit(limit) as Promise<AbandonedIntent[]>;
+}
+
+/**
+ * Discharge the intent for a settlement, keyed by the settlement id.
+ *
+ * Called from `recordX402Transaction` rather than from each rail, because that
+ * is the exact point where "the row landed" becomes true — and there are three
+ * settle sites but only one place that writes the row. Keying on settlementId
+ * rather than threading an intent id through every caller keeps the rails from
+ * having to remember; the unique partial index on that column is what makes the
+ * lookup unambiguous.
+ *
+ * Best-effort by design: the transaction row is the customer-facing record and
+ * must never fail to land because bookkeeping did. A missed mark leaves an
+ * intent the reconciler will find and resolve as already-recorded.
+ */
+export async function markRecordedBySettlement(
+  db: WalletTx,
+  params: { settlementId: string; transactionId: string },
+): Promise<void> {
+  await db
+    .update(x402SettlementIntents)
+    .set({
+      state: "recorded",
+      transactionId: params.transactionId,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(x402SettlementIntents.settlementId, params.settlementId),
+        eq(x402SettlementIntents.state, "settled"),
+      ),
+    );
+}

--- a/apps/api/src/routes/billing-parity.integration.test.ts
+++ b/apps/api/src/routes/billing-parity.integration.test.ts
@@ -28,6 +28,7 @@ import { randomUUID } from "node:crypto";
 import { useTestDatabase } from "../test-support/integration-db.js";
 import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
 import {
+  x402SettlementIntents,
   users,
   wallets,
   walletTransactions,
@@ -129,6 +130,11 @@ describeMaybe("a gated solution bills identically on both rails", () => {
     // leftover rows look like.
     if (solSlug) {
       await db.delete(transactions).where(eq(transactions.solutionSlug, solSlug));
+      // WP5 added settlement intents; the x402 rail writes one per request and
+      // they outlive the test the same way its transaction rows used to.
+      await db
+        .delete(x402SettlementIntents)
+        .where(eq(x402SettlementIntents.slug, solSlug));
     }
     if (userId) {
       await db.delete(walletReservations).where(eq(walletReservations.userId, userId));
@@ -370,6 +376,9 @@ describeMaybe("a capability returning an unusable output bills on neither rail",
       // how the solutions block broke that test in CI while passing locally.
       // `transactions` has no slug column; capability_id is the identifier.
       await db.delete(transactions).where(eq(transactions.capabilityId, capabilityId));
+      await db
+        .delete(x402SettlementIntents)
+        .where(eq(x402SettlementIntents.slug, CAP_SLUG));
       await db.delete(capabilities).where(eq(capabilities.id, capabilityId));
     }
     await client.end();

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { eq, and, gte, inArray, isNull, sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
+import * as settlementIntent from "../lib/x402-settlement-intent.js";
 import {
   assertBillableOutput,
   shouldCountAgainstCapability,
@@ -63,6 +64,7 @@ import {
   settleX402Payment,
   extractPaymentHeader,
   type X402VerifiedPayment,
+  hashPaymentHeader,
 } from "../lib/x402-gateway.js";
 import { recordUnlock, isUnlocked, getUnlockedSlugs } from "../lib/progressive-unlock.js";
 import type { AppEnv } from "../types.js";
@@ -619,6 +621,10 @@ doRoute.post(
         }
         // Stash the verified handle for executeFreeTier to settle post-success.
         c.set("x402_verified" as any, verification.verified);
+        // WP5: and the payment hash, so the settle site downstream can write a
+        // durable intent before it moves USDC. Carried the same way the handle
+        // is, because the settle happens far from where the header is in scope.
+        c.set("x402_payment_hash" as any, hashPaymentHeader(paymentHeader));
         c.set("x402_paid" as any, true);
         // Fall through to normal execution — the capability will execute
         // and the transaction will be logged with payment_method: "x402"
@@ -1316,7 +1322,34 @@ async function executeFreeTier(
     const x402Verified = c.get("x402_verified" as any) as X402VerifiedPayment | undefined;
     let x402SettlementId: string | null = null;
     if (x402Verified) {
+      // WP5: durable intent before the irreversible call. Same reasoning as the
+      // wildcard gateway — a crash between settlement and the transaction row
+      // otherwise leaves the customer's USDC moved and no record anywhere.
+      const paymentHash = c.get("x402_payment_hash" as any) as string | undefined;
+      const intent = paymentHash
+        ? await settlementIntent.openIntent(db, {
+            paymentHash,
+            slug: capability.slug,
+            solutionSlug: null,
+            priceCents: capability.priceCents,
+
+          })
+        : null;
+
       const settled = await settleX402Payment(x402Verified);
+      if (intent) {
+        if (settled.valid && settled.settlementId) {
+          await settlementIntent.markSettled(db, {
+            intentId: intent.id,
+            settlementId: settled.settlementId,
+          });
+        } else {
+          await settlementIntent.markFailed(db, {
+            intentId: intent.id,
+            reason: settled.error ?? "settlement returned invalid",
+          });
+        }
+      }
       if (!settled.valid) {
         await db
           .update(transactions)

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -1387,6 +1387,19 @@ async function executeFreeTier(
       })
       .where(eq(transactions.id, txnRecord.id));
 
+    // WP5: the row exists, so the intent is discharged. Review finding — this
+    // rail opened intents and never closed them, because markRecordedBySettlement
+    // lives inside recordX402Transaction, which /v1/do does not use. Every paid
+    // call therefore left a 'settled' intent that the reconciler picked up five
+    // minutes later as "abandoned", routing the NORMAL path through the
+    // crash-recovery path and permanently contending its bounded queue.
+    if (x402SettlementId) {
+      await settlementIntent.markRecordedBySettlement(db, {
+        settlementId: x402SettlementId,
+        transactionId: txnRecord.id,
+      });
+    }
+
     // Record circuit breaker + quality (fire-and-forget)
     fireAndForget(() => recordSuccess(capability.slug), { label: "circuit-breaker-record-success", context: { slug: capability.slug } });
     recordQuality({

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -24,6 +24,7 @@ import {
 import {
   isX402Configured,
   verifyX402PaymentOnly,
+  hashPaymentHeader,
   settleX402Payment,
   extractPaymentHeader,
   extractPayerAddress,
@@ -43,6 +44,7 @@ import { extractClientMeta, recordDiscoveryHit, hashX402Payer } from "../lib/att
 import { rateLimitByIp } from "../lib/rate-limit.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
 import { executeSolution } from "../lib/solution-executor.js";
+import * as settlementIntent from "../lib/x402-settlement-intent.js";
 import {
   aggregateSolutionOutcome,
   assertBillableOutput,
@@ -611,10 +613,6 @@ function schemaBadRequest(
 // row is `completed`, return its output as the cached response. If found
 // and `failed`, return its error.
 
-function hashPaymentHeader(header: string): string {
-  return createHash("sha256").update(header).digest("hex").slice(0, 32);
-}
-
 async function findCachedX402Response(
   paymentHash: string,
 ): Promise<{ status: string; output: unknown; latencyMs: number | null; settlementId: string | null } | null> {
@@ -845,6 +843,22 @@ async function recordX402Transaction(args: RecordX402Args): Promise<string | nul
           .where(eq(transactions.id, insertedId));
       } catch (updErr) {
         logError("x402-audit-rebuild-failed", updErr, { transactionId: insertedId });
+      }
+    }
+    // WP5: the row landed, so the intent is discharged. Best-effort — the
+    // customer-facing record must never fail to land because bookkeeping did,
+    // and a missed mark leaves an intent the reconciler resolves as
+    // already-recorded.
+    if (args.settlementId) {
+      try {
+        await settlementIntent.markRecordedBySettlement(db, {
+          settlementId: args.settlementId,
+          transactionId: insertedId,
+        });
+      } catch (intentErr) {
+        logError("x402-intent-mark-recorded-failed", intentErr, {
+          settlementId: args.settlementId,
+        });
       }
     }
     return insertedId;
@@ -1202,7 +1216,36 @@ x402GatewayV2.on(["GET", "POST"], ["/solutions/:slug", "/v2/solutions/:slug"], a
 
   let settlementId: string | undefined;
   if (verified) {
+    // WP5: durable intent BEFORE the facilitator is called. That ordering is
+    // the whole point — the orphan capture below is a catch block in this
+    // process, so it handles "the INSERT threw" and cannot handle "the process
+    // died", when it never runs either. A settlement is irreversible, so the
+    // window between it succeeding and the row landing is the one place on the
+    // platform where a crash costs a customer money with no record at all.
+    const intent = paymentHash
+      ? await settlementIntent.openIntent(getDb(), {
+          paymentHash,
+          slug: sol.slug,
+          solutionSlug: sol.slug,
+          priceCents: sol.priceCents,
+          priceUsd: sol.x402PriceUsd,
+        })
+      : null;
+
     const settled = await settleX402Payment(verified);
+    if (intent) {
+      if (settled.valid && settled.settlementId) {
+        await settlementIntent.markSettled(getDb(), {
+          intentId: intent.id,
+          settlementId: settled.settlementId,
+        });
+      } else {
+        await settlementIntent.markFailed(getDb(), {
+          intentId: intent.id,
+          reason: settled.error ?? "settlement returned invalid",
+        });
+      }
+    }
     if (!settled.valid) {
       return c.json(
         { error: "Payment settlement failed", detail: settled.error },
@@ -1520,7 +1563,36 @@ x402GatewayV2.on(["GET", "POST"], ["/:slug", "/v2/:slug"], async (c) => {
   // already passed) surface a clear error; the client can retry the paid call.
   let settlementId: string | undefined;
   if (verified) {
+    // WP5: durable intent BEFORE the facilitator is called. That ordering is
+    // the whole point — the orphan capture below is a catch block in this
+    // process, so it handles "the INSERT threw" and cannot handle "the process
+    // died", when it never runs either. A settlement is irreversible, so the
+    // window between it succeeding and the row landing is the one place on the
+    // platform where a crash costs a customer money with no record at all.
+    const intent = paymentHash
+      ? await settlementIntent.openIntent(getDb(), {
+          paymentHash,
+          slug: cap.slug,
+          solutionSlug: null,
+          priceCents: cap.priceCents,
+          priceUsd: cap.x402PriceUsd,
+        })
+      : null;
+
     const settled = await settleX402Payment(verified);
+    if (intent) {
+      if (settled.valid && settled.settlementId) {
+        await settlementIntent.markSettled(getDb(), {
+          intentId: intent.id,
+          settlementId: settled.settlementId,
+        });
+      } else {
+        await settlementIntent.markFailed(getDb(), {
+          intentId: intent.id,
+          reason: settled.error ?? "settlement returned invalid",
+        });
+      }
+    }
     if (!settled.valid) {
       return c.json(
         { error: "Payment settlement failed", detail: settled.error },

--- a/docs/remediation/CURRENT-STATE.md
+++ b/docs/remediation/CURRENT-STATE.md
@@ -2,13 +2,43 @@
 
 _Last updated: 2026-08-21 (session 1)_
 
-- **Current package:** WP4 — in independent adversarial review on `remediation/wp4`.
+- **Current package:** WP4 — ACCEPTED, merged as `c7efbb4` (PR #351).
 - **Next package:** WP5
 - **WP3:** ACCEPTED, merged as `ee7f737` (PR #350), verified live in production — table, all three indexes, and the CHECK constraint reached `validated=true`.
 - **Latest accepted SHA:** `ee7f737` on `main`
 - **Unresolved blockers:** none
 - **Human approvals granted:** program-level autonomy (run continuously; escalate only per CHECK-IN A/B/C)
 - **Awaiting founder:** nothing. One item is logged for *visibility only*, not decision — see "Codex disposition" below.
+
+## Where WP4 landed
+
+One authority for billability: `lib/execution-outcome.ts`. Payment consumes
+`billable`. A rail still decides HOW to collect; it no longer decides WHETHER.
+
+The defect was real and sharper than the audit stated. `gated` appeared twelve
+times in the wallet solution route and zero times in the x402 one, so a gated
+run refunded one customer in full and charged the other in full. `result.gated`
+was available on the x402 rail the whole time.
+
+**The review's blocking finding was about my own claim, not just my code.** I
+rewired four of five rails and recorded "no route decides billability
+independently" as MET. That was false — the x402 capability rail still settled
+on any resolution — and the half-fix *created* a new asymmetry between
+`/v1/do` + X-PAYMENT and `/x402/:slug`. The guard was green throughout because
+its import check was file-scoped: one handler importing the module satisfied it
+while another settled 250 lines away. The lesson generalises past this package:
+a guard that checks a FILE cannot protect a decision made in a FUNCTION.
+
+Also closed: `counts_against_capability` had no consumer, so the advertised
+"refusals don't count against a capability" fix was documentation only against
+an armed quality floor; `UnbillableOutputError` discarded upstream error text
+and so misfiled 5xx failures as Strale's bug; a gated x402 solution wrote no
+transaction row and no replay-dedup entry, leaving the authorization replayable
+at our cost.
+
+Three review findings were guard bugs rather than code bugs and were fixed as
+such — worth remembering that an adversarial reviewer's findings also need
+adjudicating rather than blanket acceptance.
 
 ## WP3 in production — verified, with one honest gap
 

--- a/docs/remediation/packages/WP4.yaml
+++ b/docs/remediation/packages/WP4.yaml
@@ -1,6 +1,8 @@
 package: WP4
 title: Canonical ExecutionOutcome — one authority for billability
-status: REMEDIATED
+status: ACCEPTED
+merged_sha: c7efbb4
+merged_pr: 351
 depends_on: [WP2]
 risks: [CR-02]
 
@@ -126,7 +128,7 @@ incidental_findings:
 review:
   codex: deferred_to_final_pass
   independent_agent: FAIL_REMEDIATION_REQUIRED, then all findings closed
-  fable: pending
+  fable: ACCEPT
 
   blocking_finding: >
     The x402 CAPABILITY rail was never wired. The module docstring named five

--- a/docs/remediation/packages/WP5.yaml
+++ b/docs/remediation/packages/WP5.yaml
@@ -1,0 +1,71 @@
+package: WP5
+title: x402 durable settlement state + recovery
+status: IN_PROGRESS
+depends_on: [WP3, WP4]
+risks: [CR-01]
+
+objective: >
+  Make an irreversible on-chain settlement recoverable. WP3 did this for wallet
+  debits, which are reversible; this is the harder half, because a settlement
+  cannot be undone and the customer's USDC has already moved.
+
+# Verified against the code and against production, not taken from the audit.
+current_state:
+  orphan_table_exists: >
+    x402_orphan_settlements, added by CCO P0 #12. Its schema comment says a row
+    means "customer paid USDC, settlement succeeded, but our DB write failed —
+    awaiting reconciliation."
+  prod: "0 orphan rows; 6,377 x402 transactions total"
+
+defects:
+  no_durable_intent: >
+    THE defect, and the exact structural analogue of WP3. The orphan capture is
+    a catch block in the same process (routes/x402-gateway-v2.ts:851). It
+    handles "the INSERT threw". It cannot handle "the process died between the
+    settlement succeeding and the INSERT committing", because then the catch
+    never runs either. A SIGKILL there means the customer's USDC moved
+    irreversibly and Strale holds no row anywhere — not in transactions, not in
+    the orphan table. Undetectable except by on-chain reconciliation against
+    our own wallet.
+
+    An in-process catch block is not a recovery mechanism. That was the WP3
+    lesson and it was never applied to the rail where the money movement is
+    irreversible.
+
+  no_uniqueness_per_settlement: >
+    transactions.x402_settlement_id has no unique index, and
+    x402_orphan_settlements.settlement_id has none either. Nothing structurally
+    prevents one settlement being recorded twice. The existing unique index on
+    x402_payment_hash is a DIFFERENT guarantee — it dedups a replayed payment
+    header so the work is not re-executed. It does not constrain how many rows
+    one settlement produces.
+
+  orphan_table_never_read: >
+    No job reads x402_orphan_settlements. Confirmed by grep across src/jobs/:
+    the only x402 job is settlement-watch, a 24h volume tripwire, not a
+    reconciler. "Awaiting reconciliation" means awaiting a human who has to
+    notice first, and nothing pages them. The table has been correct and inert.
+
+design:
+  durable_intent: >
+    Write the intent BEFORE calling the facilitator. state: settling → settled
+    → recorded, plus failed. A crash at any point leaves a durable row naming
+    exactly what was attempted.
+  reconciler_resolves_what_it_can: >
+    - intent 'settled' with a matching transactions row  → mark recorded
+    - intent 'settled' with NO transactions row          → recreate from stored args
+    - intent 'settling', no settlement_id, past deadline → CANNOT be resolved from
+      our side; the chain may or may not have moved. Alert, never guess.
+  the_honest_residual: >
+    That last class is real and irreducible without an on-chain oracle. The
+    reconciler must page rather than assume either way — assuming "settled"
+    invents revenue, assuming "not settled" gives away the work. Money code
+    should refuse to guess and say so loudly.
+
+exit_conditions:
+  - durable intent written before any settlement call
+  - one canonical record per settlement (enforced by a unique index, not convention)
+  - the orphan table is read by something that runs
+  - a crash between settle and record is recoverable, proved by a kill test
+  - ambiguous cases alert rather than resolve themselves
+  - independent adversarial review passes

--- a/docs/remediation/packages/WP5.yaml
+++ b/docs/remediation/packages/WP5.yaml
@@ -1,6 +1,6 @@
 package: WP5
 title: x402 durable settlement state + recovery
-status: IN_PROGRESS
+status: REMEDIATED
 depends_on: [WP3, WP4]
 risks: [CR-01]
 
@@ -62,10 +62,49 @@ design:
     invents revenue, assuming "not settled" gives away the work. Money code
     should refuse to guess and say so loudly.
 
+review:
+  codex: deferred_to_final_pass
+  independent_agent: FAIL_REMEDIATION_REQUIRED, then all findings closed
+
+  blocking_1_starvation: >
+    The sharpest finding of the program so far. The escalate branch alerted and
+    deliberately left the row untouched — but the sweep is
+    ORDER BY updated_at ASC LIMIT 25. An untouched row keeps its original
+    timestamp, so it stays permanently among the oldest; once 25 accumulate they
+    own the entire batch forever and the next real crash is NEVER examined. The
+    recovery job would have silently stopped recovering, which is precisely the
+    failure WP5 exists to prevent — and the tick log would have read
+    "examined:25 escalated:25" forever, indistinguishable from health.
+    Compounded by per-row alerting on a 6h cooldown: 25 permanent CRITICAL
+    pages every six hours would have muted the one channel that could report it.
+    Fixed with an `escalated` state that leaves the selection set, plus ONE
+    aggregate alert about the backlog.
+
+  blocking_2_silent_noop: >
+    `bestEffort` only caught THROWS. Every transition is a conditional UPDATE,
+    so a guard miss is a ZERO-ROW update — no error, no log, nothing. The
+    module's own safety argument ("it degrades to a state the reconciler
+    escalates") held for the throw case and was false here, where the row can
+    end up describing a different settlement while looking fully resolved. A
+    second settlement against one authorization was written nowhere at all.
+    Fixed: every transition returns its row count, a no-op is logged as the
+    anomaly it is, and a settlement id that cannot reach its intent is captured
+    in x402_orphan_settlements — the table that exists for exactly that.
+
+  non_blocking_closed:
+    - "/v1/do opened intents and never discharged them, routing every paid call through the crash-recovery path and permanently contending its bounded queue."
+    - "The orphan table still was not read; the two channels could disagree, and an operator following the orphan procedure would double-record or wrongly refund. The reconciler now closes the orphan row when it recovers."
+    - "The `one canonical record per settlement` exit condition was claimed but only constrained the intents table; duplicate prevention on `transactions` rested on the unrelated payment-hash index. A partial unique index now exists on transactions.x402_settlement_id — verified against production first: 0 duplicates across 5,675 rows, so it cannot abort boot."
+    - "The advisory lock spanned only the batch SELECT, so two staggered replicas could both reach the insert. The unique index is now the claim, and a 23505 loser is counted as discharged rather than failed."
+    - "The recovered row was status='completed' with null output, which poisoned the gateway replay cache (a retry received an empty body dressed as a cached success), discarded the slug the intent stores precisely to make recovery possible, and inherited a DEFAULT transparency marker of 'ai_generated' — a fabricated EU AI Act Art. 50 claim. Now 'failed' (the customer received nothing; the money is recorded by priceCents + settlement id), attributed to its capability, with an honest marker."
+    - "An openIntent failure blamed the CAPABILITY: recordFailure + triggerOnFailure against an armed quality floor, for a Strale database blip. Now a typed error WP4's classifier excludes."
+    - "Two tests did not test what they claimed — `does not recover it twice` could not reach the second tick at all, and `REFUSES to guess` reintroduced the global-counter assertion the file itself calls out."
+
 exit_conditions:
   - durable intent written before any settlement call
   - one canonical record per settlement (enforced by a unique index, not convention)
   - the orphan table is read by something that runs
   - a crash between settle and record is recoverable, proved by a kill test
   - ambiguous cases alert rather than resolve themselves
-  - independent adversarial review passes
+  - the sweep cannot be starved by unresolvable rows      # MET (added after review)
+  - independent adversarial review passes                  # MET after remediation


### PR DESCRIPTION
## The defect

An x402 settlement moves USDC on-chain and **cannot be undone**. WP3 made a crashed wallet debit recoverable; this is the harder half, because there is no "give it back".

`recordX402Transaction` captured an orphaned settlement in a **catch block**. That handles "the INSERT threw". It cannot handle "the process died" — then the catch never runs either. A SIGKILL between the settlement succeeding and the row committing left the customer's USDC moved and Strale holding no row anywhere: not in `transactions`, not in `x402_orphan_settlements`. Only the chain knew.

An in-process catch block is not a recovery mechanism. That was the WP3 lesson, never applied to the one rail where the money movement is irreversible.

Two more, found by checking rather than assuming: **nothing anywhere read** `x402_orphan_settlements` — "awaiting reconciliation" meant awaiting a human who had to notice first — and no unique index constrained how many rows one settlement could produce.

## The change

The intent is written **before** the facilitator is called, at all three settle sites. `settling → settled → recorded`, plus `failed` and `escalated`.

The reconciler treats three populations differently, which is the whole design:

| state | meaning | action |
|---|---|---|
| `settled` + row exists | bookkeeping lagged | discharge |
| `settled` + no row | money moved, record lost | recreate the row, **alert** — the customer paid and got nothing |
| `settling` + no id | **we do not know** | escalate to a human, infer nothing |

That last row is irreducible without an on-chain oracle. Assuming it settled invents revenue; assuming it didn't gives the work away. A test pins the refusal as *specified behaviour*, so nobody later "fixes" it by picking a default.

## Adversarial review found two blocking defects

**1. The reconciler would have starved itself on exactly the rows WP5 creates.** The escalate branch alerted and deliberately left the row untouched — but the sweep is `ORDER BY updated_at ASC LIMIT 25`. An untouched row keeps its timestamp, stays permanently among the oldest, and once 25 accumulate they own the entire batch **forever**. The next real crash would never be examined: the recovery job would have silently stopped recovering, while its tick log read `examined:25 escalated:25` — indistinguishable from health. Compounded by per-row alerting on a 6h cooldown: 25 standing CRITICAL pages every six hours would have muted the one channel that could report it.

Fixed with an `escalated` state that leaves the selection set, plus one aggregate alert. **Proved by measurement**, not argument — 30 permanently-stuck rows plus one real recoverable crash:

```
tick 1: examined 25, escalated 25
tick 2: examined  6, escalated  5, recovered 1   ← the real crash was reached
tick 3: examined  0                              ← queue drained
escalated_backlog: 30 in every tick log; ONE alert, then suppressed
```

**2. A zero-row UPDATE is not an exception.** `bestEffort` only caught throws. Every transition is a conditional UPDATE, so a guard miss emitted *nothing* — no error, no log, no counter. The module's own safety argument ("it degrades to a state the reconciler escalates") held for the throw case and was false here, where the row can end up describing a *different* settlement while looking fully resolved. A second settlement against one authorization was recorded nowhere at all.

Every transition now reports its row count, a no-op is logged as the anomaly it is, and a settlement id that cannot reach its intent is captured in `x402_orphan_settlements` — the table that exists for exactly that.

## Seven more, closed

- `/v1/do` opened intents and never discharged them, routing **every** paid call through the crash-recovery path and permanently contending its bounded queue.
- The orphan table still wasn't read, so the two channels could disagree — an operator following its documented procedure ("recreate the row OR refund the payer") would double-record or wrongly refund. The reconciler now closes the orphan row when it recovers.
- The "one canonical record per settlement" exit condition constrained only the intents table; duplicate prevention on `transactions` rested on the unrelated payment-hash index. A partial unique index now exists — **checked against production first: 0 duplicates across 5,675 rows**, so it cannot abort boot.
- The advisory lock spanned only the batch SELECT. The unique index is now the claim; a `23505` loser counts as discharged, not failed.
- The recovered row was `completed` with null output: it poisoned the gateway replay cache (a retry inside the authorization window received an empty body dressed as a cached success), discarded the slug the intent stores *precisely* to make recovery possible, and inherited a column default of `ai_generated` — a fabricated EU AI Act Art. 50 marker. Now `failed` (the customer received nothing; the money is recorded by `price_cents` + settlement id), attributed to its capability, with an honest marker.
- An `openIntent` failure blamed the **capability** — `recordFailure` + `triggerOnFailure` against a quality floor that is armed in production — for a Strale-side database blip. Now a typed error WP4's classifier excludes.
- Two tests didn't test what they claimed: "does not recover it twice" couldn't reach the second tick at all (the intent leaves the selection set), and "REFUSES to guess" reintroduced the global-counter assertion the same file calls out.

## One I introduced and an existing test caught

The unique index could reject `markSettled`, propagating a 500 **after** the USDC had moved — pre-WP5 the customer got their result, so the durability mechanism briefly made things strictly worse. Post-settlement bookkeeping is now best-effort, degrading to the state the reconciler escalates: an alert instead of a 500. `openIntent` still throws, deliberately — it runs before any money moves, so failing costs a retry while proceeding without durability reinstates the defect.

## Verification

Migration 0096 verified against a real database: idempotent both directions, self-heals a dropped index, and all three uniqueness guarantees proved to bite. 16 gates pass. 2,249 unit tests; 93 integration tests across 15 files, run twice — the last real bug here only appeared in a full-suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
