### PR TITLE
Remediation WP7: the audit chain has not been a chain since 2026-05-04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,24 @@ jobs:
       - name: Materialise test schema from src/db/schema.ts
         working-directory: apps/api
         run: npx drizzle-kit push --force
+      # WP7: run the startup migrations too, exactly as boot does.
+      #
+      # `drizzle-kit push` materialises TABLES AND COLUMNS from schema.ts. It
+      # does not create sequences, partial indexes, constraints or seed rows —
+      # those live in startup-migrations.ts and run at boot. So a code path
+      # depending on one of them passes locally (where the object was created by
+      # hand) and fails in CI with an error that reads like a broken feature.
+      # That is what happened here: `nextval('transactions_chain_seq')` had no
+      # sequence, so nothing was hashed at all.
+      #
+      # Running both is also the more faithful lane — it is the sequence
+      # production actually executes, so a migration that disagrees with the
+      # schema now fails here rather than at boot (DEC-20260504-C).
+      - name: Apply startup migrations (as boot does)
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql://postgres:test@localhost:5432/strale_test
+        run: npx tsx scripts/apply-startup-migrations.ts
       # STRALE_REQUIRE_INTEGRATION_DB makes a missing database a hard error
       # inside useTestDatabase() rather than a skip. Vitest exits 0 for a fully
       # skipped file, so without this the job would stay green while asserting

--- a/apps/api/scripts/apply-startup-migrations.ts
+++ b/apps/api/scripts/apply-startup-migrations.ts
@@ -1,0 +1,18 @@
+/**
+ * Apply the startup migrations, as boot does. Used by the CI integration lane.
+ *
+ * `drizzle-kit push` materialises tables and columns from schema.ts and nothing
+ * else — no sequences, partial indexes, constraints or seed rows. Those live in
+ * startup-migrations.ts and run at boot, so a code path depending on one passes
+ * locally (where the object was created by hand) and fails in CI with an error
+ * that reads like a broken feature rather than a missing object.
+ *
+ * A file rather than `npx tsx -e`: the inline form did not resolve the dynamic
+ * import and hung silently, which is a worse failure than the one it was added
+ * to catch.
+ */
+import { runStartupMigrations } from "../src/lib/startup-migrations.js";
+
+const result = await runStartupMigrations();
+console.log(`startup migrations applied: ${result.length} blocks`);
+process.exit(0);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -346,16 +346,29 @@ app.get("/health/deep", rateLimitByIp(6, 60_000), async (c) => {
   try {
     const db = getDb();
     // Test the write path on the transactions table (touches all indexes).
-    // CTE inserts a probe row and immediately deletes it — atomic, no data left behind.
     // Uses solution_slug (not capability_id) to satisfy the XOR check constraint.
-    await db.execute(sql`
-      WITH probe AS (
+    //
+    // WP7: this was ONE statement — `WITH probe AS (INSERT … RETURNING id)
+    // DELETE … WHERE id IN (SELECT id FROM probe)` — commented "atomic, no data
+    // left behind". That is false, and it is the generator of the audit-chain
+    // incident. In a data-modifying CTE the DELETE runs against the statement's
+    // snapshot, which predates the CTE's INSERT, so it matches nothing. Every
+    // call to this public endpoint therefore leaked one permanent row: 200 in
+    // August alone, 144 in May — and one of the May rows, hashed with a null
+    // completed_at, captured the chain head and acquired 150,719 children.
+    //
+    // Two statements in one transaction: the DELETE now sees the INSERT.
+    await db.transaction(async (tx) => {
+      const inserted = (await tx.execute(sql`
         INSERT INTO transactions (solution_slug, status, input, price_cents, transparency_marker, data_jurisdiction, is_free_tier)
         VALUES ('_health_probe', 'health_probe', '{}', 0, 'algorithmic', 'EU', true)
         RETURNING id
-      )
-      DELETE FROM transactions WHERE id IN (SELECT id FROM probe)
-    `);
+      `)) as unknown as Array<{ id: string }>;
+      const probeId = inserted[0]?.id;
+      if (probeId) {
+        await tx.execute(sql`DELETE FROM transactions WHERE id = ${probeId}`);
+      }
+    });
     return c.json({ status: "ok", write_path: "ok", latency_ms: Date.now() - start });
   } catch (err) {
     console.error("[health/deep] Write-path probe failed:", err instanceof Error ? err.message : err);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -13,6 +13,7 @@ import {
   uniqueIndex,
   index,
   primaryKey,
+  bigint,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 
@@ -263,6 +264,21 @@ export const transactions = pgTable(
     // Compliance infrastructure
     integrityHash: varchar("integrity_hash", { length: 128 }),
     previousHash: varchar("previous_hash", { length: 128 }),
+    /**
+     * Position in the hash chain, assigned from a sequence AT HASH TIME (WP7).
+     *
+     * The head must be "the last row the worker hashed". It cannot be
+     * `max(completed_at)`: that column is stamped from a clock read before the
+     * row's own `created_at` default (median delta in production: MINUS 1.5 ms),
+     * so a row can be admitted after the head while carrying an earlier
+     * completion time — it then chains onto the head without becoming it, and
+     * the next row chains onto the same parent. Nine such forks in 30 days of
+     * real traffic.
+     *
+     * NULL on the 863,946 rows hashed before this existed. They are not head
+     * candidates; their chain is unchanged.
+     */
+    chainSeq: bigint("chain_seq", { mode: "number" }),
     // F-0-009 Stage 2: 'pending' | 'complete' | 'failed'.
     // Hashing moved off the hot path; jobs/integrity-hash-retry.ts fills it in.
     // NOT called integrity_hash_status — that column exists on prod and is

--- a/apps/api/src/jobs/integrity-hash-chain.integration.test.ts
+++ b/apps/api/src/jobs/integrity-hash-chain.integration.test.ts
@@ -193,11 +193,13 @@ describeMaybe("integrity hash chain admission", () => {
     expect(guardsPreviousHash).toBe(false);
   }, 120_000);
 
-  it("PINS BUG: head selection and batch threading use different orderings", async () => {
-    // The worker threads a batch by (created_at, id) ASC; getPreviousHash()
-    // picks the head by (completed_at, id) DESC. This row is created before a
-    // sibling but completed after it, so the tip the batch produces is not the
-    // head the next tick resumes from.
+  it("head selection and batch threading agree (WP7 inverts the WP1 pin)", async () => {
+    // This test was named "PINS BUG" and asserted the defect: the worker
+    // threaded by (created_at, id) while getPreviousHash picked the head by
+    // (completed_at, id), so the tip a batch produced was not the head the next
+    // tick resumed from, and one parent acquired two children. Both now order
+    // by completed_at. The expectation inverts, exactly as WP1's comment said
+    // it would.
     const earlyCreatedLateCompleted = await insertCompleted({
       createdAgoMs: OLDER_THAN_GRACE + 5_000,
       completedAgoMs: OLDER_THAN_GRACE + 500,
@@ -215,19 +217,121 @@ describeMaybe("integrity hash chain admission", () => {
     ]);
     for (const row of rows) expect(row.integrityHash).toBeTruthy();
 
-    // Now the head the NEXT tick would start from.
     const { getPreviousHash } = await import("../lib/integrity-hash.js");
     const head = await getPreviousHash();
 
-    const tip = rows.find((r) => r.id === lateCreatedEarlyCompleted)!;
-    const laterCompleted = rows.find((r) => r.id === earlyCreatedLateCompleted)!;
+    // The batch threads in completed_at order, so the row completed LAST is the
+    // tip — and it is also what the next tick resumes from. One tip, one head.
+    const tip = rows.find((r) => r.id === earlyCreatedLateCompleted)!;
+    expect(head).toBe(tip.integrityHash);
+  }, 120_000);
 
-    // Threading order made `lateCreatedEarlyCompleted` the batch tip, but head
-    // selection returns the row with the greatest completed_at instead. The
-    // next admission therefore links to a row that is not the chain tip, which
-    // is how two children of one parent arise. WP7 makes the two orderings
-    // agree; this expectation then inverts.
-    expect(head).toBe(laterCompleted.integrityHash);
-    expect(head).not.toBe(tip.integrityHash);
+  it("a null completed_at row cannot capture the head", async () => {
+    // THE production defect, and the reason the chain stopped being a chain.
+    // Postgres sorts NULLs FIRST under DESC, so one hashed row with a null
+    // completed_at held the head from 2026-05-04 onward and every later batch
+    // linked to it — 150,719 children on one parent.
+    const settled = await insertCompleted({
+      createdAgoMs: OLDER_THAN_GRACE + 3_000,
+      completedAgoMs: OLDER_THAN_GRACE + 3_000,
+    });
+    await runOnce();
+
+    const { getPreviousHash, detectChainForks } = await import(
+      "../lib/integrity-hash.js"
+    );
+    const headBefore = await getPreviousHash();
+
+    // Plant exactly the shape that broke production: hashed, no completed_at.
+    const [planted] = await db
+      .insert(transactions)
+      .values({
+        status: "health_probe",
+        input: {},
+        priceCents: 0,
+        integrityHash: "f".repeat(64),
+        previousHash: headBefore,
+        complianceHashState: "complete",
+        completedAt: null,
+      })
+      .returning({ id: transactions.id });
+
+    try {
+      // The head must be unmoved by a row with no completion time.
+      expect(await getPreviousHash()).toBe(headBefore);
+      expect(headBefore).toBeTruthy();
+      expect(settled).toBeTruthy();
+    } finally {
+      await db.delete(transactions).where(eq(transactions.id, planted.id));
+    }
+  }, 120_000);
+
+  it("does not admit a non-terminal row to the chain", async () => {
+    // status and completed_at are hashed fields, so hashing a row that is still
+    // running bakes in values that will change — and the recorded hash then
+    // stops describing the row, which is indistinguishable from tampering.
+    const [running] = await db
+      .insert(transactions)
+      .values({
+        status: "executing",
+        input: {},
+        priceCents: 10,
+        complianceHashState: "pending",
+        createdAt: new Date(Date.now() - OLDER_THAN_GRACE - 10_000),
+        completedAt: null,
+      })
+      .returning({ id: transactions.id });
+
+    try {
+      await runOnce();
+
+      const [after] = await db
+        .select({
+          integrityHash: transactions.integrityHash,
+          state: transactions.complianceHashState,
+        })
+        .from(transactions)
+        .where(eq(transactions.id, running.id));
+
+      expect(after!.integrityHash).toBeNull();
+      // Still pending, not 'excluded': it may yet complete and become eligible.
+      expect(after!.state).toBe("pending");
+    } finally {
+      await db.delete(transactions).where(eq(transactions.id, running.id));
+    }
+  }, 120_000);
+
+  it("detects a fork if one ever appears again", async () => {
+    const { detectChainForks } = await import("../lib/integrity-hash.js");
+    const since = new Date(Date.now() - 60_000);
+
+    const parent = `parent-${Math.random().toString(36).slice(2, 10)}`;
+    const planted: string[] = [];
+    for (let i = 0; i < 2; i++) {
+      const [row] = await db
+        .insert(transactions)
+        .values({
+          status: "completed",
+          input: {},
+          priceCents: 0,
+          integrityHash: `child-${i}-${Math.random().toString(36).slice(2)}`,
+          previousHash: parent,
+          complianceHashState: "complete",
+          completedAt: new Date(),
+        })
+        .returning({ id: transactions.id });
+      planted.push(row.id);
+    }
+
+    try {
+      const forks = await detectChainForks(since);
+      const found = forks.find((f) => f.previousHash === parent);
+      expect(found, "two children of one parent is a fork").toBeDefined();
+      expect(found!.childCount).toBe(2);
+    } finally {
+      for (const id of planted) {
+        await db.delete(transactions).where(eq(transactions.id, id));
+      }
+    }
   }, 120_000);
 });

--- a/apps/api/src/jobs/integrity-hash-chain.integration.test.ts
+++ b/apps/api/src/jobs/integrity-hash-chain.integration.test.ts
@@ -220,10 +220,16 @@ describeMaybe("integrity hash chain admission", () => {
     const { getPreviousHash } = await import("../lib/integrity-hash.js");
     const head = await getPreviousHash();
 
-    // The batch threads in completed_at order, so the row completed LAST is the
-    // tip — and it is also what the next tick resumes from. One tip, one head.
-    const tip = rows.find((r) => r.id === earlyCreatedLateCompleted)!;
-    expect(head).toBe(tip.integrityHash);
+    // The TIP is whichever row the batch chained last — i.e. the one that is
+    // nobody's parent. Deriving it from the data rather than naming a row is
+    // what makes this discriminating: naming `earlyCreatedLateCompleted`
+    // asserted that head selection agrees with itself, which is true under the
+    // bug too. Verified by mutation — reverting the batch to (created_at, id)
+    // turns this red.
+    const parents = new Set(rows.map((r) => r.previousHash).filter(Boolean));
+    const tips = rows.filter((r) => !parents.has(r.integrityHash));
+    expect(tips, "a batch must produce exactly one tip").toHaveLength(1);
+    expect(head).toBe(tips[0]!.integrityHash);
   }, 120_000);
 
   it("a null completed_at row cannot capture the head", async () => {
@@ -278,7 +284,11 @@ describeMaybe("integrity hash chain admission", () => {
         priceCents: 10,
         complianceHashState: "pending",
         createdAt: new Date(Date.now() - OLDER_THAN_GRACE - 10_000),
-        completedAt: null,
+        // Deliberately HAS a completed_at. A null one is already excluded by
+        // the head-capture guard, so leaving it null meant this test passed
+        // with the status filter removed — it was proving the other fix.
+        // Verified by mutation: dropping the status filter now turns it red.
+        completedAt: new Date(Date.now() - OLDER_THAN_GRACE - 5_000),
       })
       .returning({ id: transactions.id });
 

--- a/apps/api/src/jobs/integrity-hash-chain.integration.test.ts
+++ b/apps/api/src/jobs/integrity-hash-chain.integration.test.ts
@@ -22,7 +22,7 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { randomUUID } from "node:crypto";
@@ -243,9 +243,7 @@ describeMaybe("integrity hash chain admission", () => {
     });
     await runOnce();
 
-    const { getPreviousHash, detectChainForks } = await import(
-      "../lib/integrity-hash.js"
-    );
+    const { getPreviousHash } = await import("../lib/integrity-hash.js");
     const headBefore = await getPreviousHash();
 
     // Plant exactly the shape that broke production: hashed, no completed_at.
@@ -266,7 +264,6 @@ describeMaybe("integrity hash chain admission", () => {
       // The head must be unmoved by a row with no completion time.
       expect(await getPreviousHash()).toBe(headBefore);
       expect(headBefore).toBeTruthy();
-      expect(settled).toBeTruthy();
     } finally {
       await db.delete(transactions).where(eq(transactions.id, planted.id));
     }
@@ -311,37 +308,92 @@ describeMaybe("integrity hash chain admission", () => {
     }
   }, 120_000);
 
-  it("detects a fork if one ever appears again", async () => {
-    const { detectChainForks } = await import("../lib/integrity-hash.js");
-    const since = new Date(Date.now() - 60_000);
+  it("detects a fork among SEQUENCED rows, and ignores the historical break", async () => {
+    // Points at the scheduled check, not at a helper. The first version tested
+    // an exported `detectChainForks` that nothing called — a fork detector no
+    // scheduler invokes detects nothing, which was the review's second blocking
+    // finding.
+    const { checkChainForks } = await import("../lib/chain-health-monitoring.js");
 
     const parent = `parent-${Math.random().toString(36).slice(2, 10)}`;
     const planted: string[] = [];
-    for (let i = 0; i < 2; i++) {
-      const [row] = await db
-        .insert(transactions)
-        .values({
-          status: "completed",
-          input: {},
-          priceCents: 0,
-          integrityHash: `child-${i}-${Math.random().toString(36).slice(2)}`,
-          previousHash: parent,
-          complianceHashState: "complete",
-          completedAt: new Date(),
-        })
-        .returning({ id: transactions.id });
-      planted.push(row.id);
-    }
-
     try {
-      const forks = await detectChainForks(since);
-      const found = forks.find((f) => f.previousHash === parent);
-      expect(found, "two children of one parent is a fork").toBeDefined();
-      expect(found!.childCount).toBe(2);
+      // Two children of one parent, but WITHOUT chain_seq — i.e. the shape of
+      // the pre-WP7 history. Must NOT be reported, or the known break drowns
+      // the signal that a new fork appeared.
+      for (let i = 0; i < 2; i++) {
+        const [row] = await db
+          .insert(transactions)
+          .values({
+            status: "completed",
+            input: {},
+            priceCents: 0,
+            integrityHash: `hist-${i}-${Math.random().toString(36).slice(2)}`,
+            previousHash: parent,
+            complianceHashState: "complete",
+            completedAt: new Date(),
+          })
+          .returning({ id: transactions.id });
+        planted.push(row.id);
+      }
+
+      const historical = await checkChainForks();
+      expect(historical.passed, "unsequenced history must not be reported").toBe(true);
+
+      // Now give them chain positions: the same rows become a REAL fork.
+      for (const id of planted) {
+        await db
+          .update(transactions)
+          .set({ chainSeq: sql`nextval('transactions_chain_seq')` })
+          .where(eq(transactions.id, id));
+      }
+
+      const detected = await checkChainForks();
+      expect(detected.passed, "two sequenced children of one parent is a fork").toBe(false);
+      expect(detected.severity).toBe("critical");
     } finally {
       for (const id of planted) {
         await db.delete(transactions).where(eq(transactions.id, id));
       }
     }
+  }, 120_000);
+
+  it("does not fork ACROSS batches when a row completes out of order", async () => {
+    // The review's blocking finding, and the case no test reached: both prior
+    // ordering tests put their rows in ONE batch, where the loop threads them
+    // correctly under either rule. The defect lives at the batch boundary.
+    //
+    // `completed_at` is stamped from a clock read before the row's own
+    // created_at default (median delta in production: MINUS 1.5 ms), so a row
+    // admitted in a later tick can carry an EARLIER completion time. Under the
+    // old max(completed_at) head rule it chained onto the head without becoming
+    // it, and the next row chained onto the same parent.
+    const first = await insertCompleted({
+      createdAgoMs: OLDER_THAN_GRACE + 9_000,
+      completedAgoMs: OLDER_THAN_GRACE + 1_000,
+    });
+    await runOnce();
+
+    // Second tick: a row whose completed_at is EARLIER than what tick 1 left as
+    // the head.
+    const backdated = await insertCompleted({
+      createdAgoMs: OLDER_THAN_GRACE + 8_000,
+      completedAgoMs: OLDER_THAN_GRACE + 7_000,
+    });
+    await runOnce();
+
+    const rows = await chainRows([first, backdated]);
+    for (const row of rows) expect(row.integrityHash).toBeTruthy();
+
+    // The property: distinct parents. Same parent for both = the fork.
+    const parents = rows.map((r) => r.previousHash);
+    expect(new Set(parents).size, "each row must chain onto a distinct parent").toBe(
+      parents.length,
+    );
+
+    // And the head is the LAST-HASHED row, not the latest-completed one.
+    const { getPreviousHash } = await import("../lib/integrity-hash.js");
+    const backdatedRow = rows.find((r) => r.id === backdated)!;
+    expect(await getPreviousHash()).toBe(backdatedRow.integrityHash);
   }, 120_000);
 });

--- a/apps/api/src/jobs/integrity-hash-retry.ts
+++ b/apps/api/src/jobs/integrity-hash-retry.ts
@@ -133,7 +133,12 @@ async function runOnce(): Promise<void> {
           and(
             eq(transactions.complianceHashState, "pending"),
             lt(transactions.createdAt, pendingCutoff),
-            sql`${transactions.status} NOT IN ('completed', 'failed', 'executing', 'pending', 'deferred')`,
+            // ALLOWLIST, not a denylist. A denylist silently drops any status
+            // literal added later — 'refunded', 'cancelled', 'expired' — from
+            // the audit chain with no signal at all. Naming what is excluded
+            // means a new status stays 'pending' and shows up in the backlog
+            // check instead of vanishing.
+            sql`${transactions.status} IN ('health_probe')`,
           ),
         );
 
@@ -189,6 +194,12 @@ async function runOnce(): Promise<void> {
               integrityHash: hash,
               previousHash: currentPrevious,
               complianceHashState: "complete",
+              // WP7: claim the next chain position AT HASH TIME. This is what
+              // makes the head well-defined — see getPreviousHash. Assigning it
+              // here, in the same UPDATE as the hash, means a row cannot be
+              // hashed without taking a position or take one without being
+              // hashed.
+              chainSeq: sql`nextval('transactions_chain_seq')`,
             })
             .where(eq(transactions.id, txn.id));
           currentPrevious = hash;

--- a/apps/api/src/jobs/integrity-hash-retry.ts
+++ b/apps/api/src/jobs/integrity-hash-retry.ts
@@ -92,6 +92,22 @@ async function runOnce(): Promise<void> {
       // id is the secondary tiebreaker for same-millisecond inserts; it's
       // a uuid().defaultRandom(), so the order is deterministic without
       // implying time semantics.
+      // WP7 — CHAIN_ORDER_NOTE. Two changes, both load-bearing:
+      //
+      // 1. TERMINAL-ONLY ADMISSION. `status` and `completed_at` are hashed
+      //    fields, so admitting a row that is still running bakes in values
+      //    that will change, and its hash silently stops describing it —
+      //    indistinguishable from tampering. Production had 507 such rows: 506
+      //    health probes with a null completed_at, and one transaction stuck in
+      //    'executing' since 2026-04-07 that WP3's reconciler will eventually
+      //    move. Requiring a completed_at is also what stops another null-head
+      //    row from ever entering the chain.
+      //
+      // 2. ONE ORDERING. This ordered by (created_at, id) while
+      //    getPreviousHash picked the head by (completed_at, id), so the tip a
+      //    batch produced was not the head the next tick resumed from. Both now
+      //    use completed_at with id as the deterministic tiebreaker. If you
+      //    change one, change the other; they are one decision expressed twice.
       const pending = await tx
         .select()
         .from(transactions)
@@ -99,10 +115,27 @@ async function runOnce(): Promise<void> {
           and(
             eq(transactions.complianceHashState, "pending"),
             lt(transactions.createdAt, pendingCutoff),
+            sql`${transactions.completedAt} IS NOT NULL`,
+            sql`${transactions.status} IN ('completed', 'failed')`,
           ),
         )
-        .orderBy(asc(transactions.createdAt), asc(transactions.id))
+        .orderBy(asc(transactions.completedAt), asc(transactions.id))
         .limit(BATCH_SIZE);
+
+      // Rows that will never be chain-eligible must LEAVE the queue, or they
+      // are reselected every tick forever and the bounded batch fills with work
+      // that cannot progress — the starvation shape WP5's review caught one
+      // package earlier. 'excluded' is terminal and says why.
+      await tx
+        .update(transactions)
+        .set({ complianceHashState: "excluded" })
+        .where(
+          and(
+            eq(transactions.complianceHashState, "pending"),
+            lt(transactions.createdAt, pendingCutoff),
+            sql`${transactions.status} NOT IN ('completed', 'failed', 'executing', 'pending', 'deferred')`,
+          ),
+        );
 
       if (pending.length === 0) return;
 

--- a/apps/api/src/lib/chain-health-monitoring.ts
+++ b/apps/api/src/lib/chain-health-monitoring.ts
@@ -266,3 +266,71 @@ export async function checkChainUnhashedLegacyCount(): Promise<MetaCheckResult> 
     };
   }
 }
+
+/**
+ * Has the hash chain forked since the WP7 fix (branch-topology check)?
+ *
+ * The property that makes a hash chain evidence is one child per parent.
+ * Production is already forked — ten parents with more than one child, the
+ * largest with 150,719, caused by a null-`completed_at` row holding the head
+ * from 2026-05-04 — so a unique index cannot enforce it without aborting boot.
+ * The constraint is therefore checked here instead.
+ *
+ * Scoped to rows the WP7 sequence actually governs. Asking globally would
+ * return the historical break on every run and drown the only signal that
+ * matters: whether a NEW fork has appeared. Scoping on `chain_seq IS NOT NULL`
+ * rather than on a timestamp is deliberate — a time window has a straddle blind
+ * spot, where a fork's two children fall either side of the boundary and each
+ * counts as one.
+ */
+export async function checkChainForks(): Promise<MetaCheckResult> {
+  const check = "chain_fork_detection";
+  try {
+    const db = getDb();
+    const rows = await db.execute(sql`
+      SELECT previous_hash, COUNT(*)::int AS child_count
+      FROM transactions
+      WHERE previous_hash IS NOT NULL AND chain_seq IS NOT NULL
+      GROUP BY previous_hash
+      HAVING COUNT(*) > 1
+      ORDER BY COUNT(*) DESC
+      LIMIT 10
+    `);
+    const forks = (Array.isArray(rows) ? rows : (rows as { rows?: unknown[] })?.rows ?? []) as Array<{
+      previous_hash: string;
+      child_count: number;
+    }>;
+
+    if (forks.length === 0) {
+      return {
+        check,
+        severity: "info",
+        passed: true,
+        details:
+          "No fork among sequenced rows: every parent has exactly one child. " +
+          "Historical rows (chain_seq IS NULL) are excluded — the pre-WP7 break " +
+          "is known and deliberately not rewritten.",
+      };
+    }
+
+    return {
+      check,
+      // A fork means the chain has stopped being evidence of ordering. That is
+      // the compliance claim itself failing, not a degradation of it.
+      severity: "critical",
+      passed: false,
+      details:
+        `${forks.length} parent(s) have more than one child AFTER the WP7 fix. ` +
+        `Largest: ${forks[0]!.previous_hash.slice(0, 16)}… with ${forks[0]!.child_count} children. ` +
+        "The chain is no longer single-parent, so it does not evidence ordering " +
+        "or absence of deletion. Investigate before relying on any audit export.",
+    };
+  } catch (err) {
+    return {
+      check,
+      severity: "warning",
+      passed: false,
+      details: `Check failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/apps/api/src/lib/integrity-hash.ts
+++ b/apps/api/src/lib/integrity-hash.ts
@@ -95,47 +95,37 @@ export function computeIntegrityHash(
  * Returns the genesis hash if no previous transactions exist.
  */
 export async function getPreviousHash(): Promise<string> {
-  // WP7: FAILS CLOSED. This used to be wrapped in `try { … } catch { return
-  // GENESIS_HASH; }`, so a transient database error during head selection
-  // silently started a SECOND chain from genesis. That is worse than stopping:
-  // it produces a plausible-looking chain with an unexplained second root, and
-  // nothing anywhere records that it happened. Genesis is now returned for
-  // exactly one reason — the chain is genuinely empty — and a read failure
-  // propagates to the caller, which is a worker that can retry on its next tick.
+  // WP7: the head is THE LAST ROW THE WORKER HASHED, read from a monotonic
+  // sequence assigned at hash time.
+  //
+  // It cannot be max(completed_at), which was WP7's first attempt and is what
+  // the adversarial review caught. That column is stamped from a clock read
+  // before the row's own `created_at` default — median delta in production is
+  // MINUS 1.5 ms — so a row can be admitted after the head while carrying an
+  // earlier completion time. It then chains onto the head without becoming it,
+  // and the next row chains onto the same parent: one parent, two children.
+  // Replaying that rule over 30 days of real traffic yields nine forks. The
+  // same shape also arises from a per-row failure inside a batch, which is
+  // retried on a later tick with a smaller completed_at.
+  //
+  // A sequence is monotone in the only order that matters — the order rows
+  // were actually chained — so backdating, clock skew and retries become
+  // structurally incapable of forking rather than merely unlikely to.
+  //
+  // FAILS CLOSED. This was once wrapped in `catch { return GENESIS_HASH; }`,
+  // so a transient DB error silently started a second chain; genesis has 11
+  // children in production, which is what that looks like. Genesis is now
+  // returned for exactly one reason: no row has ever been sequenced.
   const db = getDb();
   const [latest] = await db
     .select({ integrityHash: transactions.integrityHash })
     .from(transactions)
-    // WP7, and the defect that actually broke the chain. Postgres sorts NULLs
-    // FIRST under DESC, so a hashed row with a null `completed_at` occupies the
-    // head permanently. One health_probe row from 2026-05-04 did exactly that:
-    // every batch for the next three and a half months linked to it, giving one
-    // parent 150,719 children. The chain was a star, and a star has no
-    // sequence, so it proves nothing about ordering or deletion.
-    //
-    // Two independent guards, because this must not silently recur: the head
-    // must HAVE a completed_at, and the sort states NULLS LAST explicitly
-    // rather than relying on the filter to make it moot.
-    .where(
-      sql`${transactions.integrityHash} IS NOT NULL AND ${transactions.completedAt} IS NOT NULL`,
-    )
-    // F-A-008: stable sort via `id DESC` as tiebreaker — same-ms
-    // `completedAt` rows would otherwise be returned in storage-layer
-    // order (non-deterministic). `id` is uuid().defaultRandom(), so
-    // the secondary sort is deterministic without being time-ordered.
-    //
-    // WP7: this key must stay identical to the batch ordering in
-    // jobs/integrity-hash-retry.ts. They disagreed — batch by created_at,
-    // head by completed_at — so the tip a batch produced was not the head the
-    // next tick resumed from, and one parent acquired two children. See
-    // CHAIN_ORDER_NOTE there.
-    .orderBy(
-      sql`${transactions.completedAt} DESC NULLS LAST`,
-      desc(transactions.id),
-    )
+    .where(sql`${transactions.chainSeq} IS NOT NULL`)
+    .orderBy(desc(transactions.chainSeq))
     .limit(1);
   return latest?.integrityHash ?? GENESIS_HASH;
 }
+
 
 /**
  * Verify a single transaction's integrity hash.
@@ -147,41 +137,4 @@ export function verifyIntegrityHash(
 ): { verified: boolean } {
   const computed = computeIntegrityHash(record, previousHash);
   return { verified: computed === storedHash };
-}
-
-/**
- * Rows that share a parent — i.e. the chain forked (WP7).
- *
- * The property that makes a hash chain evidence is that each node has exactly
- * one child. Nothing enforced that: a unique index cannot be added because
- * production is already forked (ten parents with more than one child, the
- * largest with 150,719, caused by a null-`completed_at` row permanently holding
- * the head from 2026-05-04). So the constraint is checked rather than enforced.
- *
- * `since` scopes the question to rows created after the fix. Asking globally
- * would return the historical break on every call and drown the signal that
- * matters: whether a NEW fork has appeared. History is deliberately not
- * rewritten — recomputing 863,946 hashes would erase the evidence that the
- * break happened, which is the opposite of an audit chain's purpose.
- */
-export async function detectChainForks(
-  since: Date,
-  limit = 20,
-): Promise<Array<{ previousHash: string; childCount: number }>> {
-  const db = getDb();
-  const rows = (await db.execute(sql`
-    SELECT previous_hash, count(*)::int AS child_count
-    FROM transactions
-    WHERE previous_hash IS NOT NULL
-      AND created_at >= ${since.toISOString()}
-    GROUP BY previous_hash
-    HAVING count(*) > 1
-    ORDER BY count(*) DESC
-    LIMIT ${limit}
-  `)) as unknown as Array<{ previous_hash: string; child_count: number }>;
-
-  return rows.map((r) => ({
-    previousHash: r.previous_hash,
-    childCount: r.child_count,
-  }));
 }

--- a/apps/api/src/lib/integrity-hash.ts
+++ b/apps/api/src/lib/integrity-hash.ts
@@ -95,22 +95,46 @@ export function computeIntegrityHash(
  * Returns the genesis hash if no previous transactions exist.
  */
 export async function getPreviousHash(): Promise<string> {
-  try {
-    const db = getDb();
-    const [latest] = await db
-      .select({ integrityHash: transactions.integrityHash })
-      .from(transactions)
-      .where(sql`${transactions.integrityHash} IS NOT NULL`)
-      // F-A-008: stable sort via `id DESC` as tiebreaker — same-ms
-      // `completedAt` rows would otherwise be returned in storage-layer
-      // order (non-deterministic). `id` is uuid().defaultRandom(), so
-      // the secondary sort is deterministic without being time-ordered.
-      .orderBy(desc(transactions.completedAt), desc(transactions.id))
-      .limit(1);
-    return latest?.integrityHash ?? GENESIS_HASH;
-  } catch {
-    return GENESIS_HASH;
-  }
+  // WP7: FAILS CLOSED. This used to be wrapped in `try { … } catch { return
+  // GENESIS_HASH; }`, so a transient database error during head selection
+  // silently started a SECOND chain from genesis. That is worse than stopping:
+  // it produces a plausible-looking chain with an unexplained second root, and
+  // nothing anywhere records that it happened. Genesis is now returned for
+  // exactly one reason — the chain is genuinely empty — and a read failure
+  // propagates to the caller, which is a worker that can retry on its next tick.
+  const db = getDb();
+  const [latest] = await db
+    .select({ integrityHash: transactions.integrityHash })
+    .from(transactions)
+    // WP7, and the defect that actually broke the chain. Postgres sorts NULLs
+    // FIRST under DESC, so a hashed row with a null `completed_at` occupies the
+    // head permanently. One health_probe row from 2026-05-04 did exactly that:
+    // every batch for the next three and a half months linked to it, giving one
+    // parent 150,719 children. The chain was a star, and a star has no
+    // sequence, so it proves nothing about ordering or deletion.
+    //
+    // Two independent guards, because this must not silently recur: the head
+    // must HAVE a completed_at, and the sort states NULLS LAST explicitly
+    // rather than relying on the filter to make it moot.
+    .where(
+      sql`${transactions.integrityHash} IS NOT NULL AND ${transactions.completedAt} IS NOT NULL`,
+    )
+    // F-A-008: stable sort via `id DESC` as tiebreaker — same-ms
+    // `completedAt` rows would otherwise be returned in storage-layer
+    // order (non-deterministic). `id` is uuid().defaultRandom(), so
+    // the secondary sort is deterministic without being time-ordered.
+    //
+    // WP7: this key must stay identical to the batch ordering in
+    // jobs/integrity-hash-retry.ts. They disagreed — batch by created_at,
+    // head by completed_at — so the tip a batch produced was not the head the
+    // next tick resumed from, and one parent acquired two children. See
+    // CHAIN_ORDER_NOTE there.
+    .orderBy(
+      sql`${transactions.completedAt} DESC NULLS LAST`,
+      desc(transactions.id),
+    )
+    .limit(1);
+  return latest?.integrityHash ?? GENESIS_HASH;
 }
 
 /**
@@ -123,4 +147,41 @@ export function verifyIntegrityHash(
 ): { verified: boolean } {
   const computed = computeIntegrityHash(record, previousHash);
   return { verified: computed === storedHash };
+}
+
+/**
+ * Rows that share a parent — i.e. the chain forked (WP7).
+ *
+ * The property that makes a hash chain evidence is that each node has exactly
+ * one child. Nothing enforced that: a unique index cannot be added because
+ * production is already forked (ten parents with more than one child, the
+ * largest with 150,719, caused by a null-`completed_at` row permanently holding
+ * the head from 2026-05-04). So the constraint is checked rather than enforced.
+ *
+ * `since` scopes the question to rows created after the fix. Asking globally
+ * would return the historical break on every call and drown the signal that
+ * matters: whether a NEW fork has appeared. History is deliberately not
+ * rewritten — recomputing 863,946 hashes would erase the evidence that the
+ * break happened, which is the opposite of an audit chain's purpose.
+ */
+export async function detectChainForks(
+  since: Date,
+  limit = 20,
+): Promise<Array<{ previousHash: string; childCount: number }>> {
+  const db = getDb();
+  const rows = (await db.execute(sql`
+    SELECT previous_hash, count(*)::int AS child_count
+    FROM transactions
+    WHERE previous_hash IS NOT NULL
+      AND created_at >= ${since.toISOString()}
+    GROUP BY previous_hash
+    HAVING count(*) > 1
+    ORDER BY count(*) DESC
+    LIMIT ${limit}
+  `)) as unknown as Array<{ previous_hash: string; child_count: number }>;
+
+  return rows.map((r) => ({
+    previousHash: r.previous_hash,
+    childCount: r.child_count,
+  }));
 }

--- a/apps/api/src/lib/meta-monitoring.ts
+++ b/apps/api/src/lib/meta-monitoring.ts
@@ -21,6 +21,7 @@ import {
   checkChainFailedCount,
   checkChainStuckDeferred,
   checkChainUnhashedLegacyCount,
+  checkChainForks,
 } from "./chain-health-monitoring.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -980,6 +981,10 @@ export const CHECK_REGISTRY: CheckRegistration[] = [
   // Daily — informational count of pre-chain rows from migration 0047/0052.
   // Stable count; not an alert; verifies methodology page disclosure.
   { name: "chain_unhashed_legacy_count", fn: checkChainUnhashedLegacyCount, schedule: "daily" },
+  // WP7: a branch-topology check that RUNS. The first version shipped
+  // detectChainForks as an exported function nothing called — a fork detector
+  // no scheduler invokes detects nothing.
+  { name: "chain_fork_detection", fn: checkChainForks, schedule: "daily" },
 
   // Weekly — coverage sweeps (DB-heavy). SQS integrity checks retired
   // (DEC-20260503-B): score_without_evidence / stuck_scores /

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1236,7 +1236,7 @@ describe("startup-migrations — block 0087 (un-hide content-redacted rows)", ()
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 39 blocks in historical order", () => {
+  it("exports the expected 40 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1283,6 +1283,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       // WP3: wallet_reservations table + the non-negative balance constraint.
       "runMigration0095_walletReservations",
       "runMigration0096_x402SettlementIntents",
+      "runMigration0097_chainForkDetection",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1283,7 +1283,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       // WP3: wallet_reservations table + the non-negative balance constraint.
       "runMigration0095_walletReservations",
       "runMigration0096_x402SettlementIntents",
-      "runMigration0097_chainForkDetection",
+      "runMigration0097_chainSequence",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1757,6 +1757,45 @@ export async function runMigration0096_x402SettlementIntents(
 }
 
 
+/**
+ * Block 0097 — chain-fork detection index (WP7).
+ *
+ * NOT a unique index. Production is ALREADY forked: `previous_hash` has ten
+ * distinct values with more than one child, the largest with 150,719. A unique
+ * index would abort boot on the first attempt, which is exactly why the
+ * duplicate check ran against production before this was written.
+ *
+ * What happened, established by query rather than inference: `getPreviousHash`
+ * orders by `completed_at DESC`, and Postgres sorts NULLs FIRST under DESC. A
+ * `health_probe` row hashed on 2026-05-04 with a null `completed_at` has
+ * therefore occupied the head position permanently, and every batch since has
+ * linked to it. The chain has been a star, not a chain, for three and a half
+ * months.
+ *
+ * History is NOT rewritten. Recomputing 863,946 hashes would destroy the
+ * evidence that the break happened, which is the opposite of what an audit
+ * chain is for. This index exists so the fork is queryable and so the
+ * topology check can prove no NEW fork appears after the fix.
+ */
+export async function runMigration0097_chainForkDetection(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS "transactions_previous_hash_idx"
+      ON "transactions" ("previous_hash")
+      WHERE "previous_hash" IS NOT NULL
+  `);
+
+  return {
+    block: "0097_chain_fork_detection",
+    outcome: "transactions.previous_hash index for fork detection (idempotent)",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+
 export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResult>> = [
   runMigration0029_actualCostCents,
   runMigration0030_complianceColumns,
@@ -1798,6 +1837,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   // WP3: reservations table + non-negative balance constraint.
   runMigration0095_walletReservations,
   runMigration0096_x402SettlementIntents,
+  runMigration0097_chainForkDetection,
 ];
 
 /**

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1758,39 +1758,77 @@ export async function runMigration0096_x402SettlementIntents(
 
 
 /**
- * Block 0097 — chain-fork detection index (WP7).
+ * Block 0097 — monotonic chain sequence (WP7).
  *
- * NOT a unique index. Production is ALREADY forked: `previous_hash` has ten
- * distinct values with more than one child, the largest with 150,719. A unique
- * index would abort boot on the first attempt, which is exactly why the
- * duplicate check ran against production before this was written.
+ * The head of a hash chain must be "the last row the worker hashed". WP7's
+ * first attempt defined it as `max(completed_at)`, which cannot work: measured
+ * against production, the median `completed_at - created_at` is MINUS 1.5 ms —
+ * the column is stamped from a clock read before the row's `created_at`
+ * default — and 78 rows in the last 30 days complete out of creation order.
+ * A row admitted after the head but carrying an earlier `completed_at` chains
+ * onto the head without becoming it, and the next row chains onto the same
+ * parent. One parent, two children. Replaying the rule over 30 days of real
+ * traffic produces nine such forks, in clusters.
  *
- * What happened, established by query rather than inference: `getPreviousHash`
- * orders by `completed_at DESC`, and Postgres sorts NULLs FIRST under DESC. A
- * `health_probe` row hashed on 2026-05-04 with a null `completed_at` has
- * therefore occupied the head position permanently, and every batch since has
- * linked to it. The chain has been a star, not a chain, for three and a half
- * months.
+ * `chain_seq` is assigned from a sequence AT HASH TIME, so it is monotone in
+ * the only order that matters — the order rows were actually chained. Clock
+ * skew, backdating and per-row retries become structurally incapable of
+ * forking the chain rather than merely unlikely to.
  *
- * History is NOT rewritten. Recomputing 863,946 hashes would destroy the
- * evidence that the break happened, which is the opposite of what an audit
- * chain is for. This index exists so the fork is queryable and so the
- * topology check can prove no NEW fork appears after the fix.
+ * Cost. `ADD COLUMN` with no default and no NOT NULL is catalog-only in
+ * Postgres 11+, so there is no rewrite of a 902k-row / 355 MB hot table. The
+ * 863,946 historical rows keep NULL and are simply not head candidates; their
+ * chain is unchanged and still verifiable by replay. Exactly ONE row is
+ * seeded — the current head under the corrected NULLS LAST rule — so the new
+ * sequence continues from where the old chain actually ends instead of
+ * starting a second root. A one-row UPDATE, so DEC-20260504-B's backlog-drain
+ * concern does not arise.
+ *
+ * NOT included: an index on `previous_hash`. An earlier draft of this block
+ * created one, which production already has as `idx_transactions_previous_hash`
+ * (65 MB). `IF NOT EXISTS` matches on NAME, not definition, so that would have
+ * built a second 60 MB index on the same column of a hot table — permanent
+ * write amplification for zero benefit.
  */
-export async function runMigration0097_chainForkDetection(
+export async function runMigration0097_chainSequence(
   tx: MigrationExecutor,
 ): Promise<BlockResult> {
   const startedAt = Date.now();
 
   await tx.execute(sql`
-    CREATE INDEX IF NOT EXISTS "transactions_previous_hash_idx"
-      ON "transactions" ("previous_hash")
-      WHERE "previous_hash" IS NOT NULL
+    ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "chain_seq" bigint
+  `);
+
+  await tx.execute(sql`CREATE SEQUENCE IF NOT EXISTS "transactions_chain_seq"`);
+
+  // Unique so two rows can never claim the same position, which is the
+  // single-parent property expressed structurally. Partial, because every
+  // historical row is NULL and must not compete for a slot.
+  await tx.execute(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS "transactions_chain_seq_unique"
+      ON "transactions" ("chain_seq")
+      WHERE "chain_seq" IS NOT NULL
+  `);
+
+  // Seed the current head, once. Without this the first post-deploy hash would
+  // find no sequenced row and link to GENESIS, silently starting a second root
+  // — the very failure this package exists to stop.
+  const seeded = await tx.execute(sql`
+    UPDATE "transactions" SET "chain_seq" = nextval('transactions_chain_seq')
+    WHERE "id" = (
+      SELECT "id" FROM "transactions"
+      WHERE "integrity_hash" IS NOT NULL AND "completed_at" IS NOT NULL
+      ORDER BY "completed_at" DESC NULLS LAST, "id" DESC
+      LIMIT 1
+    )
+    AND NOT EXISTS (SELECT 1 FROM "transactions" WHERE "chain_seq" IS NOT NULL)
   `);
 
   return {
-    block: "0097_chain_fork_detection",
-    outcome: "transactions.previous_hash index for fork detection (idempotent)",
+    block: "0097_chain_sequence",
+    outcome:
+      "transactions.chain_seq column + sequence + unique index; " +
+      `head seeded (${(seeded as unknown as { count?: number }).count ?? 0} row)`,
     duration_ms: Date.now() - startedAt,
   };
 }
@@ -1837,7 +1875,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   // WP3: reservations table + non-negative balance constraint.
   runMigration0095_walletReservations,
   runMigration0096_x402SettlementIntents,
-  runMigration0097_chainForkDetection,
+  runMigration0097_chainSequence,
 ];
 
 /**

--- a/apps/api/src/routes/audit.ts
+++ b/apps/api/src/routes/audit.ts
@@ -514,6 +514,12 @@ auditRoute.get("/:transactionId", async (c) => {
   // audit URLs still resolve — but stamp the response so customers and
   // regulators see the row is informational, not hash-protected.
   const isUnhashedLegacy = txn.complianceHashState === "unhashed_legacy";
+  // WP7: rows deliberately kept out of the chain (internal health probes). Not
+  // reachable today — no solution profile resolves for them, so the endpoint
+  // 404s first — but the stamp must be honest if that ever changes. Falling
+  // through to the default would have served a row with a NULL integrity_hash
+  // as `audit_chain_state: "hashed"`.
+  const isExcluded = txn.complianceHashState === "excluded";
 
   // Resolve entity → fetch its compliance profile + personal-data signals.
   let profile: ComplianceProfile | null = null;
@@ -592,7 +598,19 @@ auditRoute.get("/:transactionId", async (c) => {
     // CCO P0 #5: explicit chain-state stamp. For 'unhashed_legacy' rows,
     // a clear disclaimer that the row predates the cryptographic chain
     // and is not third-party verifiable via /v1/verify.
-    audit_chain_state: isUnhashedLegacy ? "unhashed_legacy" : "hashed",
+    audit_chain_state: isUnhashedLegacy
+      ? "unhashed_legacy"
+      : isExcluded
+        ? "excluded"
+        : "hashed",
+    ...(isExcluded
+      ? {
+          excluded_disclaimer:
+            "This row is an internal platform record (not customer activity) and is " +
+            "deliberately not part of the cryptographic audit chain. It is not " +
+            "third-party verifiable via /v1/verify.",
+        }
+      : {}),
     ...(isUnhashedLegacy
       ? {
           unhashed_legacy_disclaimer:

--- a/apps/api/src/routes/health-deep.test.ts
+++ b/apps/api/src/routes/health-deep.test.ts
@@ -2,7 +2,13 @@
  * Tests for GET /health/deep — the DB write-path probe added after the
  * 2026-04-16 outage. /health (shallow) only confirms the process is
  * alive; /health/deep inserts and immediately deletes a probe row inside
- * a single CTE, exercising every index on the transactions table.
+ * two statements in one transaction, exercising every index on the
+ * transactions table.
+ *
+ * WP7: the probe used to be a single data-modifying CTE whose DELETE ran
+ * against a snapshot predating its own INSERT, so it never deleted anything and
+ * leaked a permanent row on every call. The mock therefore has to model a
+ * transaction now, not a bare execute.
  *
  * The endpoint must:
  *   1. Return 200 { status: "ok", write_path: "ok", latency_ms } on a
@@ -13,13 +19,21 @@
 
 import { describe, it, expect, beforeAll, vi } from "vitest";
 
-// execute() is the single method /health/deep calls. Toggle its behaviour
-// per test via `executeImpl`.
-let executeImpl: () => Promise<unknown> = () => Promise.resolve([]);
+// execute() is the method the probe calls, now inside a transaction. Toggle
+// its behaviour per test via `executeImpl`.
+let executeImpl: (...args: unknown[]) => Promise<unknown> = () => Promise.resolve([]);
+let transactionSpy: () => void = () => {};
 
 vi.mock("../db/index.js", () => ({
   getDb: () => ({
-    execute: (..._args: unknown[]) => executeImpl(),
+    execute: (...args: unknown[]) => executeImpl(...args),
+    // The probe wraps its INSERT + DELETE in a transaction so the DELETE can
+    // see the INSERT. Hand the callback a tx whose execute is the same toggle,
+    // so a rejecting executeImpl still surfaces as a failed probe.
+    transaction: async (fn: (tx: { execute: (..._a: unknown[]) => Promise<unknown> }) => Promise<unknown>) => {
+      transactionSpy();
+      return fn({ execute: (...args: unknown[]) => executeImpl(...args) });
+    },
     select: () => ({
       from: () => ({
         where: () => ({ limit: () => Promise.resolve([]) }),
@@ -55,7 +69,8 @@ async function loadApp() {
 
 describe("GET /health/deep", () => {
   it("returns 200 with write_path=ok when the DB probe succeeds", async () => {
-    executeImpl = () => Promise.resolve([]);
+    // Shaped like a RETURNING id result so the probe finds a row to delete.
+    executeImpl = () => Promise.resolve([{ id: "probe-row-id" }]);
     const app = await loadApp();
     const res = await app.request("/health/deep");
     expect(res.status).toBe(200);
@@ -78,5 +93,36 @@ describe("GET /health/deep", () => {
     // viewers can see WHY the deep check failed — don't swallow it.
     expect(body.error).toContain("connection refused");
     expect(typeof body.latency_ms).toBe("number");
+  });
+
+  it("deletes the probe row it inserted (WP7: it used to leak one per call)", async () => {
+    // The regression that matters. The old single-CTE form ran its DELETE
+    // against a snapshot predating its own INSERT, so it matched nothing and
+    // every call to this PUBLIC endpoint left a permanent row: 200 in August
+    // alone. One such row, hashed with a null completed_at, captured the audit
+    // chain head and acquired 150,719 children.
+    // Counting statements is the discriminator, and it is exact: the old form
+    // was ONE execute (a CTE), the fix is TWO (INSERT then DELETE) inside a
+    // transaction. Drizzle's `sql` objects do not stringify to text, so the
+    // count is a more honest assertion than pattern-matching a serialisation.
+    let executeCount = 0;
+    let transactionUsed = false;
+    executeImpl = () => {
+      executeCount += 1;
+      return Promise.resolve([{ id: "probe-row-id" }]);
+    };
+    transactionSpy = () => {
+      transactionUsed = true;
+    };
+
+    const { app } = await import("../app.js");
+    const res = await app.request("http://localhost/health/deep");
+    expect(res.status).toBe(200);
+
+    expect(transactionUsed, "INSERT and DELETE must share a transaction").toBe(true);
+    expect(
+      executeCount,
+      "two statements: a DELETE inside the same statement as its INSERT cannot see it",
+    ).toBe(2);
   });
 });

--- a/docs/remediation/CURRENT-STATE.md
+++ b/docs/remediation/CURRENT-STATE.md
@@ -2,13 +2,39 @@
 
 _Last updated: 2026-08-21 (session 1)_
 
-- **Current package:** WP4 — ACCEPTED, merged as `c7efbb4` (PR #351).
-- **Next package:** WP5
+- **Current package:** WP5 — ACCEPTED, merged as `8b4b653` (PR #352), verified live.
+- **Next package:** WP7 (audit finality) — WP6 follows per the package order
 - **WP3:** ACCEPTED, merged as `ee7f737` (PR #350), verified live in production — table, all three indexes, and the CHECK constraint reached `validated=true`.
 - **Latest accepted SHA:** `ee7f737` on `main`
 - **Unresolved blockers:** none
 - **Human approvals granted:** program-level autonomy (run continuously; escalate only per CHECK-IN A/B/C)
 - **Awaiting founder:** nothing. One item is logged for *visibility only*, not decision — see "Codex disposition" below.
+
+## Where WP5 landed
+
+Durable settlement intent, written before the facilitator is called. An x402
+settlement is irreversible, and the orphan capture was a catch block in the
+same process — it handled "the INSERT threw" and could not handle "the process
+died", when it never runs either.
+
+Two gaps found by checking rather than assuming: **nothing ever read**
+`x402_orphan_settlements`, and no unique index constrained how many rows one
+settlement could produce.
+
+**The review found the sharpest defect of the program.** The escalate branch
+deliberately left unresolvable rows untouched — but the sweep is
+`ORDER BY updated_at ASC LIMIT 25`, so untouched rows stay permanently the
+oldest, and 25 of them would own the batch forever. The recovery job would have
+silently stopped recovering, with a tick log indistinguishable from health,
+while per-row paging muted the only channel that could report it. The general
+lesson: **a queue that skips rows without mutating them is not a queue.**
+
+Proved fixed by measurement — 30 stuck rows plus one real crash: tick 1
+escalated 25, tick 2 recovered the real one, tick 3 drained.
+
+Verified live: table, all four indexes (including the new one on
+`transactions.x402_settlement_id`, checked against prod for duplicates first —
+0 across 5,675 rows), zero unreconciled orphans.
 
 ## Where WP4 landed
 

--- a/docs/remediation/packages/WP5.yaml
+++ b/docs/remediation/packages/WP5.yaml
@@ -1,6 +1,8 @@
 package: WP5
 title: x402 durable settlement state + recovery
-status: REMEDIATED
+status: ACCEPTED
+merged_sha: 8b4b653
+merged_pr: 352
 depends_on: [WP3, WP4]
 risks: [CR-01]
 

--- a/docs/remediation/packages/WP7.yaml
+++ b/docs/remediation/packages/WP7.yaml
@@ -1,0 +1,71 @@
+package: WP7
+title: Audit finality — the chain must actually be a chain
+status: IN_PROGRESS
+depends_on: [WP4]
+risks: [CR-04]
+
+objective: >
+  Make the integrity hash chain a chain: one head, one parent per child, and
+  only immutable rows admitted. Today it is a chain in shape and a forest in
+  behaviour.
+
+# Verified by reading the code, not taken from the audit.
+defects:
+  two_orderings: >
+    The worker threads a batch by (created_at, id) ASC
+    (jobs/integrity-hash-retry.ts:104). Head selection picks by
+    (completed_at, id) DESC (lib/integrity-hash.ts:107). A row created before a
+    sibling but completed after it means the tip the batch produced is NOT the
+    head the next tick resumes from — so the next batch links to a row that is
+    not the chain tip, and one parent acquires two children. WP1 pinned this
+    with a test literally named "PINS BUG"; its own comment says WP7 makes the
+    orderings agree and the expectation then inverts.
+
+  non_terminal_admission: >
+    Admission filters on `compliance_hash_state = 'pending'` and an age cutoff.
+    It does NOT require a terminal status. So a row still in 'executing' can be
+    hashed — and `status` is one of the hashed fields
+    (jobs/integrity-hash-retry.ts:137). When that row later reaches 'completed'
+    or 'failed', its recorded hash no longer describes it. The chain then
+    contains an entry that cannot be reverified, which is indistinguishable
+    from tampering.
+
+    Not hypothetical: production holds 11 rows stuck in 'executing' since
+    2026-04-07 (see WP3), each older than any grace period.
+
+  genesis_on_error: >
+    `getPreviousHash` wraps everything in `try { ... } catch { return
+    GENESIS_HASH; }` (lib/integrity-hash.ts:110). A transient DB error during
+    head selection therefore silently starts a SECOND chain from genesis rather
+    than failing. An audit chain that quietly restarts under load is worse than
+    one that stops: it produces a plausible-looking chain with an unexplained
+    second root.
+
+  no_structural_constraint: >
+    Nothing prevents two rows sharing a prev_hash. The single-parent property —
+    the thing that makes a hash chain evidence — rests entirely on the two
+    orderings agreeing, which they do not.
+
+design:
+  one_ordering: >
+    Both the batch and head selection order by the SAME key. `completed_at` is
+    the honest one for a chain of finished work, with `id` as the deterministic
+    tiebreaker, and admission restricted to rows that HAVE a completed_at.
+  terminal_only: >
+    Admit only rows whose status is terminal. A row that is not finished has
+    nothing final to attest.
+  fail_closed: >
+    A head-selection error must propagate, not become genesis. Genesis is
+    returned only when the table genuinely holds no hashed row.
+  structural_single_parent: >
+    A unique index on prev_hash. Convention has already failed here once; the
+    database can enforce what the code did not.
+
+exit_conditions:
+  - terminal-only admission, including free-tier rows
+  - one ordering for both batch threading and head selection
+  - prev_hash uniqueness enforced by an index, not by convention
+  - genesis returned only when the chain is genuinely empty
+  - a branch-topology check that detects a fork if one ever appears
+  - the WP1 "PINS BUG" test inverts
+  - independent adversarial review passes

--- a/docs/remediation/packages/WP7.yaml
+++ b/docs/remediation/packages/WP7.yaml
@@ -1,6 +1,6 @@
 package: WP7
 title: Audit finality — the chain must actually be a chain
-status: REVIEW
+status: REMEDIATED
 depends_on: [WP4]
 risks: [CR-04]
 
@@ -45,6 +45,55 @@ history_is_not_rewritten: >
   NON-unique index, and single-parent is checked by detectChainForks() rather
   than enforced. Scoping that check to rows after the fix is what keeps the
   historical break from drowning the signal that a NEW fork appeared.
+
+review:
+  codex: deferred_to_final_pass
+  independent_agent: FAIL_REMEDIATION_REQUIRED, then all findings closed
+
+  blocking_1_the_fix_did_not_fix_it: >
+    The first attempt made the SORT KEYS agree and left the ADMISSION key
+    different, so the chain still forked. `completed_at` is stamped from a clock
+    read BEFORE the row's own created_at default — median delta in production is
+    MINUS 1.5 ms — so a row can be admitted after the head while carrying an
+    earlier completion time. It chains onto the head without becoming it, and
+    the next row chains onto the same parent. The reviewer replayed the rule
+    over 30 days of real production rows: NINE new forks, in bursts of up to six
+    children on one parent. The same shape also arises from a per-row failure
+    inside a batch, retried on a later tick with a smaller completed_at.
+    Fixed properly: `chain_seq`, assigned from a sequence AT HASH TIME. The head
+    is the last row the worker actually hashed, which makes backdating, clock
+    skew and retries structurally incapable of forking rather than unlikely to.
+
+  blocking_2_dead_detector: >
+    detectChainForks was exported and called by nothing. A fork detector no
+    scheduler invokes detects nothing, and the exit condition claimed otherwise.
+    Now checkChainForks in chain-health-monitoring.ts, registered in
+    meta-monitoring's daily schedule — the module that was already wired and
+    already queries this table four times.
+
+  the_generator_was_still_live: >
+    The reviewer traced the incident to its source: /health/deep ran
+    `WITH probe AS (INSERT ... RETURNING id) DELETE ... WHERE id IN (SELECT id
+    FROM probe)` and commented it "atomic, no data left behind". False — in a
+    data-modifying CTE the DELETE runs against a snapshot predating the CTE's
+    INSERT, so it matches nothing. Every call to this PUBLIC endpoint leaked a
+    permanent row: 200 in August, 144 in May. One of the May rows is the
+    150,719-child parent. Fixed to two statements in one transaction. WP7 would
+    otherwise have marked rows 'excluded' forever on a queue nobody stopped
+    filling.
+
+  non_blocking_closed:
+    - "Migration 0097's first draft created an index on previous_hash that production ALREADY has as idx_transactions_previous_hash (65 MB). IF NOT EXISTS matches on NAME, not definition, so it would have built a second 60 MB index on a hot table for zero benefit. Removed."
+    - "The exclusion sweep was a denylist, so any status literal added later would be silently dropped from the chain. Now an allowlist."
+    - "'excluded' rows fell through /v1/audit's guards and would have been served as audit_chain_state: 'hashed' with a NULL integrity_hash. Unreachable today (no solution profile resolves, so it 404s first) but latent. Now stamped honestly."
+    - "The fork check scoped on a TIMESTAMP has a straddle blind spot — a fork whose children fall either side of the boundary counts as one. Now scoped on chain_seq IS NOT NULL, which is exact."
+    - "Two tests still did not test what they claimed: the fork test would have passed against an implementation ignoring `since`, and no test reached the cross-batch case where the blocking defect actually lives."
+
+  reviewer_finding_withdrawn_by_the_reviewer: >
+    It first reported the exclusion sweep as a no-op against its stated
+    population, then retracted: the sweep is correct and load-bearing, because
+    /health/deep keeps producing exactly those rows. Worth recording — an
+    adversarial reviewer's findings need adjudicating too, in both directions.
 
 # Verified by reading the code, not taken from the audit.
 defects:
@@ -101,7 +150,9 @@ design:
 exit_conditions:
   - terminal-only admission, including free-tier rows
   - one ordering for both batch threading and head selection
-  - single-parent CHECKED, not enforced — a unique index cannot be added over the existing forks
+  - single-parent CHECKED by a scheduled job, not enforced — a unique index cannot be added over the existing forks
+  - the head is derived from hash order, not from any wall-clock column
+  - the generator (/health/deep leaking a row per call) is closed
   - genesis returned only when the chain is genuinely empty
   - a branch-topology check that detects a fork if one ever appears
   - the WP1 "PINS BUG" test inverts

--- a/docs/remediation/packages/WP7.yaml
+++ b/docs/remediation/packages/WP7.yaml
@@ -1,6 +1,6 @@
 package: WP7
 title: Audit finality — the chain must actually be a chain
-status: IN_PROGRESS
+status: REVIEW
 depends_on: [WP4]
 risks: [CR-04]
 
@@ -8,6 +8,43 @@ objective: >
   Make the integrity hash chain a chain: one head, one parent per child, and
   only immutable rows admitted. Today it is a chain in shape and a forest in
   behaviour.
+
+# CORRECTION to an earlier draft of this file: it claimed the parent pointer
+# existed only inside the hash preimage. That was wrong — a `previous_hash`
+# column exists and the worker writes it. The claim came from grepping for
+# `prev_hash`. Having the column is what made the real defect findable.
+
+# Verified against PRODUCTION, not read off the audit.
+production_evidence:
+  the_chain_is_forked: >
+    Ten distinct `previous_hash` values have more than one child. The largest
+    has 150,719. The chain has not been a chain since 2026-05-04.
+  root_cause: >
+    getPreviousHash orders by `completed_at DESC`, and Postgres sorts NULLs
+    FIRST under DESC. A health_probe row hashed on 2026-05-04 with a null
+    completed_at has held the head position ever since — it is still what
+    getPreviousHash returns today — so every batch for three and a half months
+    linked to that same parent. A star has no sequence, so it proves nothing
+    about ordering or deletion, which is the entire tamper-evidence property.
+  genesis_restarts: >
+    GENESIS_HASH (b6abba31...) has 11 children. That is the swallowed catch in
+    getPreviousHash silently starting a new chain on a transient DB error,
+    eleven times.
+  non_terminal_rows_in_the_chain: >
+    507 hashed rows sit in a non-terminal status — 506 health probes with no
+    completed_at, and one transaction stuck in 'executing' since 2026-04-07
+    (one of WP3's stranded rows, which the reconciler will eventually move,
+    breaking its own recorded hash).
+
+history_is_not_rewritten: >
+  Deliberate. Recomputing 863,946 hashes would erase the evidence that the
+  break happened, which is the opposite of what an audit chain is for. The fix
+  is forward-only, and the fork stays queryable.
+  Consequence: the unique index this package's exit condition asked for CANNOT
+  be added — it would abort boot on the existing forks. Block 0097 adds a
+  NON-unique index, and single-parent is checked by detectChainForks() rather
+  than enforced. Scoping that check to rows after the fix is what keeps the
+  historical break from drowning the signal that a NEW fork appeared.
 
 # Verified by reading the code, not taken from the audit.
 defects:
@@ -64,7 +101,7 @@ design:
 exit_conditions:
   - terminal-only admission, including free-tier rows
   - one ordering for both batch threading and head selection
-  - prev_hash uniqueness enforced by an index, not by convention
+  - single-parent CHECKED, not enforced — a unique index cannot be added over the existing forks
   - genesis returned only when the chain is genuinely empty
   - a branch-topology check that detects a fork if one ever appears
   - the WP1 "PINS BUG" test inverts


### PR DESCRIPTION
## The audit chain has not been a chain since 2026-05-04

Found by querying production, not by reading the audit. One parent has **150,719 children**.

The cause is exact: `getPreviousHash` ordered by `completed_at DESC`, and Postgres sorts NULLs **first** under DESC. A `health_probe` row hashed on 2026-05-04 with a null `completed_at` has held the head position ever since — it is still what the function returns today. Every batch for three and a half months linked to that same parent.

A star has no sequence, so the chain proves nothing about ordering or absence of deletion. That is the entire tamper-evidence property it exists to provide.

Also live: **genesis has 11 children** (the swallowed `catch { return GENESIS_HASH }` silently restarting the chain), and **507 hashed rows sit in a non-terminal status** — including one of WP3's stranded `executing` rows, whose hash will break when the reconciler moves it.

## And the generator was still running

`/health/deep` ran `WITH probe AS (INSERT … RETURNING id) DELETE … WHERE id IN (SELECT id FROM probe)`, commented *"atomic, no data left behind"*. That is false. In a data-modifying CTE the `DELETE` runs against a snapshot predating the CTE's `INSERT`, so it matches nothing. Every call to this **public** endpoint leaked a permanent row — 200 in August, 144 in May. One of the May rows is the 150,719-child parent.

Fixed to two statements in one transaction. Without this, WP7 would have marked rows `excluded` forever on a queue nobody stopped filling.

## The head cannot be a wall-clock column

My first attempt made the sort keys agree and left the *admission* key different. The reviewer caught it and replayed the rule over 30 days of real production rows: **nine new forks**, in bursts of up to six children on one parent.

`completed_at` is stamped from a clock read **before** the row's own `created_at` default — median delta in production is **−1.5 ms** — so a row can be admitted after the head while carrying an earlier completion time. It chains onto the head without becoming it, and the next row chains onto the same parent.

The head is now `chain_seq`, assigned from a sequence **at hash time**: the last row the worker actually hashed. Backdating, clock skew and per-row retries become structurally incapable of forking rather than merely unlikely to.

Migration 0097 seeds exactly **one** row — the current head — so the sequence continues the existing chain instead of starting a second root. `ADD COLUMN` with no default is catalog-only, so no rewrite of a 902k-row / 355 MB hot table.

## History is not rewritten

Deliberate. Recomputing 863,946 hashes would erase the evidence that the break happened, which is the opposite of what an audit chain is for. The fork stays queryable.

Consequence: the unique index this package's exit condition asked for **cannot** be added — it would abort boot on the existing forks. Single-parent is now *checked* by a scheduled job. I ran that duplicate check against production before writing the migration, which is the only reason I know.

## Also closed

- **The fork detector was dead code.** `detectChainForks` was exported and called by nothing, while the exit condition claimed a branch-topology check existed. It is now `checkChainForks` in `chain-health-monitoring.ts`, registered in meta-monitoring's daily schedule.
- Migration 0097's first draft built an index production **already has** (`idx_transactions_previous_hash`, 65 MB). `IF NOT EXISTS` matches on *name*, not definition.
- The exclusion sweep was a denylist, so any status added later would be silently dropped from the chain. Now an allowlist.
- `excluded` rows would have been served by `/v1/audit` as `audit_chain_state: "hashed"` with a null hash. Unreachable today, but now stamped honestly.
- The fork check scoped on a timestamp has a straddle blind spot; it now scopes on `chain_seq IS NOT NULL`, which is exact.

## Verification

Every fix proved discriminating by mutation — reverting the head rule, the batch ordering, the status filter, the fork check, or the probe fix each turns exactly one test red. The cross-batch case, where the blocking defect actually lives, now has a test; previously both ordering tests put their rows in one batch, where the loop threads correctly under either rule.

Migration verified against a real database: idempotent, seeds exactly one row, and the head continues the existing chain.

16 gates pass. 2,250 unit tests; 97 integration tests across 15 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
