### PR TITLE
Remediation WP6: bind idempotency keys to the request they were issued for

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -244,6 +244,16 @@ export const transactions = pgTable(
       .references(() => capabilities.id), // nullable: solution executions have no single capability
     solutionSlug: text("solution_slug"), // set for solution executions, null for capability executions
     idempotencyKey: varchar("idempotency_key", { length: 255 }),
+    /**
+     * Hash of the request this key was first used for (WP6).
+     *
+     * A key without one is a key to nothing in particular: the platform
+     * replayed on the string alone, so the same key reused for different work
+     * returned the earlier answer to the later question. Null on rows predating
+     * this column; those still replay, because refusing would break clients
+     * holding keys issued before the deploy.
+     */
+    idempotencyFingerprint: varchar("idempotency_fingerprint", { length: 64 }),
     status: varchar("status", { length: 20 }).notNull().default("pending"),
     // 'pending' | 'executing' | 'completed' | 'failed'
     input: jsonb("input").notNull(),
@@ -353,8 +363,12 @@ export const transactions = pgTable(
     completedAt: timestamp("completed_at", { withTimezone: true }),
   },
   (table) => [
-    uniqueIndex("transactions_idempotency_key_unique")
-      .on(table.idempotencyKey)
+    // WP6: scoped to the CUSTOMER. A global unique index meant two customers
+    // picking the same key collided — the second neither replayed (the lookup
+    // is per-user) nor inserted (the index is not), surfacing as a 500. It was
+    // also a weak oracle for whether a key existed anywhere on the platform.
+    uniqueIndex("transactions_user_idempotency_key_unique")
+      .on(table.userId, table.idempotencyKey)
       .where(sql`idempotency_key IS NOT NULL`),
     index("transactions_user_id_idx").on(table.userId),
     index("transactions_status_idx").on(table.status),

--- a/apps/api/src/lib/chain-integrity-windows.test.ts
+++ b/apps/api/src/lib/chain-integrity-windows.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The disclosure has to be right, because it is the thing a regulator reads.
+ *
+ * These tests pin the boundaries rather than the prose. A window whose end is
+ * wrong by a day would tell a customer their record was evidenced when it was
+ * not, or the reverse — and the reverse is not the safe direction either, since
+ * over-disclosing a defect is its own kind of inaccuracy.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CHAIN_INTEGRITY_WINDOWS,
+  orderingEvidenceUnavailable,
+  windowsCovering,
+} from "./chain-integrity-windows.js";
+
+const INSIDE = new Date("2026-06-15T00:00:00.000Z");
+const BEFORE = new Date("2026-05-01T00:00:00.000Z");
+const AFTER = new Date("2026-08-22T00:00:00.000Z");
+
+describe("the 2026-05-04 ordering window", () => {
+  it("covers a record created inside it", () => {
+    expect(orderingEvidenceUnavailable(INSIDE)).toBe(true);
+    expect(windowsCovering(INSIDE)).toHaveLength(1);
+  });
+
+  it("does not cover records before it", () => {
+    // The chain worked before the null-completed_at row was written. Claiming
+    // otherwise would disclose a defect that did not exist.
+    expect(orderingEvidenceUnavailable(BEFORE)).toBe(false);
+  });
+
+  it("does not cover records after the fix", () => {
+    expect(orderingEvidenceUnavailable(AFTER)).toBe(false);
+  });
+
+  it("is closed, with an end at the deploy that fixed it", () => {
+    const w = CHAIN_INTEGRITY_WINDOWS[0]!;
+    expect(w.to, "an open window would mean the defect is still live").not.toBeNull();
+    expect(Date.parse(w.to!)).toBeGreaterThan(Date.parse(w.from));
+  });
+
+  it("states what remains reliable, not only what was lost", () => {
+    // A disclosure that omits this reads as "the audit trail is worthless",
+    // which is both false and unhelpful to whoever has to act on it.
+    const w = CHAIN_INTEGRITY_WINDOWS[0]!;
+    expect(w.unaffected).toMatch(/per-row integrity/i);
+    expect(w.lost).toEqual(["ordering_and_completeness"]);
+    expect(w.lost).not.toContain("row_integrity");
+  });
+
+  it("every window has a cause and a remedy", () => {
+    for (const w of CHAIN_INTEGRITY_WINDOWS) {
+      expect(w.cause.length, `${w.id} needs a cause`).toBeGreaterThan(40);
+      expect(w.remedy.length, `${w.id} needs a remedy`).toBeGreaterThan(40);
+    }
+  });
+});

--- a/apps/api/src/lib/chain-integrity-windows.ts
+++ b/apps/api/src/lib/chain-integrity-windows.ts
@@ -1,0 +1,84 @@
+/**
+ * Known windows where the audit chain did not provide a property it normally
+ * provides.
+ *
+ * This file exists so the knowledge does not live only in a pull request and
+ * someone's memory. If a customer, an auditor or a future maintainer asks "was
+ * this record's ordering evidenced in June 2026?", the answer has to come from
+ * the system rather than from whoever happens to remember the incident.
+ *
+ * History is deliberately not rewritten. Recomputing the affected hashes would
+ * erase the evidence that the break happened, which is the opposite of what an
+ * audit chain is for — and a rewritten chain is a far worse thing for a
+ * regulator to find than a documented break with a cause, a date and a fix.
+ *
+ * Adding an entry here is an admission, not a formality. Entries are permanent.
+ */
+
+export type ChainProperty =
+  /** Row content is unaltered since it was hashed. */
+  | "row_integrity"
+  /** Rows are in a provable sequence, and none has been removed. */
+  | "ordering_and_completeness";
+
+export interface ChainIntegrityWindow {
+  id: string;
+  /** Inclusive start, ISO 8601. */
+  from: string;
+  /** Inclusive end, ISO 8601. Null while a window is still open. */
+  to: string | null;
+  /** What the chain did NOT provide during the window. */
+  lost: ChainProperty[];
+  cause: string;
+  remedy: string;
+  /** What a reader can still rely on, so the disclosure is not read as worse than it is. */
+  unaffected: string;
+}
+
+export const CHAIN_INTEGRITY_WINDOWS: readonly ChainIntegrityWindow[] = [
+  {
+    id: "2026-05-04-null-completed-at-head",
+    from: "2026-05-04T13:45:36.776Z",
+    // Closed by the WP7 deploy, which moved head selection onto a monotonic
+    // sequence assigned at hash time.
+    to: "2026-08-21T12:10:22.625Z",
+    lost: ["ordering_and_completeness"],
+    cause:
+      "Head selection ordered by completed_at DESC. PostgreSQL sorts NULLs " +
+      "first under DESC, so a health-probe row written with a null completed_at " +
+      "occupied the head position permanently and every subsequent batch linked " +
+      "to it. The chain became a star with one parent and 150,719 children. A " +
+      "star has no sequence, so it cannot evidence ordering or the absence of a " +
+      "deletion.",
+    remedy:
+      "The head is now the last row the hashing worker actually processed, read " +
+      "from a monotonic sequence assigned at hash time, so no wall-clock column " +
+      "can capture it. The probe endpoint that produced the offending rows no " +
+      "longer leaves them behind. A daily branch-topology check reports any new " +
+      "fork.",
+    unaffected:
+      "Per-row integrity. Each row's hash still covers its own content and its " +
+      "stored parent, so alteration of an individual record remains detectable " +
+      "throughout the window; a 300-row sample verified 99.7% for records inside " +
+      "the 90-day content-retention horizon. The exceptions are rows whose " +
+      "content was zeroed by the 90-day GDPR redaction, which is by design and " +
+      "is separately disclosed by /v1/verify.",
+  },
+];
+
+/** Windows overlapping an instant — used to qualify a verification result. */
+export function windowsCovering(at: Date): ChainIntegrityWindow[] {
+  const t = at.getTime();
+  return CHAIN_INTEGRITY_WINDOWS.filter((w) => {
+    const from = Date.parse(w.from);
+    const to = w.to ? Date.parse(w.to) : Number.POSITIVE_INFINITY;
+    return t >= from && t <= to;
+  });
+}
+
+/** True when ordering cannot be evidenced for a record created at this instant. */
+export function orderingEvidenceUnavailable(at: Date): boolean {
+  return windowsCovering(at).some((w) =>
+    w.lost.includes("ordering_and_completeness"),
+  );
+}

--- a/apps/api/src/lib/chain-integrity-windows.ts
+++ b/apps/api/src/lib/chain-integrity-windows.ts
@@ -82,3 +82,39 @@ export function orderingEvidenceUnavailable(at: Date): boolean {
     w.lost.includes("ordering_and_completeness"),
   );
 }
+
+/**
+ * Customer-facing disclosure text for a record inside a known window.
+ *
+ * DRAFT — deliberately not wired into any response. `/v1/verify` already
+ * discloses redaction, and this is written in the same register: state what is
+ * unavailable, state what remains true, name the cause and the fix, and do not
+ * editorialise. But it is a claim about the reliability of an audit trail, and
+ * the charter puts regulator-facing claims with the founder rather than with
+ * the platform. This function exists so the wording can be read and approved as
+ * a concrete thing rather than described in the abstract.
+ */
+export function orderingDisclosureText(at: Date): string | null {
+  const window = windowsCovering(at).find((w) =>
+    w.lost.includes("ordering_and_completeness"),
+  );
+  if (!window) return null;
+
+  return (
+    "This record was created during a period when Strale's audit chain did not " +
+    "evidence ordering. Between " +
+    window.from.slice(0, 10) +
+    " and " +
+    (window.to ?? "").slice(0, 10) +
+    ", a defect in how the chain's head was selected caused newly hashed records " +
+    "to link to the same predecessor rather than forming a sequence. The record " +
+    "itself is intact: its content hash still covers its own data and its recorded " +
+    "predecessor, so alteration of this record remains detectable. What cannot be " +
+    "demonstrated for this period is the order of records relative to one another, " +
+    "or that no record was removed. The defect was corrected on " +
+    (window.to ?? "").slice(0, 10) +
+    "; records created after that date carry full ordering evidence. Strale has " +
+    "deliberately not recomputed the affected hashes, because doing so would remove " +
+    "the evidence that the gap occurred."
+  );
+}

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -23,6 +23,10 @@ export type ErrorCode =
   // so callers can retry the same inputs safely (execution happened; only
   // the record did not).
   | "transaction_finalization_failed"
+  // WP6: an Idempotency-Key was reused for DIFFERENT work. Distinct from
+  // invalid_request because the request itself is well-formed — the fault is
+  // in the key's reuse, and the caller can fix it by issuing a new one.
+  | "idempotency_key_reused"
   // Internal admin surface only — POST /v1/internal/tests/admin/
   // apply-migrations returns this when runStartupMigrations() throws
   // (e.g. block 0062 post-condition violation). Not exposed on the

--- a/apps/api/src/lib/idempotency-fingerprint.test.ts
+++ b/apps/api/src/lib/idempotency-fingerprint.test.ts
@@ -98,3 +98,39 @@ describe("replayability", () => {
     expect(isReplayable(null, computeIdempotencyFingerprint(base))).toBe(true);
   });
 });
+
+describe("what the key is scoped to", () => {
+  it("separates the capability rail from the solution rail", () => {
+    // Capabilities and solutions are separate tables with independent slug
+    // namespaces. Nothing prevents the same string existing in both, and
+    // without a rail discriminator one key would fingerprint identically
+    // across them.
+    expect(
+      computeIdempotencyFingerprint({ rail: "capability", capabilitySlug: "kyb-complete-se", inputs: {} }),
+    ).not.toBe(
+      computeIdempotencyFingerprint({ rail: "solution", capabilitySlug: "kyb-complete-se", inputs: {} }),
+    );
+  });
+
+  it("distinguishes a dry run from a real execution", () => {
+    // A replay answers "what DID happen" in a shape indistinguishable from a
+    // real execution. Someone asking "what WOULD happen" must not get it.
+    expect(computeIdempotencyFingerprint({ capabilitySlug: "x", inputs: {}, dryRun: true })).not.toBe(
+      computeIdempotencyFingerprint({ capabilitySlug: "x", inputs: {}, dryRun: false }),
+    );
+  });
+
+  it("distinguishes require_fresh, which a replay would silently bypass", () => {
+    expect(
+      computeIdempotencyFingerprint({ capabilitySlug: "x", inputs: {}, requireFresh: true }),
+    ).not.toBe(computeIdempotencyFingerprint({ capabilitySlug: "x", inputs: {}, requireFresh: false }));
+  });
+
+  it("does NOT include the budget knobs — replaying past those is the point", () => {
+    // max_price_cents / timeout_seconds are not part of the question being
+    // asked, and folding them in would 409 a retry that merely raised a budget.
+    const a = computeIdempotencyFingerprint({ capabilitySlug: "x", inputs: { a: 1 } });
+    const b = computeIdempotencyFingerprint({ capabilitySlug: "x", inputs: { a: 1 } });
+    expect(a).toBe(b);
+  });
+});

--- a/apps/api/src/lib/idempotency-fingerprint.test.ts
+++ b/apps/api/src/lib/idempotency-fingerprint.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeIdempotencyFingerprint,
+  isReplayable,
+} from "./idempotency-fingerprint.js";
+
+const base = {
+  capabilitySlug: "iban-validate",
+  inputs: { iban: "DE89370400440532013000", country: "DE" },
+};
+
+describe("a retry is the same request", () => {
+  it("is stable across JSON key order", () => {
+    // The case that decides whether this helps or hurts. An HTTP client has no
+    // obligation to serialise object keys the same way on a retry — and a retry
+    // is exactly when idempotency matters. Without recursive canonicalisation
+    // the fingerprint would differ and a legitimate retry would 409, which is
+    // worse than the bug being fixed.
+    const a = computeIdempotencyFingerprint(base);
+    const b = computeIdempotencyFingerprint({
+      capabilitySlug: "iban-validate",
+      inputs: { country: "DE", iban: "DE89370400440532013000" },
+    });
+    expect(a).toBe(b);
+  });
+
+  it("is stable for nested objects too", () => {
+    const a = computeIdempotencyFingerprint({
+      capabilitySlug: "x",
+      inputs: { outer: { z: 1, a: { q: 2, b: 3 } } },
+    });
+    const b = computeIdempotencyFingerprint({
+      capabilitySlug: "x",
+      inputs: { outer: { a: { b: 3, q: 2 }, z: 1 } },
+    });
+    expect(a).toBe(b);
+  });
+
+  it("does NOT reorder arrays — order is meaning there", () => {
+    const a = computeIdempotencyFingerprint({
+      capabilitySlug: "x",
+      inputs: { items: [1, 2] },
+    });
+    const b = computeIdempotencyFingerprint({
+      capabilitySlug: "x",
+      inputs: { items: [2, 1] },
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("a different request is a different request", () => {
+  it("changes when inputs change", () => {
+    expect(computeIdempotencyFingerprint(base)).not.toBe(
+      computeIdempotencyFingerprint({ ...base, inputs: { iban: "GB33BUKB20201555555555" } }),
+    );
+  });
+
+  it("changes when the capability changes", () => {
+    // The dangerous case: the same key across two capabilities returned the
+    // first one's output labelled as the second's.
+    expect(computeIdempotencyFingerprint(base)).not.toBe(
+      computeIdempotencyFingerprint({ ...base, capabilitySlug: "vat-validate" }),
+    );
+  });
+
+  it("distinguishes task routing from slug routing", () => {
+    // Both select what runs, so a key bound to one must not match the other.
+    expect(
+      computeIdempotencyFingerprint({ task: "validate an IBAN", inputs: {} }),
+    ).not.toBe(computeIdempotencyFingerprint({ capabilitySlug: "iban-validate", inputs: {} }));
+  });
+});
+
+describe("replayability", () => {
+  it("replays an identical request", () => {
+    const fp = computeIdempotencyFingerprint(base);
+    expect(isReplayable(fp, fp)).toBe(true);
+  });
+
+  it("refuses a different request under the same key", () => {
+    expect(
+      isReplayable(computeIdempotencyFingerprint(base), computeIdempotencyFingerprint({ ...base, capabilitySlug: "other" })),
+    ).toBe(false);
+  });
+
+  it("replays when the field is undefined, not just null", () => {
+    // A projection that omits the column, a fixture, or a cached row shape all
+    // yield undefined rather than null, and `undefined === null` is false.
+    // Getting this wrong 409s a legitimate retry.
+    expect(isReplayable(undefined, computeIdempotencyFingerprint(base))).toBe(true);
+  });
+
+  it("replays a row that predates the column", () => {
+    // Deliberate. Refusing would break clients holding keys issued before the
+    // deploy; the set is finite and drains as those keys age out.
+    expect(isReplayable(null, computeIdempotencyFingerprint(base))).toBe(true);
+  });
+});

--- a/apps/api/src/lib/idempotency-fingerprint.ts
+++ b/apps/api/src/lib/idempotency-fingerprint.ts
@@ -1,0 +1,82 @@
+/**
+ * What an idempotency key is a key TO (WP6, risks CR-03 / N4).
+ *
+ * An Idempotency-Key means "this is the same request as before; do not perform
+ * it twice". It does not mean "return whatever I got last time I used this
+ * string". Without a record of what the key was issued for, those two readings
+ * are indistinguishable, and the platform implemented the second — proved by
+ * three tests WP1 left in place specifically as this package's acceptance
+ * signal:
+ *
+ *   - a DIFFERENT payload under the same key replayed the old result
+ *   - a DIFFERENT capability under the same key returned the first one's output,
+ *     while the response echoed the slug the caller had just asked for
+ *   - the same key from a DIFFERENT customer collided, because the unique index
+ *     was global while the replay lookup was per-user
+ *
+ * The first two are the dangerous ones. A client that reuses a key across
+ * different work — "order-123" is the canonical example, and far more likely
+ * than a UUID collision — silently receives an answer to a question it did not
+ * ask, presented as an answer to the one it did.
+ *
+ * So a key is bound to a fingerprint of the request it was first used for. Same
+ * key and same fingerprint is a replay. Same key and a different fingerprint is
+ * a client bug, and the correct answer is 409, not a plausible-looking wrong
+ * result.
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * Stable across key order, so `{a:1,b:2}` and `{b:2,a:1}` are one request.
+ *
+ * JSON.stringify preserves insertion order, and an HTTP client has no
+ * obligation to serialise object keys consistently between a call and its
+ * retry — which is exactly when idempotency matters. Sorting recursively means
+ * a retry that differs only in serialisation still replays instead of 409ing.
+ */
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) out[key] = canonicalize(obj[key]);
+  return out;
+}
+
+/**
+ * Bind a key to the work it was issued for.
+ *
+ * Covers the routing decision as well as the payload: `task` and
+ * `capability_slug` are alternative ways of selecting what runs, and a key
+ * reused across two different capabilities is precisely the case that returned
+ * the wrong capability's output.
+ */
+export function computeIdempotencyFingerprint(params: {
+  task?: string | null;
+  capabilitySlug?: string | null;
+  inputs?: Record<string, unknown> | null;
+}): string {
+  const payload = JSON.stringify({
+    task: params.task ?? null,
+    capability_slug: params.capabilitySlug ?? null,
+    inputs: canonicalize(params.inputs ?? null),
+  });
+  return createHash("sha256").update(payload).digest("hex").slice(0, 32);
+}
+
+/**
+ * May this stored request be replayed for the incoming one?
+ *
+ * A null stored fingerprint means the row predates this column. Those replay,
+ * because refusing would break live clients holding keys issued before the
+ * deploy — and the pre-existing behaviour for them is unchanged, not worsened.
+ * The set is finite and drains as old keys age out.
+ */
+export function isReplayable(
+  storedFingerprint: string | null,
+  incomingFingerprint: string,
+): boolean {
+  if (storedFingerprint === null) return true;
+  return storedFingerprint === incomingFingerprint;
+}

--- a/apps/api/src/lib/idempotency-fingerprint.ts
+++ b/apps/api/src/lib/idempotency-fingerprint.ts
@@ -56,11 +56,30 @@ export function computeIdempotencyFingerprint(params: {
   task?: string | null;
   capabilitySlug?: string | null;
   inputs?: Record<string, unknown> | null;
+  /** Which rail issued the key. Capability and solution slugs are separate namespaces. */
+  rail?: "capability" | "solution";
+  /**
+   * Modes that change WHAT IS BEING ASKED, so a key bound to one must not
+   * replay for the other.
+   *
+   * Deliberately not the budget knobs (max_price_cents, timeout_seconds,
+   * max_latency_ms): replaying past a changed budget is what idempotency means.
+   * These two are different in kind — `dry_run` asks "what WOULD happen", and a
+   * replay answers "what DID happen" in a shape indistinguishable from a real
+   * execution; `require_fresh` is a gate that refuses stale data, and a replay
+   * returns before it, silently handing back exactly what the gate exists to
+   * refuse.
+   */
+  dryRun?: boolean | null;
+  requireFresh?: boolean | null;
 }): string {
   const payload = JSON.stringify({
+    rail: params.rail ?? "capability",
     task: params.task ?? null,
     capability_slug: params.capabilitySlug ?? null,
     inputs: canonicalize(params.inputs ?? null),
+    dry_run: params.dryRun === true,
+    require_fresh: params.requireFresh === true,
   });
   return createHash("sha256").update(payload).digest("hex").slice(0, 32);
 }

--- a/apps/api/src/lib/idempotency-fingerprint.ts
+++ b/apps/api/src/lib/idempotency-fingerprint.ts
@@ -74,9 +74,15 @@ export function computeIdempotencyFingerprint(params: {
  * The set is finite and drains as old keys age out.
  */
 export function isReplayable(
-  storedFingerprint: string | null,
+  storedFingerprint: string | null | undefined,
   incomingFingerprint: string,
 ): boolean {
-  if (storedFingerprint === null) return true;
+  // `undefined` as well as `null`. A column read as NULL arrives as null, but a
+  // row that never carried the field at all — a projection that omits it, a
+  // fixture, a cached shape — arrives as undefined, and `undefined === null` is
+  // false. Treating those differently would 409 a legitimate retry, which is a
+  // worse failure than the one this package fixes. Caught by an existing
+  // do.core test rather than by inspection.
+  if (storedFingerprint == null) return true;
   return storedFingerprint === incomingFingerprint;
 }

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1236,7 +1236,7 @@ describe("startup-migrations — block 0087 (un-hide content-redacted rows)", ()
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 40 blocks in historical order", () => {
+  it("exports the expected 41 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1284,6 +1284,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0095_walletReservations",
       "runMigration0096_x402SettlementIntents",
       "runMigration0097_chainSequence",
+      "runMigration0098_perCustomerIdempotency",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1857,21 +1857,44 @@ export async function runMigration0098_perCustomerIdempotency(
       ADD COLUMN IF NOT EXISTS "idempotency_fingerprint" varchar(64)
   `);
 
-  await tx.execute(sql`
-    CREATE UNIQUE INDEX IF NOT EXISTS "transactions_user_idempotency_key_unique"
-      ON "transactions" ("user_id", "idempotency_key")
-      WHERE "idempotency_key" IS NOT NULL
-  `);
-
-  // Only now — see the ordering note above.
-  await tx.execute(sql`
-    DROP INDEX IF EXISTS "transactions_idempotency_key_unique"
-  `);
+  // Bound the LOCK WAIT, not just the statement. Review finding: this table has
+  // ~902k rows and is written by every /v1/do call. CREATE UNIQUE INDEX takes
+  // SHARE, which conflicts with the ROW EXCLUSIVE an in-flight execution holds
+  // across its external call (bounded at 15s), and a PENDING SHARE request
+  // queues every subsequent write behind it. The connection carries
+  // statement_timeout=30s and lock wait counts toward it, so a busy deploy
+  // window could throw here — and an uncaught throw aborts boot, which on
+  // Railway means the old commit keeps serving and the failure is silent.
+  //
+  // Block 0095 reached the same conclusion for `wallets` and chose the same
+  // shape: bound the wait, and on failure log and DEFER to the next boot rather
+  // than throwing. Both statements are IF [NOT] EXISTS, so a retry is a no-op
+  // once they land.
+  let indexOutcome: string;
+  try {
+    await tx.execute(sql`SET LOCAL lock_timeout = '3s'`);
+    await tx.execute(sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS "transactions_user_idempotency_key_unique"
+        ON "transactions" ("user_id", "idempotency_key")
+        WHERE "idempotency_key" IS NOT NULL
+    `);
+    // Only now — see the ordering note above.
+    await tx.execute(sql`
+      DROP INDEX IF EXISTS "transactions_idempotency_key_unique"
+    `);
+    indexOutcome = "per-customer index created; global index dropped";
+  } catch (err) {
+    // Deferring is safe in BOTH directions. Until the new index exists the old
+    // global one is still in force and is strictly stricter, so nothing the
+    // previous release writes can later violate the new one.
+    indexOutcome =
+      "index swap deferred to next boot (lock contention): " +
+      (err instanceof Error ? err.message.slice(0, 120) : String(err).slice(0, 120));
+  }
 
   return {
     block: "0098_per_customer_idempotency",
-    outcome:
-      "idempotency_fingerprint column; unique index scoped to (user_id, idempotency_key); global index dropped",
+    outcome: `idempotency_fingerprint column ensured; ${indexOutcome}`,
     duration_ms: Date.now() - startedAt,
   };
 }

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1834,6 +1834,49 @@ export async function runMigration0097_chainSequence(
 }
 
 
+/**
+ * Block 0098 — per-customer idempotency + request fingerprint (WP6).
+ *
+ * Two changes, both verified read-only against production first:
+ *   - 0 duplicate (user_id, idempotency_key) pairs across 421 keyed rows, so
+ *     the new unique index cannot abort boot.
+ *   - 0 keyed rows with a NULL user_id, so scoping to the customer strands
+ *     nothing.
+ *
+ * The old index is dropped AFTER the new one exists. Order matters: dropping
+ * first would leave a window with no uniqueness at all, and this runs at boot
+ * while the previous release is still serving traffic.
+ */
+export async function runMigration0098_perCustomerIdempotency(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  await tx.execute(sql`
+    ALTER TABLE "transactions"
+      ADD COLUMN IF NOT EXISTS "idempotency_fingerprint" varchar(64)
+  `);
+
+  await tx.execute(sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS "transactions_user_idempotency_key_unique"
+      ON "transactions" ("user_id", "idempotency_key")
+      WHERE "idempotency_key" IS NOT NULL
+  `);
+
+  // Only now — see the ordering note above.
+  await tx.execute(sql`
+    DROP INDEX IF EXISTS "transactions_idempotency_key_unique"
+  `);
+
+  return {
+    block: "0098_per_customer_idempotency",
+    outcome:
+      "idempotency_fingerprint column; unique index scoped to (user_id, idempotency_key); global index dropped",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+
 export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResult>> = [
   runMigration0029_actualCostCents,
   runMigration0030_complianceColumns,
@@ -1876,6 +1919,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0095_walletReservations,
   runMigration0096_x402SettlementIntents,
   runMigration0097_chainSequence,
+  runMigration0098_perCustomerIdempotency,
 ];
 
 /**

--- a/apps/api/src/routes/a2a.ts
+++ b/apps/api/src/routes/a2a.ts
@@ -541,6 +541,15 @@ async function handleMessageSend(
   if (authHeader?.startsWith("Bearer ")) {
     headers.Authorization = authHeader;
   }
+  // WP6: forward the caller's idempotency key. This rail proxies to /v1/do,
+  // which supports idempotency — but only Content-Type and Authorization were
+  // passed through, so an A2A client had no way to make a retry safe no matter
+  // what it sent. A proxy that drops the header silently converts an idempotent
+  // request into a repeatable charge.
+  const idempotencyHeader = c.req.header("Idempotency-Key");
+  if (idempotencyHeader) {
+    headers["Idempotency-Key"] = idempotencyHeader;
+  }
 
   // Build the /v1/do request body
   const doBody: Record<string, unknown> = {

--- a/apps/api/src/routes/a2a.ts
+++ b/apps/api/src/routes/a2a.ts
@@ -458,6 +458,9 @@ async function handleMessageSend(
 ) {
   const message = params.message;
   let skillId: string | undefined = params.skillId;
+  // Captured before suggest() can overwrite it: an idempotency guarantee is
+  // only meaningful when the caller determined what runs.
+  const explicitSkillId: string | undefined = params.skillId;
 
   if (!message || !message.parts || !Array.isArray(message.parts)) {
     return c.json({
@@ -546,9 +549,17 @@ async function handleMessageSend(
   // passed through, so an A2A client had no way to make a retry safe no matter
   // what it sent. A proxy that drops the header silently converts an idempotent
   // request into a repeatable charge.
+  //
+  // ONLY when the caller named the skill. Review finding: when skillId is
+  // absent this handler resolves one from free text via suggest() — embeddings
+  // plus an LLM re-rank — and the fingerprint is computed downstream from the
+  // RESOLVED slug. A byte-identical retry that re-ranks differently would then
+  // be told it "reused a key for a different request", which is both false and
+  // unactionable, since the client never chose the slug. Forwarding only the
+  // deterministic case keeps the guarantee honest instead of approximate.
   const idempotencyHeader = c.req.header("Idempotency-Key");
-  if (idempotencyHeader) {
-    headers["Idempotency-Key"] = idempotencyHeader;
+  if (idempotencyHeader && explicitSkillId) {
+    headers["Idempotency-Key"] = idempotencyHeader.slice(0, 255);
   }
 
   // Build the /v1/do request body

--- a/apps/api/src/routes/do.idempotency.integration.test.ts
+++ b/apps/api/src/routes/do.idempotency.integration.test.ts
@@ -98,7 +98,10 @@ describeMaybe("/v1/do idempotency against a real database", () => {
     seededCaps.length = 0;
   });
 
-  async function seedCapability(slug: string) {
+  async function seedCapability(
+    slug: string,
+    opts: { isFreeTier?: boolean; priceCents?: number } = {},
+  ) {
     const id = randomUUID();
     seededCaps.push(id);
     await db.insert(capabilities).values({
@@ -109,9 +112,9 @@ describeMaybe("/v1/do idempotency against a real database", () => {
       category: "developer-tools",
       inputSchema: { type: "object", properties: { probe: { type: "string" } } },
       outputSchema: { type: "object", properties: { from: { type: "string" } } },
-      priceCents: PRICE_CENTS,
+      priceCents: opts.priceCents ?? PRICE_CENTS,
       isActive: true,
-      isFreeTier: false,
+      isFreeTier: opts.isFreeTier ?? false,
       avgLatencyMs: 50,
       lifecycleState: "active",
     });
@@ -252,5 +255,44 @@ describeMaybe("/v1/do idempotency against a real database", () => {
     // Independent: customer two gets their OWN execution, not customer one's.
     const otherBody = (await other.json()) as any;
     expect(otherBody.meta?.idempotency_replay ?? false).toBe(false);
+  }, 120_000);
+
+  it("binds the key on the FREE-TIER path too (the review's blocking finding)", async () => {
+    // Every case above seeds a PAID capability, so all four route through
+    // executeSync and none touched executeFreeTierAuthenticated. That path took
+    // the fingerprint as a parameter and never wrote it, so its rows carried a
+    // NULL fingerprint — and a NULL fingerprint replays by design. The guard
+    // was permanently off for free-tier keys, and the parameter's presence made
+    // it read as done.
+    await seedCapability(slugA, { isFreeTier: true, priceCents: 0 });
+    await seedCapability(slugB, { isFreeTier: true, priceCents: 0 });
+    const apiKey = await seedUser();
+    const key = randomUUID();
+
+    const first = await callDo(
+      apiKey,
+      { capability_slug: slugA, inputs: { probe: "x" }, max_price_cents: PRICE_CENTS },
+      key,
+    );
+    expect(first.status).toBe(200);
+
+    const second = await callDo(
+      apiKey,
+      { capability_slug: slugB, inputs: { probe: "x" }, max_price_cents: PRICE_CENTS },
+      key,
+    );
+    expect(second.status).toBe(409);
+    expect(((await second.json()) as any).error_code).toBe("idempotency_key_reused");
+  }, 120_000);
+
+  it("rejects an over-long key with 400, not a Postgres 500", async () => {
+    await seedCapability(slugA);
+    const apiKey = await seedUser();
+    const res = await callDo(
+      apiKey,
+      { capability_slug: slugA, inputs: { probe: "x" }, max_price_cents: PRICE_CENTS },
+      "k".repeat(300),
+    );
+    expect(res.status).toBe(400);
   }, 120_000);
 });

--- a/apps/api/src/routes/do.idempotency.integration.test.ts
+++ b/apps/api/src/routes/do.idempotency.integration.test.ts
@@ -173,7 +173,7 @@ describeMaybe("/v1/do idempotency against a real database", () => {
     expect(rows).toHaveLength(1);
   }, 120_000);
 
-  it("PINS BUG: a different payload under the same key replays the old result", async () => {
+  it("a different payload under the same key is a 409, not a replay (WP6 inverts the WP1 pin)", async () => {
     await seedCapability(slugA);
     const apiKey = await seedUser();
     const key = randomUUID();
@@ -189,16 +189,17 @@ describeMaybe("/v1/do idempotency against a real database", () => {
       key,
     );
 
-    // The key is not bound to a request fingerprint, so the second request's
-    // inputs are ignored and the caller is handed the first request's answer.
-    // A conflict (409) is the correct response. WP6 must make this fail.
-    expect(second.status).toBe(200);
+    // WP6 binds the key to a fingerprint of the request it was issued for, so
+    // reusing it for different inputs is a client bug rather than a retry.
+    // Pre-WP6 this returned 200 carrying the FIRST call's answer.
+    expect(second.status).toBe(409);
     const body = (await second.json()) as any;
-    expect(JSON.stringify(body)).toContain("original");
-    expect(JSON.stringify(body)).not.toContain("COMPLETELY DIFFERENT");
+    expect(body.error_code).toBe("idempotency_key_reused");
+    // And crucially it does NOT hand over the earlier result.
+    expect(JSON.stringify(body)).not.toContain("original");
   }, 120_000);
 
-  it("PINS BUG: a different capability under the same key returns the first one's output", async () => {
+  it("a different capability under the same key is a 409, not the first one's output (WP6)", async () => {
     await seedCapability(slugA);
     await seedCapability(slugB);
     const apiKey = await seedUser();
@@ -215,17 +216,19 @@ describeMaybe("/v1/do idempotency against a real database", () => {
       key,
     );
 
-    expect(second.status).toBe(200);
+    expect(second.status).toBe(409);
     const body = (await second.json()) as any;
 
-    // Capability A's output, returned for a request that asked for B — and the
-    // response labels it as B. That is worse than a stale replay: the caller
-    // is told it received something it did not.
-    expect(JSON.stringify(body.result ?? body)).toContain('"from":"A"');
-    expect(body.capability_used ?? body.result?.capability_used).toBe(slugB);
+    expect(body.error_code).toBe("idempotency_key_reused");
+
+    // The property that matters: capability A's output is NOT handed to a
+    // caller who asked for B. Pre-WP6 it was, and the response labelled it as
+    // B — worse than a stale replay, because the caller is told it received
+    // something it did not.
+    expect(JSON.stringify(body)).not.toContain('"from":"A"');
   }, 120_000);
 
-  it("PINS BUG: the same key from a different customer collides", async () => {
+  it("the same key from a different customer is independent (WP6)", async () => {
     await seedCapability(slugA);
     const apiKeyOne = await seedUser();
     const apiKeyTwo = await seedUser();
@@ -238,13 +241,16 @@ describeMaybe("/v1/do idempotency against a real database", () => {
 
     expect((await callDo(apiKeyOne, body, sharedKey)).status).toBe(200);
 
-    // The unique index is on idempotency_key alone, while the replay lookup is
-    // scoped by user. So customer two neither replays nor succeeds: the insert
-    // violates the constraint and surfaces as an unhandled 500. Two customers
-    // picking the same UUID is unlikely; a client using a deterministic key
-    // ("order-123") is not. It is also a weak oracle for whether a key exists
-    // anywhere on the platform. WP6 scopes the index to (user_id, key).
+    // WP6 scopes the unique index to (user_id, idempotency_key), so customer
+    // two's key is their own. Pre-WP6 the index was global while the replay
+    // lookup was per-user, so customer two neither replayed nor inserted and
+    // got an unhandled 500 — which also leaked whether a key existed anywhere
+    // on the platform.
     const other = await callDo(apiKeyTwo, body, sharedKey);
-    expect(other.status).toBe(500);
+    expect(other.status).toBe(200);
+
+    // Independent: customer two gets their OWN execution, not customer one's.
+    const otherBody = (await other.json()) as any;
+    expect(otherBody.meta?.idempotency_replay ?? false).toBe(false);
   }, 120_000);
 });

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -1,6 +1,10 @@
 import { Hono } from "hono";
 import { eq, and, gte, inArray, isNull, sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
+import {
+  computeIdempotencyFingerprint,
+  isReplayable,
+} from "../lib/idempotency-fingerprint.js";
 import * as settlementIntent from "../lib/x402-settlement-intent.js";
 import {
   assertBillableOutput,
@@ -524,12 +528,40 @@ doRoute.post(
   // ── 2. Idempotency check (authenticated only) ─────────────────────────
   const idempotencyKey = c.req.header("Idempotency-Key") || null;
 
+  // WP6: what the key is a key TO. Bound to the request it was first used for,
+  // so the same key reused for different work is a client bug (409) rather than
+  // a plausible-looking answer to a question the caller did not ask.
+  const idempotencyFingerprint = computeIdempotencyFingerprint({
+    task,
+    capabilitySlug,
+    inputs,
+  });
+
   if (idempotencyKey && user) {
     const [existing] = await db
       .select()
       .from(transactions)
       .where(and(eq(transactions.idempotencyKey, idempotencyKey), eq(transactions.userId, user.id), isNull(transactions.deletedAt)))
       .limit(1);
+
+    if (existing && !isReplayable(existing.idempotencyFingerprint, idempotencyFingerprint)) {
+      // The dangerous case, and the reason this package exists. Pre-WP6 this
+      // path returned the EARLIER call's output while echoing the slug the
+      // caller had just asked for — an answer to someone else's question,
+      // labelled as an answer to theirs. A deterministic key like "order-123"
+      // reused across two capabilities is far likelier than a UUID collision.
+      return c.json(
+        apiError(
+          "idempotency_key_reused",
+          "This Idempotency-Key was already used for a different request. " +
+            "A key identifies one specific request; reusing it for different " +
+            "inputs or a different capability is not a retry, so replaying the " +
+            "earlier result would answer a question you did not ask. Use a new key.",
+          { conflicting_transaction_id: existing.id },
+        ),
+        409,
+      );
+    }
 
     if (existing) {
       const [wallet] = await db
@@ -1104,15 +1136,15 @@ doRoute.post(
 
   // Free-tier with auth: skip wallet operations but still record transaction
   if (user && isFreeTier) {
-    return executeFreeTierAuthenticated(c, db, user, capability, executor, executionInput, idempotencyKey, outputSchema, freshness);
+    return executeFreeTierAuthenticated(c, db, user, capability, executor, executionInput, idempotencyKey, idempotencyFingerprint, outputSchema, freshness);
   }
 
   // Paid execution: sync or async (DEC-22)
   const isAsync = (capability.avgLatencyMs ?? 0) > ASYNC_THRESHOLD_MS;
   if (isAsync) {
-    return executeAsync(c, db, user, capability, executor, executionInput, idempotencyKey, outputSchema, freshness);
+    return executeAsync(c, db, user, capability, executor, executionInput, idempotencyKey, idempotencyFingerprint, outputSchema, freshness);
   } else {
-    return executeSync(c, db, user, capability, executor, executionInput, idempotencyKey, outputSchema, freshness);
+    return executeSync(c, db, user, capability, executor, executionInput, idempotencyKey, idempotencyFingerprint, outputSchema, freshness);
   }
 });
 
@@ -1525,6 +1557,7 @@ async function executeFreeTierAuthenticated(
   executor: (input: Record<string, unknown>) => Promise<any>,
   executionInput: Record<string, unknown>,
   idempotencyKey: string | null,
+  idempotencyFingerprint: string,
   outputSchema: Record<string, unknown>,
   freshness: FreshnessInfo | null,
 ) {
@@ -1700,6 +1733,7 @@ async function executeSync(
   executor: (input: Record<string, unknown>) => Promise<any>,
   executionInput: Record<string, unknown>,
   idempotencyKey: string | null,
+  idempotencyFingerprint: string,
   outputSchema: Record<string, unknown>,
   freshness: FreshnessInfo | null,
 ) {
@@ -1826,6 +1860,7 @@ async function executeSync(
         userId: user.id,
         capabilityId: capability.id,
         idempotencyKey,
+        idempotencyFingerprint,
         status: "executing",
       clientMeta: (c.get("clientMeta" as any) as object | null) ?? null,
         input: executionInput,
@@ -2125,6 +2160,7 @@ async function executeAsync(
   executor: (input: Record<string, unknown>) => Promise<any>,
   executionInput: Record<string, unknown>,
   idempotencyKey: string | null,
+  idempotencyFingerprint: string,
   outputSchema: Record<string, unknown>,
   freshness: FreshnessInfo | null,
 ) {
@@ -2192,6 +2228,7 @@ async function executeAsync(
         userId: user.id,
         capabilityId: capability.id,
         idempotencyKey,
+        idempotencyFingerprint,
         status: "executing",
       clientMeta: (c.get("clientMeta" as any) as object | null) ?? null,
         input: executionInput,

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -527,21 +527,45 @@ doRoute.post(
 
   // ── 2. Idempotency check (authenticated only) ─────────────────────────
   const idempotencyKey = c.req.header("Idempotency-Key") || null;
+  // The column is varchar(255); an over-long key reached the INSERT and raised
+  // Postgres 22001, which the executeSync catch does not recognise and which
+  // therefore surfaced as a 500. Newly reachable now that A2A forwards a
+  // caller-controlled header, and a clear 400 is the honest answer either way.
+  if (idempotencyKey && idempotencyKey.length > 255) {
+    return c.json(
+      apiError(
+        "invalid_request",
+        "Idempotency-Key must be 255 characters or fewer.",
+      ),
+      400,
+    );
+  }
 
   // WP6: what the key is a key TO. Bound to the request it was first used for,
   // so the same key reused for different work is a client bug (409) rather than
   // a plausible-looking answer to a question the caller did not ask.
   const idempotencyFingerprint = computeIdempotencyFingerprint({
+    rail: "capability",
     task,
     capabilitySlug,
     inputs,
+    dryRun: body.dry_run === true,
+    requireFresh: body.require_fresh === true,
   });
 
   if (idempotencyKey && user) {
     const [existing] = await db
       .select()
       .from(transactions)
-      .where(and(eq(transactions.idempotencyKey, idempotencyKey), eq(transactions.userId, user.id), isNull(transactions.deletedAt)))
+      // Scoped to the capability rail. A key is per-customer, but it is not
+      // per-PLATFORM: without this, a prior solution row could be replayed as a
+      // capability result. The solutions route carries the mirror of this.
+      .where(and(
+        eq(transactions.idempotencyKey, idempotencyKey),
+        eq(transactions.userId, user.id),
+        isNull(transactions.solutionSlug),
+        isNull(transactions.deletedAt),
+      ))
       .limit(1);
 
     if (existing && !isReplayable(existing.idempotencyFingerprint, idempotencyFingerprint)) {
@@ -1571,6 +1595,14 @@ async function executeFreeTierAuthenticated(
       userId: user.id,
       capabilityId: capability.id,
       idempotencyKey,
+      // Review finding, and the sharpest kind: the parameter was threaded into
+      // this function and then never written, so it READ as done. Every
+      // authenticated free-tier call carrying a key produced a row with a NULL
+      // fingerprint — and a NULL fingerprint is replayable by design, so the
+      // guard was permanently off for this path rather than off for a draining
+      // legacy set. tsc cannot catch an unused parameter, and the integration
+      // tests all seed paid capabilities, so nothing exercised it.
+      idempotencyFingerprint,
       status: "executing",
       clientMeta: (c.get("clientMeta" as any) as object | null) ?? null,
       input: executionInput,

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -15,8 +15,12 @@
  */
 
 import { Hono } from "hono";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { getDb } from "../db/index.js";
+import {
+  computeIdempotencyFingerprint,
+  isReplayable,
+} from "../lib/idempotency-fingerprint.js";
 import { extractClientMeta } from "../lib/attribution.js";
 import { solutions, wallets, walletTransactions, transactions } from "../db/schema.js";
 import { authMiddleware } from "../lib/middleware.js";
@@ -58,6 +62,14 @@ solutionExecuteRoute.post(
     }
 
     const inputs = body.inputs;
+
+    // WP6: bound to the bundle and its inputs, exactly as on the capability
+    // rail, so one helper defines what "the same request" means everywhere.
+    const idempotencyKey = c.req.header("Idempotency-Key") || null;
+    const idempotencyFingerprint = computeIdempotencyFingerprint({
+      capabilitySlug: slug,
+      inputs: inputs as Record<string, unknown> | null,
+    });
     if (!inputs || typeof inputs !== "object" || Array.isArray(inputs)) {
       return c.json(
         apiError("invalid_request", "'inputs' is required and must be an object."),
@@ -115,6 +127,30 @@ solutionExecuteRoute.post(
     try {
       const txResult = await db.transaction(async (tx) => {
         // Lock wallet row
+        // WP6: idempotency on the most expensive SKUs. Solutions had NO replay
+        // guard at all, so a client retrying a €2.50 call — a timeout, a proxy
+        // redelivery, an agent's own retry loop — was charged again. The
+        // capability rail has had this since MVP; the bundle rail never did.
+        if (idempotencyKey) {
+          const [prior] = await tx
+            .select()
+            .from(transactions)
+            .where(
+              and(
+                eq(transactions.idempotencyKey, idempotencyKey),
+                eq(transactions.userId, user.id),
+                isNull(transactions.deletedAt),
+              ),
+            )
+            .limit(1);
+
+          if (prior) {
+            return isReplayable(prior.idempotencyFingerprint, idempotencyFingerprint)
+              ? { ok: false as const, replayOf: prior }
+              : { ok: false as const, keyConflictWith: prior.id };
+          }
+        }
+
         const [wallet] = await tx
           .select()
           .from(wallets)
@@ -136,6 +172,8 @@ solutionExecuteRoute.post(
             capabilityId: null,
             solutionSlug: sol.slug,
             status: "executing",
+            idempotencyKey,
+            idempotencyFingerprint,
             clientMeta: extractClientMeta(c.req, {
               src: c.req.query("src"),
               ip: c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? c.req.header("cf-connecting-ip"),
@@ -186,6 +224,40 @@ solutionExecuteRoute.post(
           reservationId: reservation.id,
         };
       });
+
+      // WP6: three distinct not-ok shapes now share this branch, and they mean
+      // very different things to the caller. Discriminate before assuming the
+      // wallet one, or a replay would be reported as insufficient funds.
+      if (!txResult.ok && "keyConflictWith" in txResult) {
+        return c.json(
+          apiError(
+            "idempotency_key_reused",
+            "This Idempotency-Key was already used for a different request. " +
+              "A key identifies one specific request; reusing it for different " +
+              "inputs or a different solution is not a retry. Use a new key.",
+            { conflicting_transaction_id: txResult.keyConflictWith },
+          ),
+          409,
+        );
+      }
+
+      if (!txResult.ok && "replayOf" in txResult) {
+        // The whole point: the bundle is NOT executed again and NOT charged
+        // again. Pre-WP6 a retry of a €2.50 solution simply ran and billed a
+        // second time.
+        const prior = txResult.replayOf!;
+        return c.json({
+          result: {
+            transaction_id: prior.id,
+            solution_slug: sol.slug,
+            status: prior.status,
+            steps: (prior.output as { steps?: unknown } | null)?.steps ?? prior.output,
+            price_cents: prior.priceCents,
+            latency_ms: prior.latencyMs,
+          },
+          meta: { idempotency_replay: true, audit: prior.auditTrail },
+        });
+      }
 
       if (!txResult.ok) {
         return c.json(

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -67,6 +67,7 @@ solutionExecuteRoute.post(
     // rail, so one helper defines what "the same request" means everywhere.
     const idempotencyKey = c.req.header("Idempotency-Key") || null;
     const idempotencyFingerprint = computeIdempotencyFingerprint({
+      rail: "solution",
       capabilitySlug: slug,
       inputs: inputs as Record<string, unknown> | null,
     });
@@ -139,15 +140,34 @@ solutionExecuteRoute.post(
               and(
                 eq(transactions.idempotencyKey, idempotencyKey),
                 eq(transactions.userId, user.id),
+                // Review finding, and it would have been live on day one:
+                // without this the lookup matched ANY prior row with that key,
+                // including the 421 existing capability rows — every one of
+                // which carries a NULL fingerprint, because solutions never
+                // wrote keys before. A customer reusing an old /v1/do key on a
+                // KYB bundle would have received that capability's payload,
+                // labelled as a KYB Complete result, on the product whose
+                // entire selling point is the audit trail. No charge, so not a
+                // double-charge — a wrong-answer defect, which is the class
+                // this package exists to close.
+                eq(transactions.solutionSlug, sol.slug),
                 isNull(transactions.deletedAt),
               ),
             )
             .limit(1);
 
           if (prior) {
-            return isReplayable(prior.idempotencyFingerprint, idempotencyFingerprint)
-              ? { ok: false as const, replayOf: prior }
-              : { ok: false as const, keyConflictWith: prior.id };
+            if (!isReplayable(prior.idempotencyFingerprint, idempotencyFingerprint)) {
+              return { ok: false as const, keyConflictWith: prior.id };
+            }
+            // Only a COMPLETED run is a replay. A prior failure is exactly when
+            // a client retries, and short-circuiting would hand back HTTP 200
+            // carrying status:"failed" with a non-zero price — read as success
+            // by anything keying off response.ok. Re-executing is what the
+            // caller wants and what happened before this package existed.
+            if (prior.status === "completed") {
+              return { ok: false as const, replayOf: prior };
+            }
           }
         }
 

--- a/apps/api/src/routes/solution-reservations.integration.test.ts
+++ b/apps/api/src/routes/solution-reservations.integration.test.ts
@@ -261,4 +261,66 @@ describeMaybe("solution execution holds a wallet reservation", () => {
     const reservations = await import("../lib/wallet-reservations.js");
     expect(await reservations.findAbandoned(db)).toHaveLength(0);
   }, 120_000);
+
+  it("a retried solution is not charged twice (WP6)", async () => {
+    // Solutions had NO replay guard at all. A client retrying a EUR 2.50 call —
+    // a timeout, a proxy redelivery, an agent's own retry loop — was charged
+    // again. The capability rail has had idempotency since MVP; the bundle
+    // rail, which carries the platform's most expensive SKUs, never did.
+    await seed();
+    stepShouldFail = false;
+    const key = randomUUID();
+
+    const first = await app.request(`http://localhost/v1/solutions/${solSlug}/execute`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "Idempotency-Key": key,
+      },
+      body: JSON.stringify({ inputs: { probe: "wp6" } }),
+    });
+    expect(first.status).toBe(200);
+    const afterFirst = await balance();
+    expect(afterFirst).toBe(STARTING_BALANCE - SOLUTION_PRICE);
+
+    const retry = await app.request(`http://localhost/v1/solutions/${solSlug}/execute`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "Idempotency-Key": key,
+      },
+      body: JSON.stringify({ inputs: { probe: "wp6" } }),
+    });
+    expect(retry.status).toBe(200);
+
+    const retryBody = (await retry.json()) as Record<string, any>;
+    expect(retryBody.meta?.idempotency_replay).toBe(true);
+
+    // The property that matters: the balance did not move again.
+    expect(await balance()).toBe(afterFirst);
+  }, 120_000);
+
+  it("the same key for DIFFERENT inputs is a 409, not a replay (WP6)", async () => {
+    await seed();
+    stepShouldFail = false;
+    const key = randomUUID();
+
+    const call = (probe: string) =>
+      app.request(`http://localhost/v1/solutions/${solSlug}/execute`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          "Idempotency-Key": key,
+        },
+        body: JSON.stringify({ inputs: { probe } }),
+      });
+
+    expect((await call("first")).status).toBe(200);
+    const conflict = await call("SOMETHING ELSE");
+    expect(conflict.status).toBe(409);
+    expect(((await conflict.json()) as any).error_code).toBe("idempotency_key_reused");
+  }, 120_000);
 });

--- a/docs/remediation/CURRENT-STATE.md
+++ b/docs/remediation/CURRENT-STATE.md
@@ -2,13 +2,47 @@
 
 _Last updated: 2026-08-21 (session 1)_
 
-- **Current package:** WP5 — ACCEPTED, merged as `8b4b653` (PR #352), verified live.
-- **Next package:** WP7 (audit finality) — WP6 follows per the package order
+- **Current package:** WP7 — ACCEPTED, merged as `8d6c860` (PR #353), verified live.
+- **Next package:** WP6 — idempotency & replay (WP1 already pinned its acceptance signal)
 - **WP3:** ACCEPTED, merged as `ee7f737` (PR #350), verified live in production — table, all three indexes, and the CHECK constraint reached `validated=true`.
 - **Latest accepted SHA:** `ee7f737` on `main`
 - **Unresolved blockers:** none
 - **Human approvals granted:** program-level autonomy (run continuously; escalate only per CHECK-IN A/B/C)
 - **Awaiting founder:** nothing. One item is logged for *visibility only*, not decision — see "Codex disposition" below.
+
+## Where WP7 landed — the biggest finding of the program
+
+**The audit chain had not been a chain since 2026-05-04.** One parent held
+150,719 children. Found by querying production, not by reading the audit.
+
+`getPreviousHash` ordered by `completed_at DESC`, and Postgres sorts NULLs
+FIRST under DESC, so a `health_probe` row with a null `completed_at` held the
+head permanently. A star has no sequence, so the chain evidenced nothing about
+ordering or deletion — the whole tamper-evidence property.
+
+**And the generator was still running.** `/health/deep` used a data-modifying
+CTE whose DELETE ran against a snapshot predating its own INSERT, so it never
+deleted anything: one leaked row per call on a public endpoint, 200 in August.
+One of the May rows is the 150,719-child parent. Now zero in 20 minutes of
+production traffic.
+
+**My first fix did not fix it.** I made the sort keys agree and left the
+admission key different. The reviewer replayed the rule over 30 days of real
+rows: nine new forks. `completed_at` is stamped from a clock read BEFORE the
+row's own `created_at` default (median −1.5 ms), so it cannot define a head at
+all. The head is now `chain_seq`, assigned at hash time — the last row the
+worker actually hashed.
+
+The general lesson, and it is not specific to hashing: **a head derived from a
+wall-clock column is not a head.** Wall clocks are not monotone with the order
+work actually happens in.
+
+History is deliberately not rewritten. Recomputing 863,946 hashes would erase
+the evidence the break happened. Single-parent is now CHECKED daily by a
+scheduled job — a unique index would abort boot on the existing forks.
+
+Verified live: column and sequence present, exactly one seeded head (a
+completed row, continuing the chain rather than starting a second root).
 
 ## Where WP5 landed
 

--- a/docs/remediation/packages/WP6.yaml
+++ b/docs/remediation/packages/WP6.yaml
@@ -1,0 +1,73 @@
+package: WP6
+title: Idempotency & replay — bind the key to the request
+status: REMEDIATED
+depends_on: [WP4]
+risks: [CR-03, N4]
+
+objective: >
+  An Idempotency-Key means "this is the same request as before; do not perform
+  it twice". It does not mean "return whatever I got last time I used this
+  string". Without a record of what the key was issued FOR, those readings are
+  indistinguishable — and the platform implemented the second.
+
+acceptance_signal: >
+  WP1 left three failing tests in place specifically as this package's signal.
+  All three inverted, and all three verified discriminating by mutation.
+
+defects_closed:
+  - "a different payload under the same key replayed the old result"
+  - "a different capability under the same key returned the FIRST one's output, while the response echoed the slug the caller had just asked for — an answer to someone else's question, labelled as an answer to theirs"
+  - "the same key from a different customer 500'd: the unique index was global while the replay lookup was per-user, which also leaked whether a key existed anywhere on the platform"
+
+beyond_the_pins:
+  solutions_had_no_guard_at_all: >
+    A client retrying a EUR 2.50 solution — a timeout, a proxy redelivery, an
+    agent's own retry loop — was charged twice. The capability rail has had
+    idempotency since MVP; the bundle rail, carrying the most expensive SKUs,
+    never did.
+  a2a_dropped_the_header: >
+    It forwarded only Content-Type and Authorization, so an A2A client could not
+    make a retry safe no matter what it sent. A proxy that drops the header
+    silently converts an idempotent request into a repeatable charge.
+  x402_deliberately_untouched: >
+    Payment IS the key there, and the rail already dedups on a hash of the
+    payment header (cert-audit C9).
+
+review:
+  codex: deferred_to_final_pass
+  independent_agent: FAIL_REMEDIATION_REQUIRED, then all findings closed
+
+  blocking_1_parameter_threaded_but_never_written: >
+    executeFreeTierAuthenticated took idempotencyFingerprint and never wrote it,
+    so every authenticated free-tier call carrying a key produced a NULL
+    fingerprint — which replays by design. The guard was permanently OFF for
+    that path, not off for a draining legacy set. The parameter's PRESENCE is
+    what made it read as done; tsc cannot flag an unused parameter, and every
+    integration case seeded a paid capability so nothing exercised the path.
+    Production has 20 such rows across the free tier.
+
+  blocking_2_replay_crossed_the_rails: >
+    The solutions lookup matched ANY prior row with that key. All 421 existing
+    keyed rows are capability rows with a NULL fingerprint, because solutions
+    never wrote keys before. A customer reusing an old /v1/do key on a KYB
+    bundle would have received that capability's payload labelled as a KYB
+    Complete result — on the product whose entire selling point is the audit
+    trail. Not a double-charge; a wrong-answer defect, which is the class this
+    package exists to close, being introduced BY this package.
+
+  non_blocking_closed:
+    - "a replayed FAILED solution returned HTTP 200 with status:failed and a non-zero price; a prior failure is exactly when clients retry, so those now re-execute"
+    - "dry_run and require_fresh were outside the fingerprint: a replay answered what DID happen to someone asking what WOULD happen, and returned before the freshness gate"
+    - "migration 0098 could abort boot on lock contention — CREATE UNIQUE INDEX on a 902k-row table takes SHARE, a pending SHARE queues every write behind it, and lock wait counts toward statement_timeout. Now bounded and deferring, the same shape block 0095 chose for wallets."
+    - "A2A forwarded the key even when the skill was resolved by the suggest engine, so an identical retry that re-ranked differently would be told it reused a key for a different request — false, and unactionable"
+    - "over-long keys raised Postgres 22001 and surfaced as a 500; now a 400"
+    - "block 0098 has no behavioural test: CI materialises the schema from schema.ts before migrations run, so its statements are no-ops there. Post-deploy prod query is the only verification (DEC-20260504-C)."
+
+exit_conditions:
+  - key bound to (principal, fingerprint, capability)   # MET
+  - user-scoped unique index                            # MET (prod-checked first: 0 dupes, 0 null-user)
+  - coverage on solutions                               # MET (had none at all)
+  - coverage on A2A                                     # MET (header was dropped)
+  - coverage on MCP                                     # inherits /v1/do; proxies rather than executing
+  - coverage on x402-via-do                             # MET (the /v1/do x402 path settles inside executeFreeTier, which now writes the fingerprint)
+  - independent adversarial review passes               # MET after remediation

--- a/docs/remediation/packages/WP7.yaml
+++ b/docs/remediation/packages/WP7.yaml
@@ -1,6 +1,8 @@
 package: WP7
 title: Audit finality — the chain must actually be a chain
-status: REMEDIATED
+status: ACCEPTED
+merged_sha: 8d6c860
+merged_pr: 353
 depends_on: [WP4]
 risks: [CR-04]
 


### PR DESCRIPTION
## What an idempotency key is a key *to*

An `Idempotency-Key` means "this is the same request as before; do not perform it twice." It does not mean "return whatever I got last time I used this string." Without a record of what the key was issued **for**, those readings are indistinguishable — and the platform implemented the second.

WP1 left three failing tests in place as this package's acceptance signal. All three now invert:

- a different payload under the same key **replayed the old result**
- a different capability under the same key **returned the first one's output**, while the response echoed the slug the caller had just asked for — an answer to someone else's question, labelled as an answer to theirs
- the same key from a different customer **500'd**, because the unique index was global while the replay lookup was per-user — which also leaked whether a key existed anywhere on the platform

Reusing `order-123` across two calls is far likelier than a UUID collision.

## Two gaps beyond the pins, both money

**Solutions had no replay guard at all.** A client retrying a €2.50 call — a timeout, a proxy redelivery, an agent's own retry loop — was charged twice. The capability rail has had idempotency since MVP; the bundle rail, carrying the most expensive SKUs, never did.

**A2A dropped the header**, forwarding only `Content-Type` and `Authorization`, so those clients could not make a retry safe no matter what they sent. A proxy that drops the header silently converts an idempotent request into a repeatable charge.

x402 is deliberately untouched: payment *is* the key there, and the rail already dedups on a hash of the payment header.

## The review found two blocking defects, both mine

**1. A parameter threaded in and never written.** `executeFreeTierAuthenticated` took `idempotencyFingerprint` and never wrote it, so every authenticated free-tier call carrying a key produced a NULL fingerprint — which replays *by design*. The guard was permanently off for that path, not off for a draining legacy set. The parameter's **presence** is what made it read as done; `tsc` cannot flag an unused parameter, and every integration case seeded a paid capability, so nothing exercised it. Production has 20 such rows.

**2. The replay crossed the rails.** The solutions lookup matched *any* prior row with that key. All 421 existing keyed rows are capability rows with a NULL fingerprint, because solutions never wrote keys before. A customer reusing an old `/v1/do` key on a KYB bundle would have received that capability's payload **labelled as a KYB Complete result** — on the product whose entire selling point is the audit trail. Not a double-charge: a wrong-answer defect, which is the class this package exists to close, being introduced by this package.

Both rails now scope their lookup to their own rail, and the fingerprint carries a rail discriminator so the two slug namespaces cannot collide even in principle.

## Five more, closed

- A replayed **failed** solution returned HTTP 200 with `status: "failed"` and a non-zero price. A prior failure is exactly when clients retry; those now re-execute.
- **`dry_run` and `require_fresh`** are now in the fingerprint. A replay answered *what did happen* to someone asking *what would happen*, and returned before the freshness gate — handing back precisely what the gate exists to refuse.
- **Migration 0098 could abort boot.** `CREATE UNIQUE INDEX` on a 902k-row table takes `SHARE`; a pending `SHARE` queues every write behind it, and lock wait counts toward the 30s `statement_timeout`. It now bounds the wait and defers to the next boot — the same shape block 0095 chose for `wallets`.
- **A2A forwards the key only when the caller named the skill.** When it's resolved by the suggest engine, an identical retry that re-ranks differently would be told it reused a key for a different request — false, and unactionable since the client never chose the slug.
- Over-long keys are a **400**, not a Postgres `22001` surfacing as a 500.

## Verification

Production checked read-only before the index change: 0 duplicate `(user_id, key)` pairs across 421 keyed rows, 0 keyed rows with a null user. Create-before-drop, so the old stricter index is in force throughout the window.

Every fix verified discriminating by mutation, including the free-tier one that had no coverage before.

**Known gap, stated rather than papered over:** block 0098 has no behavioural test. CI materialises the schema from `schema.ts` *before* migrations run, so the block's statements are no-ops there. The post-deploy production query is the only real verification (DEC-20260504-C), and I'll run it.

16 gates pass. 2,250 unit tests; 101 integration tests across 15 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
