### PR TITLE
Remediation WP8: solutions were running capabilities the platform had withdrawn

### DIFF
--- a/apps/api/scripts/ceo-dashboard.ts
+++ b/apps/api/scripts/ceo-dashboard.ts
@@ -271,7 +271,10 @@ async function main() {
         icon("pulse", hv && hv.breakersOpen > 0 ? "i-warn" : "i-good")}</div>
         <div class="kval">${hv ? `${hv.breakersOpen}<span class="unit"> switched off</span>` : "—"}</div>
         <div class="kfoot">${hv
-          ? `${hv.active} data services working · ${hv.quarantined} paused`
+          // WP8: renamed from `quarantined`, which the number never was — most
+          // of it is pre-launch capabilities, not paused ones. "not yet live"
+          // covers both honestly for a founder-facing dashboard.
+          ? `${hv.active} data services working · ${hv.withheldFromCatalog} not yet live`
           : healthNote}</div></div>
 
       <div class="kpi"><div class="krow"><span class="klabel">Money spent this week</span>${

--- a/apps/api/src/lib/execution-outcome.ts
+++ b/apps/api/src/lib/execution-outcome.ts
@@ -175,6 +175,10 @@ export function assessOutput(
 
   if (obj.skipped === true) quality_flags.push("step_skipped");
   if (obj.unavailable === true) quality_flags.push("step_unavailable");
+  // WP8: the platform WITHHELD this component (quarantined or deactivated).
+  // Distinct from "not deployed" because it changes the economics: a component
+  // we removed is our decision, not partial delivery the customer chose.
+  if (obj.platform_withheld === true) quality_flags.push("platform_withheld");
 
   const isFailureMarker = isExecutorFailureMarker(obj);
   if (isFailureMarker) quality_flags.push("executor_error_marker");
@@ -369,6 +373,38 @@ export function aggregateSolutionOutcome(
 ): SolutionOutcome {
   const steps_total = stepOutcomes.length;
   const steps_succeeded = stepOutcomes.filter((o) => o.success).length;
+
+  // WP8 remediation. This rule first shipped inside routes/solution-execute.ts,
+  // so the WALLET rail applied it and the x402 rail did not — a partially
+  // successful x402 run with a withheld component would still have settled full
+  // price. That is CR-02 exactly: one economic fact, two rails, two answers.
+  // Putting it here is the whole point of this module; putting it in a rail was
+  // a violation of the principle the module exists to enforce.
+  //
+  // Precedence over the gate check below is deliberate. Both make a run
+  // unbillable, but a withheld component is the more specific explanation and
+  // the one an operator needs to see: the gate tripped because WE removed the
+  // thing behind it.
+  const withheld = stepOutcomes.filter((o) =>
+    o.output_assessment?.quality_flags.includes("platform_withheld"),
+  );
+  if (withheld.length > 0) {
+    return {
+      success: false,
+      failure_class: "output_unusable",
+      billable: false,
+      retryable: false,
+      // Not the capability's fault and not the customer's — ours.
+      fault: "strale",
+      output_assessment: null,
+      counts_against_capability: false,
+      error_message:
+        `${withheld.length} component(s) were withheld by Strale (quarantined or ` +
+        "deactivated); the bundle could not be delivered in full and was not charged",
+      steps_total,
+      steps_succeeded,
+    };
+  }
 
   if (gate) {
     return { ...outcomeFromGate(gate), steps_total, steps_succeeded };

--- a/apps/api/src/lib/matching.ts
+++ b/apps/api/src/lib/matching.ts
@@ -43,6 +43,10 @@ export async function matchCapability(
         and(
           eq(capabilities.slug, req.capabilitySlug),
           eq(capabilities.isActive, true),
+          // Quarantine is unbypassable by naming the slug. The floor sets
+          // visible=false, so omitting this would let an explicit /v1/do call
+          // reach a capability the platform had just withdrawn.
+          eq(capabilities.visible, true),
           // WP8: the shared servability floor, not a third rule.
           //
           // This admitted 'degraded' — a state every other rail refuses — so a

--- a/apps/api/src/lib/matching.ts
+++ b/apps/api/src/lib/matching.ts
@@ -1,6 +1,7 @@
 import { eq, and, inArray } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { capabilities } from "../db/schema.js";
+import { SERVABLE_LIFECYCLE_STATES } from "./x402-eligibility.js";
 import { tokenize } from "./tokenize.js";
 
 type CapabilityRow = typeof capabilities.$inferSelect;
@@ -42,8 +43,21 @@ export async function matchCapability(
         and(
           eq(capabilities.slug, req.capabilitySlug),
           eq(capabilities.isActive, true),
-          // Probation allows internal testing by slug; draft/validating/suspended blocked
-          inArray(capabilities.lifecycleState, ["active", "degraded", "probation"]),
+          // WP8: the shared servability floor, not a third rule.
+          //
+          // This admitted 'degraded' — a state every other rail refuses — so a
+          // capability the platform had assessed as failing could still be
+          // bought by naming it explicitly. That is quarantine-bypass in
+          // another costume: an assessment that does not bind is not an
+          // assessment. Behaviour change recorded rather than slipped in; it
+          // has no live effect today because no capability is currently both
+          // degraded and active.
+          //
+          // Probation stays, which is what the original comment was protecting.
+          inArray(
+            capabilities.lifecycleState,
+            [...SERVABLE_LIFECYCLE_STATES],
+          ),
         ),
       )
       .limit(1);
@@ -64,6 +78,12 @@ export async function matchCapability(
       and(
         eq(capabilities.isActive, true),
         eq(capabilities.visible, true),
+        // Deliberately STRICTER than the servability floor, and allowed to be.
+        // The floor answers "may this be served if asked for"; automatic
+        // routing additionally requires that we are willing to CHOOSE it, and
+        // 'probation' means not yet. A rail may be stricter than the authority.
+        // It may never be more permissive — that is the direction that produced
+        // the divergence WP8 exists to remove.
         eq(capabilities.lifecycleState, "active"),
       ),
     );

--- a/apps/api/src/lib/metrics/metrics.ts
+++ b/apps/api/src/lib/metrics/metrics.ts
@@ -326,9 +326,15 @@ export interface PlatformHealth { breakersOpen: number; active: number; quaranti
  * the states in production are active, deactivated, degraded, probation and
  * validating. The quality floor quarantines by clearing `visible` and
  * `x402_enabled` (jobs/quality-floor.ts), so this gauge reported 0 no matter
- * how many capabilities the armed floor had quarantined. Nine are quarantined
- * as of this change; the dashboard said zero, and an operator watching it would
- * conclude the floor never fires.
+ * how many capabilities the armed floor had quarantined.
+ *
+ * What it counts now is WITHHELD FROM THE CATALOGUE — nine rows today, of which
+ * only one (page-speed-test) is a floor quarantine; the rest are pre-launch
+ * capabilities hidden by the onboarding pipeline. That conflation is deliberate
+ * and disclosed rather than silently precise-looking: both groups are "not
+ * currently offered", which is what an operator reading this number wants to
+ * know. A quarantine-only count needs health_monitor_events minus subsequent
+ * promotions, which is a different measurement and belongs with the floor.
  */
 export async function platformHealth(): Promise<Measurement<PlatformHealth>> {
   const r = await rows<{ breakers: string; active: string; quarantined: string }>(sql`

--- a/apps/api/src/lib/metrics/metrics.ts
+++ b/apps/api/src/lib/metrics/metrics.ts
@@ -319,12 +319,23 @@ export async function topSellers(w: Window, limit = 6): Promise<Measurement<TopS
 export interface PlatformHealth { breakersOpen: number; active: number; quarantined: number }
 
 /** Operational state. A point-in-time reading, so its window is "now". */
+/**
+ * WP8: `quarantined` counts what quarantine ACTUALLY is.
+ *
+ * It read `lifecycle_state = 'quarantined'`, and that value does not exist —
+ * the states in production are active, deactivated, degraded, probation and
+ * validating. The quality floor quarantines by clearing `visible` and
+ * `x402_enabled` (jobs/quality-floor.ts), so this gauge reported 0 no matter
+ * how many capabilities the armed floor had quarantined. Nine are quarantined
+ * as of this change; the dashboard said zero, and an operator watching it would
+ * conclude the floor never fires.
+ */
 export async function platformHealth(): Promise<Measurement<PlatformHealth>> {
   const r = await rows<{ breakers: string; active: string; quarantined: string }>(sql`
     SELECT (SELECT COUNT(*)::int FROM capability_health WHERE state <> 'closed') AS breakers,
            (SELECT COUNT(*)::int FROM capabilities WHERE is_active) AS active,
            (SELECT COUNT(*)::int FROM capabilities
-             WHERE is_active AND lifecycle_state = 'quarantined') AS quarantined`);
+             WHERE is_active AND NOT visible) AS quarantined`);
   const now = new Date();
   return {
     status: "observed",

--- a/apps/api/src/lib/metrics/metrics.ts
+++ b/apps/api/src/lib/metrics/metrics.ts
@@ -316,11 +316,11 @@ export async function topSellers(w: Window, limit = 6): Promise<Measurement<TopS
   };
 }
 
-export interface PlatformHealth { breakersOpen: number; active: number; quarantined: number }
+export interface PlatformHealth { breakersOpen: number; active: number; withheldFromCatalog: number }
 
 /** Operational state. A point-in-time reading, so its window is "now". */
 /**
- * WP8: `quarantined` counts what quarantine ACTUALLY is.
+ * WP8: named for what it MEASURES.
  *
  * It read `lifecycle_state = 'quarantined'`, and that value does not exist —
  * the states in production are active, deactivated, degraded, probation and
@@ -328,7 +328,8 @@ export interface PlatformHealth { breakersOpen: number; active: number; quaranti
  * `x402_enabled` (jobs/quality-floor.ts), so this gauge reported 0 no matter
  * how many capabilities the armed floor had quarantined.
  *
- * What it counts now is WITHHELD FROM THE CATALOGUE — nine rows today, of which
+ * It was renamed rather than left as `quarantined`, because it counts WITHHELD
+ * FROM THE CATALOGUE — nine rows today, of which
  * only one (page-speed-test) is a floor quarantine; the rest are pre-launch
  * capabilities hidden by the onboarding pipeline. That conflation is deliberate
  * and disclosed rather than silently precise-looking: both groups are "not
@@ -337,18 +338,18 @@ export interface PlatformHealth { breakersOpen: number; active: number; quaranti
  * promotions, which is a different measurement and belongs with the floor.
  */
 export async function platformHealth(): Promise<Measurement<PlatformHealth>> {
-  const r = await rows<{ breakers: string; active: string; quarantined: string }>(sql`
+  const r = await rows<{ breakers: string; active: string; withheld_from_catalog: string }>(sql`
     SELECT (SELECT COUNT(*)::int FROM capability_health WHERE state <> 'closed') AS breakers,
            (SELECT COUNT(*)::int FROM capabilities WHERE is_active) AS active,
            (SELECT COUNT(*)::int FROM capabilities
-             WHERE is_active AND NOT visible) AS quarantined`);
+             WHERE is_active AND NOT visible) AS withheld_from_catalog`);
   const now = new Date();
   return {
     status: "observed",
     value: {
       breakersOpen: Number(r[0]?.breakers ?? 0),
       active: Number(r[0]?.active ?? 0),
-      quarantined: Number(r[0]?.quarantined ?? 0),
+      withheldFromCatalog: Number(r[0]?.withheld_from_catalog ?? 0),
     },
     window: { from: now, to: now, label: "right now" },
     population: "all_transactions", instruments: [],

--- a/apps/api/src/lib/solution-executor.ts
+++ b/apps/api/src/lib/solution-executor.ts
@@ -16,8 +16,9 @@
 
 import { eq } from "drizzle-orm";
 import { getDb } from "../db/index.js";
-import { solutionSteps } from "../db/schema.js";
+import { capabilities, solutionSteps } from "../db/schema.js";
 import { getExecutor } from "../capabilities/index.js";
+import { isServableCapability } from "./x402-eligibility.js";
 import {
   assertGuardedAllow,
   CapabilityInvocationRefusedError,
@@ -331,6 +332,9 @@ export async function executeSolution(
   inputs: Record<string, unknown>,
 ): Promise<SolutionExecutionResult | null> {
   const db = getDb();
+  // WP8: the step's own eligibility comes back with it. A LEFT JOIN, not an
+  // inner one — a step naming a capability that no longer exists must still
+  // appear in the audit trail rather than vanishing from the step list.
   const steps = await db
     .select({
       capabilitySlug: solutionSteps.capabilitySlug,
@@ -339,8 +343,11 @@ export async function executeSolution(
       canParallel: solutionSteps.canParallel,
       parallelGroup: solutionSteps.parallelGroup,
       gateCondition: solutionSteps.gateCondition,
+      capIsActive: capabilities.isActive,
+      capLifecycleState: capabilities.lifecycleState,
     })
     .from(solutionSteps)
+    .leftJoin(capabilities, eq(capabilities.slug, solutionSteps.capabilitySlug))
     .where(eq(solutionSteps.solutionId, solutionId))
     .orderBy(solutionSteps.stepOrder);
 
@@ -394,15 +401,40 @@ export async function executeSolution(
 
   for (const { steps: groupSteps } of sortedGroups) {
     const executions = groupSteps.map(async (step) => {
-      const executor = getExecutor(step.capabilitySlug);
+      // WP8: is this capability fit to run at all? Checked BEFORE the executor
+      // lookup, because a registered executor for a quarantined capability is
+      // exactly the case that used to slip through — the code was present, so
+      // the step ran, even though the platform had decided to stop serving it.
+      //
+      // Solution steps consulted no eligibility rule of any kind before this.
+      // Not yet a live incident (every offending step in production sits in an
+      // already-inactive solution), but 103 live solutions depend on 99
+      // capabilities and 19 moved to a non-servable state in the last 90 days,
+      // with the quality floor quarantining automatically. The gap was one
+      // quarantine away from putting a delisted capability inside a paid bundle.
+      const servable =
+        step.capIsActive != null &&
+        step.capLifecycleState != null &&
+        isServableCapability({
+          isActive: step.capIsActive,
+          lifecycleState: step.capLifecycleState,
+        });
+
+      const executor = servable ? getExecutor(step.capabilitySlug) : undefined;
       if (!executor) {
-        stepErrors.push(`${step.capabilitySlug}: executor unavailable`);
+        stepErrors.push(
+          servable
+            ? `${step.capabilitySlug}: executor unavailable`
+            : `${step.capabilitySlug}: capability is not currently servable`,
+        );
         // Money-integrity 2026-08-12: the step must still APPEAR — a bare
         // return made deactivated steps vanish from the audit trail entirely
         // (a solution advertising 14 steps audited 13 with no gap marker).
         stepResults[step.capabilitySlug] = {
           unavailable: true,
-          reason: "capability unavailable (deactivated or not deployed) — this step did not run",
+          reason: servable
+            ? "capability unavailable (not deployed) — this step did not run"
+            : "capability is not currently servable (deactivated or quarantined) — this step did not run",
         };
         completedSteps[stepIndex.get(step)!] = {};
         stepTimings.push({ capabilitySlug: step.capabilitySlug, latencyMs: 0 });

--- a/apps/api/src/lib/solution-executor.ts
+++ b/apps/api/src/lib/solution-executor.ts
@@ -14,7 +14,7 @@
  *   anything else       — passed through as a literal value
  */
 
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { capabilities, solutionSteps } from "../db/schema.js";
 import { getExecutor } from "../capabilities/index.js";
@@ -332,9 +332,11 @@ export async function executeSolution(
   inputs: Record<string, unknown>,
 ): Promise<SolutionExecutionResult | null> {
   const db = getDb();
-  // WP8: the step's own eligibility comes back with it. A LEFT JOIN, not an
-  // inner one — a step naming a capability that no longer exists must still
-  // appear in the audit trail rather than vanishing from the step list.
+  // WP8: eligibility is deliberately NOT read here. It is re-read per group at
+  // execution time (see the loop below), because a snapshot taken at solution
+  // start goes stale while later groups run — a capability quarantined mid-run
+  // would still execute. Joining it here as well would leave a tempting stale
+  // copy in scope, which is how the first version of this gate went wrong.
   const steps = await db
     .select({
       capabilitySlug: solutionSteps.capabilitySlug,
@@ -343,12 +345,8 @@ export async function executeSolution(
       canParallel: solutionSteps.canParallel,
       parallelGroup: solutionSteps.parallelGroup,
       gateCondition: solutionSteps.gateCondition,
-      capIsActive: capabilities.isActive,
-      capLifecycleState: capabilities.lifecycleState,
-      capVisible: capabilities.visible,
     })
     .from(solutionSteps)
-    .leftJoin(capabilities, eq(capabilities.slug, solutionSteps.capabilitySlug))
     .where(eq(solutionSteps.solutionId, solutionId))
     .orderBy(solutionSteps.stepOrder);
 
@@ -401,6 +399,36 @@ export async function executeSolution(
   let entityContext: Record<string, unknown> = {};
 
   for (const { steps: groupSteps } of sortedGroups) {
+    // WP8 remediation — eligibility is re-read PER GROUP, not once per run.
+    //
+    // The first version loaded visible/is_active/lifecycle_state for every step
+    // in one query before execution began. A solution runs its groups in
+    // sequence and can take seconds to minutes, so a capability quarantined
+    // after the run started would still execute in a later group from a stale
+    // snapshot. WP8 closed exactly this shape on the x402 catalogue cache and
+    // called it a delisting race; leaving it open here would be the same defect
+    // with a shorter window and no justification for the inconsistency.
+    //
+    // The invariant, stated so it is testable: a quarantine stops all step
+    // execution that has not already begun. Steps already in flight when the
+    // quarantine lands are allowed to finish — stopping those would mean
+    // killing work the customer is about to receive, which is the same
+    // reasoning WP3 used for reservation TTLs.
+    //
+    // One indexed read per group. Groups are few (typically one to four), and
+    // this is the path where a wrong answer runs a capability we withdrew.
+    const groupSlugs = groupSteps.map((s) => s.capabilitySlug);
+    const freshRows = await db
+      .select({
+        slug: capabilities.slug,
+        isActive: capabilities.isActive,
+        lifecycleState: capabilities.lifecycleState,
+        visible: capabilities.visible,
+      })
+      .from(capabilities)
+      .where(inArray(capabilities.slug, groupSlugs));
+    const freshBySlug = new Map(freshRows.map((r) => [r.slug, r]));
+
     const executions = groupSteps.map(async (step) => {
       // WP8: is this capability fit to run at all? Checked BEFORE the executor
       // lookup, because a registered executor for a quarantined capability is
@@ -413,14 +441,15 @@ export async function executeSolution(
       // capabilities and 19 moved to a non-servable state in the last 90 days,
       // with the quality floor quarantining automatically. The gap was one
       // quarantine away from putting a delisted capability inside a paid bundle.
+      // The FRESH row, not the one loaded with the step list. A capability
+      // absent from the fresh read was deleted mid-run and is not servable.
+      const fresh = freshBySlug.get(step.capabilitySlug);
       const servable =
-        step.capIsActive != null &&
-        step.capLifecycleState != null &&
-        step.capVisible != null &&
+        fresh != null &&
         isServableCapability({
-          isActive: step.capIsActive,
-          lifecycleState: step.capLifecycleState,
-          visible: step.capVisible,
+          isActive: fresh.isActive,
+          lifecycleState: fresh.lifecycleState,
+          visible: fresh.visible,
         });
 
       const executor = servable ? getExecutor(step.capabilitySlug) : undefined;

--- a/apps/api/src/lib/solution-executor.ts
+++ b/apps/api/src/lib/solution-executor.ts
@@ -345,6 +345,7 @@ export async function executeSolution(
       gateCondition: solutionSteps.gateCondition,
       capIsActive: capabilities.isActive,
       capLifecycleState: capabilities.lifecycleState,
+      capVisible: capabilities.visible,
     })
     .from(solutionSteps)
     .leftJoin(capabilities, eq(capabilities.slug, solutionSteps.capabilitySlug))
@@ -415,9 +416,11 @@ export async function executeSolution(
       const servable =
         step.capIsActive != null &&
         step.capLifecycleState != null &&
+        step.capVisible != null &&
         isServableCapability({
           isActive: step.capIsActive,
           lifecycleState: step.capLifecycleState,
+          visible: step.capVisible,
         });
 
       const executor = servable ? getExecutor(step.capabilitySlug) : undefined;
@@ -432,9 +435,12 @@ export async function executeSolution(
         // (a solution advertising 14 steps audited 13 with no gap marker).
         stepResults[step.capabilitySlug] = {
           unavailable: true,
+          // Distinguished because the two mean different things for BILLING.
+          // A capability we withheld is our decision, not partial delivery.
+          ...(servable ? {} : { platform_withheld: true }),
           reason: servable
             ? "capability unavailable (not deployed) — this step did not run"
-            : "capability is not currently servable (deactivated or quarantined) — this step did not run",
+            : "capability was withheld by Strale (quarantined or deactivated) — this step did not run",
         };
         completedSteps[stepIndex.get(step)!] = {};
         stepTimings.push({ capabilitySlug: step.capabilitySlug, latencyMs: 0 });

--- a/apps/api/src/lib/solution-gate.test.ts
+++ b/apps/api/src/lib/solution-gate.test.ts
@@ -167,7 +167,10 @@ describe("the refund path, structurally", () => {
     // pinning the literal `allFailed || gated !== undefined` would now forbid
     // the fix. What it pins instead is stronger — that this rail derives the
     // decision rather than making one.
-    expect(src).toContain("const refundRequired = !outcome.billable;");
+    // WP8 widened this: a component WE withheld also blocks the charge.
+    expect(src).toContain(
+      "const refundRequired = !outcome.billable || platformWithheldStep;",
+    );
     expect(src).toContain("if (refundRequired) {");
 
     // Behavioural coverage for the gate itself now lives in

--- a/apps/api/src/lib/solution-gate.test.ts
+++ b/apps/api/src/lib/solution-gate.test.ts
@@ -167,10 +167,10 @@ describe("the refund path, structurally", () => {
     // pinning the literal `allFailed || gated !== undefined` would now forbid
     // the fix. What it pins instead is stronger — that this rail derives the
     // decision rather than making one.
-    // WP8 widened this: a component WE withheld also blocks the charge.
-    expect(src).toContain(
-      "const refundRequired = !outcome.billable || platformWithheldStep;",
-    );
+    // WP8 remediation moved the withheld rule INTO aggregateSolutionOutcome,
+    // so this rail derives it from `billable` again — which is the point. A
+    // second copy here is what let the x402 rail settle a withheld run.
+    expect(src).toContain("const refundRequired = !outcome.billable;");
     expect(src).toContain("if (refundRequired) {");
 
     // Behavioural coverage for the gate itself now lives in

--- a/apps/api/src/lib/suggest.ts
+++ b/apps/api/src/lib/suggest.ts
@@ -1,4 +1,5 @@
 import { eq, and, asc, inArray, sql } from "drizzle-orm";
+import { SERVABLE_LIFECYCLE_STATES } from "./x402-eligibility.js";
 import Anthropic from "@anthropic-ai/sdk";
 import { getDb } from "../db/index.js";
 import {
@@ -335,7 +336,11 @@ async function loadCatalog(): Promise<CatalogItem[]> {
             // strale.dev surfacing per DEC-20260503-A — semantic suggest
             // mirrors the public marketplace.
             eq(capabilities.marketplaceEligible, true),
-            inArray(capabilities.lifecycleState, ["active", "degraded"]),
+            // WP8: was ["active","degraded"] — MORE permissive than the
+            // servability floor, so this recommended capabilities /v1/do then
+            // refused. A recommender may be stricter than the floor; it may
+            // never be looser.
+            inArray(capabilities.lifecycleState, [...SERVABLE_LIFECYCLE_STATES]),
           ),
         );
 

--- a/apps/api/src/lib/x402-eligibility.guard.test.ts
+++ b/apps/api/src/lib/x402-eligibility.guard.test.ts
@@ -119,17 +119,28 @@ describe("one authority answers 'may this capability be served'", () => {
     ).toEqual([]);
   });
 
-  it("the solution executor consults the authority", () => {
-    // Named explicitly because its absence was the WP8 defect: solution steps
-    // checked nothing, so a quarantined capability ran inside a paid bundle.
-    const src = readFileSync(join(API_SRC, "lib/solution-executor.ts"), "utf8");
-    expect(src).toMatch(/isServableCapability/);
+  // The two below are lint assertions, not behavioural tests, and the review
+  // caught them being satisfied by an IMPORT LINE alone — delete the logic,
+  // keep the import, and they stayed green. They now require a CALL with an
+  // argument, which an import cannot satisfy. Behavioural coverage lives in
+  // routes/solution-reservations.integration.test.ts, which quarantines a
+  // capability the way the quality floor actually does and asserts the step
+  // does not run.
+
+  it("the solution executor CALLS the authority", () => {
+    const src = stripComments(
+      readFileSync(join(API_SRC, "lib/solution-executor.ts"), "utf8"),
+    );
+    expect(src).toMatch(/isServableCapability\(\s*\{/);
+    // And on the quarantine signal specifically — the field whose absence made
+    // the first version of this package miss every floor quarantine.
+    expect(src).toMatch(/visible:/);
   });
 
-  it("the x402 gateway verifies against the database, not only its cache", () => {
-    // The cache holds 60s and delisting must take effect immediately, so the
-    // handler re-reads before executing or settling.
-    const src = readFileSync(join(API_SRC, "routes/x402-gateway-v2.ts"), "utf8");
-    expect(src).toMatch(/isX402PayableCapability/);
+  it("the x402 gateway CALLS its rail predicate against a live row", () => {
+    const src = stripComments(
+      readFileSync(join(API_SRC, "routes/x402-gateway-v2.ts"), "utf8"),
+    );
+    expect(src).toMatch(/isX402RailEligible\(\w+\)/);
   });
 });

--- a/apps/api/src/lib/x402-eligibility.guard.test.ts
+++ b/apps/api/src/lib/x402-eligibility.guard.test.ts
@@ -23,8 +23,28 @@ const API_SRC = join(import.meta.dirname, "..");
  * standing in for "may we serve this", written anywhere other than the module
  * that owns the decision.
  */
-const OPEN_CODED_LIFECYCLE =
-  /lifecycleState\s*(?:===|!==|,)\s*["']|lifecycle_state\s*(?:=|<>|!=|IN)\s*|inArray\(\s*capabilities\.lifecycleState/;
+const OPEN_CODED_LIFECYCLE = [
+  // A direct comparison or a drizzle inArray on the column.
+  /lifecycleState\s*(?:===|!==|,)\s*["']|lifecycle_state\s*(?:=|<>|!=|IN)\s*|inArray\(\s*capabilities\.lifecycleState/,
+  // A BARE ARRAY LITERAL of the states. Review finding: routes/a2a.ts held a
+  // fifth copy written exactly this way and the guard could not see it — which
+  // is the worst possible miss, because it is the literal body of
+  // isServableCapability and therefore the most likely copy-paste.
+  /\[\s*["']active["']\s*,\s*["'](?:probation|degraded)["']/,
+];
+
+/*
+ * `is_active` is deliberately NOT a pattern here.
+ *
+ * The review was right that a rail gating on isActive alone is the /v1/do
+ * divergence in miniature. But `eq(capabilities.isActive, true)` appears in
+ * every backfill script, test generator and listing query in the tree —
+ * scanning for it flagged twenty legitimate files. A guard that needs a
+ * thirty-entry allowlist is not a guard; it is noise, and noise gets silenced.
+ *
+ * The lifecycle patterns are what actually diverged, they are rare, and they
+ * are unambiguous about intent. Narrow and enforced beats broad and disabled.
+ */
 
 /**
  * Files reviewed once and found NOT to be deciding servability.
@@ -43,6 +63,10 @@ const REVIEWED_NOT_DECIDING = new Set([
   "lib/x402-eligibility.ts",
   // WRITE lifecycle transitions — they must name the states they move between.
   "jobs/quality-floor.ts",
+  // Selects which capabilities the floor EVALUATES (active + degraded). That is
+  // a different question from whether they may be served — a degraded one is
+  // exactly what the floor exists to assess.
+  "lib/quality-floor.ts",
   "jobs/capability-promotion.ts",
   "jobs/fix-lifecycle-anomalies.ts",
   "lib/startup-migrations.ts",
@@ -92,18 +116,32 @@ describe("one authority answers 'may this capability be served'", () => {
   it("no rail open-codes a lifecycle-state rule", () => {
     const offenders: string[] = [];
 
-    for (const dir of ["routes", "lib", "jobs", "capabilities"]) {
-      for (const file of readdirRecursive(join(API_SRC, dir))) {
+    // Every source directory, not a hand-listed subset: a new top-level dir
+    // (src/middleware/, src/web3-assurance/) was a free bypass.
+    for (const file of readdirRecursive(API_SRC)) {
+      {
         if (!file.endsWith(".ts") || file.includes(".test.")) continue;
         const rel = file.slice(API_SRC.length + 1).replace(/\\/g, "/");
         if (REVIEWED_NOT_DECIDING.has(rel)) continue;
 
         const src = stripComments(readFileSync(file, "utf8"));
-        if (!OPEN_CODED_LIFECYCLE.test(src)) continue;
+        if (!OPEN_CODED_LIFECYCLE.some((re) => re.test(src))) continue;
 
-        // Reading the column to PASS to the predicate is fine; deciding with it
-        // is not. A file that imports the authority is presumed to be feeding it.
-        if (src.includes("x402-eligibility.js")) continue;
+        // A file that CALLS the authority is feeding it, not deciding.
+        //
+        // Was `src.includes("x402-eligibility.js")` — an import line exempted
+        // the WHOLE file, so x402-gateway-v2.ts became invisible the moment it
+        // imported the module, including the open-coded SQL it still contains.
+        // Requiring a call is narrower; a file that both calls and open-codes
+        // is still exempt, which is a known and accepted limit of a regex guard.
+        // Calling a predicate, or consuming the shared state list, both count
+        // as deferring to the authority.
+        if (
+          /isServableCapability\(|isX402RailEligible\(|isX402PayableCapability\(/.test(src) ||
+          /SERVABLE_LIFECYCLE_STATES|X402_PAYABLE_LIFECYCLE_STATES/.test(src)
+        ) {
+          continue;
+        }
 
         offenders.push(rel);
       }

--- a/apps/api/src/lib/x402-eligibility.guard.test.ts
+++ b/apps/api/src/lib/x402-eligibility.guard.test.ts
@@ -1,0 +1,135 @@
+/**
+ * WP8 bypass guard: "may this be served" has one answer.
+ *
+ * The predicate `isX402PayableCapability` already existed and was already
+ * correct. It was imported by exactly ONE file. That is how two authorities
+ * came to exist without anyone deciding to create them: the wallet rail gated
+ * on `isActive`, the x402 gateway open-coded `lifecycle_state IN (…)` in its
+ * cache query, and solution steps checked nothing at all. In production those
+ * two rules already disagree about six capabilities.
+ *
+ * A shared predicate that nothing is required to use is a convention. This test
+ * is what makes it an authority.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const API_SRC = join(import.meta.dirname, "..");
+
+/**
+ * Open-coded eligibility: a lifecycle-state comparison, or an is_active filter
+ * standing in for "may we serve this", written anywhere other than the module
+ * that owns the decision.
+ */
+const OPEN_CODED_LIFECYCLE =
+  /lifecycleState\s*(?:===|!==|,)\s*["']|lifecycle_state\s*(?:=|<>|!=|IN)\s*|inArray\(\s*capabilities\.lifecycleState/;
+
+/**
+ * Files reviewed once and found NOT to be deciding servability.
+ *
+ * A ratchet, in the shape this codebase already uses for console calls and
+ * migration blocks: the existing set is grandfathered, anything NEW fails.
+ * Every entry was read, and each falls into one of three groups — it WRITES
+ * lifecycle transitions, it REPORTS on them, or it filters a listing for
+ * display. None of them gate execution or payment.
+ *
+ * Adding an entry here is a claim that the file does not decide whether a
+ * capability may run. Make that claim only after reading it.
+ */
+const REVIEWED_NOT_DECIDING = new Set([
+  // Owns the decision.
+  "lib/x402-eligibility.ts",
+  // WRITE lifecycle transitions — they must name the states they move between.
+  "jobs/quality-floor.ts",
+  "jobs/capability-promotion.ts",
+  "jobs/fix-lifecycle-anomalies.ts",
+  "lib/startup-migrations.ts",
+  "lib/capability-persistence.ts",
+  "lib/capability-onboarding.ts",
+  // REPORT on lifecycle — dashboards, digests, monitors, issue filing.
+  "jobs/invariant-checker.ts",
+  "lib/digest-compiler.ts",
+  "lib/event-triggers.ts",
+  "lib/github-issues.ts",
+  "lib/meta-monitoring.ts",
+  "lib/platform-facts.ts",
+  "lib/test-runner.ts",
+  "lib/metrics/metrics.ts",
+  "routes/admin.ts",
+  "routes/internal-health-monitor.ts",
+  "routes/reply-webhook.ts",
+  // Filter a LISTING for display. Stricter than the floor, never more
+  // permissive, which is the direction that stays safe.
+  "routes/capabilities.ts",
+  "lib/suggest.ts",
+]);
+
+function readdirRecursive(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...readdirRecursive(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+describe("one authority answers 'may this capability be served'", () => {
+  it("no rail open-codes a lifecycle-state rule", () => {
+    const offenders: string[] = [];
+
+    for (const dir of ["routes", "lib", "jobs", "capabilities"]) {
+      for (const file of readdirRecursive(join(API_SRC, dir))) {
+        if (!file.endsWith(".ts") || file.includes(".test.")) continue;
+        const rel = file.slice(API_SRC.length + 1).replace(/\\/g, "/");
+        if (REVIEWED_NOT_DECIDING.has(rel)) continue;
+
+        const src = stripComments(readFileSync(file, "utf8"));
+        if (!OPEN_CODED_LIFECYCLE.test(src)) continue;
+
+        // Reading the column to PASS to the predicate is fine; deciding with it
+        // is not. A file that imports the authority is presumed to be feeding it.
+        if (src.includes("x402-eligibility.js")) continue;
+
+        offenders.push(rel);
+      }
+    }
+
+    expect(
+      offenders,
+      "this file reads lifecycle state without consulting lib/x402-eligibility.ts. " +
+        "If it DECIDES whether a capability may run, use the shared predicate — two " +
+        "authorities is how the wallet and x402 rails came to disagree about six " +
+        "capabilities in production. If it only reports or lists, read it and add it " +
+        "to REVIEWED_NOT_DECIDING with which group it falls into.",
+    ).toEqual([]);
+  });
+
+  it("the solution executor consults the authority", () => {
+    // Named explicitly because its absence was the WP8 defect: solution steps
+    // checked nothing, so a quarantined capability ran inside a paid bundle.
+    const src = readFileSync(join(API_SRC, "lib/solution-executor.ts"), "utf8");
+    expect(src).toMatch(/isServableCapability/);
+  });
+
+  it("the x402 gateway verifies against the database, not only its cache", () => {
+    // The cache holds 60s and delisting must take effect immediately, so the
+    // handler re-reads before executing or settling.
+    const src = readFileSync(join(API_SRC, "routes/x402-gateway-v2.ts"), "utf8");
+    expect(src).toMatch(/isX402PayableCapability/);
+  });
+});

--- a/apps/api/src/lib/x402-eligibility.test.ts
+++ b/apps/api/src/lib/x402-eligibility.test.ts
@@ -20,6 +20,7 @@ const payable: X402EligibilityFields = {
   x402Enabled: true,
   marketplaceEligible: true,
   lifecycleState: "active",
+      visible: true,
 };
 
 describe("isX402PayableCapability", () => {

--- a/apps/api/src/lib/x402-eligibility.ts
+++ b/apps/api/src/lib/x402-eligibility.ts
@@ -53,3 +53,51 @@ export function isX402PayableCapability(cap: X402EligibilityFields): boolean {
     cap.lifecycleState,
   );
 }
+
+// ─── The general question, of which x402 payability is one special case ──────
+
+/**
+ * The fields "may this capability be served at all" depends on.
+ *
+ * Deliberately smaller than `X402EligibilityFields`: whether something is
+ * free-tier, x402-enabled or marketplace-eligible answers "may it be sold on
+ * THAT rail", which is a different question from "is it fit to run".
+ */
+export interface ServabilityFields {
+  isActive: boolean;
+  lifecycleState: string;
+}
+
+/** Lifecycle states in which a capability is fit to execute. */
+export const SERVABLE_LIFECYCLE_STATES = ["active", "probation"] as const;
+
+/**
+ * May this capability execute right now, on any rail?
+ *
+ * WP8. Before this, "may it be served" was answered by two different columns
+ * consulted by different rails: `/v1/do` gated on `isActive`, the x402 gateway
+ * on `lifecycle_state`. They already disagree in production — six capabilities
+ * sit at lifecycle 'validating' with is_active = true, so the wallet rail would
+ * run them and the x402 rail would not. Same capability, same instant, two
+ * answers, decided by which rail the caller happened to use.
+ *
+ * And solution steps consulted NEITHER. lib/solution-executor.ts had no
+ * eligibility check of any kind, so a capability the platform had decided to
+ * stop serving still ran as a step inside the bundles that are the most
+ * expensive thing we sell. That has not yet bitten a live bundle — every
+ * offending step today sits in an already-inactive solution — but 103 live
+ * solutions depend on 99 capabilities, 19 capabilities moved to a non-servable
+ * state in the last 90 days, and the quality floor quarantines automatically.
+ * The gap is one quarantine away from being real, which is the wrong time to
+ * discover it.
+ *
+ * Both conditions, not either: `is_active` is the operator's switch and
+ * `lifecycle_state` is the platform's own assessment. A capability needs both
+ * to be fit, and requiring both is what makes the two columns stop disagreeing.
+ */
+export function isServableCapability(cap: ServabilityFields): boolean {
+  if (!cap.isActive) return false;
+  return (SERVABLE_LIFECYCLE_STATES as readonly string[]).includes(
+    cap.lifecycleState,
+  );
+}

--- a/apps/api/src/lib/x402-eligibility.ts
+++ b/apps/api/src/lib/x402-eligibility.ts
@@ -66,6 +66,20 @@ export function isX402PayableCapability(cap: X402EligibilityFields): boolean {
 export interface ServabilityFields {
   isActive: boolean;
   lifecycleState: string;
+  /**
+   * THE quarantine signal, and the one this predicate originally missed.
+   *
+   * jobs/quality-floor.ts quarantines with `{visible: false, x402Enabled:
+   * false}` — it changes NEITHER is_active NOR lifecycle_state. So a predicate
+   * reading only those two returns true for every floor-quarantined capability,
+   * which is how the first version of this function failed to stop the exact
+   * thing it was written to stop. Verified in production: page-speed-test was
+   * quarantined 2026-08-20 and is still is_active=true, lifecycle_state=active.
+   *
+   * It also covers pre-launch capabilities, which are invisible for a different
+   * reason and equally should not run.
+   */
+  visible: boolean;
 }
 
 /** Lifecycle states in which a capability is fit to execute. */
@@ -97,7 +111,38 @@ export const SERVABLE_LIFECYCLE_STATES = ["active", "probation"] as const;
  */
 export function isServableCapability(cap: ServabilityFields): boolean {
   if (!cap.isActive) return false;
+  // Quarantined or pre-launch. See the field docs — omitting this made the
+  // predicate blind to the platform's own primary delisting action.
+  if (!cap.visible) return false;
   return (SERVABLE_LIFECYCLE_STATES as readonly string[]).includes(
+    cap.lifecycleState,
+  );
+}
+
+/**
+ * May this capability be SOLD over the x402 rail?
+ *
+ * Distinct from `isX402PayableCapability`, which is `/v1/do`'s rule and
+ * excludes free-tier because that rail serves those calls for nothing. The
+ * gateway is different: on it "free" means `price_cents === 0`, and free-tier
+ * capabilities carry a real price and are genuinely sold there — six of them,
+ * including `email-validate`, the single highest-volume x402 slug.
+ *
+ * Applying /v1/do's predicate to the gateway inverts its own rule and would
+ * have permanently 503'd all six. This mirrors the catalogue-building filter
+ * exactly, so the SQL and the runtime check cannot drift — which is the whole
+ * point of the package.
+ */
+export function isX402RailEligible(cap: {
+  isActive: boolean;
+  x402Enabled: boolean;
+  marketplaceEligible: boolean;
+  lifecycleState: string;
+}): boolean {
+  if (!cap.isActive) return false;
+  if (!cap.x402Enabled) return false;
+  if (!cap.marketplaceEligible) return false;
+  return (X402_PAYABLE_LIFECYCLE_STATES as readonly string[]).includes(
     cap.lifecycleState,
   );
 }

--- a/apps/api/src/routes/a2a.ts
+++ b/apps/api/src/routes/a2a.ts
@@ -10,6 +10,7 @@
  */
 
 import { Hono } from "hono";
+import { X402_PAYABLE_LIFECYCLE_STATES } from "../lib/x402-eligibility.js";
 import { recordDiscoveryHit } from "../lib/attribution.js";
 import { eq, and, isNull } from "drizzle-orm";
 import { createHash, timingSafeEqual } from "node:crypto";
@@ -138,7 +139,15 @@ function payableViaX402(row: {
   if (row.isFreeTier) return false; // free tier needs no payment endpoint
   if (!row.x402Enabled) return false;
   // Solutions carry no lifecycle column; absence means "not gated on it".
-  if (row.lifecycleState && !["active", "probation"].includes(row.lifecycleState)) return false;
+  // WP8: the states come from the authority rather than a fifth inline copy —
+  // this one was invisible to the guard precisely because it was written as a
+  // bare array literal, the most likely shape of a copy-paste.
+  if (
+    row.lifecycleState &&
+    !(X402_PAYABLE_LIFECYCLE_STATES as readonly string[]).includes(row.lifecycleState)
+  ) {
+    return false;
+  }
   return true;
 }
 

--- a/apps/api/src/routes/billing-parity.integration.test.ts
+++ b/apps/api/src/routes/billing-parity.integration.test.ts
@@ -195,6 +195,7 @@ describeMaybe("a gated solution bills identically on both rails", () => {
         isActive: true,
         avgLatencyMs: 50,
         lifecycleState: "active",
+      visible: true,
       });
     }
 
@@ -400,6 +401,7 @@ describeMaybe("a capability returning an unusable output bills on neither rail",
       isActive: true,
       avgLatencyMs: 50,
       lifecycleState: "active",
+      visible: true,
       x402Enabled: true,
       x402PriceUsd: 0.3,
     });

--- a/apps/api/src/routes/billing-parity.integration.test.ts
+++ b/apps/api/src/routes/billing-parity.integration.test.ts
@@ -423,3 +423,132 @@ describeMaybe("a capability returning an unusable output bills on neither rail",
     expect(res.status).not.toBe(200);
   }, 120_000);
 });
+/**
+ * WP8: a component Strale withheld makes the bundle unbillable on BOTH rails.
+ *
+ * The review's blocking finding. The rule first shipped inside
+ * routes/solution-execute.ts, so the wallet rail applied it and the x402 rail
+ * did not — a partially successful x402 run with a quarantined component would
+ * still have settled full price. That is CR-02 again: one economic fact, two
+ * rails, two answers. The rule now lives in aggregateSolutionOutcome.
+ */
+describeMaybe("a withheld component is unbillable on the x402 rail too", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let app: Awaited<typeof import("../app.js")>["app"];
+
+  let solutionId = "";
+  let solSlug = "";
+  const capIds: string[] = [];
+  const GOOD = `wp8-good-${randomUUID().slice(0, 8)}`;
+  const WITHHELD = `wp8-withheld-${randomUUID().slice(0, 8)}`;
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 4 });
+    db = drizzle(client);
+    const { registerCapability } = await import("../capabilities/index.js");
+    for (const slug of [GOOD, WITHHELD]) {
+      registerCapability(slug, async () => ({
+        output: { ok: true, from: slug },
+        provenance: { source: "wp8", fetched_at: new Date().toISOString() },
+      }));
+    }
+    ({ app } = await import("../app.js"));
+  }, 120_000);
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  afterEach(async () => {
+    settleSpy.mockClear();
+    if (solSlug) {
+      await db.delete(transactions).where(eq(transactions.solutionSlug, solSlug));
+      await db.delete(x402SettlementIntents).where(eq(x402SettlementIntents.slug, solSlug));
+    }
+    if (solutionId) {
+      await db.delete(solutionSteps).where(eq(solutionSteps.solutionId, solutionId));
+      await db.delete(solutions).where(eq(solutions.id, solutionId));
+    }
+    for (const id of capIds.splice(0)) {
+      await db.delete(capabilities).where(eq(capabilities.id, id));
+    }
+    solutionId = solSlug = "";
+  });
+
+  it("does not settle when one component was quarantined", async () => {
+    solutionId = randomUUID();
+    solSlug = `wp8-sol-${randomUUID().slice(0, 8)}`;
+
+    for (const slug of [GOOD, WITHHELD]) {
+      const id = randomUUID();
+      capIds.push(id);
+      await db.insert(capabilities).values({
+        id,
+        slug,
+        name: `WP8 ${slug}`,
+        description: "Seeded by the WP8 x402 parity test.",
+        category: "developer-tools",
+        inputSchema: { type: "object" },
+        outputSchema: { type: "object" },
+        priceCents: 10,
+        isActive: true,
+        visible: true,
+        avgLatencyMs: 50,
+        lifecycleState: "active",
+      });
+    }
+
+    await db.insert(solutions).values({
+      id: solutionId,
+      slug: solSlug,
+      name: "WP8 x402 parity solution",
+      description: "Seeded by the WP8 x402 parity test.",
+      category: "compliance",
+      priceCents: 250,
+      componentSumCents: 20,
+      valueTier: "standard",
+      maintenanceLevel: "low",
+      geography: "EU",
+      inputSchema: { type: "object", properties: { probe: { type: "string" } } },
+      isActive: true,
+      x402Enabled: true,
+      x402PriceUsd: 2.75,
+    });
+    await db.insert(solutionSteps).values([
+      { solutionId, capabilitySlug: GOOD, stepOrder: 1, inputMap: { probe: "probe" } },
+      { solutionId, capabilitySlug: WITHHELD, stepOrder: 2, inputMap: { probe: "probe" } },
+    ]);
+
+    // Quarantine EXACTLY as the quality floor does.
+    await db
+      .update(capabilities)
+      .set({ visible: false, x402Enabled: false })
+      .where(eq(capabilities.slug, WITHHELD));
+
+    const { __resetX402CacheForTests } = await import("./x402-gateway-v2.js");
+    __resetX402CacheForTests();
+
+    const res = await app.request(`http://localhost/x402/solutions/${solSlug}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-PAYMENT": `wp8-auth-${randomUUID()}`,
+      },
+      body: JSON.stringify({ probe: "wp8" }),
+    });
+
+    // Step 1 SUCCEEDED, so the pre-WP8-remediation aggregate would have called
+    // this billable and settled the full USDC.
+    expect(settleSpy, "a withheld component must stop settlement").not.toHaveBeenCalled();
+    expect(res.status).toBe(502);
+
+    // And the run is recorded rather than vanishing — the canonical unbilled row.
+    const rows = await db
+      .select({ priceCents: transactions.priceCents })
+      .from(transactions)
+      .where(eq(transactions.solutionSlug, solSlug));
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[0]!.priceCents).toBe(0);
+  }, 120_000);
+});

--- a/apps/api/src/routes/do.core.test.ts
+++ b/apps/api/src/routes/do.core.test.ts
@@ -359,6 +359,7 @@ const CAPABILITY_FIXTURE = {
   isActive: true,
   isFreeTier: false,
   lifecycleState: "active",
+      visible: true,
   capabilityType: "deterministic",
   transparencyTag: "algorithmic",
   dataSource: "Test Source",

--- a/apps/api/src/routes/do.crash-recovery.integration.test.ts
+++ b/apps/api/src/routes/do.crash-recovery.integration.test.ts
@@ -127,6 +127,7 @@ describeMaybe("async /v1/do — surviving a hard process kill", () => {
       // Above ASYNC_THRESHOLD_MS, so /v1/do takes the debit-first async path.
       avgLatencyMs: 20_000,
       lifecycleState: "active",
+      visible: true,
     });
   }
 

--- a/apps/api/src/routes/do.idempotency.integration.test.ts
+++ b/apps/api/src/routes/do.idempotency.integration.test.ts
@@ -117,6 +117,7 @@ describeMaybe("/v1/do idempotency against a real database", () => {
       isFreeTier: opts.isFreeTier ?? false,
       avgLatencyMs: 50,
       lifecycleState: "active",
+      visible: true,
     });
   }
 

--- a/apps/api/src/routes/do.usage-summary.integration.test.ts
+++ b/apps/api/src/routes/do.usage-summary.integration.test.ts
@@ -120,6 +120,7 @@ describeMaybe("conversion-email usage summary against a real database", () => {
       isFreeTier: false,
       avgLatencyMs: 50,
       lifecycleState: "active",
+      visible: true,
     });
   }
 

--- a/apps/api/src/routes/do.wallet-concurrency.integration.test.ts
+++ b/apps/api/src/routes/do.wallet-concurrency.integration.test.ts
@@ -127,6 +127,7 @@ describeMaybe("concurrent /v1/do debits — no overspend", () => {
       // Below ASYNC_THRESHOLD_MS, so this takes the synchronous debit path.
       avgLatencyMs: 50,
       lifecycleState: "active",
+      visible: true,
     });
   }
 

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -413,23 +413,13 @@ solutionExecuteRoute.post(
       ),
       execResult.gated,
     );
-    // WP8: a bundle we could not run in full because WE withheld a component
-    // is not partial delivery — it is us failing to deliver what was sold. Six
-    // live solutions currently contain a quarantined capability, two of them
-    // EUR 2.50 KYB bundles; billing full price for a KYB check missing its
-    // registry lookup would be charging for a hollow answer. DEC-14: no charge
-    // for work not delivered.
-    const platformWithheldStep = Object.values(execResult.steps).some(
-      (v) =>
-        v != null &&
-        typeof v === "object" &&
-        (v as Record<string, unknown>).platform_withheld === true,
-    );
-
     const gated = execResult.gated;
     const stepsSucceeded = outcome.steps_succeeded;
     const allFailed = stepsSucceeded === 0;
-    const refundRequired = !outcome.billable || platformWithheldStep;
+    // WP8 remediation: the withheld rule moved into aggregateSolutionOutcome, so
+    // `billable` already accounts for it and BOTH rails inherit it. Keeping a
+    // second copy here was what let the x402 rail settle a withheld run.
+    const refundRequired = !outcome.billable;
 
     // /v1/do vocabulary: "completed" or "failed". Partial success maps to
     // "completed" with per-step detail in audit_trail. A gated run completed —

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -413,10 +413,23 @@ solutionExecuteRoute.post(
       ),
       execResult.gated,
     );
+    // WP8: a bundle we could not run in full because WE withheld a component
+    // is not partial delivery — it is us failing to deliver what was sold. Six
+    // live solutions currently contain a quarantined capability, two of them
+    // EUR 2.50 KYB bundles; billing full price for a KYB check missing its
+    // registry lookup would be charging for a hollow answer. DEC-14: no charge
+    // for work not delivered.
+    const platformWithheldStep = Object.values(execResult.steps).some(
+      (v) =>
+        v != null &&
+        typeof v === "object" &&
+        (v as Record<string, unknown>).platform_withheld === true,
+    );
+
     const gated = execResult.gated;
     const stepsSucceeded = outcome.steps_succeeded;
     const allFailed = stepsSucceeded === 0;
-    const refundRequired = !outcome.billable;
+    const refundRequired = !outcome.billable || platformWithheldStep;
 
     // /v1/do vocabulary: "completed" or "failed". Partial success maps to
     // "completed" with per-step detail in audit_trail. A gated run completed —

--- a/apps/api/src/routes/solution-reservations.integration.test.ts
+++ b/apps/api/src/routes/solution-reservations.integration.test.ts
@@ -146,6 +146,7 @@ describeMaybe("solution execution holds a wallet reservation", () => {
       isActive: true,
       avgLatencyMs: 50,
       lifecycleState: "active",
+      visible: true,
     });
 
     await db.insert(solutions).values({
@@ -335,11 +336,18 @@ describeMaybe("solution execution holds a wallet reservation", () => {
     await seed();
     stepShouldFail = false;
 
-    // Quarantine the step's capability AFTER the solution was built, which is
-    // exactly how it happens: the bundle is live and its dependency degrades.
+    // Quarantine EXACTLY as jobs/quality-floor.ts does it: visible=false and
+    // x402_enabled=false, leaving is_active and lifecycle_state alone.
+    //
+    // The first version of this test set {lifecycleState:'degraded',
+    // isActive:false} — which is DEACTIVATION, a different transition. It
+    // passed, and proved the deactivation gate works, while its title and the
+    // commit message claimed quarantine. Production contradicted both:
+    // page-speed-test was quarantined 2026-08-20 and is still is_active=true,
+    // lifecycle_state='active', sitting in two live paid solutions.
     await db
       .update(capabilities)
-      .set({ lifecycleState: "degraded", isActive: false })
+      .set({ visible: false, x402Enabled: false })
       .where(eq(capabilities.slug, capSlug));
 
     const res = await runSolution();
@@ -348,11 +356,30 @@ describeMaybe("solution execution holds a wallet reservation", () => {
     // The step is recorded as unavailable rather than executed...
     const stepOutput = body.result?.steps?.[capSlug];
     expect(stepOutput?.unavailable).toBe(true);
-    expect(String(stepOutput?.reason)).toMatch(/not currently servable/i);
+    expect(stepOutput?.platform_withheld).toBe(true);
+    expect(String(stepOutput?.reason)).toMatch(/withheld by Strale/i);
 
-    // ...and because no step produced usable output, WP4's aggregate makes the
-    // run unbillable. The customer is not charged for a bundle whose only step
-    // the platform refused to run.
+    // ...and the customer is not charged. A component WE withheld is not
+    // partial delivery; charging for a bundle missing a piece we removed would
+    // be charging for a hollow answer.
+    expect(await balance()).toBe(STARTING_BALANCE);
+  }, 120_000);
+
+  it("also refuses a step whose capability was DEACTIVATED (WP8)", async () => {
+    // The transition the first version of the quarantine test actually tested.
+    // Kept as its own case so both paths are covered explicitly rather than one
+    // standing in for the other.
+    await seed();
+    stepShouldFail = false;
+
+    await db
+      .update(capabilities)
+      .set({ isActive: false, lifecycleState: "deactivated" })
+      .where(eq(capabilities.slug, capSlug));
+
+    const res = await runSolution();
+    const body = (await res.json()) as Record<string, any>;
+    expect(body.result?.steps?.[capSlug]?.unavailable).toBe(true);
     expect(await balance()).toBe(STARTING_BALANCE);
   }, 120_000);
 });

--- a/apps/api/src/routes/solution-reservations.integration.test.ts
+++ b/apps/api/src/routes/solution-reservations.integration.test.ts
@@ -323,4 +323,36 @@ describeMaybe("solution execution holds a wallet reservation", () => {
     expect(conflict.status).toBe(409);
     expect(((await conflict.json()) as any).error_code).toBe("idempotency_key_reused");
   }, 120_000);
+
+  it("does NOT run a step whose capability has been quarantined (WP8)", async () => {
+    // The gap this closes. lib/solution-executor.ts had no eligibility check of
+    // any kind, so a capability the platform had decided to stop serving still
+    // ran as a step inside a paid bundle. Not yet a live incident — every
+    // offending step in production sits in an already-inactive solution — but
+    // 103 live solutions depend on 99 capabilities, 19 moved to a non-servable
+    // state in the last 90 days, and the quality floor quarantines
+    // automatically. This is the transition that would have made it real.
+    await seed();
+    stepShouldFail = false;
+
+    // Quarantine the step's capability AFTER the solution was built, which is
+    // exactly how it happens: the bundle is live and its dependency degrades.
+    await db
+      .update(capabilities)
+      .set({ lifecycleState: "degraded", isActive: false })
+      .where(eq(capabilities.slug, capSlug));
+
+    const res = await runSolution();
+    const body = (await res.json()) as Record<string, any>;
+
+    // The step is recorded as unavailable rather than executed...
+    const stepOutput = body.result?.steps?.[capSlug];
+    expect(stepOutput?.unavailable).toBe(true);
+    expect(String(stepOutput?.reason)).toMatch(/not currently servable/i);
+
+    // ...and because no step produced usable output, WP4's aggregate makes the
+    // run unbillable. The customer is not charged for a bundle whose only step
+    // the platform refused to run.
+    expect(await balance()).toBe(STARTING_BALANCE);
+  }, 120_000);
 });

--- a/apps/api/src/routes/solution-reservations.integration.test.ts
+++ b/apps/api/src/routes/solution-reservations.integration.test.ts
@@ -54,6 +54,8 @@ describeMaybe("solution execution holds a wallet reservation", () => {
   let userId = "";
   let walletId = "";
   let capabilityId = "";
+  /** Extra capabilities seeded by individual tests, cleaned up alongside. */
+  const extraCapabilityIds: string[] = [];
   let solutionId = "";
   let capSlug = "";
   let solSlug = "";
@@ -102,6 +104,9 @@ describeMaybe("solution execution holds a wallet reservation", () => {
         .delete(solutionSteps)
         .where(eq(solutionSteps.solutionId, solutionId));
       await db.delete(solutions).where(eq(solutions.id, solutionId));
+    }
+    for (const id of extraCapabilityIds.splice(0)) {
+      await db.delete(capabilities).where(eq(capabilities.id, id));
     }
     if (capabilityId)
       await db.delete(capabilities).where(eq(capabilities.id, capabilityId));
@@ -380,6 +385,78 @@ describeMaybe("solution execution holds a wallet reservation", () => {
     const res = await runSolution();
     const body = (await res.json()) as Record<string, any>;
     expect(body.result?.steps?.[capSlug]?.unavailable).toBe(true);
+    expect(await balance()).toBe(STARTING_BALANCE);
+  }, 120_000);
+
+  it("a quarantine landing MID-RUN stops the next group (WP8 TOCTOU)", async () => {
+    // The review's second blocking finding. Eligibility was loaded once before
+    // any group executed, so a capability quarantined after the run started
+    // still executed in a later group from a stale snapshot — the same
+    // delisting race WP8 closed on the x402 catalogue cache, with a shorter
+    // window and no justification for the inconsistency.
+    //
+    // The invariant this pins: a quarantine stops step execution that has NOT
+    // yet begun. Steps already in flight are allowed to finish, because killing
+    // those would discard work the customer is about to receive.
+    await seed();
+    stepShouldFail = false;
+
+    // Step 1 quarantines step 2's capability WHILE the run is in progress —
+    // after the snapshot would have been taken, before group 2 executes.
+    const { registerCapability } = await import("../capabilities/index.js");
+    const secondSlug = `wp8-second-${randomUUID().slice(0, 8)}`;
+    const secondId = randomUUID();
+    extraCapabilityIds.push(secondId);
+
+    registerCapability(secondSlug, async () => ({
+      output: { ok: true, ran: true },
+      provenance: { source: "wp8", fetched_at: new Date().toISOString() },
+    }));
+
+    await db.insert(capabilities).values({
+      id: secondId,
+      slug: secondSlug,
+      name: "WP8 second-group capability",
+      description: "Seeded by the WP8 TOCTOU test.",
+      category: "developer-tools",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      priceCents: 10,
+      isActive: true,
+      visible: true,
+      avgLatencyMs: 50,
+      lifecycleState: "active",
+    });
+    await db.insert(solutionSteps).values({
+      solutionId,
+      capabilitySlug: secondSlug,
+      stepOrder: 2,
+      inputMap: { probe: "probe" },
+    });
+
+    // Re-register step 1 so that RUNNING it quarantines step 2 — the quarantine
+    // lands strictly between the two groups, which is the race.
+    registerCapability(capSlug, async () => {
+      await db
+        .update(capabilities)
+        .set({ visible: false, x402Enabled: false })
+        .where(eq(capabilities.slug, secondSlug));
+      return {
+        output: { ok: true },
+        provenance: { source: "wp8", fetched_at: new Date().toISOString() },
+      };
+    });
+
+    const res = await runSolution();
+    const body = (await res.json()) as Record<string, any>;
+
+    // Step 2 must NOT have executed against the stale snapshot.
+    const second = body.result?.steps?.[secondSlug];
+    expect(second?.unavailable, "the quarantined step must not run").toBe(true);
+    expect(second?.platform_withheld).toBe(true);
+    expect(second?.ran).toBeUndefined();
+
+    // And a withheld component makes the whole bundle unbillable.
     expect(await balance()).toBe(STARTING_BALANCE);
   }, 120_000);
 });

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -45,6 +45,7 @@ import { rateLimitByIp } from "../lib/rate-limit.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
 import { executeSolution } from "../lib/solution-executor.js";
 import * as settlementIntent from "../lib/x402-settlement-intent.js";
+import { isX402PayableCapability } from "../lib/x402-eligibility.js";
 import {
   aggregateSolutionOutcome,
   assertBillableOutput,
@@ -1315,6 +1316,46 @@ x402GatewayV2.on(["GET", "POST"], ["/:slug", "/v2/:slug"], async (c) => {
   await ensureCache();
 
   const cap = _capCache.get(slug);
+
+  // WP8: the cache is a ROUTING HINT, not an eligibility authority.
+  //
+  // It holds for 60 seconds, and the quality floor delists by clearing
+  // x402_enabled — so a capability quarantined mid-window kept selling until
+  // the cache turned over. Delisting is precisely the event that must take
+  // effect immediately: the floor fires because a capability is failing real
+  // customers, and up to a minute of further sales is the opposite of the
+  // intent.
+  //
+  // One indexed read on the money path, before anything is executed or
+  // settled. Checked against the same predicate every other rail uses, so a
+  // capability cannot be servable here and not there.
+  if (cap) {
+    const [live] = await getDb()
+      .select({
+        isActive: capabilities.isActive,
+        isFreeTier: capabilities.isFreeTier,
+        x402Enabled: capabilities.x402Enabled,
+        marketplaceEligible: capabilities.marketplaceEligible,
+        lifecycleState: capabilities.lifecycleState,
+      })
+      .from(capabilities)
+      .where(eq(capabilities.slug, slug))
+      .limit(1);
+
+    if (!live || !isX402PayableCapability(live)) {
+      // Drop the stale entry so the next caller does not pay for the same
+      // lookup, and answer as the catalogue would once it refreshes.
+      _capCache.delete(slug);
+      return c.json(
+        {
+          error: "Capability is no longer available via x402. No payment was taken.",
+          hint: `${BASE_URL}/x402/catalog`,
+        },
+        503,
+      );
+    }
+  }
+
   if (!cap) {
     // Two very different things wear the same 404. Distinguish them before
     // recording, or the demand table fills with "someone wanted X" for every

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -45,7 +45,7 @@ import { rateLimitByIp } from "../lib/rate-limit.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
 import { executeSolution } from "../lib/solution-executor.js";
 import * as settlementIntent from "../lib/x402-settlement-intent.js";
-import { isX402PayableCapability } from "../lib/x402-eligibility.js";
+import { isX402RailEligible } from "../lib/x402-eligibility.js";
 import {
   aggregateSolutionOutcome,
   assertBillableOutput,
@@ -1333,7 +1333,6 @@ x402GatewayV2.on(["GET", "POST"], ["/:slug", "/v2/:slug"], async (c) => {
     const [live] = await getDb()
       .select({
         isActive: capabilities.isActive,
-        isFreeTier: capabilities.isFreeTier,
         x402Enabled: capabilities.x402Enabled,
         marketplaceEligible: capabilities.marketplaceEligible,
         lifecycleState: capabilities.lifecycleState,
@@ -1342,7 +1341,7 @@ x402GatewayV2.on(["GET", "POST"], ["/:slug", "/v2/:slug"], async (c) => {
       .where(eq(capabilities.slug, slug))
       .limit(1);
 
-    if (!live || !isX402PayableCapability(live)) {
+    if (!live || !isX402RailEligible(live)) {
       // Drop the stale entry so the next caller does not pay for the same
       // lookup, and answer as the catalogue would once it refreshes.
       _capCache.delete(slug);

--- a/docs/remediation/CURRENT-STATE.md
+++ b/docs/remediation/CURRENT-STATE.md
@@ -2,13 +2,43 @@
 
 _Last updated: 2026-08-21 (session 1)_
 
-- **Current package:** WP7 — ACCEPTED, merged as `8d6c860` (PR #353), verified live.
-- **Next package:** WP6 — idempotency & replay (WP1 already pinned its acceptance signal)
+- **Current package:** WP6 — ACCEPTED, merged as `4302547` (PR #354), verified live.
+- **Next package:** WP8
 - **WP3:** ACCEPTED, merged as `ee7f737` (PR #350), verified live in production — table, all three indexes, and the CHECK constraint reached `validated=true`.
 - **Latest accepted SHA:** `ee7f737` on `main`
 - **Unresolved blockers:** none
 - **Human approvals granted:** program-level autonomy (run continuously; escalate only per CHECK-IN A/B/C)
 - **Awaiting founder:** nothing. One item is logged for *visibility only*, not decision — see "Codex disposition" below.
+
+## Where WP6 landed
+
+Idempotency keys are bound to a fingerprint of the request they were issued
+for. WP1's three pinned defects all inverted.
+
+The sharpest was that a key reused across two capabilities returned the FIRST
+one's output while the response echoed the slug the caller had just asked for.
+Reusing `order-123` across two calls is far likelier than a UUID collision.
+
+Two gaps beyond the pins, both money: **solutions had no replay guard at all**
+(a retried EUR 2.50 call was charged twice — the capability rail has had this
+since MVP, the bundle rail never did), and **A2A dropped the header**, so those
+clients could not make a retry safe no matter what they sent.
+
+The review's two blocking findings were both mine and both instructive:
+
+1. A parameter threaded into `executeFreeTierAuthenticated` and never written.
+   Its PRESENCE is what made the omission read as done — tsc cannot flag an
+   unused parameter, and every integration case seeded a paid capability.
+2. The solutions replay matched ANY prior row with that key, and all 421
+   existing keyed rows are capability rows with a null fingerprint. A customer
+   reusing an old key on a KYB bundle would have received a capability's payload
+   labelled as a KYB Complete result — the wrong-answer class this package
+   exists to close, introduced BY it.
+
+**Post-deploy verification mattered here specifically.** Block 0098 has no
+behavioural test — CI materialises the schema before migrations run, so its
+statements are no-ops there. Confirmed against production: fingerprint column
+present, global unique index dropped, per-user index in force.
 
 ## Where WP7 landed — the biggest finding of the program
 

--- a/docs/remediation/packages/WP6.yaml
+++ b/docs/remediation/packages/WP6.yaml
@@ -1,6 +1,8 @@
 package: WP6
 title: Idempotency & replay — bind the key to the request
-status: REMEDIATED
+status: ACCEPTED
+merged_sha: 4302547
+merged_pr: 354
 depends_on: [WP4]
 risks: [CR-03, N4]
 

--- a/docs/remediation/packages/WP8.yaml
+++ b/docs/remediation/packages/WP8.yaml
@@ -1,0 +1,67 @@
+package: WP8
+title: Policy convergence — one eligibility authority
+status: IN_PROGRESS
+depends_on: [WP4]
+risks: [CR-05, N5, N6]
+
+objective: >
+  "May this capability be served right now?" is currently answered by two
+  different columns, consulted by different rails, and by neither in the place
+  that matters most. WP4 did this for billability; this is the same move for
+  eligibility.
+
+# Measured against PRODUCTION, not read off the audit.
+production_evidence:
+  two_authorities_already_disagree: >
+    6 capabilities have lifecycle_state = 'validating' with is_active = true.
+    The wallet rail gates on `isActive` (routes/do.ts:642) and would serve them.
+    The x402 rail gates on lifecycle_state IN ('active','probation')
+    (routes/x402-gateway-v2.ts:157-164) and would not. Same capability, same
+    instant, two answers — decided by which rail the caller used. This is CR-02
+    restated for eligibility instead of billability.
+  solution_steps_are_gated_by_nothing: >
+    24 solution steps point at a capability that is either non-servable by
+    lifecycle or is_active = false. lib/solution-executor.ts contains no
+    eligibility check of any kind — grep for lifecycleState, isActive or
+    quarantine returns nothing. So a capability the platform has decided not to
+    serve still runs, as a step, inside the bundles that are the most expensive
+    thing we sell.
+  catalogue_shape:
+    - "active/is_active=true: 299"
+    - "deactivated/is_active=false: 20"
+    - "degraded/is_active=false: 8"
+    - "validating/is_active=true: 6   <- the divergence"
+    - "active/is_active=false: 5      <- and the mirror of it"
+    - "probation/is_active=true: 1"
+
+defects:
+  divergent_predicates: >
+    lib/x402-eligibility.ts::isX402PayableCapability exists and is correct, but
+    it is imported by exactly one file (routes/do.ts). Every other rail
+    open-codes its own rule, so the shared predicate is a convention rather than
+    an authority.
+  in_flight_delisting_race: >
+    The x402 gateway answers from a 60-second catalogue cache
+    (routes/x402-gateway-v2.ts, CACHE_TTL_MS). A capability quarantined mid-
+    window keeps serving until the cache turns over, and the quality floor's
+    delisting is exactly the event that should take effect immediately.
+  breaker_does_not_hear_x402: >
+    WP4 wired counts_against_capability into the /v1/do breaker sites. The x402
+    rail records failures in its own transaction rows but does not feed the same
+    signal, so a capability failing only on the x402 rail is invisible to the
+    circuit breaker and to the quality floor.
+
+# Exit condition 2 named `checkSolutionGates` autoactivation. That symbol does
+# not exist anywhere in the tree — verified by grep across src/. Either it was
+# removed before this program began or the audit named it from an older
+# revision. Recorded rather than silently dropped; nothing to delete.
+checkSolutionGates: ABSENT_ALREADY
+
+exit_conditions:
+  - one predicate answers "may this be served", consumed by every rail
+  - solution steps consult it                      # 24 live steps do not today
+  - quarantine unbypassable on /v1/do X-Payment    # already true (WP0); keep it true by construction
+  - the delisting race is closed or bounded
+  - x402 failures feed the same breaker signal as wallet failures
+  - a guard prevents a new rail open-coding its own rule
+  - independent adversarial review passes

--- a/docs/remediation/packages/WP8.yaml
+++ b/docs/remediation/packages/WP8.yaml
@@ -83,6 +83,39 @@ review:
     email-validate, the single highest-volume x402 slug at roughly a fifth of
     call volume. isX402RailEligible mirrors the gateway's own catalogue filter.
 
+  second_review_round:
+    blocking_1_the_rule_was_in_a_rail_not_the_authority: >
+      The withheld-component rule shipped inside routes/solution-execute.ts, so
+      the WALLET rail applied it and the x402 rail did not — a partially
+      successful x402 run with a quarantined component would still have settled
+      full price. CR-02 again: one economic fact, two rails, two answers. Worse,
+      putting the rule in a rail violated the exact principle
+      lib/execution-outcome.ts exists to enforce, which I had written myself one
+      package earlier. Now in aggregateSolutionOutcome, so `billable` accounts
+      for it and both rails inherit it.
+    blocking_2_toctou_on_solution_eligibility: >
+      Eligibility was loaded once before any group executed, so a capability
+      quarantined after the run started still executed in a later group from a
+      stale snapshot — the same delisting race WP8 closed on the x402 catalogue
+      cache, with a shorter window and no justification for the inconsistency.
+      Re-read per group now, with the invariant stated so it is testable: a
+      quarantine stops execution that has NOT begun; steps already in flight
+      finish, because killing those discards work the customer is about to
+      receive (the WP3 reservation-TTL reasoning). The stale columns were
+      REMOVED from the step query rather than left in scope — a tempting stale
+      copy is how the first version went wrong.
+    non_blocking_metric_name: >
+      platformHealth.quarantined counted every active invisible capability while
+      the docs said eight of nine are pre-launch. Renamed to
+      withheldFromCatalog. Publishing a knowingly wrong name is worse than an
+      imprecise one. The rename surfaced a consumer in scripts/ceo-dashboard.ts
+      that my earlier grep missed because it searched only src/ — it printed
+      "N paused", which was never true; it now reads "not yet live".
+    tests_added:
+      - "x402 solution with a quality-floor-style quarantine: withheld step never executes, settlement never occurs, an unbilled canonical row exists"
+      - "quarantine landing BETWEEN groups: the next group does not run against the stale snapshot"
+      - "both mutation-checked — removing the aggregate rule reddens the parity test, defeating the per-group re-read reddens the race test"
+
   non_blocking_closed:
     - "a fifth open-coded copy in routes/a2a.ts, invisible to the guard because it was a bare array literal — the most likely copy-paste shape"
     - "lib/suggest.ts was MORE permissive than the floor; my allowlist entry claimed the opposite, classified without reading"

--- a/docs/remediation/packages/WP8.yaml
+++ b/docs/remediation/packages/WP8.yaml
@@ -1,6 +1,6 @@
 package: WP8
 title: Policy convergence — one eligibility authority
-status: IN_PROGRESS
+status: REMEDIATED
 depends_on: [WP4]
 risks: [CR-05, N5, N6]
 
@@ -56,6 +56,50 @@ defects:
 # removed before this program began or the audit named it from an older
 # revision. Recorded rather than silently dropped; nothing to delete.
 checkSolutionGates: ABSENT_ALREADY
+
+review:
+  independent_agent: FAIL_REMEDIATION_REQUIRED, then all findings closed
+
+  blocking_1_the_gate_could_not_see_quarantine: >
+    isServableCapability read is_active and lifecycle_state. The quality floor
+    quarantines with {visible:false, x402Enabled:false} — it touches NEITHER, so
+    the predicate returned true for every floor-quarantined capability and the
+    gate let them straight through. Production: page-speed-test quarantined
+    2026-08-20, still is_active=true and lifecycle_state='active', and a step in
+    TWO live x402-enabled paid solutions; danish-company-data the same in FOUR
+    more, two of them EUR 2.50 KYB bundles. Six live paid solutions contain a
+    quarantined capability.
+
+    This also made my report to Petter wrong. I had told him there was no live
+    exposure, having queried the two columns quarantine does not use. His
+    instinct that "solutions using forbidden capabilities is not ok" was right
+    and my correction of it was not.
+
+  blocking_2_would_have_broken_the_biggest_x402_earner: >
+    The live re-read used /v1/do's predicate, which excludes free-tier because
+    that rail serves those calls for free. The gateway is different: on it
+    "free" means price_cents = 0, and free-tier capabilities carry a real price
+    and are genuinely sold there. Six would have 503'd permanently — including
+    email-validate, the single highest-volume x402 slug at roughly a fifth of
+    call volume. isX402RailEligible mirrors the gateway's own catalogue filter.
+
+  non_blocking_closed:
+    - "a fifth open-coded copy in routes/a2a.ts, invisible to the guard because it was a bare array literal — the most likely copy-paste shape"
+    - "lib/suggest.ts was MORE permissive than the floor; my allowlist entry claimed the opposite, classified without reading"
+    - "an import line exempted a whole file from the guard; now a call or shared-constant import is required"
+    - "only four directories were scanned; a new top-level dir was a free bypass"
+    - "two guard assertions were satisfied by the import line alone — delete the logic, keep the import, still green"
+    - "the quarantine test set {lifecycleState:'degraded', isActive:false}, which is DEACTIVATION; it passed while proving something else, and its title contradicted production"
+    - "the metrics comment claimed nine quarantines; one is a floor quarantine, eight are pre-launch"
+
+  consequence_for_petter: >
+    Six live paid solutions currently depend on a quarantined capability. With
+    the gate working, those bundles no longer run that step — and because a
+    component WE withheld is not partial delivery, they no longer charge for the
+    run either (DEC-14). Four DK solutions lose danish-company-data, two SEO
+    solutions lose page-speed-test. Not charging is the platform's call;
+    DEACTIVATING a revenue earner is not, so the solutions stay live and simply
+    do not bill until the capabilities are promoted back.
 
 exit_conditions:
   - one predicate answers "may this be served", consumed by every rail


### PR DESCRIPTION
## Solutions were running capabilities the platform had withdrawn

`lib/solution-executor.ts` contained no eligibility check of any kind. A capability quarantined by the quality floor still ran as a step inside a paid bundle.

**Live in production when this was written:** `page-speed-test` and `danish-company-data` are quarantined and sit inside **six live paid solutions**, two of them €2.50 KYB bundles. `danish-company-data` is the Danish registry lookup — the central component of a Danish KYB check.

## Why the first attempt missed it

The quality floor quarantines with `{visible: false, x402Enabled: false}`. It touches **neither** `is_active` nor `lifecycle_state`.

My first version of `isServableCapability` read exactly those two columns. So it returned `true` for every floor-quarantined capability and the gate I had just added let them straight through — and the same blind spot made my report of the exposure wrong, not just my code. The predicate now reads `visible`, which is the platform's actual delisting signal.

The test made the same mistake: it set `{lifecycleState: "degraded", isActive: false}`, which is *deactivation*. It passed while proving something else, and its title contradicted production. It now quarantines exactly the way the floor does; deactivation is covered separately.

## The second blocking find: this nearly took out the biggest x402 earner

The live re-read I added to close the delisting race used `/v1/do`'s predicate — which excludes free-tier, because that rail serves those calls for nothing. The gateway is different: on it "free" means `price_cents = 0`, and free-tier capabilities carry a real price and are genuinely sold there.

All six would have returned `503` permanently, including `email-validate` — roughly a fifth of x402 call volume. `isX402RailEligible` now mirrors the gateway's own catalogue filter, so the SQL and the runtime check cannot drift.

## What else converged

- **The delisting race is closed.** The 60-second catalogue cache is now a routing hint; eligibility is verified against the database before anything executes or settles.
- **Quarantine is unbypassable by naming a slug** on `/v1/do`.
- **`lib/suggest.ts` was *more* permissive than the floor** (`["active","degraded"]`), recommending capabilities `/v1/do` then refused. My own allowlist entry claimed the opposite — I had classified it without reading it.
- **A fifth open-coded copy** lived in `routes/a2a.ts`, written as a bare array literal, which is why the guard couldn't see it — the worst possible miss, since that's the literal body of `isServableCapability` and the most likely copy-paste.
- **`lib/matching.ts` held a third and fourth rule**, one admitting `degraded` — a state every other rail refuses. Converged on the floor, with recommendation allowed to be *stricter* and never looser.

## A bundle we couldn't fully run doesn't charge

A component **we** withheld is not partial delivery. A KYB Complete missing its registry lookup is not a KYB Complete, and billing €2.50 for it would be charging for a hollow answer (DEC-14).

**Consequence for the six affected solutions:** they stay live and bill €0 until their dependencies are promoted back. Not charging is the platform's call; *deactivating a revenue earner* is not, so I have not withdrawn them.

## The guard

Two of its assertions were satisfied by an **import line alone** — delete the logic, keep the import, still green. Both now require a call, and both were verified to go red when the logic is removed. Its file-level exemption meant `x402-gateway-v2.ts` went invisible the moment it imported the module; it only scanned four directories, so a new top-level dir was a free bypass.

Deliberately **not** added: an `is_active` pattern. A rail gating on `isActive` alone is the divergence in miniature, but that expression appears in every backfill script and listing query in the tree — scanning for it flagged twenty legitimate files. A guard needing a thirty-entry allowlist is noise, and noise gets silenced.

## Verification

16 gates pass. 2,272 unit tests; 103 integration tests across 15 files. Every fix verified discriminating by mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
