### PR TITLE
WP8 hotfix: withheld means the floor's full signature, not half of it

### DIFF
--- a/apps/api/src/lib/solution-executor.ts
+++ b/apps/api/src/lib/solution-executor.ts
@@ -424,6 +424,7 @@ export async function executeSolution(
         isActive: capabilities.isActive,
         lifecycleState: capabilities.lifecycleState,
         visible: capabilities.visible,
+        x402Enabled: capabilities.x402Enabled,
       })
       .from(capabilities)
       .where(inArray(capabilities.slug, groupSlugs));
@@ -450,6 +451,7 @@ export async function executeSolution(
           isActive: fresh.isActive,
           lifecycleState: fresh.lifecycleState,
           visible: fresh.visible,
+          x402Enabled: fresh.x402Enabled,
         });
 
       const executor = servable ? getExecutor(step.capabilitySlug) : undefined;

--- a/apps/api/src/lib/x402-eligibility.test.ts
+++ b/apps/api/src/lib/x402-eligibility.test.ts
@@ -12,6 +12,7 @@ import {
   isX402PayableCapability,
   X402_PAYABLE_LIFECYCLE_STATES,
   type X402EligibilityFields,
+  isServableCapability,
 } from "./x402-eligibility.js";
 
 const payable: X402EligibilityFields = {
@@ -74,5 +75,46 @@ describe("isX402PayableCapability", () => {
 
   it("only ever admits the two documented lifecycle states", () => {
     expect([...X402_PAYABLE_LIFECYCLE_STATES]).toEqual(["active", "probation"]);
+  });
+});
+describe("what counts as WITHHELD (the post-deploy correction)", () => {
+  const base = { isActive: true, lifecycleState: "active" };
+
+  it("a floor quarantine is withheld — both flags off", () => {
+    // jobs/quality-floor.ts sets {visible:false, x402Enabled:false}.
+    expect(
+      isServableCapability({ ...base, visible: false, x402Enabled: false }),
+    ).toBe(false);
+  });
+
+  it("merely hidden from the catalogue is NOT withheld", () => {
+    // The regression this test exists to prevent. danish-company-data is
+    // invisible but x402-enabled, marketplace-eligible, lifecycle active, with
+    // zero health-monitor events — never withdrawn. Reading `visible` alone
+    // made it unservable and broke four live DK solutions, which skipped their
+    // Danish registry lookup and billed nothing.
+    expect(
+      isServableCapability({ ...base, visible: false, x402Enabled: true }),
+    ).toBe(true);
+  });
+
+  it("a published capability is servable whether or not it is on the x402 rail", () => {
+    // Most capabilities are wallet-only. Requiring x402Enabled would have
+    // withheld the majority of the catalogue.
+    expect(
+      isServableCapability({ ...base, visible: true, x402Enabled: false }),
+    ).toBe(true);
+    expect(
+      isServableCapability({ ...base, visible: true, x402Enabled: true }),
+    ).toBe(true);
+  });
+
+  it("still refuses a deactivated or non-servable lifecycle regardless of flags", () => {
+    expect(
+      isServableCapability({ ...base, isActive: false, visible: true, x402Enabled: true }),
+    ).toBe(false);
+    expect(
+      isServableCapability({ ...base, lifecycleState: "validating", visible: true, x402Enabled: true }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/lib/x402-eligibility.ts
+++ b/apps/api/src/lib/x402-eligibility.ts
@@ -67,7 +67,7 @@ export interface ServabilityFields {
   isActive: boolean;
   lifecycleState: string;
   /**
-   * THE quarantine signal, and the one this predicate originally missed.
+   * Half of the quarantine signal. See `x402Enabled` — BOTH are required.
    *
    * jobs/quality-floor.ts quarantines with `{visible: false, x402Enabled:
    * false}` — it changes NEITHER is_active NOR lifecycle_state. So a predicate
@@ -80,6 +80,24 @@ export interface ServabilityFields {
    * reason and equally should not run.
    */
   visible: boolean;
+  /**
+   * The other half, and the correction that post-deploy verification forced.
+   *
+   * The floor quarantines with `{visible:false, x402Enabled:false}` — BOTH. I
+   * first read `visible` alone, which is overloaded: it also means "hidden from
+   * the catalogue" for reasons that have nothing to do with quality.
+   * `danish-company-data` is exactly that — invisible, but x402-enabled,
+   * marketplace-eligible, lifecycle active, and with ZERO health-monitor
+   * events. It was never withdrawn. Treating it as withheld broke four live DK
+   * solutions, which skipped their Danish registry lookup and billed nothing
+   * for a capability nobody had quarantined.
+   *
+   * Verified against every invisible-but-active capability in production: the
+   * conjunction exonerates danish-company-data and correctly withholds the
+   * floor quarantine plus the seven pre-launch rows, which equally should not
+   * run inside a paid bundle.
+   */
+  x402Enabled: boolean;
 }
 
 /** Lifecycle states in which a capability is fit to execute. */
@@ -111,9 +129,9 @@ export const SERVABLE_LIFECYCLE_STATES = ["active", "probation"] as const;
  */
 export function isServableCapability(cap: ServabilityFields): boolean {
   if (!cap.isActive) return false;
-  // Quarantined or pre-launch. See the field docs — omitting this made the
-  // predicate blind to the platform's own primary delisting action.
-  if (!cap.visible) return false;
+  // Withheld == the floor's full signature, not half of it. `visible` alone is
+  // overloaded and catches capabilities that were merely hidden, never withdrawn.
+  if (!cap.visible && !cap.x402Enabled) return false;
   return (SERVABLE_LIFECYCLE_STATES as readonly string[]).includes(
     cap.lifecycleState,
   );


### PR DESCRIPTION
## Caught by the post-deploy verification, and it was live

`visible` is overloaded. The quality floor quarantines with **both** `{visible:false, x402Enabled:false}` — but `visible=false` alone also means "hidden from the catalogue" for reasons unrelated to quality.

`danish-company-data` is exactly that: invisible, but **x402-enabled, marketplace-eligible, lifecycle active, and with zero health-monitor events**. It was never withdrawn.

Reading `visible` alone made it unservable, so four live DK solutions skipped their Danish registry lookup — the central component of a Danish KYB check — and billed €0 for a capability nobody had quarantined:

| Solution | Price |
|---|---|
| `kyb-complete-dk` | €2.50 |
| `invoice-verify-dk` | €2.50 |
| `kyb-essentials-dk` | €1.50 |
| `kyc-denmark` | €1.50 |

## The fix

Withheld requires the floor's full signature. Verified against every invisible-but-active capability in production:

```
danish-company-data      x402=true   -> withheld=false   (never withdrawn)
page-speed-test          x402=false  -> withheld=true    (real floor quarantine)
page-exists              x402=false  -> withheld=true    (pre-launch)
google-news-search       x402=false  -> withheld=true    (pre-launch)
serp-related-questions   x402=false  -> withheld=true    (pre-launch)
uk-gazette-notice-search x402=false  -> withheld=true    (pre-launch)
us-company-data-cobalt   x402=false  -> withheld=true    (pre-launch)
us-ein-match             x402=false  -> withheld=true    (pre-launch)
us-sec-filings-extended  x402=false  -> withheld=true    (pre-launch)
```

The conjunction exonerates the one capability that was merely hidden and correctly withholds the real quarantine plus the seven pre-launch rows, which equally should not run inside a paid bundle.

## Tests

The existing integration tests already quarantine with both flags — they were written to mirror the floor exactly — and pass unchanged. Four unit tests now pin the distinction so "hidden" and "withdrawn" cannot be conflated again.

16 gates pass. 2,277 unit tests; 105 integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)