### PR TITLE
WP8 follow-up: enforce no-half-quarantine in Postgres, plus the mutation-test guard

### DIFF
--- a/apps/api/scripts/mutation-test.mjs
+++ b/apps/api/scripts/mutation-test.mjs
@@ -1,46 +1,61 @@
 #!/usr/bin/env node
 /**
- * Run a mutation test safely.
+ * Run a mutation test safely, and prove the result means something.
  *
  * WHY THIS EXISTS
  *
  * During the 2026-08-21 remediation program, `git checkout -- <file>` destroyed
- * uncommitted work FOUR times. Each time the sequence was identical: write a
- * fix, mutate it to prove a test discriminates, then "restore" with
- * `git checkout --` — which does not restore anything, it discards. Work that
- * had never been committed was simply gone. Twice it was caught only because a
- * later step failed for an unrelated reason; once an entire migration block
- * vanished and only the mutation check itself noticed.
+ * uncommitted work FOUR times. Each time: write a fix, mutate it to prove a test
+ * discriminates, then "restore" with `git checkout --` — which does not restore,
+ * it discards. Work never committed was simply gone.
  *
- * A rule was not enough, because the rule was known and broken anyway. This is
- * the tooling.
+ * A rule was not enough, because the rule was known and broken anyway.
  *
- * WHAT IT GUARANTEES
+ * THE PROTOCOL, AND WHY EACH STEP IS THERE
  *
- *   1. It REFUSES to run if the working tree is dirty. Nothing uncommitted can
- *      be lost, because nothing uncommitted is allowed to exist.
- *   2. It records the candidate commit SHA before touching anything.
- *   3. It restores from that SHA — a named commit, never the "discard local
- *      changes" form — and verifies the tree matches afterwards.
+ *   clean tree → baseline PASS → mutate → FAIL → restore → PASS → clean tree
+ *
+ * The first version of this script mutated first and treated ANY non-zero exit
+ * as "mutation caught". That is wrong, and it produced a false result inside
+ * this very package: four tests were committed with a missing import, so the
+ * suite was already red, and the tool cheerfully reported MUTATION CAUGHT. An
+ * already-failing suite catches every mutation and proves nothing. So does a
+ * missing database, a bad env var, a timeout, or a typo in the test command —
+ * all of them exit non-zero, and none of them are evidence.
+ *
+ * Requiring green BEFORE and green AFTER is what separates "this test
+ * discriminates" from "something is broken". The trailing green also proves the
+ * restore actually worked, rather than leaving a half-mutated tree behind.
  *
  * USAGE
  *
  *   node scripts/mutation-test.mjs \
  *     --file src/lib/x.ts \
- *     --find "the exact source text to replace" \
- *     --replace "the mutated text" \
- *     --test "npx vitest run --no-file-parallelism src/lib/x.test.ts"
- *
- * A mutation test PASSES when the suite goes RED. A green suite under mutation
- * means the test does not discriminate and is not evidence of anything.
+ *     --find "exact source text to replace" \
+ *     --replace "mutated text" \
+ *     --test "npx vitest run src/lib/x.test.ts"
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
-import { argv, exit } from "node:process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { argv, exit, platform } from "node:process";
 
 function git(...args) {
   return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+/** Runs the caller's test command. Returns true when it exits 0. */
+function runTest(command) {
+  try {
+    execFileSync(
+      platform === "win32" ? "cmd" : "sh",
+      platform === "win32" ? ["/c", command] : ["-c", command],
+      { stdio: "inherit" },
+    );
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function arg(name) {
@@ -60,67 +75,116 @@ if (!file || !find || !test) {
   exit(2);
 }
 
-// ── Guard 1: the tree must be clean ─────────────────────────────────────────
-//
-// This is the whole safety property. Everything below can overwrite files, and
-// overwriting is only safe when the pre-state is recoverable from a commit.
-const dirty = git("status", "--porcelain", "--untracked-files=no");
-if (dirty) {
-  console.error(
-    "REFUSING TO RUN: the working tree has uncommitted changes.\n\n" +
-      dirty +
-      "\n\nCommit the candidate first. Mutation testing overwrites files and\n" +
-      "restores them from a commit; anything not committed cannot be restored.\n" +
-      "This guard exists because `git checkout --` destroyed uncommitted\n" +
-      "remediation work four times in one session.",
-  );
+function refuse(reason) {
+  console.error(`REFUSING TO RUN: ${reason}`);
   exit(1);
+}
+
+// ── Guard 1: the tree must be clean, INCLUDING UNTRACKED FILES ──────────────
+//
+// The first version passed `--untracked-files=no`, which let an UNTRACKED
+// target through: the file looked clean, got mutated, and could not be restored
+// because it does not exist in any commit. The restore would then either fail or
+// delete it outright. Untracked files are precisely the ones with no recoverable
+// copy, so they are the last thing that should be exempt.
+const dirty = git("status", "--porcelain");
+if (dirty) {
+  refuse(
+    "the working tree is not clean.\n\n" +
+      dirty +
+      "\n\nCommit the candidate first. This script overwrites files and restores\n" +
+      "them from a commit; anything not committed cannot be restored. Untracked\n" +
+      "files count — they are the ones with no recoverable copy at all.",
+  );
 }
 
 const candidateSha = git("rev-parse", "HEAD");
-console.log(`candidate commit: ${candidateSha}`);
+
+// ── Guard 2: the target must exist IN THE CANDIDATE COMMIT ──────────────────
+//
+// A clean tree is not sufficient on its own: a path can be clean and still be
+// absent from HEAD (for example, ignored). Restoring it would fail.
+try {
+  git("cat-file", "-e", `${candidateSha}:${file}`);
+} catch {
+  refuse(
+    `${file} does not exist in the candidate commit ${candidateSha.slice(0, 12)}.\n` +
+      "It could be mutated but not restored.",
+  );
+}
+
+if (!existsSync(file)) refuse(`${file} does not exist on disk.`);
 
 const original = readFileSync(file, "utf8");
 if (!original.includes(find)) {
-  console.error(
-    `REFUSING TO RUN: the --find text is not present in ${file}.\n` +
+  refuse(
+    `the --find text is not present in ${file}.\n` +
       "A mutation that changes nothing produces a green run and proves nothing.",
+  );
+}
+
+console.log(`candidate commit: ${candidateSha}`);
+
+// ── Step 1: BASELINE MUST BE GREEN ──────────────────────────────────────────
+//
+// Without this the whole exercise is meaningless — see the header. A red
+// baseline "catches" every mutation, and so does a broken environment.
+console.log("\n── baseline (must PASS) ─────────────────────────────────────");
+if (!runTest(test)) {
+  refuse(
+    "the baseline test run FAILED before any mutation was applied.\n\n" +
+      "An already-failing suite reports every mutation as caught, which is how a\n" +
+      "false result entered this package. Fix the baseline, then mutate.\n" +
+      "The same applies to a missing database, a bad env var, or a typo in the\n" +
+      "test command: all exit non-zero and none are evidence.",
+  );
+}
+
+// ── Step 2: mutate, and the test MUST go red ────────────────────────────────
+let mutationCaught = false;
+let restoredGreen = false;
+try {
+  writeFileSync(file, original.replace(find, replace), "utf8");
+  console.log(`\n── mutated ${file} (must FAIL) ──────────────────────────────`);
+  mutationCaught = !runTest(test);
+} finally {
+  // ── Step 3: restore from the RECORDED COMMIT ──────────────────────────────
+  //
+  // `git checkout <sha> -- <path>` restores a known version. The banned form is
+  // `git checkout -- <path>`, which discards uncommitted work — the cause of the
+  // four incidents this script exists to prevent.
+  git("checkout", candidateSha, "--", file);
+
+  const afterwards = git("status", "--porcelain");
+  if (afterwards) {
+    console.error(
+      `\nRESTORE INCOMPLETE — tree still dirty after restoring from ${candidateSha}:\n${afterwards}`,
+    );
+    exit(1);
+  }
+  console.log(`\n── restored ${file} from ${candidateSha.slice(0, 12)} ───────`);
+}
+
+// ── Step 4: GREEN AGAIN ─────────────────────────────────────────────────────
+//
+// Proves the restore genuinely put the candidate back, and that the red run was
+// the mutation rather than something that broke midway and stayed broken.
+console.log("\n── after restore (must PASS again) ─────────────────────────");
+restoredGreen = runTest(test);
+
+if (!restoredGreen) {
+  console.error(
+    "\nINCONCLUSIVE — the suite is still red after restoring the candidate.\n" +
+      "The red run cannot be attributed to the mutation. Investigate before\n" +
+      "trusting any mutation result from this file.",
   );
   exit(1);
 }
 
-let testFailed = false;
-try {
-  writeFileSync(file, original.replace(find, replace), "utf8");
-  console.log(`mutated ${file}`);
-
-  try {
-    execFileSync(process.platform === "win32" ? "cmd" : "sh",
-      process.platform === "win32" ? ["/c", test] : ["-c", test],
-      { stdio: "inherit" });
-  } catch {
-    testFailed = true;
-  }
-} finally {
-  // ── Guard 3: restore from the RECORDED COMMIT ─────────────────────────────
-  //
-  // `git checkout <sha> -- <path>` restores a known-good version. The banned
-  // form is `git checkout -- <path>`, which silently discards uncommitted work
-  // — and is what caused the incidents this script exists to prevent.
-  git("checkout", candidateSha, "--", file);
-
-  const afterwards = git("status", "--porcelain", "--untracked-files=no");
-  if (afterwards) {
-    console.error(
-      `RESTORE INCOMPLETE — the tree is still dirty after restoring from ${candidateSha}:\n${afterwards}`,
-    );
-    exit(1);
-  }
-  console.log(`restored ${file} from ${candidateSha}; tree clean`);
-}
-
-if (testFailed) {
-  console.log("\nMUTATION CAUGHT — the suite went red. The test discriminates.");
+if (mutationCaught) {
+  console.log(
+    "\nMUTATION CAUGHT — green → red → green. The test discriminates.",
+  );
   exit(0);
 }
 

--- a/apps/api/scripts/mutation-test.mjs
+++ b/apps/api/scripts/mutation-test.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Run a mutation test safely.
+ *
+ * WHY THIS EXISTS
+ *
+ * During the 2026-08-21 remediation program, `git checkout -- <file>` destroyed
+ * uncommitted work FOUR times. Each time the sequence was identical: write a
+ * fix, mutate it to prove a test discriminates, then "restore" with
+ * `git checkout --` — which does not restore anything, it discards. Work that
+ * had never been committed was simply gone. Twice it was caught only because a
+ * later step failed for an unrelated reason; once an entire migration block
+ * vanished and only the mutation check itself noticed.
+ *
+ * A rule was not enough, because the rule was known and broken anyway. This is
+ * the tooling.
+ *
+ * WHAT IT GUARANTEES
+ *
+ *   1. It REFUSES to run if the working tree is dirty. Nothing uncommitted can
+ *      be lost, because nothing uncommitted is allowed to exist.
+ *   2. It records the candidate commit SHA before touching anything.
+ *   3. It restores from that SHA — a named commit, never the "discard local
+ *      changes" form — and verifies the tree matches afterwards.
+ *
+ * USAGE
+ *
+ *   node scripts/mutation-test.mjs \
+ *     --file src/lib/x.ts \
+ *     --find "the exact source text to replace" \
+ *     --replace "the mutated text" \
+ *     --test "npx vitest run --no-file-parallelism src/lib/x.test.ts"
+ *
+ * A mutation test PASSES when the suite goes RED. A green suite under mutation
+ * means the test does not discriminate and is not evidence of anything.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { argv, exit } from "node:process";
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function arg(name) {
+  const i = argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : argv[i + 1];
+}
+
+const file = arg("file");
+const find = arg("find");
+const replace = arg("replace") ?? "";
+const test = arg("test");
+
+if (!file || !find || !test) {
+  console.error(
+    "usage: mutation-test.mjs --file <path> --find <text> [--replace <text>] --test <command>",
+  );
+  exit(2);
+}
+
+// ── Guard 1: the tree must be clean ─────────────────────────────────────────
+//
+// This is the whole safety property. Everything below can overwrite files, and
+// overwriting is only safe when the pre-state is recoverable from a commit.
+const dirty = git("status", "--porcelain", "--untracked-files=no");
+if (dirty) {
+  console.error(
+    "REFUSING TO RUN: the working tree has uncommitted changes.\n\n" +
+      dirty +
+      "\n\nCommit the candidate first. Mutation testing overwrites files and\n" +
+      "restores them from a commit; anything not committed cannot be restored.\n" +
+      "This guard exists because `git checkout --` destroyed uncommitted\n" +
+      "remediation work four times in one session.",
+  );
+  exit(1);
+}
+
+const candidateSha = git("rev-parse", "HEAD");
+console.log(`candidate commit: ${candidateSha}`);
+
+const original = readFileSync(file, "utf8");
+if (!original.includes(find)) {
+  console.error(
+    `REFUSING TO RUN: the --find text is not present in ${file}.\n` +
+      "A mutation that changes nothing produces a green run and proves nothing.",
+  );
+  exit(1);
+}
+
+let testFailed = false;
+try {
+  writeFileSync(file, original.replace(find, replace), "utf8");
+  console.log(`mutated ${file}`);
+
+  try {
+    execFileSync(process.platform === "win32" ? "cmd" : "sh",
+      process.platform === "win32" ? ["/c", test] : ["-c", test],
+      { stdio: "inherit" });
+  } catch {
+    testFailed = true;
+  }
+} finally {
+  // ── Guard 3: restore from the RECORDED COMMIT ─────────────────────────────
+  //
+  // `git checkout <sha> -- <path>` restores a known-good version. The banned
+  // form is `git checkout -- <path>`, which silently discards uncommitted work
+  // — and is what caused the incidents this script exists to prevent.
+  git("checkout", candidateSha, "--", file);
+
+  const afterwards = git("status", "--porcelain", "--untracked-files=no");
+  if (afterwards) {
+    console.error(
+      `RESTORE INCOMPLETE — the tree is still dirty after restoring from ${candidateSha}:\n${afterwards}`,
+    );
+    exit(1);
+  }
+  console.log(`restored ${file} from ${candidateSha}; tree clean`);
+}
+
+if (testFailed) {
+  console.log("\nMUTATION CAUGHT — the suite went red. The test discriminates.");
+  exit(0);
+}
+
+console.error(
+  "\nMUTATION SURVIVED — the suite stayed green with the fix removed.\n" +
+    "The test does not discriminate and is not evidence that the fix works.",
+);
+exit(1);

--- a/apps/api/src/jobs/invariant-checker.ts
+++ b/apps/api/src/jobs/invariant-checker.ts
@@ -17,6 +17,7 @@ import { getDb } from "../db/index.js";
 import { capabilities, solutions, solutionSteps, testResults, testSuites, capabilityHealth, healthMonitorEvents } from "../db/schema.js";
 import { logHealthEvent } from "../lib/health-monitor.js";
 import { sendAlert } from "../lib/alerting.js";
+import { alertOnce } from "../lib/alert-once.js";
 import { randomUUID } from "node:crypto";
 import { log, logError, logWarn } from "../lib/log.js";
 import { isShuttingDown } from "../lib/shutdown.js";
@@ -75,6 +76,14 @@ export async function runInvariantChecks(): Promise<void> {
     checked += r3.checked;
   } catch (err) {
     jobLog.error({ label: "invariant-check-3-failed", check: "orphaned-steps", err: err instanceof Error ? { message: err.message, stack: err.stack } : err }, "invariant-check-3-failed");
+  }
+
+  try {
+    const r6 = await checkPartialQuarantineState(jobLog);
+    alerts += r6.alerts;
+    checked += r6.checked;
+  } catch (err) {
+    jobLog.error({ label: "invariant-check-6-failed", check: "partial-quarantine", err: err instanceof Error ? { message: err.message, stack: err.stack } : err }, "invariant-check-6-failed");
   }
 
   // Correlated failure detection deferred (lived inside the CHECK 4 block
@@ -1195,3 +1204,67 @@ async function checkLyingBreakers(): Promise<{ alerts: number; checked: number }
   return { alerts: 1, checked: lying.length };
 }
 
+
+
+/**
+ * A capability must not sit HALF-quarantined.
+ *
+ * `jobs/quality-floor.ts` withdraws with `{visible:false, x402Enabled:false}`
+ * and `jobs/capability-promotion.ts` restores `{visible:true, x402Enabled:…}` —
+ * both write the pair together, in one statement, inside a transaction. So
+ * neither can produce `visible=false, x402_enabled=true`.
+ *
+ * Production held exactly that state anyway. `danish-company-data` was
+ * quarantined on 2026-08-12 with the intended DB state recorded in its
+ * manifest, and on 2026-08-21T00:08 a single un-audited row write set
+ * `x402_enabled` back to true while leaving it invisible. No job wrote it, no
+ * commit corresponds, and no health-monitor event records it — the platform has
+ * no audit trail for capability flag changes at all.
+ *
+ * The consequence was not cosmetic: the capability was listed and purchasable
+ * over x402 while failing 100% of real customer calls (14 of 14 over 90 days),
+ * and a review of WP8 nearly redefined the servability authority around the
+ * drifted row rather than repairing it.
+ *
+ * So the invariant is asserted rather than assumed. It alerts; it does not
+ * self-heal, because which direction to repair — withdraw or promote — is a
+ * quality judgement that belongs to the floor and the promotion job, not to a
+ * consistency sweep guessing from two booleans.
+ */
+export async function checkPartialQuarantineState(
+  jobLog: { error: (obj: unknown, msg: string) => void },
+): Promise<{ alerts: number; checked: number }> {
+  const db = getDb();
+  const rows = (await db.execute(sql`
+    SELECT slug, lifecycle_state
+    FROM capabilities
+    WHERE is_active = true AND visible = false AND x402_enabled = true
+    ORDER BY slug
+  `)) as unknown as Array<{ slug: string; lifecycle_state: string }>;
+
+  if (rows.length === 0) return { alerts: 0, checked: 1 };
+
+  const slugs = rows.map((r) => r.slug);
+  jobLog.error(
+    { label: "invariant-partial-quarantine", slugs, count: rows.length },
+    "invariant-partial-quarantine",
+  );
+
+  await alertOnce("invariant-partial-quarantine", 6 * 60 * 60 * 1000, {
+    subject: `${rows.length} capability(ies) are half-quarantined`,
+    body:
+      `${slugs.join(", ")} — withdrawn from the catalogue (visible=false) but still ` +
+      `enabled on the x402 rail. Neither the quality floor nor the promotion job can ` +
+      `produce this state; both write the pair together. It therefore indicates an ` +
+      `out-of-band row write.
+
+` +
+      `A capability in this state is purchasable while the platform considers it ` +
+      `withdrawn. Decide which way it should go and apply BOTH flags: withdraw ` +
+      `(visible=false, x402_enabled=false) or promote via the promotion job, which ` +
+      `restores lifecycle, visibility and rail together.`,
+    severity: "critical",
+  });
+
+  return { alerts: 1, checked: 1 };
+}

--- a/apps/api/src/jobs/invariant-checker.ts
+++ b/apps/api/src/jobs/invariant-checker.ts
@@ -1250,6 +1250,28 @@ export async function checkPartialQuarantineState(
     "invariant-partial-quarantine",
   );
 
+  // Recorded INDEPENDENTLY of the page. alertOnce suppresses on a cooldown, so
+  // a condition that persists for days would leave one alert and no further
+  // trace — "the condition existed" and "a page was sent" are separate facts,
+  // and only the first belongs in the health record.
+  try {
+    await logHealthEvent({
+      eventType: "invariant_alert",
+      capabilitySlug: slugs[0],
+      // Tier 1: the capability is purchasable while the platform considers it
+      // withdrawn, which is a revenue-integrity fault, not a degradation.
+      tier: 1,
+      actionTaken:
+        `half-quarantined (visible=false, x402_enabled=true): ${slugs.join(", ")}`,
+      details: { slugs, count: rows.length, invariant: "no_half_quarantine" },
+    });
+  } catch (err) {
+    jobLog.error(
+      { label: "invariant-partial-quarantine-event-failed", err },
+      "invariant-partial-quarantine-event-failed",
+    );
+  }
+
   await alertOnce("invariant-partial-quarantine", 6 * 60 * 60 * 1000, {
     subject: `${rows.length} capability(ies) are half-quarantined`,
     body:

--- a/apps/api/src/jobs/partial-quarantine.integration.test.ts
+++ b/apps/api/src/jobs/partial-quarantine.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * A capability must never sit half-quarantined (WP8 follow-up).
+ *
+ * Neither job that writes these flags can produce the state: the quality floor
+ * withdraws with `{visible:false, x402Enabled:false}` and the promotion job
+ * restores `{visible:true, x402Enabled:…}` — both write the pair together, in
+ * one statement, inside a transaction.
+ *
+ * Production held it anyway. `danish-company-data` was quarantined on
+ * 2026-08-12 with the intended DB state recorded in its manifest, and on
+ * 2026-08-21T00:08 a single un-audited write set `x402_enabled` back to true
+ * while leaving it invisible. No job wrote it, no commit corresponds, no
+ * health-monitor event records it. It was then listed and purchasable over
+ * x402 while failing 100% of real customer calls — 14 of 14 over 90 days.
+ *
+ * The drift also nearly cost the platform its servability authority: a proposed
+ * fix read the drifted row as evidence that `visible=false` should stop meaning
+ * "withdrawn", which would have redefined the rule around corrupted state.
+ *
+ * So the invariant is checked against a real database rather than asserted in
+ * prose.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../test-support/integration-db.js";
+import { capabilities } from "../db/schema.js";
+
+if (process.env.DATABASE_URL_TEST) {
+  process.env.AUDIT_HMAC_SECRET ??= "wp8-inv-secret-at-least-32-chars-0000000";
+  process.env.ADMIN_SECRET ??= "wp8-inv-admin-secret-at-least-32-chars00";
+}
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+describeMaybe("half-quarantined capabilities are detected", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  const seeded: string[] = [];
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 4 });
+    db = drizzle(client);
+  }, 120_000);
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  afterEach(async () => {
+    for (const id of seeded.splice(0)) {
+      await db.delete(capabilities).where(eq(capabilities.id, id));
+    }
+  });
+
+  async function seedCapability(flags: {
+    visible: boolean;
+    x402Enabled: boolean;
+    isActive?: boolean;
+  }): Promise<string> {
+    const id = randomUUID();
+    const slug = `wp8-inv-${randomUUID().slice(0, 8)}`;
+    seeded.push(id);
+    await db.insert(capabilities).values({
+      id,
+      slug,
+      name: `WP8 invariant probe ${slug}`,
+      description: "Seeded by the partial-quarantine invariant test.",
+      category: "developer-tools",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      priceCents: 10,
+      isActive: flags.isActive ?? true,
+      visible: flags.visible,
+      x402Enabled: flags.x402Enabled,
+      lifecycleState: "active",
+      avgLatencyMs: 50,
+    });
+    return slug;
+  }
+
+  /** The invariant, expressed exactly as the checker queries it. */
+  async function halfQuarantined(): Promise<string[]> {
+    const rows = await db
+      .select({ slug: capabilities.slug })
+      .from(capabilities)
+      .where(
+        eq(capabilities.isActive, true),
+      );
+    const flagged: string[] = [];
+    for (const r of rows) {
+      const [full] = await db
+        .select({
+          slug: capabilities.slug,
+          visible: capabilities.visible,
+          x402Enabled: capabilities.x402Enabled,
+        })
+        .from(capabilities)
+        .where(eq(capabilities.slug, r.slug))
+        .limit(1);
+      if (full && !full.visible && full.x402Enabled) flagged.push(full.slug);
+    }
+    return flagged;
+  }
+
+  it("flags withdrawn-from-catalogue-but-still-sellable", async () => {
+    // The exact shape production held: invisible, yet on the paid rail.
+    const slug = await seedCapability({ visible: false, x402Enabled: true });
+    expect(await halfQuarantined()).toContain(slug);
+  });
+
+  it("does not flag a fully withdrawn capability", async () => {
+    // What the quality floor actually writes.
+    const slug = await seedCapability({ visible: false, x402Enabled: false });
+    expect(await halfQuarantined()).not.toContain(slug);
+  });
+
+  it("does not flag a published capability, on or off the rail", async () => {
+    // Most capabilities are wallet-only; flagging those would make the check
+    // noise, and noise gets silenced.
+    const onRail = await seedCapability({ visible: true, x402Enabled: true });
+    const offRail = await seedCapability({ visible: true, x402Enabled: false });
+    const flagged = await halfQuarantined();
+    expect(flagged).not.toContain(onRail);
+    expect(flagged).not.toContain(offRail);
+  });
+
+  it("the CHECKER itself flags it — not a re-implementation of its query", async () => {
+    // The first draft of this test re-ran the predicate inline and asserted on
+    // that, which proves the test's own SQL and nothing about the checker. It
+    // now calls the checker.
+    const { checkPartialQuarantineState } = await import("./invariant-checker.js");
+
+    const clean = await checkPartialQuarantineState({ error: () => {} });
+    expect(clean.alerts, "no drift seeded yet").toBe(0);
+
+    await seedCapability({ visible: false, x402Enabled: true });
+
+    const logged: unknown[] = [];
+    const dirty = await checkPartialQuarantineState({
+      error: (obj) => logged.push(obj),
+    });
+
+    expect(dirty.alerts).toBe(1);
+    expect(JSON.stringify(logged)).toMatch(/partial-quarantine|wp8-inv-/);
+  });
+});

--- a/apps/api/src/jobs/partial-quarantine.integration.test.ts
+++ b/apps/api/src/jobs/partial-quarantine.integration.test.ts
@@ -27,6 +27,8 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { randomUUID } from "node:crypto";
 
+import { sql as sqlRaw } from "drizzle-orm";
+
 import { useTestDatabase } from "../test-support/integration-db.js";
 import { capabilities } from "../db/schema.js";
 
@@ -42,10 +44,25 @@ describeMaybe("half-quarantined capabilities are detected", () => {
   let client: ReturnType<typeof postgres>;
   let db: ReturnType<typeof drizzle>;
   const seeded: string[] = [];
+  /**
+   * The constraint definition AS THE MIGRATION INSTALLED IT.
+   *
+   * Captured once, before any test touches it, and restored verbatim. The first
+   * version of the helper re-added a hardcoded correct predicate, which
+   * overwrote whatever block 0099 had actually written — so replacing the
+   * migration's CHECK with `CHECK (true)` left every test green. Restoring the
+   * original is what keeps this suite honest about the migration.
+   */
+  let originalConstraintDef: string | null = null;
 
   beforeAll(async () => {
     client = postgres(DATABASE_URL_TEST!, { max: 4 });
     db = drizzle(client);
+    const rows = (await db.execute(
+      sqlRaw`SELECT pg_get_constraintdef(oid) AS def
+             FROM pg_constraint WHERE conname = 'capabilities_no_half_quarantine'`,
+    )) as unknown as Array<{ def: string }>;
+    originalConstraintDef = rows[0]?.def ?? null;
   }, 120_000);
 
   afterAll(async () => {
@@ -57,6 +74,48 @@ describeMaybe("half-quarantined capabilities are detected", () => {
       await db.delete(capabilities).where(eq(capabilities.id, id));
     }
   });
+
+  /**
+   * Seed a state the CHECK constraint forbids.
+   *
+   * Block 0099 makes half-quarantine unreachable through normal writes, which
+   * is the point — but it also means the scheduled checker can no longer be
+   * exercised by inserting the condition. That is not a reason to stop testing
+   * the checker: the migration DEFERS on lock contention, so a boot can leave
+   * the constraint absent, and the checker is exactly what covers that window.
+   *
+   * So the constraint is dropped for the duration of the assertion and restored
+   * immediately, modelling the real scenario rather than pretending the checker
+   * is dead code.
+   */
+  async function withoutConstraint<T>(fn: () => Promise<T>): Promise<T> {
+    await db.execute(
+      sqlRaw`ALTER TABLE capabilities DROP CONSTRAINT IF EXISTS capabilities_no_half_quarantine`,
+    );
+    try {
+      return await fn();
+    } finally {
+      // Clear the violators BEFORE restoring: afterEach has not run yet, so a
+      // VALIDATE here would find the very rows the assertion just used and
+      // throw inside the finally, masking the test result.
+      await db.execute(
+        sqlRaw`DELETE FROM capabilities
+               WHERE is_active AND NOT visible AND x402_enabled`,
+      );
+      // Verbatim, so the suite never substitutes its own idea of the rule for
+      // the migration's. If the migration installed nothing, restore nothing.
+      if (originalConstraintDef) {
+        await db.execute(
+          sqlRaw`ALTER TABLE capabilities
+                 ADD CONSTRAINT capabilities_no_half_quarantine
+                 ${sqlRaw.raw(originalConstraintDef)} NOT VALID`,
+        );
+        await db.execute(
+          sqlRaw`ALTER TABLE capabilities VALIDATE CONSTRAINT capabilities_no_half_quarantine`,
+        );
+      }
+    }
+  }
 
   async function seedCapability(flags: {
     visible: boolean;
@@ -110,8 +169,10 @@ describeMaybe("half-quarantined capabilities are detected", () => {
 
   it("flags withdrawn-from-catalogue-but-still-sellable", async () => {
     // The exact shape production held: invisible, yet on the paid rail.
-    const slug = await seedCapability({ visible: false, x402Enabled: true });
-    expect(await halfQuarantined()).toContain(slug);
+    await withoutConstraint(async () => {
+      const slug = await seedCapability({ visible: false, x402Enabled: true });
+      expect(await halfQuarantined()).toContain(slug);
+    });
   });
 
   it("does not flag a fully withdrawn capability", async () => {
@@ -139,14 +200,90 @@ describeMaybe("half-quarantined capabilities are detected", () => {
     const clean = await checkPartialQuarantineState({ error: () => {} });
     expect(clean.alerts, "no drift seeded yet").toBe(0);
 
-    await seedCapability({ visible: false, x402Enabled: true });
+    await withoutConstraint(async () => {
+      await seedCapability({ visible: false, x402Enabled: true });
 
-    const logged: unknown[] = [];
-    const dirty = await checkPartialQuarantineState({
-      error: (obj) => logged.push(obj),
+      const logged: unknown[] = [];
+      const dirty = await checkPartialQuarantineState({
+        error: (obj) => logged.push(obj),
+      });
+
+      expect(dirty.alerts).toBe(1);
+      expect(JSON.stringify(logged)).toMatch(/partial-quarantine|wp8-inv-/);
     });
+  });
 
-    expect(dirty.alerts).toBe(1);
-    expect(JSON.stringify(logged)).toMatch(/partial-quarantine|wp8-inv-/);
+  it("the MIGRATION installed a constraint with the right predicate", async () => {
+    // Without this the rejection test below proves nothing about the migration:
+    // withoutConstraint() drops and re-adds a correct constraint of its own, so
+    // by the time the rejection runs, the constraint under test may be the
+    // helper's rather than block 0099's. Caught by mutation — replacing the
+    // migration's predicate with CHECK (true) left every test green.
+    expect(originalConstraintDef, "block 0099 must install the constraint").not.toBeNull();
+    const def = originalConstraintDef!.toLowerCase();
+    expect(def).toContain("is_active");
+    expect(def).toContain("visible");
+    expect(def).toContain("x402_enabled");
+    expect(def, "a CHECK (true) would satisfy a mere existence assertion").not.toMatch(
+      /check \(true\)/,
+    );
+  });
+
+  it("POSTGRES rejects the invalid transition — the checker is defence in depth", async () => {
+    // The blocking review point. A scheduled check catches the NEXT out-of-band
+    // write only after up to two hours during which the capability is on sale.
+    // The database refuses it outright, which is the difference between
+    // detecting and preventing.
+    const slug = await seedCapability({ visible: true, x402Enabled: true });
+
+    // Withdrawing from the catalogue while leaving it on the paid rail is
+    // exactly the shape production held.
+    await expect(
+      db
+        .update(capabilities)
+        .set({ visible: false })
+        .where(eq(capabilities.slug, slug)),
+    ).rejects.toThrow(/capabilities_no_half_quarantine/i);
+
+    // The row is unchanged — the write was refused, not partially applied.
+    const [after] = await db
+      .select({ visible: capabilities.visible, x402Enabled: capabilities.x402Enabled })
+      .from(capabilities)
+      .where(eq(capabilities.slug, slug));
+    expect(after!.visible).toBe(true);
+    expect(after!.x402Enabled).toBe(true);
+  });
+
+  it("but a COMPLETE withdrawal is still allowed", async () => {
+    // The constraint must not block the quality floor doing its job. It writes
+    // both flags in one statement, which satisfies the CHECK.
+    const slug = await seedCapability({ visible: true, x402Enabled: true });
+    await db
+      .update(capabilities)
+      .set({ visible: false, x402Enabled: false })
+      .where(eq(capabilities.slug, slug));
+
+    const [after] = await db
+      .select({ visible: capabilities.visible, x402Enabled: capabilities.x402Enabled })
+      .from(capabilities)
+      .where(eq(capabilities.slug, slug));
+    expect(after!.visible).toBe(false);
+    expect(after!.x402Enabled).toBe(false);
+  });
+
+  it("and a deactivated capability may hold any flag combination", async () => {
+    // The constraint is scoped to is_active. A deactivated row is not on sale
+    // whatever its flags say, and constraining it would block ordinary
+    // deactivation paths for no safety gain.
+    const slug = await seedCapability({
+      visible: false,
+      x402Enabled: true,
+      isActive: false,
+    });
+    const [row] = await db
+      .select({ slug: capabilities.slug })
+      .from(capabilities)
+      .where(eq(capabilities.slug, slug));
+    expect(row).toBeDefined();
   });
 });

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1236,7 +1236,7 @@ describe("startup-migrations — block 0087 (un-hide content-redacted rows)", ()
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 41 blocks in historical order", () => {
+  it("exports the expected 42 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1285,6 +1285,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0096_x402SettlementIntents",
       "runMigration0097_chainSequence",
       "runMigration0098_perCustomerIdempotency",
+      "runMigration0099_noHalfQuarantine",
     ]);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1900,6 +1900,71 @@ export async function runMigration0098_perCustomerIdempotency(
 }
 
 
+/**
+ * Block 0099 — half-quarantine is invalid, enforced by the database (WP8).
+ *
+ * `is_active AND NOT visible AND x402_enabled` means "withdrawn from the
+ * catalogue, still purchasable on the paid rail". No code path produces it: the
+ * quality floor writes both flags together to withdraw, and the promotion job
+ * writes both together to restore.
+ *
+ * Production held it anyway. `danish-company-data` was quarantined 2026-08-12
+ * with the intended state recorded in its manifest, and an out-of-band write on
+ * 2026-08-21 set `x402_enabled` back to true while leaving it invisible. It was
+ * then listed and purchasable while failing 100% of real customer calls — 14 of
+ * 14 over 90 days. Nothing detected it; the manifest note is the only reason it
+ * was diagnosable at all.
+ *
+ * A scheduled checker (jobs/invariant-checker.ts) catches the NEXT one, but only
+ * after up to two hours during which the capability is on sale. The database can
+ * refuse it outright, which is the difference between detecting and preventing.
+ *
+ * Shape, per block 0095: ADD CONSTRAINT ... NOT VALID first, so no full-table
+ * ACCESS EXCLUSIVE scan blocks writes on a hot table, then VALIDATE separately.
+ * Failure is logged and retried next boot rather than thrown — a throw aborts
+ * boot, and a failed Railway deploy does not cut over.
+ *
+ * Verified read-only against production before writing: 0 violating rows across
+ * 340 capabilities. `solutions` has no `visible` column, so the rule is
+ * capability-only by construction.
+ */
+export async function runMigration0099_noHalfQuarantine(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  let outcome: string;
+
+  try {
+    await tx.execute(sql`SET LOCAL lock_timeout = '3s'`);
+    await tx.execute(sql`
+      DO $$
+      BEGIN
+        ALTER TABLE "capabilities"
+          ADD CONSTRAINT "capabilities_no_half_quarantine"
+          CHECK (NOT ("is_active" AND NOT "visible" AND "x402_enabled")) NOT VALID;
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+    `);
+    await tx.execute(sql`
+      ALTER TABLE "capabilities" VALIDATE CONSTRAINT "capabilities_no_half_quarantine"
+    `);
+    outcome = "constraint present and validated";
+  } catch (err) {
+    // Deferring is safe: until the constraint exists the scheduled invariant
+    // check still reports the state, so the platform is not blind in the gap.
+    outcome =
+      "deferred to next boot: " +
+      (err instanceof Error ? err.message.slice(0, 140) : String(err).slice(0, 140));
+  }
+
+  return {
+    block: "0099_no_half_quarantine",
+    outcome: `capabilities_no_half_quarantine — ${outcome}`,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+
 export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResult>> = [
   runMigration0029_actualCostCents,
   runMigration0030_complianceColumns,
@@ -1943,6 +2008,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0096_x402SettlementIntents,
   runMigration0097_chainSequence,
   runMigration0098_perCustomerIdempotency,
+  runMigration0099_noHalfQuarantine,
 ];
 
 /**

--- a/apps/api/src/lib/x402-eligibility.test.ts
+++ b/apps/api/src/lib/x402-eligibility.test.ts
@@ -76,3 +76,33 @@ describe("isX402PayableCapability", () => {
     expect([...X402_PAYABLE_LIFECYCLE_STATES]).toEqual(["active", "probation"]);
   });
 });
+
+describe("isServableCapability — may this run at all", () => {
+  const base = { isActive: true, lifecycleState: "active" };
+
+  it("refuses a capability withdrawn from the catalogue", () => {
+    // The quality floor's withdrawal signal. Found missing by
+    // scripts/mutation-test.mjs: deleting this branch from the predicate left
+    // the whole unit suite green, because the only coverage was an integration
+    // test. A rule with no unit test is a rule one refactor from disappearing.
+    expect(isServableCapability({ ...base, visible: false })).toBe(false);
+  });
+
+  it("allows a published capability", () => {
+    expect(isServableCapability({ ...base, visible: true })).toBe(true);
+  });
+
+  it("refuses a deactivated capability whatever its visibility", () => {
+    expect(isServableCapability({ ...base, isActive: false, visible: true })).toBe(false);
+  });
+
+  it("allows probation but refuses the pre-launch and failed states", () => {
+    expect(isServableCapability({ ...base, lifecycleState: "probation", visible: true })).toBe(true);
+    for (const state of ["validating", "degraded", "deactivated", "draft"]) {
+      expect(
+        isServableCapability({ ...base, lifecycleState: state, visible: true }),
+        `${state} must not be servable`,
+      ).toBe(false);
+    }
+  });
+});

--- a/apps/api/src/lib/x402-eligibility.test.ts
+++ b/apps/api/src/lib/x402-eligibility.test.ts
@@ -12,6 +12,7 @@ import {
   isX402PayableCapability,
   X402_PAYABLE_LIFECYCLE_STATES,
   type X402EligibilityFields,
+  isServableCapability,
 } from "./x402-eligibility.js";
 
 const payable: X402EligibilityFields = {

--- a/apps/api/test/mutation-test.test.ts
+++ b/apps/api/test/mutation-test.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The mutation-test guard must itself be discriminating.
+ *
+ * It exists because `git checkout --` destroyed uncommitted remediation work
+ * four times, and its first version shipped two holes that a review caught:
+ *
+ *   1. `--untracked-files=no` let an UNTRACKED target through. Untracked files
+ *      are exactly the ones with no recoverable copy, so exempting them
+ *      inverted the guard's purpose.
+ *   2. It mutated first and treated any non-zero exit as "caught", which makes
+ *      a red baseline, a missing database, a bad env var and a typo in the test
+ *      command all indistinguishable from a discriminating test. That produced
+ *      a false MUTATION CAUGHT inside this very package.
+ *
+ * Every case below runs the real script against a THROWAWAY git repository
+ * created per test, so a bug in the tool cannot reach this one.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { platform } from "node:process";
+
+// The test lives in test/ because vitest only globs src/** and test/**; the
+// script itself stays in scripts/ with its siblings.
+const SCRIPT = join(import.meta.dirname, "..", "scripts", "mutation-test.mjs");
+
+let repo: string;
+
+function git(...args: string[]): string {
+  return execFileSync("git", args, { cwd: repo, encoding: "utf8" }).trim();
+}
+
+/** Run the guard; capture its exit code and combined output. */
+function runGuard(opts: {
+  file: string;
+  find: string;
+  replace?: string;
+  test: string;
+}): { code: number; out: string } {
+  try {
+    const out = execFileSync(
+      process.execPath,
+      [
+        SCRIPT,
+        "--file", opts.file,
+        "--find", opts.find,
+        "--replace", opts.replace ?? "",
+        "--test", opts.test,
+      ],
+      { cwd: repo, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return { code: 0, out };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { code: e.status ?? 1, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
+
+/**
+ * Test commands built from shell builtins rather than `node -e`.
+ *
+ * `node -e "..."` looked obvious and does not survive the round trip: on Windows
+ * `process.execPath` is "C:\Program Files\nodejs\node.exe" and cmd splits it on
+ * the space, and the nested quoting mangles differently again on sh. The guard
+ * correctly REFUSED the broken command as a failing baseline — which is how the
+ * problem was found, and a small demonstration that the refusal works.
+ */
+const isWin = platform === "win32";
+const PASS_CMD = "exit 0";
+const FAIL_CMD = "exit 1";
+/** Passes only while the marker is present — i.e. a discriminating test. */
+const DISCRIMINATING_CMD = isWin
+  ? "findstr GUARD src.txt >nul"
+  : "grep -q GUARD src.txt";
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "mutation-guard-"));
+  git("init", "-q");
+  git("config", "user.email", "t@example.test");
+  git("config", "user.name", "t");
+  mkdirSync(join(repo, "sub"), { recursive: true });
+  writeFileSync(join(repo, "src.txt"), "keep GUARD here\n");
+  git("add", "-A");
+  git("commit", "-q", "-m", "candidate");
+});
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe("the guard refuses what it cannot restore", () => {
+  it("refuses when the tree is dirty", () => {
+    writeFileSync(join(repo, "src.txt"), "modified\n");
+    const r = runGuard({ file: "src.txt", find: "modified", test: PASS_CMD });
+    expect(r.code).not.toBe(0);
+    expect(r.out).toMatch(/working tree is not clean/i);
+  });
+
+  it("refuses an UNTRACKED target, and leaves it untouched", () => {
+    // The review's first blocking finding. An untracked file has no copy in any
+    // commit, so mutating it is unrecoverable — the exact case the earlier
+    // `--untracked-files=no` flag waved through.
+    const untracked = join(repo, "sub", "new.txt");
+    writeFileSync(untracked, "ORIGINAL CONTENT\n");
+
+    const r = runGuard({
+      file: "sub/new.txt",
+      find: "ORIGINAL",
+      replace: "MUTATED",
+      test: PASS_CMD,
+    });
+
+    expect(r.code).not.toBe(0);
+    expect(r.out).toMatch(/not clean|does not exist in the candidate commit/i);
+    // Not modified — refusing must mean refusing, not "refused after writing".
+    expect(readFileSync(untracked, "utf8")).toBe("ORIGINAL CONTENT\n");
+  });
+
+  it("refuses when the find text is absent", () => {
+    const r = runGuard({ file: "src.txt", find: "NOT PRESENT", test: PASS_CMD });
+    expect(r.code).not.toBe(0);
+    expect(r.out).toMatch(/not present/i);
+  });
+});
+
+describe("a result only counts as green → red → green", () => {
+  it("REFUSES a red baseline rather than reporting a caught mutation", () => {
+    // The review's second blocking finding, and it already produced a false
+    // result in this package: four tests were committed with a missing import,
+    // so the suite was red, and the tool reported MUTATION CAUGHT.
+    const r = runGuard({ file: "src.txt", find: "GUARD", test: FAIL_CMD });
+
+    expect(r.code).not.toBe(0);
+    expect(r.out).toMatch(/baseline test run FAILED/i);
+    expect(r.out, "a red baseline must never read as success").not.toMatch(
+      /MUTATION CAUGHT/,
+    );
+    // And it must refuse BEFORE mutating.
+    expect(readFileSync(join(repo, "src.txt"), "utf8")).toContain("GUARD");
+  });
+
+  it("reports MUTATION CAUGHT for a genuinely discriminating test", () => {
+    const r = runGuard({
+      file: "src.txt",
+      find: "GUARD",
+      replace: "gone",
+      test: DISCRIMINATING_CMD,
+    });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/MUTATION CAUGHT/);
+    // Restored, and the tree is clean again.
+    expect(readFileSync(join(repo, "src.txt"), "utf8")).toContain("GUARD");
+    expect(git("status", "--porcelain")).toBe("");
+  });
+
+  it("reports MUTATION SURVIVED when the test does not discriminate", () => {
+    const r = runGuard({
+      file: "src.txt",
+      find: "GUARD",
+      replace: "gone",
+      test: PASS_CMD,
+    });
+
+    expect(r.code).not.toBe(0);
+    expect(r.out).toMatch(/MUTATION SURVIVED/);
+    expect(readFileSync(join(repo, "src.txt"), "utf8")).toContain("GUARD");
+  });
+
+  it("restores the candidate even when the mutated run fails", () => {
+    runGuard({
+      file: "src.txt",
+      find: "GUARD",
+      replace: "gone",
+      test: DISCRIMINATING_CMD,
+    });
+    // Line-ending agnostic: git restores using the platform checkout
+    // convention, so an exact-bytes comparison fails on Windows for reasons
+    // unrelated to the guard.
+    expect(readFileSync(join(repo, "src.txt"), "utf8").trim()).toBe("keep GUARD here");
+    expect(git("status", "--porcelain")).toBe("");
+  });
+});

--- a/docs/remediation/CURRENT-STATE.md
+++ b/docs/remediation/CURRENT-STATE.md
@@ -10,6 +10,29 @@ _Last updated: 2026-08-21 (session 1)_
 - **Human approvals granted:** program-level autonomy (run continuously; escalate only per CHECK-IN A/B/C)
 - **Awaiting founder:** nothing. One item is logged for *visibility only*, not decision — see "Codex disposition" below.
 
+## The `danish-company-data` chronology — recorded so it cannot be re-litigated
+
+Written out in full because a later reader could easily reconstruct the wrong
+story from the code alone, and one review round already did.
+
+| When | What |
+|---|---|
+| **2026-08-12** | Legitimately quarantined by the quality floor — the first action under DEC-20260812-A's escalation contract. 0% completion on 11 external calls over 90 days; cvrapi.dk's free tier was exhausted and failing even identifier lookups. Intended DB state recorded in `manifests/danish-company-data.yaml`: **`visible=false, x402_enabled=false`**. Recovery condition documented: quota top-up (Petter's action), then re-verify via a prod sweep. |
+| **2026-08-21 00:08:18Z** | An **unexplained out-of-band write** set `x402_enabled` back to `true`, leaving `visible=false`. No job can produce this: the quality floor and the promotion job each write both flags together in one statement. No commit corresponds, no `health_monitor_events` row records it, and exactly one capability row changed in that minute. The platform has **no audit trail for capability flag changes**, which is why the writer is unidentifiable. |
+| **2026-08-21 (WP8)** | WP8 shipped and **correctly** treated the capability as non-servable — it was withdrawn from the catalogue, and that is what `visible=false` means. |
+| **2026-08-21 (PR #356)** | I inferred from the drifted row that `visible=false` should stop meaning "withdrawn", and opened a hotfix to redefine the servability authority around it. **Wrong on two counts**: the premise contradicted repository history, and the change coupled the global "fit to execute" authority to `x402Enabled`, a rail-specific flag — the exact coupling WP8 exists to remove. **Closed unmerged.** |
+| **2026-08-21 21:06Z** | Production restored to the intended `visible=false, x402_enabled=false` by one conditional update. No other capability was in that shape. |
+| **2026-08-21 (this package)** | A DB `CHECK` constraint now **prevents** the state, and a scheduled invariant check **detects** it if the constraint ever fails to apply. |
+
+**The capability is still not healthy and the quarantine still stands**: 14 real
+customer calls over 90 days, all 14 failed, zero successes. Promotion requires
+the manifest's documented recovery condition, not a flag flip.
+
+**The lesson worth keeping**: a production row is evidence of *state*, never of
+*policy*. Policy lives in the manifest, the decision record and the code that
+writes the state. I read a row and inferred a rule from it, which is the same
+error class as reading two columns without checking what writes them.
+
 ## Where WP6 landed
 
 Idempotency keys are bound to a fingerprint of the request they were issued

--- a/docs/remediation/packages/WP17.yaml
+++ b/docs/remediation/packages/WP17.yaml
@@ -55,6 +55,15 @@ requirements:
   - "Survives the writer being unaware of it. A script author must not need to remember anything."
   - "Bounded growth. These fields change rarely; a retention rule still needs stating rather than discovering later."
 
+v1_default: >
+  Immutable RECORDING, plus writer inventory and permission narrowing. Not
+  blocking. Recording is strictly additive and cannot break an operator mid-
+  incident; blocking is a behavioural change to every path that touches these
+  fields, and its cost is only knowable once the inventory exists.
+
+  Escalate to the founder ONLY with a concrete proposal: this class of write,
+  currently done by these paths, would be refused, at this operational cost.
+
 non_goals:
   - "Not a general row-audit system for every table. The value is concentrated in state that decides what is sold and at what price."
   - "Not a replacement for health_monitor_events, which records WHY the platform changed something. This records THAT it changed and by whom."
@@ -72,7 +81,12 @@ second_deliverable_inventory_and_narrowing: >
 open_questions_for_the_implementer:
   - "Trigger-based capture costs a write per state change and adds a failure mode to every UPDATE. Rare-change fields make that cheap, but the trade needs stating explicitly rather than assumed."
   - "Does the DB role separation exist to make the ledger genuinely append-only, or does the application connect as owner? If the latter, immutability is a convention and should be described as one."
-  - "Should a write with no recorded authority be REFUSED rather than recorded? That is a stronger and more disruptive design; it belongs to Petter, not the platform, because it can block legitimate operator action."
+  # Deliberately NOT an open question for the founder at spec time. Asking
+  # "should unattributed writes be refused?" in the abstract invites a policy
+  # decision with no concrete trade-off attached, which is the wrong shape of
+  # question to hand someone. v1 defaults to RECORDING, and escalates only if
+  # implementation produces a specific proposal to block an identified class of
+  # legitimate operator write, with the operational cost stated.
 
 exit_conditions:
   - a direct psql UPDATE to any scoped field is captured, with old and new values

--- a/docs/remediation/packages/WP17.yaml
+++ b/docs/remediation/packages/WP17.yaml
@@ -1,0 +1,83 @@
+package: WP17
+title: Immutable capability-state change ledger
+status: SPECIFIED_NOT_STARTED
+depends_on: [WP8]
+risks: [CR-05]
+
+# SPECIFICATION ONLY. Deliberately not implemented alongside WP8 — the reviewer
+# was explicit that this must not be folded into a package already in review,
+# and the scope below is larger than WP8's remaining surface.
+
+why_this_exists: >
+  On 2026-08-21 an out-of-band write flipped `danish-company-data.x402_enabled`
+  from false to true while leaving it invisible, putting a capability on the
+  paid rail that the platform had withdrawn and that fails 100% of real customer
+  calls. It was purchasable in that state for roughly 21 hours.
+
+  The writer could not be identified. Not "was difficult to identify" —
+  could not, at all. No job can produce the state, no commit corresponds, no
+  health-monitor event records it, and exactly one row changed in that minute.
+  The only reason the drift was diagnosable is that the capability's manifest
+  happened to record the intended state in a comment.
+
+  WP8 added a CHECK constraint that prevents that specific invalid combination
+  and an invariant check that detects it. Neither answers the general question:
+  WHO changed a capability's state, WHEN, and on what authority.
+
+the_gap_precisely: >
+  Application-level logging is insufficient and must not be proposed as the
+  solution. The write that caused this incident did not go through the
+  application — that is the defining property of the incident. A ledger that
+  only records what the application does would have recorded nothing.
+
+  Whatever is built must capture a direct `UPDATE capabilities SET ...` issued
+  from a psql session, a migration, a one-off script, or an admin tool, without
+  those writers cooperating.
+
+scope:
+  fields:
+    - is_active
+    - visible
+    - x402_enabled
+    - marketplace_eligible
+    - lifecycle_state
+    - deactivation_reason
+    - price_cents          # a silent price change is the same class of problem
+    - cost_class           # governs budget enforcement
+  tables:
+    - capabilities
+    - solutions            # is_active and x402_enabled carry the same weight there
+
+requirements:
+  - "Captures out-of-band SQL writes. A database-level mechanism — a trigger writing to an append-only table is the obvious candidate — not application middleware."
+  - "Immutable in practice: the ledger table must not be updatable or deletable by the application role."
+  - "Records the OLD and NEW value per field, the timestamp, and whatever actor identity the database can observe (session_user, application_name, client_addr). Honest about what it cannot know: a shared connection string reduces attribution to 'something using the app credentials'."
+  - "Survives the writer being unaware of it. A script author must not need to remember anything."
+  - "Bounded growth. These fields change rarely; a retention rule still needs stating rather than discovering later."
+
+non_goals:
+  - "Not a general row-audit system for every table. The value is concentrated in state that decides what is sold and at what price."
+  - "Not a replacement for health_monitor_events, which records WHY the platform changed something. This records THAT it changed and by whom."
+
+second_deliverable_inventory_and_narrowing: >
+  Alongside the ledger, inventory every path that can write these fields and
+  narrow it where possible. Known writers today: jobs/quality-floor.ts,
+  jobs/capability-promotion.ts, jobs/fix-lifecycle-anomalies.ts,
+  lib/capability-persistence.ts, lib/capability-onboarding.ts, the startup
+  migration blocks, and an unknown number of one-off scripts under
+  apps/api/scripts/ and its archive/. The incident write matched none of them.
+  Narrowing means: fewer paths, each identifiable, and a documented reason for
+  every one that remains.
+
+open_questions_for_the_implementer:
+  - "Trigger-based capture costs a write per state change and adds a failure mode to every UPDATE. Rare-change fields make that cheap, but the trade needs stating explicitly rather than assumed."
+  - "Does the DB role separation exist to make the ledger genuinely append-only, or does the application connect as owner? If the latter, immutability is a convention and should be described as one."
+  - "Should a write with no recorded authority be REFUSED rather than recorded? That is a stronger and more disruptive design; it belongs to Petter, not the platform, because it can block legitimate operator action."
+
+exit_conditions:
+  - a direct psql UPDATE to any scoped field is captured, with old and new values
+  - the ledger cannot be modified by the application role
+  - every known writer is inventoried, and unnecessary ones removed
+  - a retention rule exists for the ledger table
+  - the 2026-08-21 incident is replayable as a test: apply the same out-of-band write to a test database and show the ledger records it
+  - independent adversarial review passes


### PR DESCRIPTION
## What this closes

An out-of-band write put `danish-company-data` on the paid rail while the platform considered it withdrawn — for roughly 21 hours, while it failed 100% of real customer calls. Nothing detected it. The writer could not be identified.

## 1. Postgres refuses the state (the blocking item)

Block `0099_no_half_quarantine` adds:

```sql
CHECK (NOT (is_active AND NOT visible AND x402_enabled))
```

`NOT VALID` first — so no full-table `ACCESS EXCLUSIVE` scan blocks writes on a hot table — then `VALIDATE` separately, with a bounded lock wait and deferral rather than a throw (a throw aborts boot, and a failed Railway deploy does not cut over). Block 0095's shape.

**Production census verified read-only first:** 0 violating rows across 340 capabilities. `solutions` has no `visible` column, so the rule is capability-only by construction.

## 2. Real-DB discrimination tests

`partial-quarantine.integration.test.ts`, 8 tests against a real database, including that Postgres **rejects** the invalid transition and that a *complete* withdrawal (what the quality floor actually writes) is still allowed.

**This test took three attempts to become honest**, which is worth recording:

1. The helper dropped and re-added a *hardcoded correct* constraint — so replacing the migration's predicate with `CHECK (true)` left everything green.
2. Adding a predicate assertion didn't help; the helper still overwrote the migration's constraint before that test ran.
3. The helper now captures `pg_get_constraintdef` in `beforeAll` and restores it **verbatim**. Gutting the migration now turns exactly two tests red.

The checker's own tests drop the constraint deliberately, modelling the window where the checker actually matters — the migration *defers* on lock contention, so a boot can leave it absent.

## 3. Scheduled checker, as defence in depth

`checkPartialQuarantineState`, wired into the invariant checker. It alerts and does **not** self-heal: which way to repair is a quality judgement belonging to the floor and the promotion job, not a sweep guessing from two booleans.

## 4. Durable invariant event

A tier-1 `invariant_alert` health-monitor event, written independently of `alertOnce` — a cooldown must not erase the record that the condition existed.

## 5. Ledger chronology

`CURRENT-STATE.md` now carries the full `danish-company-data` timeline so the 2026-08-12 quarantine and the 2026-08-21 drift cannot be conflated, including that PR #356 inferred policy from the drifted row and was closed. The lesson is stated plainly: **a production row is evidence of state, never of policy.**

## 6. Follow-up package specified, not started

`docs/remediation/packages/WP17.yaml` — the immutable capability-state change ledger. Specification only. Its defining requirement is that it must capture writes that never touch the application, which is exactly what made this incident undiagnosable; application-level logging is explicitly ruled out as a solution.

## 7. Mutation-testing guard

`git checkout -- <file>` destroyed uncommitted remediation work **four times** in one session. The rule was known and broken anyway, so this is tooling: `scripts/mutation-test.mjs` refuses to run on a dirty tree, records the candidate SHA, restores from that commit, verifies the tree is clean afterwards, and refuses when the `--find` text is absent (a mutation that changes nothing produces a green run and proves nothing).

**It found a real gap on its first run:** deleting the `visible` branch from `isServableCapability` left the entire unit suite green — the only coverage was an integration test. Four unit tests added.

## Verification

16 gates pass. 2,277 unit tests; 113 integration tests across 16 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
