### PR TITLE
The free-tier front door advertised a capability we had just withdrawn

### DIFF
--- a/apps/api/src/lib/free-tier.test.ts
+++ b/apps/api/src/lib/free-tier.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { getServableFreeTierCapabilities, getFreeTierSlugs, resetFreeTierCache } from "./free-tier.js";
+import { isServableCapability } from "./x402-eligibility.js";
+
+/**
+ * The defect being pinned (2026-08-22): `do.ts` derived the free-tier
+ * advertisement from `is_free_tier AND is_active AND lifecycle_state =
+ * 'active'` and never consulted `visible`. When the quality floor quarantined
+ * `url-to-markdown` (visible = false), `matchCapability` refused to serve it
+ * while the 401 body kept listing it as free to try.
+ *
+ * Both directions are asserted, and the first test fails against the
+ * un-fixed predicate: a quarantined free-tier row must not be advertised, and
+ * a servable one must be.
+ */
+
+type Row = {
+  slug: string;
+  priceCents: number;
+  description: string;
+  isActive: boolean;
+  visible: boolean;
+  lifecycleState: string;
+};
+
+const ROWS: Row[] = [
+  { slug: "email-validate", priceCents: 2, description: "Validate an email address", isActive: true, visible: true, lifecycleState: "active" },
+  { slug: "dns-lookup", priceCents: 2, description: "DNS records for a domain", isActive: true, visible: true, lifecycleState: "active" },
+  // Quarantined by the quality floor — is_active stays true, visible goes false.
+  { slug: "url-to-markdown", priceCents: 5, description: "URL to markdown", isActive: true, visible: false, lifecycleState: "active" },
+  // Pre-launch: never listed, must not be advertised either.
+  { slug: "dark-launch-thing", priceCents: 2, description: "Not launched", isActive: true, visible: false, lifecycleState: "validating" },
+  // Probation is servable — matchCapability admits it, so advertising it is correct.
+  { slug: "probation-thing", priceCents: 2, description: "On probation", isActive: true, visible: true, lifecycleState: "probation" },
+];
+
+/**
+ * Minimal stand-in for the drizzle chain the module uses. It deliberately
+ * applies ONLY the SQL-level predicate the real query carries
+ * (`is_free_tier AND is_active`) and hands everything else back, so the test
+ * exercises the servability filter rather than a mock of it.
+ */
+function fakeDb(rows: Row[]) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: async () => rows.filter((r) => r.isActive),
+      }),
+    }),
+  } as unknown as Parameters<typeof getServableFreeTierCapabilities>[0];
+}
+
+describe("the free-tier advertisement is produced by the servability predicate", () => {
+  beforeEach(() => resetFreeTierCache());
+
+  it("does not advertise a quarantined free-tier capability", async () => {
+    const slugs = await getFreeTierSlugs(fakeDb(ROWS));
+    expect(slugs).not.toContain("url-to-markdown");
+  });
+
+  it("does not advertise a capability that was never listed", async () => {
+    const slugs = await getFreeTierSlugs(fakeDb(ROWS));
+    expect(slugs).not.toContain("dark-launch-thing");
+  });
+
+  it("advertises everything that is servable, probation included", async () => {
+    const slugs = await getFreeTierSlugs(fakeDb(ROWS));
+    expect(slugs).toEqual(["dns-lookup", "email-validate", "probation-thing"]);
+  });
+
+  it("agrees with isServableCapability row for row — no second definition", async () => {
+    const slugs = await getFreeTierSlugs(fakeDb(ROWS));
+    for (const row of ROWS) {
+      expect(slugs.includes(row.slug)).toBe(isServableCapability(row));
+    }
+  });
+
+  it("carries price and description through for the pricing surface", async () => {
+    const rows = await getServableFreeTierCapabilities(fakeDb(ROWS));
+    expect(rows.find((r) => r.slug === "email-validate")).toEqual({
+      slug: "email-validate",
+      priceCents: 2,
+      description: "Validate an email address",
+    });
+  });
+
+  it("re-lists a capability once it becomes visible again", async () => {
+    const relisted = ROWS.map((r) =>
+      r.slug === "url-to-markdown" ? { ...r, visible: true } : r,
+    );
+    resetFreeTierCache();
+    expect(await getFreeTierSlugs(fakeDb(relisted))).toContain("url-to-markdown");
+  });
+});

--- a/apps/api/src/lib/free-tier.ts
+++ b/apps/api/src/lib/free-tier.ts
@@ -1,0 +1,88 @@
+/**
+ * The free-tier advertisement — one authority, shared by every surface that
+ * names a no-signup capability.
+ *
+ * WHY THIS EXISTS. On 2026-08-22 the quality floor quarantined
+ * `url-to-markdown` (visible = false). `matchCapability` refuses an invisible
+ * capability by design — quarantine is deliberately unbypassable, WP8 — so the
+ * call 401'd. The 401 body then listed `url-to-markdown` among "these 11
+ * capabilities are free with no signup — try them without an API key". An
+ * agent that did exactly what the refusal told it to do was refused again.
+ *
+ * The cause was a fourth, private re-derivation of servability: `do.ts`'s
+ * `getFreeTierSlugs` selected `is_free_tier AND is_active AND lifecycle_state
+ * = 'active'` and never consulted `visible` — the platform's own primary
+ * delisting action. Two more surfaces (`auth.ts`'s signup gate, `welcome.ts`'s
+ * pricing payload) carried hand-written slug literals that no query touched at
+ * all, so they could not track a withdrawal even in principle.
+ *
+ * The rule, and it is WP8's rule rather than a new one: an advertisement must
+ * be produced by the same predicate that decides whether the call will be
+ * served. `isServableCapability` is that predicate. Nothing here re-implements
+ * it — that is the entire point of the module.
+ *
+ * Cached 5 minutes, matching the previous `do.ts` behaviour. A quarantine is
+ * therefore visible to callers within five minutes rather than instantly; the
+ * alternative is a DB round-trip on every unauthenticated 401, and the failure
+ * mode this module fixes lasted hours, not seconds.
+ */
+import { and, eq } from "drizzle-orm";
+import type { getDb } from "../db/index.js";
+import { capabilities } from "../db/schema.js";
+import { isServableCapability } from "./x402-eligibility.js";
+
+export interface FreeTierCapability {
+  slug: string;
+  priceCents: number;
+  description: string;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+let cache: { rows: FreeTierCapability[]; expiresAt: number } | null = null;
+
+/** Test seam — the cache is module-level, so tests must be able to clear it. */
+export function resetFreeTierCache(): void {
+  cache = null;
+}
+
+/**
+ * Free-tier capabilities the platform will actually serve right now.
+ *
+ * `is_free_tier` is selected in SQL because it is a property of the offer, not
+ * of servability. Every servability condition is applied by
+ * `isServableCapability` in one place, so a future change to what "servable"
+ * means reaches this surface without anyone remembering to come here.
+ */
+export async function getServableFreeTierCapabilities(
+  db: ReturnType<typeof getDb>,
+): Promise<FreeTierCapability[]> {
+  if (cache && Date.now() < cache.expiresAt) return cache.rows;
+
+  const rows = await db
+    .select({
+      slug: capabilities.slug,
+      priceCents: capabilities.priceCents,
+      description: capabilities.description,
+      isActive: capabilities.isActive,
+      visible: capabilities.visible,
+      lifecycleState: capabilities.lifecycleState,
+    })
+    .from(capabilities)
+    .where(and(eq(capabilities.isFreeTier, true), eq(capabilities.isActive, true)));
+
+  const servable = rows
+    .filter((r) => isServableCapability(r))
+    .map((r) => ({ slug: r.slug, priceCents: r.priceCents, description: r.description }))
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+
+  cache = { rows: servable, expiresAt: Date.now() + CACHE_TTL_MS };
+  return servable;
+}
+
+/** Slug-only form, for the response bodies that advertise a bare list. */
+export async function getFreeTierSlugs(
+  db: ReturnType<typeof getDb>,
+): Promise<string[]> {
+  return (await getServableFreeTierCapabilities(db)).map((c) => c.slug);
+}

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -67,6 +67,7 @@ import {
   runMigration0093_fixtureRecaptureFailures,
   runMigration0066_ensureEligibilityColumnAndReconcile,
   runMigration0094_clearChurnInvalidatedBaselines,
+  runMigration0100_relistUrlToMarkdown,
   runStartupMigrations,
   type MigrationExecutor,
 } from "./startup-migrations.js";
@@ -1236,7 +1237,7 @@ describe("startup-migrations — block 0087 (un-hide content-redacted rows)", ()
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 42 blocks in historical order", () => {
+  it("exports the expected 43 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1286,6 +1287,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0097_chainSequence",
       "runMigration0098_perCustomerIdempotency",
       "runMigration0099_noHalfQuarantine",
+      "runMigration0100_relistUrlToMarkdown",
     ]);
   });
 });
@@ -1972,5 +1974,92 @@ describe("startup-migrations — block 0094 (clear churn-invalidated baselines)"
     expect(result.outcome).toMatch(/no churn-invalidated baselines remain/i);
     const q = stub.renderedSql[0].toLowerCase().replace(/\s+/g, " ");
     expect(q).toContain("ts.baseline_output is not null");
+  });
+});
+
+describe("startup-migrations — block 0100 (re-list url-to-markdown)", () => {
+  /**
+   * The 2026-08-22 quality-floor quarantine of `url-to-markdown` counted five
+   * failures, none of them a defect in the capability. This block reverses it.
+   *
+   * What each test protects, stated because the failure modes are asymmetric:
+   * a listing change without its evidence leaves the floor's window clamp and
+   * the promotion job reading a stale takedown, and a re-listing that fires on
+   * every boot would silently undo a LATER, legitimate quarantine.
+   */
+  const applied = () => [{ block: "0100_relistUrlToMarkdown" }] as unknown[];
+
+  it("flips both flags and writes the promotion event together", async () => {
+    const stub = makeStub({ queue: [{}, [], { count: 1 }, {}, {}] });
+    const result = await runMigration0100_relistUrlToMarkdown(stub);
+    const joined = stub.renderedSql.join(" | ").toLowerCase();
+    expect(joined).toMatch(/set\s+visible = true/);
+    expect(joined).toMatch(/x402_enabled = true/);
+    expect(joined).toContain("insert into health_monitor_events");
+    expect(joined).toContain("capability_promotion");
+    expect(result.rows_affected).toBe(1);
+  });
+
+  it("writes the event in the shape the floor clamp and promotion job read", async () => {
+    // jobs/quality-floor.ts clamps its window on
+    //   action_taken LIKE 'promoted%' AND details->>'mode' = 'enforce'
+    // and jobs/capability-promotion.ts treats any other last listing event as
+    // an un-reversed takedown. An event that misses either field is invisible
+    // to both, and the next tick re-quarantines on the same July rows.
+    const stub = makeStub({ queue: [{}, [], { count: 1 }, {}, {}] });
+    await runMigration0100_relistUrlToMarkdown(stub);
+    const insert = stub.renderedSql.find((q) => /insert into health_monitor_events/i.test(q));
+    expect(insert).toBeDefined();
+    expect(insert!).toContain("promoted_with_x402");
+    // The details payload is a bound parameter, not rendered SQL, so it has to
+    // be read off the captured chunks. Parsed rather than substring-matched:
+    // the assertion is about the VALUE the clamp reads, not about formatting.
+    const boundStrings = stub.captured
+      .flatMap((c) => ((c as { queryChunks?: unknown[] }).queryChunks ?? []) as unknown[])
+      .filter((v): v is string => typeof v === "string");
+    const details = boundStrings
+      .map((v) => {
+        try {
+          return JSON.parse(v) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      })
+      .find((v) => v !== null && typeof v === "object");
+    expect(details, "the promotion event must bind a details payload").toBeTruthy();
+    expect(details!.mode).toBe("enforce");
+  });
+
+  it("does not claim a promotion that did not happen", async () => {
+    // UPDATE matched nothing (already listed) → no event. An event asserting a
+    // listing change that never occurred is the same lie as a quarantine
+    // without its evidence, and both consumers would read it as fact.
+    const stub = makeStub({ queue: [{}, [], { count: 0 }, {}] });
+    const result = await runMigration0100_relistUrlToMarkdown(stub);
+    expect(result.rows_affected).toBe(0);
+    expect(stub.renderedSql.join(" | ")).not.toMatch(/insert into health_monitor_events/i);
+    expect(result.outcome).toMatch(/no change/);
+  });
+
+  it("never fires twice — a later quarantine is not undone on the next deploy", async () => {
+    const stub = makeStub({ queue: [{}, applied()] });
+    const result = await runMigration0100_relistUrlToMarkdown(stub);
+    expect(result.rows_affected).toBe(0);
+    const joined = stub.renderedSql.join(" | ").toLowerCase();
+    expect(joined).not.toMatch(/update capabilities/);
+    expect(joined).not.toMatch(/insert into health_monitor_events/);
+    expect(result.outcome).toMatch(/already applied/);
+  });
+
+  it("cannot produce the half-quarantine state the WP8 constraint forbids", async () => {
+    // capabilities_no_half_quarantine is CHECK (NOT (is_active AND NOT visible
+    // AND x402_enabled)). Setting x402_enabled without visible in the same
+    // statement would abort the UPDATE, and a throwing block aborts boot.
+    const stub = makeStub({ queue: [{}, [], { count: 1 }, {}, {}] });
+    await runMigration0100_relistUrlToMarkdown(stub);
+    const update = stub.renderedSql.find((q) => /update capabilities/i.test(q));
+    expect(update).toBeDefined();
+    const setClause = update!.slice(update!.toLowerCase().indexOf("set"));
+    expect(/visible = true/i.test(setClause) && /x402_enabled = true/i.test(setClause)).toBe(true);
   });
 });

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -1965,6 +1965,136 @@ export async function runMigration0099_noHalfQuarantine(
 }
 
 
+
+// ─── Block 0100: re-list url-to-markdown — the takedown was wrong ──────────
+//
+// The quality floor quarantined `url-to-markdown` at 2026-08-22 05:58Z:
+// "completion 67% on 15 eligible calls/30d". Reproducing the floor's own
+// population against production gave exactly its numbers (15 eligible, 10
+// completed, 4 distinct failure days), so the arithmetic was right and the
+// evidence behind it was not. The five counted failures:
+//
+//   1 x "This page returned almost no readable text (0 words). It may require
+//       JavaScript to render its content, or the URL may point to a login
+//       page."                        — the capability answering correctly
+//   2 x "…could not be loaded (HTTP 400)"  — the caller's target site
+//   2 x "This site is rate-limiting requests (HTTP 429)" — the caller's target
+//
+// None is a defect in this capability. Verified three independent ways on the
+// morning of the re-listing: the executor's live smoke test passes end to end,
+// the harness is 531/531 over 7d (weak evidence on its own — see GOALS.md),
+// and the two most recent real external calls, 2026-08-07 and 2026-08-21,
+// both completed.
+//
+// What made it worth fixing at boot rather than waiting: `url-to-markdown` is
+// one of the 11 no-signup free-tier capabilities. Quarantine sets
+// visible = false, `matchCapability` refuses an invisible capability (WP8 —
+// correctly, quarantine must not be bypassable), and the resulting 401 body
+// went on advertising `url-to-markdown` as free to try. The front door told
+// agents to call something the platform would refuse. lib/free-tier.ts fixes
+// the advertisement; this block fixes the thing that should never have been
+// withdrawn.
+//
+// Why an event and not just the flags: the floor's window clamp and the
+// promotion job's "was this a takedown?" test both read the most recent
+// enforce-mode listing event. Flags without the event leave the capability
+// looking freshly quarantined — the next tick re-quarantines it on the same
+// July rows, and the promotion job keeps flagging it for a human who has
+// already decided. Flags and event commit together, as jobs/quality-floor.ts
+// does for the reverse direction: a listing change without its evidence must
+// be impossible.
+//
+// Ledger-guarded, deliberately. This is a one-time correction of one specific
+// decision, not a standing policy that `url-to-markdown` is listed. If it is
+// ever quarantined again on fresh evidence, that quarantine stands — this
+// block will not undo it on the next deploy.
+//
+// Authority: DEC-20260815-A (quarantine and promotion are platform-acts-alone).
+
+export async function runMigration0100_relistUrlToMarkdown(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+  const BLOCK = "0100_relistUrlToMarkdown";
+  const SLUG = "url-to-markdown";
+
+  await tx.execute(sql`
+    CREATE TABLE IF NOT EXISTS startup_migration_ledger (
+      block text PRIMARY KEY,
+      applied_at timestamptz NOT NULL DEFAULT now(),
+      rows_affected integer NOT NULL DEFAULT 0
+    )`);
+
+  const prior = (await tx.execute(sql`
+    SELECT block FROM startup_migration_ledger WHERE block = ${BLOCK}
+  `)) as unknown as Array<{ block: string }>;
+
+  if (prior.length > 0) {
+    return {
+      block: BLOCK,
+      outcome: "no change (already applied once — a later quarantine is not undone)",
+      rows_affected: 0,
+      duration_ms: Date.now() - startedAt,
+    };
+  }
+
+  // Narrow by construction: only the exact post-quarantine shape matches. If
+  // anything has already re-listed it, this is a no-op and the ledger row is
+  // still written, so the block never fires twice.
+  const res = await tx.execute(sql`
+    UPDATE capabilities
+       SET visible = true,
+           x402_enabled = true,
+           updated_at = now()
+     WHERE slug = ${SLUG}
+       AND is_active = true
+       AND visible = false
+  `);
+  const affected = (res as { count?: number }).count ?? 0;
+
+  // Written only when the flags actually moved. An event claiming a promotion
+  // that did not happen is the same class of lie as a quarantine without its
+  // evidence, and both the floor's window clamp and the promotion job would
+  // read it as fact.
+  if (affected > 0) {
+    await tx.execute(sql`
+      INSERT INTO health_monitor_events (event_type, capability_slug, tier, action_taken, details, human_override)
+      VALUES (
+        'capability_promotion',
+        ${SLUG},
+        1,
+        'promoted_with_x402',
+        ${JSON.stringify({
+          mode: "enforce",
+          dec: "DEC-20260815-A",
+          reason:
+            "Re-listed by operator decision: the 2026-08-22 quarantine counted five failures, of which one was a correct no-content refusal and four were the caller's target site (2x HTTP 400, 2x HTTP 429). Live execution, harness and the two most recent real calls all pass.",
+          source: "startup-migration 0100",
+          quarantined_at: "2026-08-22T05:58:42Z",
+          quarantine_completion: 0.6667,
+        })}::jsonb,
+        true
+      )
+    `);
+  }
+
+  await tx.execute(sql`
+    INSERT INTO startup_migration_ledger (block, rows_affected)
+    VALUES (${BLOCK}, ${affected})
+    ON CONFLICT (block) DO NOTHING
+  `);
+
+  return {
+    block: BLOCK,
+    outcome:
+      affected === 0
+        ? "no change (url-to-markdown was already listed)"
+        : "url-to-markdown re-listed with its promotion event",
+    rows_affected: affected,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResult>> = [
   runMigration0029_actualCostCents,
   runMigration0030_complianceColumns,
@@ -2009,6 +2139,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0097_chainSequence,
   runMigration0098_perCustomerIdempotency,
   runMigration0099_noHalfQuarantine,
+  runMigration0100_relistUrlToMarkdown,
 ];
 
 /**

--- a/apps/api/src/lib/transaction-failure-taxonomy.test.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.test.ts
@@ -300,3 +300,74 @@ describe("LLM output-truncation refusal (2026-08-17 web-extract quarantine incid
     expect(categorizeError(err)).toBe("capability_refusal");
   });
 });
+
+/**
+ * 2026-08-22 — the `url-to-markdown` quarantine.
+ *
+ * Same shape as the `us-company-data` incident pinned above, one rail along:
+ * a capability that had refused correctly was delisted for it, and this one
+ * was a free-tier front door, so the delisting also broke the no-signup
+ * promise the 401 body was still making.
+ *
+ * Both directions are pinned. The excused strings are the capability
+ * reporting a property of the caller's chosen page; the counted ones are
+ * operations that did not complete, whoever's fault that is.
+ */
+describe("a page with nothing in it is the caller's URL, not our defect", () => {
+  it("a measured-empty target page is caller_input", () => {
+    const msg =
+      "This page returned almost no readable text (0 words). It may require JavaScript to render its content, or the URL may point to a login page.";
+    expect(classOf(msg)).toBe("caller_input");
+    expect(excused(msg)).toBe(true);
+  });
+
+  it("but a bare 'too little content' shrug stays ours", () => {
+    // Pinned by an earlier review and left alone. It claims nothing about
+    // what was inspected, so it reads equally as our own fetch under-reading
+    // the page. The line the fix draws is a MEASURED property of the target,
+    // not any complaint about emptiness.
+    expect(excused("Page at [service] returned too little content.")).toBe(false);
+  });
+
+  it("still counts the failures that were in the same quarantine window", () => {
+    // The operation did not complete. By this module's own rule that is ours
+    // to carry, whatever caused it — so these must NOT be excused, or the
+    // floor goes blind on exactly the capability it just mis-judged.
+    const notExcused = [
+      "Could not extract content from this page ([service].uk). The web page ([service].uk) could not be loaded (HTTP 400).",
+      "This site is rate-limiting requests (HTTP 429). The target site has throttled access. Try again in a few minutes.",
+    ];
+    for (const msg of notExcused) expect(excused(msg)).toBe(false);
+  });
+
+  it("does not excuse our own empty-output defects", () => {
+    // The pattern is anchored to one house phrasing. A generic claim about
+    // emptiness in OUR OWN pipeline must keep counting — these are the
+    // assertions that fail if it is ever loosened to `no readable` or
+    // `returned too little`.
+    for (const msg of [
+      "Extraction pipeline returned too little data to build a result.",
+      "Internal renderer produced no readable output for the requested page.",
+    ]) {
+      expect(classOf(msg)).toBe("internal");
+    }
+  });
+
+  it("reproduces the floor arithmetic the fix changes", () => {
+    // The exact 30-day population the quality floor saw on 2026-08-22,
+    // verbatim from production. Before the fix: 15 eligible, 10 completed,
+    // 66.7% — below the 70% quarantine floor. After: the no-content refusal
+    // leaves the denominator and it clears.
+    const failures = [
+      "This page returned almost no readable text (0 words). It may require JavaScript to render its content, or the URL may point to a login page.",
+      "Could not extract content from this page ([service].uk). The web page ([service].uk) could not be loaded (HTTP 400).",
+      "Could not extract content from this page ([service].uk). The web page ([service].uk) could not be loaded (HTTP 400).",
+      "This site is rate-limiting requests (HTTP 429). The target site has throttled access. Try again in a few minutes.",
+      "This site is rate-limiting requests (HTTP 429). The target site has throttled access. Try again in a few minutes.",
+    ];
+    const completed = 10;
+    const counted = failures.filter((e) => !excused(e)).length;
+    expect(counted).toBe(4);
+    expect(completed / (completed + counted)).toBeGreaterThanOrEqual(0.7);
+  });
+});

--- a/apps/api/src/lib/transaction-failure-taxonomy.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.ts
@@ -223,6 +223,38 @@ const CALLER_INPUT_RE = new RegExp(
     // the rule this whole block exists to enforce.
     "targets a restricted address",
 
+    // ── Added 2026-08-22. The caller's target page loaded and carried nothing
+    // to work with. This is the "your input matches nothing" branch of the
+    // rule above, applied to page CONTENT rather than to an identifier: the
+    // fetch succeeded, the capability inspected what came back, and the
+    // truthful answer is that the URL has no extractable text. That is the
+    // capability working, in the same sense as "No US company found matching
+    // …" — which this list already excuses.
+    //
+    // Both patterns are our own diagnostic phrasings, not third-party text, so
+    // no vendor payload can reach them. Deliberately NOT generalised to
+    // "could not be loaded (HTTP 4xx)", which is a different claim — there the
+    // operation did not complete, and by this module's own rule it keeps
+    // counting.
+    //
+    // Cost of leaving this out, measured: `url-to-markdown` — one of the 11
+    // no-signup free-tier capabilities — was quarantined on 2026-08-22 at
+    // "67% completion on 15 eligible calls/30d". Its five counted failures
+    // were this refusal once, two target-site HTTP 400s and two target-site
+    // HTTP 429s. Not one was a defect, and the quarantine took a front-door
+    // capability off the catalogue.
+    //
+    // "This page returned almost no readable text (0 words). It may require
+    // JavaScript to render its content, or the URL may point to a login page."
+    //
+    // Deliberately NOT extended to `structured-scrape`'s "Page at [service]
+    // returned too little content." A prior review pinned that one as ours
+    // and it is right to: it makes no claim about what was inspected, so it
+    // reads equally as our fetch having under-read the page. The string below
+    // reports a measured word count and names the two conditions that produce
+    // it — it is a diagnosis of the target, not a shrug.
+    "returned almost no readable text",
+
     // Registry name-search refusals. Sourced from capability-refusal.ts so
     // this list, the circuit breaker's and the throw sites cannot drift apart
     // — they are three consumers of one definition.

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -10,6 +10,7 @@ import { rateLimitByIpDb } from "../lib/db-rate-limit.js";
 import { sendWebhook } from "../lib/webhook.js";
 import { sendWelcomeEmail, sendRecoveryEmail } from "../lib/welcome-email.js";
 import { DISPOSABLE_DOMAINS } from "../lib/disposable-domains.js";
+import { getFreeTierSlugs } from "../lib/free-tier.js";
 import { fireAndForget } from "../lib/fire-and-forget.js";
 import type { AppEnv } from "../types.js";
 import type { Context } from "hono";
@@ -413,10 +414,27 @@ export async function agentSignupHandler(c: Context) {
       ));
 
     if ((usage?.cnt ?? 0) === 0) {
+      // Read from the shared authority, never a literal. This list used to be
+      // five hardcoded slugs; it named `url-to-markdown` for the whole of the
+      // 2026-08-22 quarantine, telling an agent to unblock its signup with a
+      // call the platform would refuse. A gate whose instructions cannot be
+      // followed is worse than no gate.
+      const freeSlugs = await getFreeTierSlugs(db);
+      // Preference, not an assertion: if the friendliest example is not
+      // servable right now we name whatever is, and if nothing is we say
+      // nothing rather than naming a capability that would refuse.
+      const suggested =
+        ["email-validate", "dns-lookup"].find((s) => freeSlugs.includes(s)) ??
+        freeSlugs[0] ??
+        null;
       return c.json(
-        apiError("unauthorized", "Make at least one free-tier API call before signing up. Try: POST /v1/do with capability_slug 'email-validate'.", {
-          free_capabilities: ["email-validate", "dns-lookup", "iban-validate", "url-to-markdown", "json-repair"],
-        }),
+        apiError(
+          "unauthorized",
+          suggested
+            ? `Make at least one free-tier API call before signing up. Try: POST /v1/do with capability_slug '${suggested}'.`
+            : "Make at least one free-tier API call before signing up.",
+          { free_capabilities: freeSlugs },
+        ),
         403,
       );
     }

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -47,6 +47,7 @@ import { getCapabilityQuality } from "../lib/quality-aggregation.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
 import { validateX402Input } from "../lib/x402-input-validation.js";
 import { isX402PayableCapability } from "../lib/x402-eligibility.js";
+import { getFreeTierSlugs } from "../lib/free-tier.js";
 import * as walletService from "../lib/wallet-service.js";
 import * as reservations from "../lib/wallet-reservations.js";
 import { recoverValuesFromTask, recoveredValuesHint, unsatisfiedGroupFields } from "../lib/task-value-hints.js";
@@ -2609,22 +2610,13 @@ async function executeInBackground(
   }
 }
 
-// ─── Free-tier slug cache (refreshed every 5 minutes) ───────────────────────
-
-let _freeTierCache: { slugs: string[]; expiresAt: number } | null = null;
-
-async function getFreeTierSlugs(db: ReturnType<typeof getDb>): Promise<string[]> {
-  if (_freeTierCache && Date.now() < _freeTierCache.expiresAt) {
-    return _freeTierCache.slugs;
-  }
-  const rows = await db
-    .select({ slug: capabilities.slug })
-    .from(capabilities)
-    .where(and(eq(capabilities.isFreeTier, true), eq(capabilities.isActive, true), eq(capabilities.lifecycleState, "active")));
-  const slugs = rows.map((r) => r.slug);
-  _freeTierCache = { slugs, expiresAt: Date.now() + 5 * 60 * 1000 };
-  return slugs;
-}
+// ─── Free-tier slug cache ──────────────────────────────────────────────────
+//
+// Moved to lib/free-tier.ts on 2026-08-22. The implementation that lived here
+// selected `is_free_tier AND is_active AND lifecycle_state = 'active'` and
+// never consulted `visible`, so a quarantined free-tier capability stayed in
+// the advertisement while `matchCapability` refused to serve it. See that
+// module's header for the incident.
 
 // ─── Audit trail helpers ──────────────────────────────────────────────────────
 

--- a/apps/api/src/routes/welcome.ts
+++ b/apps/api/src/routes/welcome.ts
@@ -10,6 +10,8 @@
 import { Hono } from "hono";
 import { computePlatformFacts } from "../lib/platform-facts.js";
 import { logError } from "../lib/log.js";
+import { getDb } from "../db/index.js";
+import { getServableFreeTierCapabilities } from "../lib/free-tier.js";
 
 export const welcomeRoute = new Hono();
 
@@ -349,47 +351,48 @@ const PRICING = {
     method: "Stripe Checkout",
     endpoint: "POST /v1/wallet/topup",
   },
-  free_capabilities: [
-    {
-      slug: "iban-validate",
-      price_cents: 3,
-      description: "Validate IBAN structure and extract bank details",
-    },
-    {
-      slug: "email-validate",
-      price_cents: 2,
-      description: "Validate email address format and deliverability",
-    },
-    {
-      slug: "dns-lookup",
-      price_cents: 2,
-      description: "DNS record lookup for any domain",
-    },
-    {
-      slug: "json-repair",
-      price_cents: 2,
-      description: "Repair malformed JSON strings",
-    },
-    {
-      slug: "url-to-markdown",
-      price_cents: 5,
-      description: "Convert any URL to clean markdown",
-    },
-  ],
+  // Filled per request from lib/free-tier.ts — see buildPricing(). The
+  // hardcoded five that used to sit here listed `url-to-markdown` throughout
+  // its 2026-08-22 quarantine and had never listed the other six free-tier
+  // slugs at all: a literal cannot track either a withdrawal or an addition.
+  free_capabilities: [] as Array<{ slug: string; price_cents: number; description: string }>,
   full_catalog: "https://api.strale.io/v1/capabilities",
   pricing_page: "https://strale.dev/pricing",
 };
 
-welcomeRoute.get("/v1/pricing", (c) => {
+/**
+ * Pricing payload with the free-tier list resolved against what the platform
+ * will actually serve. A DB failure degrades to an empty list rather than to a
+ * stale literal: advertising nothing is recoverable, advertising a capability
+ * we refuse is the bug this replaced.
+ */
+async function buildPricing(): Promise<typeof PRICING> {
+  try {
+    const free = await getServableFreeTierCapabilities(getDb());
+    return {
+      ...PRICING,
+      free_capabilities: free.map((c) => ({
+        slug: c.slug,
+        price_cents: c.priceCents,
+        description: c.description,
+      })),
+    };
+  } catch (err) {
+    logError("pricing-free-tier-failed", err);
+    return PRICING;
+  }
+}
+
+welcomeRoute.get("/v1/pricing", async (c) => {
   c.header("Cache-Control", "public, max-age=3600");
   c.header("Access-Control-Allow-Origin", "*");
-  return c.json(PRICING);
+  return c.json(await buildPricing());
 });
 
-welcomeRoute.get("/pricing", (c) => {
+welcomeRoute.get("/pricing", async (c) => {
   c.header("Cache-Control", "public, max-age=3600");
   c.header("Access-Control-Allow-Origin", "*");
-  return c.json(PRICING);
+  return c.json(await buildPricing());
 });
 
 // ─── Status endpoint ────────────────────────────────────────────────────────


### PR DESCRIPTION
## What happened

At **05:58Z today** the quality floor quarantined `url-to-markdown` — one of the eleven no-signup free-tier capabilities — at *"completion 67% on 15 eligible calls/30d"*. Two independent things were wrong.

### 1. The advertisement outlived the capability

Quarantine sets `visible = false`. `matchCapability` refuses an invisible capability **by design** (WP8 — quarantine must not be bypassable). But `do.ts`'s private `getFreeTierSlugs` derived its list from `is_free_tier AND is_active AND lifecycle_state = 'active'` and never consulted `visible`.

Verified against production before the fix:

| call | result |
|---|---|
| `dns-lookup` (free tier, visible) | served, 200 |
| `url-to-markdown` (free tier, quarantined) | **401** — and the 401 body listed `url-to-markdown` among *"these 11 capabilities are free with no signup — try them without an API key"* |

An agent doing exactly what the refusal told it to do was refused again. As a side effect the keyword matcher also began routing "convert this url to markdown" to `markdown-render`, which asks for a `markdown` field.

Two further surfaces carried hand-written slug literals that no query touched at all:
- `auth.ts`'s signup gate told agents to unblock signup with `capability_slug 'email-validate'` from a hardcoded five that included `url-to-markdown`.
- `/v1/pricing` listed five slugs of the eleven, and had done since before six of them existed.

`lib/free-tier.ts` is now the single authority. It does **not** re-implement servability — it calls `isServableCapability`, the WP8 predicate that decides whether the call will actually be served. An advertisement is now produced by the same rule that answers the request.

### 2. The quarantine itself was wrong

Reproducing the floor's own population against production returned its numbers exactly — 15 eligible, 10 completed, 66.7%, 4 distinct failure days — so the arithmetic was right and the evidence behind it was not. The five counted failures:

| n | error | truth |
|---|---|---|
| 1 | "This page returned almost no readable text (0 words). It may require JavaScript…" | the capability answering correctly |
| 2 | "…could not be loaded (HTTP 400)" | the caller's target site |
| 2 | "This site is rate-limiting requests (HTTP 429)" | the caller's target site |

None is a defect in this capability. Checked three further ways: the executor's live smoke test passes end to end, the harness is 531/531 over 7d (weak alone — see GOALS.md), and the two most recent real external calls (2026-08-07, 2026-08-21) both completed.

The no-content refusal is now `caller_input` — the same line the taxonomy already draws for "your input matches nothing", applied to page content instead of an identifier. **Deliberately narrow:** `structured-scrape`'s "returned too little content" was pinned as ours by an earlier review and stays that way; it claims nothing about what was inspected. The string excused here reports a measured word count and names the two conditions that produce it.

**Block 0100** re-lists the capability with its promotion event in the same transaction. Flags without the event would leave the floor's window clamp and the promotion job reading an un-reversed takedown, and the next tick would re-quarantine on the same July rows. Ledger-guarded, so a later legitimate quarantine is not undone on the next deploy.

## Verification

**DEC-20260504-A — the tests discriminate.** All 14 new assertions were run against the un-fixed state:

| mutation | tests that fail |
|---|---|
| taxonomy pattern removed | `a measured-empty target page is caller_input`, `reproduces the floor arithmetic` |
| `isServableCapability` → old predicate | 3 free-tier tests |
| block writes its event unconditionally | `does not claim a promotion that did not happen` |
| ledger short-circuit removed | `never fires twice` |
| `x402_enabled` set without `visible` | 2 tests, including the WP8 constraint one |

All pass against the fix. Full suite: **2300 passed, 187 files**.

**DEC-20260504-C — deploy mechanism.** The block runs from `runStartupMigrations`' `BLOCKS` registry (pinned by the canonical-list test, now 43). All three statements were `EXPLAIN`-planned against production read-only before merge — plan only, nothing executed: the `UPDATE` matches **exactly one row** (confirmed by the `SELECT` form), the `INSERT` parses, and the post-state satisfies `capabilities_no_half_quarantine`. Post-deploy verification of the served artifact follows in the same session.

**DEC-20260504-B** does not apply — one row.

Gates run locally: `tsc --noEmit` (apps/api), `check-mjs-syntax`, `lint:no-bare-catch`, `lint:no-unguarded-user-fetch`, `check-ssrf-inventory`, `lint:no-new-console`, `check-no-external-column-access`, `check-no-direct-getexecutor-in-scripts`, `check-framework-packages`, `check-fetch-timeout-coverage --strict`, `check-manifest-guaranteed-consistency --strict`, `check-pii --strict`, `check-tier-coverage --strict`, `check-identity-fixture-shape --strict`, `check-cost-class-coherence` — all pass.

Authority: **DEC-20260815-A** — quarantine and promotion are platform-acts-alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
