### PR TITLE
chore(mcp): 0.2.7 — first release via trusted publishing

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strale-mcp",
   "mcpName": "io.github.strale-io/strale",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "MCP server for Strale — pre-flight check any paid API before your agent pays, plus 250+ business data, compliance, and validation tools for Claude, Cursor, Windsurf, and any MCP client",
   "type": "module",
   "main": "./dist/server.js",


### PR DESCRIPTION
Version bump only. **Merging this does not publish anything** — publishing happens when a `strale-mcp@0.2.7` tag is pushed after this lands, and that run pauses for approval in the `npm-release` environment.

## What ships

142 lines of `src/tools.ts` accumulated on main since 0.2.6 was published on 2026-08-14:

| PR | change |
|---|---|
| [#222](https://github.com/strale-io/strale/pull/222) | wire `search_tags` into ranking |
| [#245](https://github.com/strale-io/strale/pull/245) | instrument the MCP funnel, hash the x402 payer |
| [#249](https://github.com/strale-io/strale/pull/249) | tell refused agents about the route they can actually take |
| [#313](https://github.com/strale-io/strale/pull/313) | typecheck the package in CI |

**Patch, not minor — a deliberate call.** Two of those are `feat:`, which under strict semver argues for 0.3.0. Pre-1.0, with no interface removed or renamed and the tool surface unchanged, 0.2.7 is the honest description of what a consumer sees. Say so if you'd rather cut 0.3.0.

## Diff

One line. `packages/mcp-server/package.json`: `"version": "0.2.6"` → `"0.2.7"`.

An `npm install` in the release worktree incidentally rewrote 17 `"peer": true` markers in `package-lock.json`; that churn was reverted so this PR carries nothing but the bump.

## Tarball (`npm pack --dry-run`)

`strale-mcp-0.2.7.tgz` — 11 files, 27.7 kB packed, 103.9 kB unpacked:

```
LICENSE  README.md  package.json
dist/server.js  dist/server.d.ts  dist/server.js.map  dist/server.d.ts.map
dist/tools.js   dist/tools.d.ts   dist/tools.js.map   dist/tools.d.ts.map
```

`main` and `bin` both resolve to `dist/server.js`, which is present and carries its shebang.

## Verification

- Build and typecheck clean.
- Full suite green on two consecutive runs (2,555 passed, 126 skipped). A first run reported 9 failed files; it did not reproduce, and the failures were in DB-mocking tests unrelated to a version string. Flaky, not caused by this change — but worth knowing the suite is not reliably green on a cold run.
- Release resolver accepts `strale-mcp@0.2.7` and rejects the stale `strale-mcp@0.2.6`.

## Release procedure after merge

```
git tag strale-mcp@0.2.7 && git push origin strale-mcp@0.2.7
```

That triggers `.github/workflows/release-npm.yml`, which pauses for a required reviewer in the `npm-release` environment before publishing via OIDC.

**This will be the first end-to-end exercise of trusted publishing.** A dry run cannot prove the OIDC path — it packs the tarball and skips the publish step, so it never authenticates. If the tag run fails at `npm publish`, delete the tag, fix the npm-side config, and re-cut; the version is not burned unless the publish succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
