### PR TITLE
fix(mcp): trust data has been silently empty for every public install

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -36,6 +36,7 @@ import { internalHealthMonitorRoute } from "./routes/internal-health-monitor.js"
 import { replyWebhookRoute } from "./routes/reply-webhook.js";
 import { auditRoute } from "./routes/audit.js";
 import { internalOnboardingRoute } from "./routes/internal-onboarding.js";
+import { publicTrustRoute } from "./routes/public-trust.js";
 import { x402GatewayV2, getX402Manifest, getX402WellKnownResources, getX402OpenApiPaths } from "./routes/x402-gateway-v2.js";
 import { mcpServerCardRoute } from "./routes/mcp-server-card.js";
 import { aiCatalogRoute } from "./routes/ai-catalog.js";
@@ -486,6 +487,11 @@ const PUBLIC_OPS_ALLOWLIST: RegExp[] = [
   /^\/v1\/public\/ops\/tests\/solutions\/[^/]+\/runs$/,
   /^\/v1\/public\/ops\/tests\/dependency-health\/(?:summary|history)$/,
   /^\/v1\/public\/ops\/tests\/situations$/,
+  // trust/ — public trust projection consumed by the published strale-mcp
+  // package. GET only, badge + already-public test facts, no admin fields.
+  // See routes/public-trust.ts for what may and may not be projected here.
+  /^\/v1\/public\/ops\/trust\/capabilities\/batch$/,
+  /^\/v1\/public\/ops\/trust\/solutions\/batch$/,
   // limitations/ — public GETs (quality/ and trust/ retired with SQS engine)
   /^\/v1\/public\/ops\/limitations\/[^/]+$/,
   /^\/v1\/public\/ops\/limitations\/[^/]+\/[^/]+$/,
@@ -508,6 +514,13 @@ app.route("/v1/public/ops/tests", internalTestsRoute);
 app.route("/v1/public/ops/limitations", internalLimitationsRoute);
 app.route("/v1/public/ops", internalHealthMonitorRoute);
 app.route("/v1/public/ops/onboarding", internalOnboardingRoute);
+// Public trust projection. Mounted under /v1/public/ops/* deliberately: the
+// /v1/internal/trust routes it replaces were deleted with the SQS engine, and
+// the adminOnly wall on /v1/internal/* turned requests for them into 401s, so
+// every public strale-mcp install has started with zero trust data since
+// 2026-05-05. The admin wall is unchanged; this carries only fields already
+// public through /v1/public/ops/tests/*. See routes/public-trust.ts.
+app.route("/v1/public/ops/trust", publicTrustRoute);
 
 // F-0-003: admin-only wall. Any handler under /v1/internal/* now requires
 // `Authorization: Bearer $ADMIN_SECRET` — enforced at the mount, not by

--- a/apps/api/src/lib/mcp-trust-contract.test.ts
+++ b/apps/api/src/lib/mcp-trust-contract.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Contract tests for the published `strale-mcp` client, covering the two
+ * defects a clean-user smoke test of 0.2.7 exposed.
+ *
+ * 1. Startup collapsed to `0 cap trust, 0 sol trust` because the client asked
+ *    for `/v1/internal/trust/*` — routes deleted with the SQS engine, sitting
+ *    behind the `adminOnly` wall on the whole `/v1/internal/*` prefix, so the
+ *    wall answered 401 before routing could 404. The client logged and carried
+ *    on, which is why nobody noticed for months.
+ *
+ * 2. `STRALE_CLIENT_ID` was the literal `"strale-mcp/0.2.6"` while 0.2.7 was on
+ *    the registry, so every attribution datapoint was mislabelled by a release.
+ *
+ * These read the SOURCE rather than mocking fetch: the failure mode was "which
+ * URL do we ask for", and a mock would have been written against whatever URL
+ * the code already used.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { STRALE_CLIENT_ID } from "strale-mcp/tools";
+
+const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+const TOOLS_SRC = readFileSync(`${REPO_ROOT}packages/mcp-server/src/tools.ts`, "utf8");
+const MCP_PKG = JSON.parse(
+  readFileSync(`${REPO_ROOT}packages/mcp-server/package.json`, "utf8"),
+) as { version: string };
+
+describe("startup cannot silently collapse to zero trust", () => {
+  it("asks for no path under the admin-walled /v1/internal prefix", () => {
+    // `adminOnly` is mounted on /v1/internal/* in app.ts. An unauthenticated
+    // public install can never satisfy it, so any such path here is guaranteed
+    // to fail at runtime -- and the failure is swallowed into empty trust maps.
+    const offenders = [...TOOLS_SRC.matchAll(/["'`](\/v1\/internal\/[^"'`]*)/g)].map((m) => m[1]);
+    expect(offenders).toEqual([]);
+  });
+
+  it("reads trust from the public projection", () => {
+    expect(TOOLS_SRC).toContain("/v1/public/ops/trust/capabilities/batch");
+    expect(TOOLS_SRC).toContain("/v1/public/ops/trust/solutions/batch");
+  });
+
+  it("fetches solution trust in batches rather than one request per solution", () => {
+    // The old implementation issued one request per solution -- 104 on a cold
+    // start -- which made the outage 104 log lines wide and would be a
+    // thundering herd against the new public route if left as-is.
+    const fn = TOOLS_SRC.slice(
+      TOOLS_SRC.indexOf("export async function fetchSolutionTrust("),
+      TOOLS_SRC.indexOf("// ─── Register all tools on an McpServer"),
+    );
+    expect(fn).toContain("slice(i, i + 50)");
+  });
+});
+
+describe("client attribution reports the real package version", () => {
+  it("matches package.json rather than a hardcoded literal", () => {
+    expect(STRALE_CLIENT_ID).toBe(`strale-mcp/${MCP_PKG.version}`);
+  });
+
+  it("carries no hand-maintained version string", () => {
+    // Discriminating: the pre-fix source contained `strale-mcp/0.2.6` as a
+    // literal. Any future literal of that shape fails here.
+    expect(TOOLS_SRC).not.toMatch(/["'`]strale-mcp\/\d+\.\d+\.\d+["'`]/);
+  });
+
+  it("derives the version from package metadata at runtime", () => {
+    expect(TOOLS_SRC).toContain('new URL("../package.json", import.meta.url)');
+  });
+});

--- a/apps/api/src/routes/public-trust.test.ts
+++ b/apps/api/src/routes/public-trust.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression tests for the 2026-08-22 "0 cap trust, 0 sol trust" defect.
+ *
+ * A clean-user smoke test of the published `strale-mcp` package printed, on
+ * every start:
+ *
+ *   Failed to fetch trust batch: Strale API 401:
+ *     {"error_code":"unauthorized","message":"Admin authentication required."}
+ *   Loaded 297 capabilities, 104 solutions, 0 cap trust, 0 sol trust
+ *
+ * Root cause was not an access-control decision. `/v1/internal/trust/*` was
+ * DELETED with the SQS engine (DEC-20260503-B, 2026-05-05), and because
+ * `adminOnly` is mounted on the whole `/v1/internal/*` prefix (app.ts), requests
+ * for the now-nonexistent path were rejected by the wall before routing could
+ * 404 them. The client caught the error, logged to stderr, and continued with
+ * empty trust maps — invisible inside an MCP client, so it shipped for months.
+ *
+ * The fix is a narrow PUBLIC projection, not a hole in the admin wall. These
+ * tests pin both halves of that: the projection is reachable unauthenticated,
+ * and it cannot grow admin-only fields.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const suiteRows = [
+  { id: "suite-1", slug: "email-validate" },
+  { id: "suite-2", slug: "email-validate" },
+];
+
+const latestResults = [
+  { test_suite_id: "suite-1", passed: true, executed_at: new Date("2026-08-22T10:00:00Z") },
+  { test_suite_id: "suite-2", passed: false, executed_at: new Date("2026-08-22T11:00:00Z") },
+];
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: async () => suiteRows,
+        innerJoin: () => ({ where: async () => [] }),
+      }),
+    }),
+    execute: async () => latestResults,
+  }),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+async function get(path: string, headers: Record<string, string> = {}) {
+  const { app } = await import("../app.js");
+  return app.request(new Request(`http://localhost${path}`, { headers }));
+}
+
+describe("an unauthenticated public install can read trust metadata", () => {
+  it("serves the capability batch with no Authorization header", async () => {
+    const resp = await get("/v1/public/ops/trust/capabilities/batch?slugs=email-validate");
+
+    // Discriminating: against the pre-fix tree this path did not exist, and the
+    // client's old path returned 401 from the admin wall. Either way, not 200.
+    expect(resp.status).toBe(200);
+
+    const body = (await resp.json()) as Record<string, any>;
+    expect(body).toHaveProperty("email-validate");
+    expect(body["email-validate"].tested).toBe(true);
+    expect(body["email-validate"].badge).toBe("strale_tested");
+    // One of two suites passed.
+    expect(body["email-validate"].pass_rate).toBe(50);
+  });
+
+  it("never answers 401 — the projection is outside the admin wall", async () => {
+    const resp = await get("/v1/public/ops/trust/capabilities/batch?slugs=email-validate");
+    expect(resp.status).not.toBe(401);
+  });
+
+  it("still rejects a request with no slugs, rather than scanning the catalog", async () => {
+    const resp = await get("/v1/public/ops/trust/capabilities/batch");
+    expect(resp.status).toBe(400);
+  });
+});
+
+describe("no admin-only field reaches the public projection", () => {
+  it("returns only the allowlisted fields", async () => {
+    const { PUBLIC_TRUST_FIELDS } = await import("./public-trust.js");
+    const resp = await get("/v1/public/ops/trust/capabilities/batch?slugs=email-validate");
+    const body = (await resp.json()) as Record<string, Record<string, unknown>>;
+
+    for (const entry of Object.values(body)) {
+      expect(Object.keys(entry).sort()).toEqual([...PUBLIC_TRUST_FIELDS].sort());
+    }
+  });
+
+  it("does not resurrect the retired SQS/guidance internals", async () => {
+    const resp = await get("/v1/public/ops/trust/capabilities/batch?slugs=email-validate");
+    const raw = await resp.text();
+
+    // These were fields of the deleted /v1/internal/trust route. Reviving any of
+    // them here would republish a scoring surface the platform retired, and
+    // would do it on an unauthenticated endpoint.
+    for (const forbidden of [
+      "sqs",
+      "raw_sqs",
+      "sqs_label",
+      "matrix_sqs",
+      "qp_score",
+      "rp_score",
+      "guidance_usable",
+      "guidance_strategy",
+      "quality",
+      "reliability",
+      "trend",
+    ]) {
+      expect(raw).not.toContain(`"${forbidden}"`);
+    }
+  });
+});
+
+describe("the admin wall itself is untouched", () => {
+  it("still refuses an unauthenticated request under /v1/internal/*", async () => {
+    const resp = await get("/v1/internal/tests/health");
+    expect(resp.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/public-trust.ts
+++ b/apps/api/src/routes/public-trust.ts
@@ -1,0 +1,201 @@
+import { Hono } from "hono";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { getDb } from "../db/index.js";
+import { testSuites, solutions, solutionSteps } from "../db/schema.js";
+import { apiError } from "../lib/errors.js";
+
+/**
+ * Public trust projection — `/v1/public/ops/trust/*`.
+ *
+ * Why this exists: the published `strale-mcp` package called
+ * `/v1/internal/trust/*` for the badges it shows next to search results. Those
+ * routes were deleted with the SQS engine (DEC-20260503-B, 2026-05-05), and
+ * because `adminOnly` is mounted on the whole `/v1/internal/*` prefix, requests
+ * to the now-nonexistent path returned 401 rather than 404. Every public
+ * install has therefore started with `0 cap trust, 0 sol trust` since then,
+ * logging the failure to stderr and continuing — invisible in an MCP client.
+ *
+ * The fix is NOT to relax the admin wall. `/v1/internal/*` stays admin-only.
+ * This is a deliberately narrow public projection carrying only fields that are
+ * already public through `/v1/public/ops/tests/*`, in canonical machine-readable
+ * form per the wire-shape rule (integers, ISO dates, no pre-formatted values).
+ *
+ * What the badge asserts, precisely: that Strale runs its own tests against this
+ * capability — not that the capability is currently healthy. `pass_rate` is
+ * returned alongside so a consumer can judge that for itself, rather than the
+ * badge silently encoding a quality threshold nobody can see. The retired SQS
+ * grades, guidance strategy, and raw sub-scores are deliberately NOT projected:
+ * they were retired, and reviving them here would recreate a scoring surface
+ * the platform decided to stop publishing.
+ */
+export const publicTrustRoute = new Hono();
+
+/** Fields a public trust entry may ever contain. Asserted in tests. */
+export const PUBLIC_TRUST_FIELDS = [
+  "badge",
+  "badge_label",
+  "tested",
+  "last_tested_at",
+  "pass_rate",
+] as const;
+
+export const PUBLIC_SOLUTION_TRUST_FIELDS = [
+  ...PUBLIC_TRUST_FIELDS,
+  "capabilities_total",
+  "capabilities_tested",
+] as const;
+
+const MAX_SLUGS = 100;
+const BADGE = "strale_tested";
+const BADGE_LABEL = "Strale tested";
+
+export interface PublicTrustEntry {
+  badge: string | null;
+  badge_label: string | null;
+  tested: boolean;
+  last_tested_at: string | null;
+  pass_rate: number | null;
+}
+
+function parseSlugs(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, MAX_SLUGS);
+}
+
+const untested = (): PublicTrustEntry => ({
+  badge: null,
+  badge_label: null,
+  tested: false,
+  last_tested_at: null,
+  pass_rate: null,
+});
+
+/**
+ * Latest result per active suite, aggregated per capability slug.
+ *
+ * Mirrors the DISTINCT ON query the per-slug public tests handler already uses
+ * (internal-tests.ts) rather than inventing a second definition of "the latest
+ * test result" that could drift from it.
+ */
+async function capabilityTrust(slugs: string[]): Promise<Map<string, PublicTrustEntry>> {
+  const out = new Map<string, PublicTrustEntry>();
+  for (const slug of slugs) out.set(slug, untested());
+  if (slugs.length === 0) return out;
+
+  const db = getDb();
+  const suites = await db
+    .select({ id: testSuites.id, slug: testSuites.capabilitySlug })
+    .from(testSuites)
+    .where(and(inArray(testSuites.capabilitySlug, slugs), eq(testSuites.active, true)));
+
+  if (suites.length === 0) return out;
+
+  const suiteIds = suites.map((s) => s.id);
+  const rows = await db.execute<{
+    test_suite_id: string;
+    passed: boolean;
+    executed_at: string | Date;
+  }>(sql`
+    SELECT DISTINCT ON (test_suite_id) test_suite_id, passed, executed_at
+    FROM test_results
+    WHERE test_suite_id IN (${sql.join(suiteIds.map((id) => sql`${id}`), sql`, `)})
+    ORDER BY test_suite_id, executed_at DESC
+  `);
+  const list = (Array.isArray(rows) ? rows : (rows as any)?.rows ?? []) as Array<{
+    test_suite_id: string;
+    passed: boolean;
+    executed_at: string | Date;
+  }>;
+  const bySuite = new Map(list.map((r) => [r.test_suite_id, r]));
+
+  const agg = new Map<string, { total: number; passed: number; last: Date | null }>();
+  for (const suite of suites) {
+    const latest = bySuite.get(suite.id);
+    if (!latest) continue;
+    const a = agg.get(suite.slug) ?? { total: 0, passed: 0, last: null };
+    a.total += 1;
+    if (latest.passed) a.passed += 1;
+    const at = latest.executed_at instanceof Date ? latest.executed_at : new Date(latest.executed_at);
+    if (!a.last || at > a.last) a.last = at;
+    agg.set(suite.slug, a);
+  }
+
+  for (const [slug, a] of agg) {
+    if (a.total === 0) continue;
+    out.set(slug, {
+      badge: BADGE,
+      badge_label: BADGE_LABEL,
+      tested: true,
+      last_tested_at: a.last ? a.last.toISOString() : null,
+      pass_rate: Math.round((a.passed / a.total) * 100),
+    });
+  }
+  return out;
+}
+
+publicTrustRoute.get("/capabilities/batch", async (c) => {
+  const slugs = parseSlugs(c.req.query("slugs"));
+  if (slugs.length === 0) {
+    return c.json(apiError("invalid_request", "slugs query parameter is required"), 400);
+  }
+  const trust = await capabilityTrust(slugs);
+  return c.json(Object.fromEntries(trust));
+});
+
+publicTrustRoute.get("/solutions/batch", async (c) => {
+  const slugs = parseSlugs(c.req.query("slugs"));
+  if (slugs.length === 0) {
+    return c.json(apiError("invalid_request", "slugs query parameter is required"), 400);
+  }
+
+  const db = getDb();
+  const steps = await db
+    .select({ solutionSlug: solutions.slug, capabilitySlug: solutionSteps.capabilitySlug })
+    .from(solutionSteps)
+    .innerJoin(solutions, eq(solutionSteps.solutionId, solutions.id))
+    .where(inArray(solutions.slug, slugs));
+
+  const bySolution = new Map<string, string[]>();
+  for (const s of slugs) bySolution.set(s, []);
+  for (const row of steps) {
+    if (!row.capabilitySlug) continue;
+    bySolution.get(row.solutionSlug)?.push(row.capabilitySlug);
+  }
+
+  const allCaps = [...new Set(steps.map((s) => s.capabilitySlug).filter(Boolean) as string[])];
+  const capTrust = await capabilityTrust(allCaps);
+
+  const out: Record<string, PublicTrustEntry & { capabilities_total: number; capabilities_tested: number }> = {};
+  for (const slug of slugs) {
+    const caps = bySolution.get(slug) ?? [];
+    const entries = caps.map((c2) => capTrust.get(c2)).filter(Boolean) as PublicTrustEntry[];
+    const tested = entries.filter((e) => e.tested);
+
+    // A solution is only "Strale tested" when every step it runs is. A bundle
+    // is exactly as verified as its least-verified step, and claiming otherwise
+    // would let an untested step hide behind a tested sibling.
+    const allTested = caps.length > 0 && tested.length === caps.length;
+    const last = tested
+      .map((e) => e.last_tested_at)
+      .filter(Boolean)
+      .sort()
+      .pop() ?? null;
+
+    out[slug] = {
+      badge: allTested ? BADGE : null,
+      badge_label: allTested ? BADGE_LABEL : null,
+      tested: allTested,
+      last_tested_at: allTested ? last : null,
+      pass_rate: tested.length
+        ? Math.round(tested.reduce((s, e) => s + (e.pass_rate ?? 0), 0) / tested.length)
+        : null,
+      capabilities_total: caps.length,
+      capabilities_tested: tested.length,
+    };
+  }
+
+  return c.json(out);
+});

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "strale-mcp",
   "mcpName": "io.github.strale-io/strale",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "MCP server for Strale — pre-flight check any paid API before your agent pays, plus 250+ business data, compliance, and validation tools for Claude, Cursor, Windsurf, and any MCP client",
   "type": "module",
   "main": "./dist/server.js",

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -12,6 +12,7 @@
  * within days.
  */
 
+import { readFileSync } from "node:fs";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
@@ -111,7 +112,22 @@ function emitFunnelEvent(opts: StraleClientOptions, event: McpFunnelEvent): void
 
 // Attribution client identifier — package name/version, sent as
 // X-Strale-Client on every API call this package makes.
-const STRALE_CLIENT_ID = "strale-mcp/0.2.6";
+function readPackageVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+    ) as { version?: unknown };
+    return typeof pkg.version === "string" ? pkg.version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+// Derived from package.json rather than hand-maintained: the literal here was
+// left at version 0.2.6 while 0.2.7 was on the registry, so every attribution
+// datapoint was mislabelled by a release. A string a human must remember to
+// bump is a string that will be stale.
+export const STRALE_CLIENT_ID = `strale-mcp/${readPackageVersion()}`;
 
 // ─── HTTP helpers ───────────────────────────────────────────────────────────
 
@@ -444,7 +460,7 @@ export async function fetchTrustBatch(
     const param = chunk.join(",");
     try {
       const resp = await straleGet<Record<string, TrustBatchEntry>>(
-        `/v1/internal/trust/capabilities/batch?slugs=${encodeURIComponent(param)}`,
+        `/v1/public/ops/trust/capabilities/batch?slugs=${encodeURIComponent(param)}`,
         { baseUrl, apiKey: "" },
       );
       for (const [slug, entry] of Object.entries(resp)) {
@@ -464,29 +480,25 @@ export async function fetchSolutionTrust(
   solutionSlugs: string[],
 ): Promise<Map<string, SolutionTrustEntry>> {
   const map = new Map<string, SolutionTrustEntry>();
-  const results = await Promise.allSettled(
-    solutionSlugs.map(async (slug) => {
-      const resp = await fetch(
-        `${baseUrl}/v1/internal/trust/solutions/${encodeURIComponent(slug)}`,
-        {
-          headers: { Accept: "application/json" },
-          signal: AbortSignal.timeout(10000),
-        },
+  // Batched, like the capability path. This previously issued one request per
+  // solution -- 104 on a cold start -- against a route that no longer exists.
+  for (let i = 0; i < solutionSlugs.length; i += 50) {
+    const chunk = solutionSlugs.slice(i, i + 50);
+    try {
+      const resp = await straleGet<Record<string, { badge?: string | null; badge_label?: string | null }>>(
+        `/v1/public/ops/trust/solutions/batch?slugs=${encodeURIComponent(chunk.join(","))}`,
+        { baseUrl, apiKey: "" },
       );
-      if (!resp.ok) return null;
-      const data = await resp.json() as any;
-      return {
-        slug,
-        entry: {
-          badge: data.badge ?? null,
-          badge_label: data.badge_label ?? null,
-        } as SolutionTrustEntry,
-      };
-    }),
-  );
-  for (const r of results) {
-    if (r.status === "fulfilled" && r.value) {
-      map.set(r.value.slug, r.value.entry);
+      for (const [slug, entry] of Object.entries(resp)) {
+        map.set(slug, {
+          badge: entry.badge ?? null,
+          badge_label: entry.badge_label ?? null,
+        });
+      }
+    } catch (err) {
+      console.error(
+        `[strale-mcp] Failed to fetch solution trust batch: ${err instanceof Error ? err.message : err}`,
+      );
     }
   }
   if (map.size < solutionSlugs.length) {
@@ -992,10 +1004,12 @@ REFERENCES
       }),
     },
     async ({ slug, type }) => {
+      // Single-slug read of the batch projection -- one public surface rather
+      // than a second per-slug route to keep in step with it.
       const endpoint =
         type === "solution"
-          ? `/v1/internal/trust/solutions/${encodeURIComponent(slug)}`
-          : `/v1/internal/trust/capabilities/${encodeURIComponent(slug)}`;
+          ? `/v1/public/ops/trust/solutions/batch?slugs=${encodeURIComponent(slug)}`
+          : `/v1/public/ops/trust/capabilities/batch?slugs=${encodeURIComponent(slug)}`;
 
       try {
         const resp = await fetch(`${opts.baseUrl}${endpoint}`, {
@@ -1026,12 +1040,25 @@ REFERENCES
           };
         }
 
-        const data = await resp.json();
+        // The batch projection is keyed by slug; unwrap so this tool keeps
+        // returning a single profile rather than a one-entry map.
+        const data = (await resp.json()) as Record<string, unknown>;
+        const entry = data?.[slug];
+        if (!entry) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `No trust profile found for ${type} '${slug}'. Use strale_search to find valid slugs.`,
+              },
+            ],
+          };
+        }
         return {
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify(data, null, 2),
+              text: JSON.stringify(entry, null, 2),
             },
           ],
         };


### PR DESCRIPTION
A clean-user smoke test of the freshly published `strale-mcp@0.2.7` printed, on every start:

```
Failed to fetch trust batch: Strale API 401: {"error_code":"unauthorized","message":"Admin authentication required."}
Loaded 297 capabilities, 104 solutions, 0 cap trust, 0 sol trust
```

**Not a regression from 0.2.7.** Running the previously published `0.2.6` reproduces it identically, and the same four call sites exist at the 0.2.6 release commit.

## Root cause — not an access-control decision

`/v1/internal/trust/*` was **deleted** with the SQS engine (DEC-20260503-B, 2026-05-05); `app.ts` still carries the comment saying so. Because `adminOnly` is mounted on the whole `/v1/internal/*` prefix, a request for the now-nonexistent path is rejected by the wall **before routing can 404 it**.

So a deleted route reported itself as an authorization failure. The client caught it, logged to stderr, and continued with empty maps — and stderr is invisible inside an MCP client. It shipped that way for ~3.5 months.

## The security boundary

**The admin wall is not touched.** Nothing under `/v1/internal/*` is relaxed, and a test asserts it still answers 401 unauthenticated.

The fix is a narrow public projection at `/v1/public/ops/trust/{capabilities,solutions}/batch`, carrying only fields already public via `/v1/public/ops/tests/*`:

| field | why it's public |
|---|---|
| `badge`, `badge_label` | the display signal the client consumes |
| `tested` | whether Strale runs its own tests against it |
| `last_tested_at` | ISO date, already public per-slug |
| `pass_rate` | integer 0–100, already public per-slug |

**Deliberately not revived:** the retired SQS grades, raw sub-scores, guidance strategy. Republishing those here would restore a scoring surface the platform decided to stop publishing — on an unauthenticated endpoint. A test asserts none of eleven such field names appear in the body.

Both paths are added explicitly to `PUBLIC_OPS_ALLOWLIST`, which is the *real* access boundary for that prefix, rather than relying on the mount.

**What the badge asserts is now precise:** that Strale tests the capability, not that it currently passes. `pass_rate` sits alongside so consumers judge health themselves rather than a badge silently encoding an invisible threshold. A solution is "tested" only when *every* step is — a bundle is as verified as its least-verified step.

## Second defect

`STRALE_CLIENT_ID` was the literal `strale-mcp/0.2.6` while 0.2.7 was on the registry, so every attribution datapoint was mislabelled by a release. Now derived from `package.json` at runtime, the same way `server.ts` already reads its version.

Solution trust is now batched in chunks of 50; it previously issued **one request per solution** — 104 on a cold start — against a route that hadn't existed since May.

## Tests — 12, verified discriminating

**9 of 12 fail against the pre-fix sources.** They live in `apps/api` so the existing CI suite runs them.

- unauthenticated request returns 200 with real trust data
- response keys are exactly the public allowlist; no retired field name appears
- `/v1/internal/*` still 401s unauthenticated — the wall is intact
- the client requests no path under `/v1/internal/*` (what made the failure silent)
- solution trust is batched, not one-request-per-solution
- `STRALE_CLIENT_ID` equals `strale-mcp/<package.json version>`, and no hand-maintained version literal remains

Full suite: 2,567 passed, 126 skipped. Typecheck clean.

## Verified against the real public API — no paid calls

- old path → **401** (still walled)
- new path → **404** (not deployed yet, as expected)
- rebuilt client against prod → reports the clean 404 instead of a misleading auth error

## ⚠️ Deploy order

**The API must ship before `strale-mcp@0.2.8` is published.** Publishing the client first swaps a 401 for a 404 and leaves trust just as empty.

Prepared as `0.2.8`. **Not published.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
