### PR TITLE
docs: require a production contract smoke test after every publish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,8 +317,21 @@ scheduler excludes them from all runs (test-runner.ts line 117). They are never 
 
 5. **Polishing is not a substitute for verification.** A cleaner-looking PR containing a fabricated import is worse than the original. If a bot finding points at prose but the code example has an import problem underneath, fix the import first and the prose second, or stop and flag.
 
+6. **Run the production contract smoke test after every publish.** Install the
+   published artefact the way a stranger would (`npx -y <pkg>@<version>`), run it
+   against production, and record the observed startup values -- not "looks fine".
+   Look specifically for errors the program logs and then continues from: a caught,
+   logged, non-fatal degradation is what CI cannot see and users never report.
+   CI tests source against doubles; it never runs the published artefact against
+   production, and that gap is where this class of defect lives. On 2026-08-22 this
+   check found `strale-mcp` had shipped `0 cap trust, 0 sol trust` for ~3.5 months
+   (routes deleted in May; the admin wall on their prefix answered 401 instead of
+   404; the client logged to invisible stderr and carried on). Procedure and the
+   per-package contract: `docs/release/npm-publishing.md`.
+
 **At session end, report:**
 - Every distribution PR touched, with the verification result for each.
+- Every package published, with the observed production smoke-test values.
 - Every `*-strale` package modified, with the check-framework-packages output.
 - Anything that couldn't be verified and why.
 

--- a/docs/release/npm-publishing.md
+++ b/docs/release/npm-publishing.md
@@ -141,6 +141,44 @@ node apps/api/scripts/npm-release-resolve.mjs --tag strale-mcp@0.2.7
 It prints the resolved directory, name, and version, or exits non-zero with the
 reason. Use it before cutting a tag.
 
+## Required post-release check: the production contract smoke test
+
+**Mandatory for every externally distributed package.** A release is not done
+when CI is green, when the tarball looks right, or even when the publish
+succeeds with provenance. It is done when the *published artefact* has been run
+against *production* and observed to work.
+
+Immediately after publishing, install the published version the way a stranger
+would -- not from the repo, not from a local build -- and check the startup
+output and one real call path:
+
+```bash
+npx -y <package>@<version>
+```
+
+Read the output. Specifically look for errors the program logged and then
+carried on from. A dependency that fails into a caught, logged, non-fatal
+degradation is exactly what CI cannot see and what a user will never report,
+because it does not look like a crash.
+
+Record the observed values, not "looks fine". For `strale-mcp` the contract is
+the startup line: capability count, solution count, capability trust count,
+solution trust count -- all four non-zero and consistent with the catalog.
+
+### Why this is a required step
+
+On 2026-08-22 this check, run once by hand after a release, found that
+`strale-mcp` had been starting with `0 cap trust, 0 sol trust` for roughly three
+and a half months. The trust routes it called had been deleted in May; the admin
+wall on their URL prefix answered 401 instead of 404; the client caught the
+error, logged it to stderr and continued. Inside an MCP client stderr is
+invisible, so no user could have reported it.
+
+Nothing in CI would ever have caught this, for a structural reason worth stating
+plainly: **CI tests the source against test doubles; it never runs the published
+artefact against production.** Those are different systems. The gap between them
+is exactly where this class of defect lives.
+
 ## Troubleshooting
 
 **`npm error need auth` / OIDC exchange fails.** The trusted-publisher entry on


### PR DESCRIPTION
Closes the MCP trust-retrieval incident by recording the check that found it.

## What happened

A clean-user smoke test of the freshly published `strale-mcp@0.2.7` showed `0 cap trust, 0 sol trust` on every start. The trust routes it called had been deleted in May with the SQS engine; the `adminOnly` wall on `/v1/internal/*` answered **401 before routing could 404**; the client caught the error, logged to stderr, and continued.

Inside an MCP client stderr is invisible, so no user could have reported it. It shipped that way for **~3.5 months**, across at least two releases.

## Why CI could never have caught it

CI tests the **source** against **test doubles**. It never runs the **published artefact** against **production**. Those are different systems, and the gap between them is where this class of defect lives — a dependency failing into a caught, logged, non-fatal degradation looks like success to every automated gate.

## The change

The post-publish smoke test becomes a **required** release check for externally distributed packages:

- `docs/release/npm-publishing.md` — procedure, what to look for, and the rationale.
- `CLAUDE.md` — step 6 of the Distribution PR Integrity Protocol; the session-end report now also asks for observed smoke-test values of anything published.

Install the published version the way a stranger would (`npx -y <pkg>@<version>`), run it against production, and **record observed values, not "looks fine"**. For `strale-mcp` the contract is the startup line: capability, solution, capability-trust and solution-trust counts, all non-zero and consistent with the catalog.

Docs only. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
