### PR TITLE
An agent that asked for a paid capability by describing it got HTTP 500

### DIFF
--- a/apps/api/src/routes/do.core.test.ts
+++ b/apps/api/src/routes/do.core.test.ts
@@ -390,6 +390,8 @@ function makeApp() {
 // Imports after the mocks/helpers above so vi.mock hoisting applies cleanly.
 import { doRoute } from "./do.js";
 import { matchCapability } from "../lib/matching.js";
+import { isX402Configured, build402Response } from "../lib/x402-gateway.js";
+import { resetFreeTierCache } from "../lib/free-tier.js";
 import { getExecutor } from "../capabilities/index.js";
 
 const mockMatchCapability = matchCapability as unknown as ReturnType<typeof vi.fn>;
@@ -742,5 +744,92 @@ describe("POST /v1/do — execution failure shape + DEC-14 ordering", () => {
     // The transaction row is still marked failed for the audit trail.
     const txnUpdate = tx.__updateCalls.find((c) => c.table === transactions);
     expect((txnUpdate!.vals as any).status).toBe("failed");
+  });
+});
+
+// ─── Anonymous caller, paid capability, no slug named ────────────────────────
+//
+// The gap these close: `/v1/do`'s early auth gate is entered only when the
+// request NAMES a capability slug. `task` is the documented way in, so an
+// anonymous caller who described what they wanted matched a paid capability
+// and then fell through every anonymous branch into executeSync with `user`
+// undefined — where the wallet read threw and app.ts answered HTTP 500.
+//
+// Both tests below fail against the un-fixed route (500, and the executor is
+// reached) and pass against it. The 402 case is the one that matters
+// commercially: x402 IS configured in production, so an arriving agent should
+// be quoted a price, not handed an error.
+
+describe("POST /v1/do — anonymous, task-based, paid capability", () => {
+  it("quotes a price over x402 instead of 500-ing, and never reaches the executor or the wallet", async () => {
+    resetFreeTierCache();
+    const payable = {
+      ...CAPABILITY_FIXTURE,
+      x402Enabled: true,
+      marketplaceEligible: true,
+    };
+    mockMatchCapability.mockResolvedValue({ capability: payable });
+    const executorSpy = vi.fn(async () => ({ output: {}, provenance: { source: "x", fetched_at: "now" } }));
+    mockGetExecutor.mockReturnValue(executorSpy);
+
+    vi.mocked(isX402Configured).mockReturnValue(true);
+    vi.mocked(build402Response).mockReturnValue({
+      body: { x402Version: 1, error: "Payment required. Test Capability costs $0.005 USDC per call." },
+    } as any);
+
+    const app = makeApp();
+    const res = await app.request("/v1/do", {
+      method: "POST",
+      // No Authorization header. This is the arriving-agent shape.
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ task: "do the paid thing", inputs: { value: "x" }, max_price_cents: 100 }),
+    });
+
+    expect(res.status).toBe(402);
+    const body = await res.json();
+    expect(body.x402Version).toBe(1);
+    // The quote is for the capability that actually matched, at its price —
+    // not a generic 402 that tells the caller nothing.
+    expect(vi.mocked(build402Response)).toHaveBeenCalledWith({
+      slug: payable.slug,
+      name: payable.name,
+      priceCents: payable.priceCents,
+    });
+
+    expect(executorSpy).not.toHaveBeenCalled();
+    expect(mocks.dbTransactionCalls).toBe(0);
+  });
+
+  it("falls back to a 401 that names the free capabilities when the x402 rail is not configured", async () => {
+    resetFreeTierCache();
+    mockMatchCapability.mockResolvedValue({ capability: CAPABILITY_FIXTURE });
+    const executorSpy = vi.fn(async () => ({ output: {}, provenance: { source: "x", fetched_at: "now" } }));
+    mockGetExecutor.mockReturnValue(executorSpy);
+
+    vi.mocked(isX402Configured).mockReturnValue(false);
+    // The free-tier advertisement is read from the database through
+    // isServableCapability — never from a literal here, which is the defect
+    // lib/free-tier.ts exists to prevent.
+    mocks.outerSelectQueue.push([
+      { slug: "dns-lookup", priceCents: 0, description: "d", isActive: true, visible: true, lifecycleState: "active" },
+      { slug: "email-validate", priceCents: 0, description: "e", isActive: true, visible: true, lifecycleState: "active" },
+    ]);
+
+    const app = makeApp();
+    const res = await app.request("/v1/do", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ task: "do the paid thing", inputs: { value: "x" }, max_price_cents: 100 }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error_code).toBe("unauthorized");
+    expect(body.free_capabilities).toEqual(["dns-lookup", "email-validate"]);
+    expect(body.hint).toContain("2 capabilities are free");
+    expect(body.self_signup.url).toBe("https://api.strale.io/v1/signup");
+
+    expect(executorSpy).not.toHaveBeenCalled();
+    expect(mocks.dbTransactionCalls).toBe(0);
   });
 });

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { eq, and, gte, inArray, isNull, sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import {
@@ -285,6 +285,69 @@ type CapabilityInfo = {
   processesPersonalData: boolean;
   personalDataCategories: string[] | null;
 };
+
+/**
+ * The refusal an anonymous caller gets when the capability that answers their
+ * request costs money.
+ *
+ * ONE function, two call sites, because for five months there was one call
+ * site and a hole. The early auth gate in section 3 fires only when the caller
+ * NAMES a slug — but `task` is the documented, advertised way to call this
+ * endpoint, so a caller who described what they wanted instead of naming it
+ * fell past the gate, past the free-tier fork, and into the paid execution
+ * path with no user and no wallet. The wallet read threw and app.ts's
+ * top-level handler answered `internal_error`, HTTP 500.
+ *
+ * What that cost: an agent arriving the way we tell agents to arrive, asking
+ * for something we sell, was told "An unexpected error occurred" instead of
+ * the price and how to pay it. It is the same defect class as the free-tier
+ * front door on 2026-08-22 — the answer a caller is given must come from the
+ * code that decides, not from a second site that happens to agree.
+ *
+ * Live from 2026-03-08 (`1e8ebe6`, the commit that introduced the gate) to
+ * 2026-08-23.
+ */
+async function anonymousPaidRefusal(
+  c: Context,
+  db: ReturnType<typeof getDb>,
+  cap: {
+    slug: string;
+    name: string;
+    priceCents: number;
+    isActive: boolean;
+    isFreeTier: boolean | null;
+    x402Enabled: boolean;
+    marketplaceEligible: boolean;
+    lifecycleState: string;
+  },
+) {
+  if (isX402Configured() && isX402PayableCapability(cap)) {
+    const resp = build402Response({
+      slug: cap.slug,
+      name: cap.name,
+      priceCents: cap.priceCents,
+    });
+    return c.json(resp.body, 402);
+  }
+  const freeSlugs = await getFreeTierSlugs(db);
+  return c.json(
+    {
+      error_code: "unauthorized",
+      message:
+        "This capability requires an API key. Sign up at strale.dev/signup for full access with €2 free credits.",
+      free_capabilities: freeSlugs,
+      hint: `These ${freeSlugs.length} capabilities are free with no signup — try them without an API key.`,
+      self_signup: {
+        url: "https://api.strale.io/v1/signup",
+        method: "POST",
+        body: { email: "your-agent@yourdomain.com" },
+        description:
+          "Create an account programmatically and get €2 free credits. Requires at least one prior free-tier call from this IP.",
+      },
+    },
+    401,
+  );
+}
 
 /**
  * Cert-audit C8: in-transaction spend-cap check. Caller must hold the
@@ -793,29 +856,12 @@ doRoute.post(
         c.set("x402_paid" as any, true);
         // Fall through to normal execution — the capability will execute
         // and the transaction will be logged with payment_method: "x402"
-      } else if (isX402Configured() && x402Payable) {
-        // No payment header, x402 configured → return 402 with price
-        const resp = build402Response({
-          slug: capabilitySlug,
-          name: lookedUp.name,
-          priceCents: lookedUp.priceCents,
-        });
-        return c.json(resp.body, 402);
       } else {
-        // x402 not configured → return 401 with signup prompt
-        const freeSlugs = await getFreeTierSlugs(db);
-        return c.json({
-          error_code: "unauthorized",
-          message: "This capability requires an API key. Sign up at strale.dev/signup for full access with €2 free credits.",
-          free_capabilities: freeSlugs,
-          hint: `These ${freeSlugs.length} capabilities are free with no signup — try them without an API key.`,
-          self_signup: {
-            url: "https://api.strale.io/v1/signup",
-            method: "POST",
-            body: { email: "your-agent@yourdomain.com" },
-            description: "Create an account programmatically and get €2 free credits. Requires at least one prior free-tier call from this IP.",
-          },
-        }, 401);
+        // No payment header: 402 with the price if the rail can take it,
+        // otherwise 401 with the free list and the signup route. Both come
+        // from anonymousPaidRefusal, which the task-based path below also
+        // calls — one answer, two ways in.
+        return anonymousPaidRefusal(c, db, { ...lookedUp, slug: capabilitySlug });
       }
       } // close progressive unlock else
     }
@@ -1265,6 +1311,17 @@ doRoute.post(
     }
 
     return executeFreeTier(c, db, capability, executor, executionInput, outputSchema, freshness);
+  }
+
+  // Anonymous, and the capability that answered is not free.
+  //
+  // Reached only by the task-based caller: the x402-paid, free-tier and
+  // progressive-unlock branches above have all been taken, so `!user` here
+  // means an unauthenticated request that matched something we charge for.
+  // Without this the request fell into executeSync with `user` null and the
+  // wallet read threw — HTTP 500 to an arriving agent, for five months.
+  if (!user) {
+    return anonymousPaidRefusal(c, db, capability);
   }
 
   // Free-tier with auth: skip wallet operations but still record transaction


### PR DESCRIPTION
## What was wrong, measured against production

`/v1/do` accepts either a `capability_slug` or a free-text `task`. The early
auth gate for unauthenticated callers is entered only in the first case
(`if (!user && capabilitySlug)`), so a caller who described what they wanted
instead of naming a slug matched normally, passed the x402-paid branch (no
payment header), passed the free-tier and progressive-unlock branches, and
fell into `executeSync` with `user` undefined. The wallet read threw and the
top-level handler answered HTTP 500.

Checked against production before touching anything:

| request | before |
|---|---|
| `{"task":"search the web for news"}` | **HTTP 500** `internal_error` |
| `{"task":"take a screenshot of this page"}` | **HTTP 500** `internal_error` |
| `{"capability_slug":"google-search"}` | HTTP 402 + a valid x402 challenge |
| `{"task":"validate this email"}` (free tier) | HTTP 200 |

The rail answered correctly for anyone who already knew our slugs, and
returned an error to everyone who did not. `task` is what the MCP server, the
SDKs and the docs tell an agent to send.

Live since `1e8ebe6` (2026-03-08), the commit that introduced the gate — not a
regression from anything shipped this week.

## The fix

One `anonymousPaidRefusal`, called from both sites: it quotes the x402 price
where the rail can take the capability, and otherwise returns the 401 that
names the free capabilities and the programmatic signup route. Since x402 *is*
configured in production, the live effect is that these callers now get a price
instead of an error.

Same rule as `lib/free-tier.ts` after the 2026-08-22 incident: the answer a
caller is given must be produced by the code that decides, not by a second site
that happens to agree today.

## Tests

Two route-level tests in `do.core.test.ts`, both verified failing against the
un-fixed state by deleting the new call site:

```
AssertionError: expected 500 to be 402
AssertionError: expected 500 to be 401
```

which is the production symptom reproduced in the harness. They also assert the
executor is never invoked and no wallet transaction is opened, and that the 402
quotes the capability that actually matched at its own price.

Full unit suite: 2,644 passed / 206 files. `tsc --noEmit` clean.