### PR TITLE
Execution receipt, Phases 1-3: current-truth audit, strale.execution.v1 spec, and the RFC 8785 primitive

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -57,7 +57,7 @@
     "canonicalize": "^2.1.0",
     "drizzle-kit": "^0.30.6",
     "js-yaml": "^4.1.1",
-    "json-canonicalize": "^2.0.0",
+    "json-canonicalize": "2.0.1",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^4.1.4"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -54,8 +54,10 @@
     "@types/jsdom": "^28.0.1",
     "@types/node": "^22.12.0",
     "@types/turndown": "^5.0.6",
+    "canonicalize": "^2.1.0",
     "drizzle-kit": "^0.30.6",
     "js-yaml": "^4.1.1",
+    "json-canonicalize": "^2.0.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^4.1.4"

--- a/apps/api/src/lib/canonical/domain-digest.ts
+++ b/apps/api/src/lib/canonical/domain-digest.ts
@@ -1,0 +1,42 @@
+/**
+ * Domain-separated digests over RFC 8785 bytes (Phase 2, amendment 5).
+ *
+ *     digest = SHA-256( DOMAIN_TAG || 0x00 || RFC8785(payload) )
+ *
+ * Bare `SHA-256(canonical_bytes)` would let two different kinds of material
+ * collide, and would let a payload valid under one schema be replayed as
+ * another. The tag is US-ASCII and contains no NUL, so the separator is
+ * unambiguous — no length prefix is needed and none is used.
+ *
+ * The version lives in the tag as well as inside the receipt body. That is
+ * deliberate belt-and-braces: changing the schema changes the preimage even if
+ * a caller forgets to bump the `version` member.
+ */
+
+import { createHash } from "node:crypto";
+import { canonicalBytes } from "./jcs.js";
+
+/**
+ * Every domain in the system. Closed on purpose — a new kind of hashed material
+ * is a decision, not a string literal someone passes at a call site.
+ */
+export const DOMAIN_TAGS = {
+  /** A `strale.execution.v1` execution receipt payload. */
+  executionReceipt: "strale.execution.v1",
+  /** A normalized capability/solution declaration snapshot. */
+  manifestSnapshot: "strale.manifest-snapshot.v1",
+} as const;
+
+export type DomainTag = (typeof DOMAIN_TAGS)[keyof typeof DOMAIN_TAGS];
+
+const NUL = Buffer.from([0x00]);
+
+/** The exact bytes that get hashed. Exported so tests can assert on the preimage. */
+export function digestPreimage(domain: DomainTag, payload: unknown): Buffer {
+  return Buffer.concat([Buffer.from(domain, "ascii"), NUL, canonicalBytes(payload)]);
+}
+
+/** `sha256:<64 lowercase hex>` — the prefixed form that gets persisted. */
+export function domainDigest(domain: DomainTag, payload: unknown): string {
+  return `sha256:${createHash("sha256").update(digestPreimage(domain, payload)).digest("hex")}`;
+}

--- a/apps/api/src/lib/canonical/domain-digest.ts
+++ b/apps/api/src/lib/canonical/domain-digest.ts
@@ -33,7 +33,11 @@ const NUL = Buffer.from([0x00]);
 
 /** The exact bytes that get hashed. Exported so tests can assert on the preimage. */
 export function digestPreimage(domain: DomainTag, payload: unknown): Buffer {
-  return Buffer.concat([Buffer.from(domain, "ascii"), NUL, canonicalBytes(payload)]);
+  // utf8, not ascii: Buffer.from(x, "ascii") TRUNCATES to 7 bits rather
+  // than throwing, so a non-ASCII tag would frame byte-identically to an
+  // ASCII one. Not reachable today — DOMAIN_TAGS is closed and the suite
+  // asserts both members are printable ASCII — but the masking is gratuitous.
+  return Buffer.concat([Buffer.from(domain, "utf8"), NUL, canonicalBytes(payload)]);
 }
 
 /** `sha256:<64 lowercase hex>` — the prefixed form that gets persisted. */

--- a/apps/api/src/lib/canonical/fingerprint-stability.test.ts
+++ b/apps/api/src/lib/canonical/fingerprint-stability.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Consolidating onto one ordering rule must not move the idempotency digest.
+ *
+ * Phase 3 replaced `idempotency-fingerprint.ts`'s private recursive key-sort
+ * with the shared `sortKeysDeep`, so the codebase has one definition of
+ * canonical key order. That is a refactor and must be byte-neutral: a changed
+ * fingerprint makes `isReplayable` return false, and every idempotency key in
+ * flight across the deploy would 409 on a legitimate retry.
+ *
+ * These are frozen expected digests, computed from the PRE-refactor
+ * implementation and pasted here. If the shared rule ever diverges from what
+ * the private one did, this suite goes red before anything reaches production.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+
+import { computeIdempotencyFingerprint } from "../idempotency-fingerprint.js";
+import { sortKeysDeep, canonicalize } from "./jcs.js";
+
+/** The exact private implementation that shipped before this refactor. */
+function legacySortKeysDeep(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(legacySortKeysDeep);
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) out[key] = legacySortKeysDeep(obj[key]);
+  return out;
+}
+
+/** The exact pre-refactor digest computation, reproduced. */
+function legacyFingerprint(params: {
+  task?: string | null;
+  capabilitySlug?: string | null;
+  inputs?: Record<string, unknown> | null;
+  rail?: "capability" | "solution";
+  dryRun?: boolean | null;
+  requireFresh?: boolean | null;
+}): string {
+  const payload = JSON.stringify({
+    rail: params.rail ?? "capability",
+    task: params.task ?? null,
+    capability_slug: params.capabilitySlug ?? null,
+    inputs: legacySortKeysDeep(params.inputs ?? null),
+    dry_run: params.dryRun === true,
+    require_fresh: params.requireFresh === true,
+  });
+  return createHash("sha256").update(payload).digest("hex").slice(0, 32);
+}
+
+/** Realistic request shapes, plus the awkward ones. */
+const CORPUS: Array<Parameters<typeof computeIdempotencyFingerprint>[0]> = [
+  { capabilitySlug: "vat-validate", inputs: { vat_number: "SE556677889901" } },
+  { capabilitySlug: "vat-validate", inputs: { vat_number: "SE556677889901" }, dryRun: true },
+  { capabilitySlug: "vat-validate", inputs: { vat_number: "SE556677889901" }, requireFresh: true },
+  { task: "check this company", inputs: { name: "Acme AB", country: "SE" } },
+  { rail: "solution", capabilitySlug: "kyb-complete-se", inputs: { org_number: "556677-8899" } },
+  { capabilitySlug: "x", inputs: {} },
+  { capabilitySlug: "x", inputs: null },
+  { capabilitySlug: "x" },
+  { capabilitySlug: "nested", inputs: { b: { d: 1, c: [3, 1, 2] }, a: "z" } },
+  { capabilitySlug: "deep", inputs: { a: [{ z: 1, y: [{ q: 2, p: 3 }] }] } },
+  { capabilitySlug: "unicode", inputs: { "é": "naïve", "😀": "emoji key" } },
+  { capabilitySlug: "numbers", inputs: { a: 0, b: -0, c: 1.5, d: 1e21, e: 1e-7 } },
+  { capabilitySlug: "literals", inputs: { t: true, f: false, n: null, s: "", arr: [], obj: {} } },
+  { capabilitySlug: "controls", inputs: { k: "line\nbreak\ttab" } },
+];
+
+describe("the ordering-rule consolidation is byte-neutral for idempotency", () => {
+  it("the corpus is not trivially small", () => {
+    expect(CORPUS.length).toBeGreaterThanOrEqual(14);
+  });
+
+  it.each(CORPUS.map((c, i) => [i, c] as const))(
+    "case %i produces the pre-refactor digest",
+    (_i, params) => {
+      expect(computeIdempotencyFingerprint(params)).toBe(legacyFingerprint(params));
+    },
+  );
+
+  it("the shared and legacy shape normalizers agree structurally", () => {
+    for (const params of CORPUS) {
+      const inputs = params.inputs ?? null;
+      expect(JSON.stringify(sortKeysDeep(inputs))).toBe(
+        JSON.stringify(legacySortKeysDeep(inputs)),
+      );
+    }
+  });
+
+  it("still returns a 128-bit key, not a commitment", () => {
+    // It is a replay key. Widening it to look like the receipt digest would
+    // invite reading it as one.
+    expect(computeIdempotencyFingerprint(CORPUS[0])).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("and the full canonicalizer would NOT have been byte-neutral", () => {
+    // The reason the serialization was left alone, stated as a test rather
+    // than only as a comment: JCS sorts the six outer members too, so adopting
+    // it here changes the digest and 409s every live idempotency key.
+    const params = CORPUS[0];
+    const legacyPayload = JSON.stringify({
+      rail: "capability",
+      task: null,
+      capability_slug: params.capabilitySlug ?? null,
+      inputs: sortKeysDeep(params.inputs ?? null),
+      dry_run: false,
+      require_fresh: false,
+    });
+    const jcsPayload = canonicalize({
+      rail: "capability",
+      task: null,
+      capability_slug: params.capabilitySlug ?? null,
+      inputs: params.inputs ?? null,
+      dry_run: false,
+      require_fresh: false,
+    });
+    expect(jcsPayload).not.toBe(legacyPayload);
+  });
+});

--- a/apps/api/src/lib/canonical/jcs-vectors.json
+++ b/apps/api/src/lib/canonical/jcs-vectors.json
@@ -1,0 +1,494 @@
+{
+  "_comment": [
+    "RFC 8785 conformance vectors, committed. `expected` is the canonical STRING.",
+    "Hand-derived from the RFC's rules, NOT generated from the implementation under",
+    "test — a vector produced by the code it checks proves nothing. Two independent",
+    "implementations are asserted to agree with every one of them in jcs.test.ts;",
+    "a disagreement fails the suite rather than being noted.",
+    "Values outside the JSON domain (NaN, BigInt, cycles, Map, Date, sparse arrays,",
+    "lone surrogates) cannot be expressed in a JSON file and live in the test."
+  ],
+  "property_ordering": [
+    {
+      "name": "top-level keys sort by UTF-16 code unit",
+      "input": {
+        "b": 1,
+        "a": 2,
+        "c": 3
+      },
+      "expected": "{\"a\":2,\"b\":1,\"c\":3}"
+    },
+    {
+      "name": "sorting is recursive, not just top level",
+      "input": {
+        "z": {
+          "d": 1,
+          "b": 2
+        },
+        "a": {
+          "y": 3,
+          "x": 4
+        }
+      },
+      "expected": "{\"a\":{\"x\":4,\"y\":3},\"z\":{\"b\":2,\"d\":1}}"
+    },
+    {
+      "name": "digits and uppercase sort before lowercase (code unit, not locale)",
+      "input": {
+        "a": 1,
+        "A": 2,
+        "1": 3,
+        "_": 4
+      },
+      "expected": "{\"1\":3,\"A\":2,\"_\":4,\"a\":1}"
+    },
+    {
+      "name": "the empty key is legal and sorts first",
+      "input": {
+        "a": 1,
+        "": 2
+      },
+      "expected": "{\"\":2,\"a\":1}"
+    },
+    {
+      "name": "a shorter key that is a prefix sorts before the longer one",
+      "input": {
+        "ab": 1,
+        "a": 2,
+        "abc": 3
+      },
+      "expected": "{\"a\":2,\"ab\":1,\"abc\":3}"
+    },
+    {
+      "name": "array order is DATA and is never sorted",
+      "input": {
+        "k": [
+          3,
+          1,
+          2
+        ]
+      },
+      "expected": "{\"k\":[3,1,2]}"
+    }
+  ],
+  "unicode_ordering": [
+    {
+      "name": "ASCII sorts before Latin-1 supplement",
+      "input": {
+        "é": 1,
+        "z": 2,
+        "a": 3
+      },
+      "expected": "{\"a\":3,\"z\":2,\"é\":1}"
+    },
+    {
+      "name": "UTF-16 CODE UNIT order, not code point order - the discriminating case",
+      "_why": [
+        "U+1F600 is the surrogate pair D83D DE00; U+FB00 is the single unit FB00.",
+        "By CODE POINT, FB00 (64256) < 1F600 (128512), so the ligature would sort first.",
+        "By UTF-16 CODE UNIT, D83D (55357) < FB00 (64256), so the emoji sorts first.",
+        "RFC 8785 section 3.2.3 mandates the code-unit rule. An implementation that",
+        "sorted by code point, or by UTF-8 bytes, fails exactly here."
+      ],
+      "input": {
+        "ﬀ": 1,
+        "😀": 2
+      },
+      "expected": "{\"😀\":2,\"ﬀ\":1}"
+    },
+    {
+      "name": "non-ASCII is emitted literally, never backslash-u escaped",
+      "input": {
+        "k": "héllo wörld — ünïcode ✓ 😀"
+      },
+      "expected": "{\"k\":\"héllo wörld — ünïcode ✓ 😀\"}"
+    },
+    {
+      "name": "combining marks are not normalized (NFC is NOT applied)",
+      "_why": "RFC 8785 does not normalize. e + combining acute stays two code points.",
+      "input": {
+        "k": "é"
+      },
+      "expected": "{\"k\":\"é\"}"
+    },
+    {
+      "name": "precomposed and decomposed forms are DIFFERENT keys",
+      "_why": "Follows from no normalization; a verifier must not silently fold them.",
+      "input": {
+        "é": 1,
+        "é": 2
+      },
+      "expected": "{\"é\":2,\"é\":1}"
+    }
+  ],
+  "string_escaping": [
+    {
+      "name": "quote and backslash",
+      "input": {
+        "k": "a\"b\\c"
+      },
+      "expected": "{\"k\":\"a\\\"b\\\\c\"}"
+    },
+    {
+      "name": "the five short control escapes",
+      "input": {
+        "k": "\b\t\n\f\r"
+      },
+      "expected": "{\"k\":\"\\b\\t\\n\\f\\r\"}"
+    },
+    {
+      "name": "other C0 controls use lowercase backslash-u00xx",
+      "input": {
+        "k": "\u0000\u0001\u001f"
+      },
+      "expected": "{\"k\":\"\\u0000\\u0001\\u001f\"}"
+    },
+    {
+      "name": "DEL (U+007F) is NOT escaped",
+      "_why": "RFC 8785 escapes only the C0 range, quote and backslash.",
+      "input": {
+        "k": ""
+      },
+      "expected": "{\"k\":\"\"}"
+    },
+    {
+      "name": "forward slash is NOT escaped",
+      "input": {
+        "k": "a/b"
+      },
+      "expected": "{\"k\":\"a/b\"}"
+    },
+    {
+      "name": "control characters in KEYS escape the same way",
+      "input": {
+        "a\nb": 1
+      },
+      "expected": "{\"a\\nb\":1}"
+    },
+    {
+      "name": "U+0080 and U+009F (C1 controls) are NOT escaped",
+      "_why": "Only C0 is in scope; C1 are ordinary non-ASCII characters here.",
+      "input": {
+        "k": ""
+      },
+      "expected": "{\"k\":\"\"}"
+    }
+  ],
+  "nesting": [
+    {
+      "name": "arrays of objects keep array order and sort object keys",
+      "input": {
+        "a": [
+          {
+            "b": 1,
+            "a": 2
+          },
+          {
+            "d": 3,
+            "c": 4
+          }
+        ]
+      },
+      "expected": "{\"a\":[{\"a\":2,\"b\":1},{\"c\":4,\"d\":3}]}"
+    },
+    {
+      "name": "deeply nested mixed structure",
+      "input": {
+        "z": [
+          [
+            1,
+            [
+              2,
+              {
+                "b": [],
+                "a": {}
+              }
+            ]
+          ],
+          []
+        ],
+        "a": {
+          "n": [
+            null,
+            true
+          ]
+        }
+      },
+      "expected": "{\"a\":{\"n\":[null,true]},\"z\":[[1,[2,{\"a\":{},\"b\":[]}]],[]]}"
+    },
+    {
+      "name": "array of arrays preserves inner order",
+      "input": [
+        [
+          3,
+          2,
+          1
+        ],
+        [
+          1,
+          2,
+          3
+        ]
+      ],
+      "expected": "[[3,2,1],[1,2,3]]"
+    }
+  ],
+  "numbers": [
+    {
+      "name": "zero",
+      "input": {
+        "k": 0
+      },
+      "expected": "{\"k\":0}"
+    },
+    {
+      "name": "negative zero serializes as 0",
+      "_why": "RFC 8785 section 3.2.2.3. -0 and 0 are the same JSON number.",
+      "input": {
+        "k": -0.0
+      },
+      "expected": "{\"k\":0}"
+    },
+    {
+      "name": "negative integer",
+      "input": {
+        "k": -1
+      },
+      "expected": "{\"k\":-1}"
+    },
+    {
+      "name": "trailing zeros are dropped (1.0 is the double 1)",
+      "input": {
+        "k": 1.0
+      },
+      "expected": "{\"k\":1}"
+    },
+    {
+      "name": "simple fraction",
+      "input": {
+        "k": 1.5
+      },
+      "expected": "{\"k\":1.5}"
+    },
+    {
+      "name": "shortest round-tripping form, not the input spelling",
+      "input": {
+        "k": 0.1
+      },
+      "expected": "{\"k\":0.1}"
+    },
+    {
+      "name": "classic binary-float sum keeps full precision",
+      "input": {
+        "k": 0.30000000000000004
+      },
+      "expected": "{\"k\":0.30000000000000004}"
+    },
+    {
+      "name": "max safe integer",
+      "input": {
+        "k": 9007199254740991
+      },
+      "expected": "{\"k\":9007199254740991}"
+    },
+    {
+      "name": "large negative",
+      "input": {
+        "k": -9007199254740991
+      },
+      "expected": "{\"k\":-9007199254740991}"
+    }
+  ],
+  "exponents": [
+    {
+      "name": "small exponents expand to plain digits",
+      "input": {
+        "k": 100.0
+      },
+      "expected": "{\"k\":100}"
+    },
+    {
+      "name": "1e20 stays expanded",
+      "input": {
+        "k": 1e+20
+      },
+      "expected": "{\"k\":100000000000000000000}"
+    },
+    {
+      "name": "1e21 switches to exponent form with an explicit plus",
+      "_why": "ECMAScript Number::toString switches to exponent form at 1e21.",
+      "input": {
+        "k": 1e+21
+      },
+      "expected": "{\"k\":1e+21}"
+    },
+    {
+      "name": "small magnitudes expand down to 1e-6",
+      "input": {
+        "k": 1e-06
+      },
+      "expected": "{\"k\":0.000001}"
+    },
+    {
+      "name": "1e-7 switches to exponent form",
+      "input": {
+        "k": 1e-07
+      },
+      "expected": "{\"k\":1e-7}"
+    },
+    {
+      "name": "denormal minimum",
+      "input": {
+        "k": 5e-324
+      },
+      "expected": "{\"k\":5e-324}"
+    },
+    {
+      "name": "near-max double",
+      "input": {
+        "k": 1.7976931348623157e+308
+      },
+      "expected": "{\"k\":1.7976931348623157e+308}"
+    }
+  ],
+  "literals_and_empty": [
+    {
+      "name": "booleans",
+      "input": {
+        "t": true,
+        "f": false
+      },
+      "expected": "{\"f\":false,\"t\":true}"
+    },
+    {
+      "name": "null",
+      "input": {
+        "k": null
+      },
+      "expected": "{\"k\":null}"
+    },
+    {
+      "name": "empty object",
+      "input": {},
+      "expected": "{}"
+    },
+    {
+      "name": "empty array",
+      "input": [],
+      "expected": "[]"
+    },
+    {
+      "name": "empty string value",
+      "input": {
+        "k": ""
+      },
+      "expected": "{\"k\":\"\"}"
+    },
+    {
+      "name": "empty nested containers",
+      "input": {
+        "a": {},
+        "b": []
+      },
+      "expected": "{\"a\":{},\"b\":[]}"
+    },
+    {
+      "name": "top-level scalar string",
+      "input": "hi",
+      "expected": "\"hi\""
+    },
+    {
+      "name": "top-level scalar number",
+      "input": 42,
+      "expected": "42"
+    },
+    {
+      "name": "top-level null",
+      "input": null,
+      "expected": "null"
+    },
+    {
+      "name": "top-level true",
+      "input": true,
+      "expected": "true"
+    }
+  ],
+  "receipt_shape": [
+    {
+      "name": "a strale.execution.v1 payload canonicalizes stably",
+      "_why": "The shape Phase 2 specifies, run end to end through the primitive.",
+      "input": {
+        "version": "strale.execution.v1",
+        "transaction_id": "8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f",
+        "subject": {
+          "kind": "capability",
+          "slug": "vat-validate"
+        },
+        "implementation": {
+          "deploy_commit": "ce5e63f091863f56764829b498525211cd2ab234",
+          "manifest_digest": "sha256:9a3f0000000000000000000000000000000000000000000000000000000000ff",
+          "steps": null
+        },
+        "request": {
+          "rail": "v1_do",
+          "inputs": {
+            "vat_number": "SE556677889901"
+          }
+        },
+        "response": {
+          "status": "completed",
+          "result": {
+            "valid": true
+          },
+          "error": null
+        },
+        "execution": {
+          "method": "algorithmic",
+          "source_observation": {
+            "kind": "live_fetch",
+            "observed_at": "2026-08-23T09:14:50.311Z"
+          }
+        }
+      },
+      "expected": "{\"execution\":{\"method\":\"algorithmic\",\"source_observation\":{\"kind\":\"live_fetch\",\"observed_at\":\"2026-08-23T09:14:50.311Z\"}},\"implementation\":{\"deploy_commit\":\"ce5e63f091863f56764829b498525211cd2ab234\",\"manifest_digest\":\"sha256:9a3f0000000000000000000000000000000000000000000000000000000000ff\",\"steps\":null},\"request\":{\"inputs\":{\"vat_number\":\"SE556677889901\"},\"rail\":\"v1_do\"},\"response\":{\"error\":null,\"result\":{\"valid\":true},\"status\":\"completed\"},\"subject\":{\"kind\":\"capability\",\"slug\":\"vat-validate\"},\"transaction_id\":\"8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f\",\"version\":\"strale.execution.v1\"}"
+    },
+    {
+      "name": "a FAILED execution receipt canonicalizes stably",
+      "_why": "Amendment: failures are executions. result null, error bound.",
+      "input": {
+        "version": "strale.execution.v1",
+        "transaction_id": "0000aaaa-bbbb-cccc-dddd-eeeeffff0000",
+        "subject": {
+          "kind": "capability",
+          "slug": "iban-validate"
+        },
+        "implementation": {
+          "deploy_commit": "unknown-local-build",
+          "manifest_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+          "steps": null
+        },
+        "request": {
+          "rail": "x402",
+          "inputs": {
+            "iban": "XX00"
+          }
+        },
+        "response": {
+          "status": "failed",
+          "result": null,
+          "error": {
+            "code": "invalid_input",
+            "message": "iban is not valid"
+          }
+        },
+        "execution": {
+          "method": "algorithmic",
+          "source_observation": {
+            "kind": "computed"
+          }
+        }
+      },
+      "expected": "{\"execution\":{\"method\":\"algorithmic\",\"source_observation\":{\"kind\":\"computed\"}},\"implementation\":{\"deploy_commit\":\"unknown-local-build\",\"manifest_digest\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"steps\":null},\"request\":{\"inputs\":{\"iban\":\"XX00\"},\"rail\":\"x402\"},\"response\":{\"error\":{\"code\":\"invalid_input\",\"message\":\"iban is not valid\"},\"result\":null,\"status\":\"failed\"},\"subject\":{\"kind\":\"capability\",\"slug\":\"iban-validate\"},\"transaction_id\":\"0000aaaa-bbbb-cccc-dddd-eeeeffff0000\",\"version\":\"strale.execution.v1\"}"
+    }
+  ]
+}

--- a/apps/api/src/lib/canonical/jcs.test.ts
+++ b/apps/api/src/lib/canonical/jcs.test.ts
@@ -25,6 +25,7 @@ import refA from "canonicalize";
 import { canonicalize as refB } from "json-canonicalize/src/index.ts";
 
 import { canonicalize, canonicalBytes, sortKeysDeep, CanonicalizationError } from "./jcs.js";
+import { computeIdempotencyFingerprint } from "../idempotency-fingerprint.js";
 import { DOMAIN_TAGS, domainDigest, digestPreimage } from "./domain-digest.js";
 
 interface Vector {
@@ -437,6 +438,168 @@ describe("nesting depth is bounded by us, not by the stack", () => {
   it("the input that overflows the stack still parses, so the bound is load-bearing", () => {
     // If JSON.parse refused first, the bound would be unreachable decoration.
     expect(() => nest(5000)).not.toThrow();
+  });
+});
+
+describe("the array branch enforces the same invariant as the object branch", () => {
+  // Every value read during serialization must be an own DATA property of a
+  // PLAIN container, with no member the reader will not visit. Three holes,
+  // all reviewer-demonstrated at acb97a4.
+
+  it("an accessor at an array INDEX is refused", () => {
+    let n = 0;
+    const arr: unknown[] = [];
+    Object.defineProperty(arr, "0", { get: () => ++n, enumerable: true, configurable: true });
+    arr.length = 1;
+    let err: unknown;
+    try {
+      canonicalize(arr);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+    expect((err as CanonicalizationError).code).toBe("accessor_property");
+  });
+
+  it("keys that merely LOOK numeric are refused, not treated as indices", () => {
+    // `String(Number(k)) !== k` admitted every one of these, and
+    // JSON.stringify drops all of them.
+    for (const key of ["-1", "1.5", "NaN", "Infinity", "4294967296", "1e+21", "01"]) {
+      const arr: unknown[] = [1];
+      (arr as unknown as Record<string, unknown>)[key] = "SECRET";
+      expect(JSON.stringify(arr), `${key} baseline`).toBe("[1]");
+      let err: unknown;
+      try {
+        canonicalize(arr);
+      } catch (e) {
+        err = e;
+      }
+      expect(err, `key ${key} was not refused`).toBeInstanceOf(CanonicalizationError);
+      expect((err as CanonicalizationError).code).toBe("sparse_or_exotic_array");
+    }
+  });
+
+  it("an Array subclass supplying an index from its PROTOTYPE is refused", () => {
+    // Passes a stray-key check (no own keys) and an `in` hole check (the
+    // prototype answers), while map() reads the varying getter.
+    let n = 0;
+    class Sneaky extends Array {}
+    Object.defineProperty(Sneaky.prototype, "0", { get: () => ++n, configurable: true });
+    const sneaky = new Sneaky();
+    sneaky.length = 1;
+    let err: unknown;
+    try {
+      canonicalize(sneaky);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+    expect((err as CanonicalizationError).code).toBe("sparse_or_exotic_array");
+    delete (Sneaky.prototype as unknown as Record<string, unknown>)["0"];
+  });
+
+  it("ordinary arrays are unaffected", () => {
+    expect(canonicalize([1, "a", null, true, [], {}])).toBe('[1,"a",null,true,[],{}]');
+    expect(canonicalize([])).toBe("[]");
+  });
+});
+
+describe("the depth bound covers the path production actually reaches", () => {
+  function nest(depth: number): unknown {
+    return JSON.parse("[".repeat(depth) + "1" + "]".repeat(depth));
+  }
+
+  it("sortKeysDeep refuses with OUR error, not a RangeError", () => {
+    // THE ONE THAT MATTERED. canonicalize has no production caller; this does,
+    // through computeIdempotencyFingerprint from do.ts, on the raw parsed body
+    // before input validation. A ~6 KB body nested 3,000 deep produced a bare
+    // RangeError and a 500.
+    let err: unknown;
+    try {
+      sortKeysDeep(nest(5000));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+    expect((err as CanonicalizationError).code).toBe("max_depth_exceeded");
+    expect(err).not.toBeInstanceOf(RangeError);
+  });
+
+  it("the fingerprint refuses the same input the same way", () => {
+    let err: unknown;
+    try {
+      computeIdempotencyFingerprint({ capabilitySlug: "x", inputs: { deep: nest(5000) } as never });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+  });
+
+  it("real-world depth is untouched — production's deepest input carries 42 brackets", () => {
+    expect(() => sortKeysDeep(nest(100))).not.toThrow();
+    expect(() => sortKeysDeep(nest(500))).not.toThrow();
+  });
+});
+
+describe("differential fuzz against both references", () => {
+  // Coverage gap the review named: the reference implementations only ever saw
+  // the 49 committed vectors, so the suite had no oracle beyond those points.
+  // Seeded, so a failure is reproducible rather than a one-off.
+  function makeRng(seed: number): () => number {
+    let s = seed >>> 0;
+    return () => {
+      s = (s * 1664525 + 1013904223) >>> 0;
+      return s / 0x100000000;
+    };
+  }
+
+  function randomJson(rnd: () => number, depth = 0): unknown {
+    const r = rnd();
+    if (depth > 3 || r < 0.3) {
+      const leaf = rnd();
+      if (leaf < 0.2) return null;
+      if (leaf < 0.35) return rnd() < 0.5;
+      if (leaf < 0.6) return (rnd() - 0.5) * Math.pow(10, Math.floor(rnd() * 40) - 20);
+      const chars = [
+        "a",
+        "é",
+        "😀",
+        String.fromCharCode(10), // newline
+        String.fromCharCode(34), // quote
+        String.fromCharCode(92), // backslash
+        String.fromCharCode(0), // NUL
+        String.fromCharCode(127), // DEL
+        "ﬀ",
+        "",
+        "/",
+      ];
+      return Array.from({ length: Math.floor(rnd() * 5) }, () =>
+        chars[Math.floor(rnd() * chars.length)],
+      ).join("");
+    }
+    if (r < 0.55) {
+      return Array.from({ length: Math.floor(rnd() * 4) }, () => randomJson(rnd, depth + 1));
+    }
+    const obj: Record<string, unknown> = {};
+    const keys = ["a", "b", "é", "😀", "ﬀ", "__proto__", "0", "10", "2", "", "Z"];
+    for (let i = 0; i < Math.floor(rnd() * 5); i++) {
+      obj[keys[Math.floor(rnd() * keys.length)]] = randomJson(rnd, depth + 1);
+    }
+    return obj;
+  }
+
+  it("2000 random JSON values agree with both references, byte for byte", () => {
+    const rnd = makeRng(20260823);
+    let compared = 0;
+    for (let i = 0; i < 2000; i++) {
+      // Round-trip so the value is exactly what JSON.parse would hand us.
+      const value = JSON.parse(JSON.stringify(randomJson(rnd)));
+      const ours = canonicalize(value);
+      expect(ours, `case ${i}`).toBe(refA(value as never));
+      expect(ours, `case ${i}`).toBe(refB(value));
+      compared++;
+    }
+    expect(compared).toBe(2000);
   });
 });
 

--- a/apps/api/src/lib/canonical/jcs.test.ts
+++ b/apps/api/src/lib/canonical/jcs.test.ts
@@ -24,7 +24,7 @@ import { join } from "node:path";
 import refA from "canonicalize";
 import { canonicalize as refB } from "json-canonicalize/src/index.ts";
 
-import { canonicalize, canonicalBytes, CanonicalizationError } from "./jcs.js";
+import { canonicalize, canonicalBytes, sortKeysDeep, CanonicalizationError } from "./jcs.js";
 import { DOMAIN_TAGS, domainDigest, digestPreimage } from "./domain-digest.js";
 
 interface Vector {
@@ -220,6 +220,81 @@ describe("values outside the JSON domain are refused, never coerced", () => {
     expect(JSON.stringify(o)).toBe('{"k":"hijacked"}');
     // We refuse, because toJSON is a function member.
     refusal(o, "unsupported_type");
+  });
+});
+
+describe("properties JavaScript treats specially", () => {
+  it("a literal __proto__ key survives canonicalization", () => {
+    // JSON.parse produces __proto__ as an OWN property, and `out[key] = v` on
+    // an ordinary object would set the prototype instead of storing it.
+    const parsed = JSON.parse('{"__proto__": 1, "a": 2}');
+    expect(Object.keys(parsed)).toContain("__proto__");
+    expect(canonicalize(parsed)).toBe('{"__proto__":1,"a":2}');
+  });
+
+  it("sortKeysDeep preserves __proto__ instead of silently dropping it", () => {
+    // The bug this fixes: two requests differing only in __proto__ produced
+    // the SAME idempotency fingerprint and would have replayed each other.
+    const parsed = JSON.parse('{"__proto__": 1, "a": 2}');
+    const sorted = sortKeysDeep(parsed) as Record<string, unknown>;
+    expect(Object.keys(sorted)).toEqual(["__proto__", "a"]);
+    expect(JSON.stringify(sorted)).toBe('{"__proto__":1,"a":2}');
+  });
+
+  it("two inputs differing ONLY in __proto__ get different fingerprints", () => {
+    const a = JSON.parse('{"__proto__": 1, "x": 1}');
+    const b = JSON.parse('{"x": 1}');
+    expect(JSON.stringify(sortKeysDeep(a))).not.toBe(JSON.stringify(sortKeysDeep(b)));
+  });
+
+  it("a getter is refused, because it has no stable value", () => {
+    let n = 0;
+    const withGetter = {
+      a: 1,
+      get k() {
+        return ++n;
+      },
+    };
+    let err: unknown;
+    try {
+      canonicalize(withGetter);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+    expect((err as CanonicalizationError).code).toBe("accessor_property");
+  });
+
+  it("integer-like keys sort by code unit, not by JS integer-key order", () => {
+    // Object.keys returns integer-like keys first, ascending numerically:
+    // ["1","2","10","b"]. RFC 8785 wants "1","10","2","b".
+    const o = { "10": 1, "2": 2, b: 3, "1": 4 };
+    expect(Object.keys(o)).toEqual(["1", "2", "10", "b"]);
+    expect(canonicalize(o)).toBe('{"1":4,"10":1,"2":2,"b":3}');
+  });
+
+  it("a toJSON on the PROTOTYPE is ignored, not honoured", () => {
+    class T {
+      a = 1;
+      toJSON() {
+        return "hijacked";
+      }
+    }
+    const inst = new T();
+    expect(JSON.stringify({ k: inst })).toBe('{"k":"hijacked"}');
+    // Not an own enumerable member, so it is simply not serialized.
+    expect(canonicalize({ k: inst })).toBe('{"k":{"a":1}}');
+  });
+
+  it("symbol keys and non-enumerable properties are excluded, as JSON requires", () => {
+    // Documented rather than refused: these are not JSON members at all, and
+    // JSON.stringify omits them too. Pinned so the behaviour is a decision.
+    const withSymbol = { a: 1, [Symbol("s")]: 2 };
+    expect(canonicalize(withSymbol)).toBe('{"a":1}');
+
+    const withHidden = { a: 1 };
+    Object.defineProperty(withHidden, "hidden", { value: 2, enumerable: false });
+    expect(canonicalize(withHidden)).toBe('{"a":1}');
   });
 });
 

--- a/apps/api/src/lib/canonical/jcs.test.ts
+++ b/apps/api/src/lib/canonical/jcs.test.ts
@@ -643,10 +643,24 @@ describe("differential fuzz against both references", () => {
     expect(refB(nulled)).toBe(canonicalize(nulled));
   });
 
-  it("sortKeysDeep cannot be passed a depth by a stray .map()", () => {
-    // An exported optional depth parameter would make `xs.map(sortKeysDeep)`
-    // pass the array INDEX as the depth, throwing at element 513.
-    expect(sortKeysDeep.length).toBe(1);
+  it("sortKeysDeep ignores a second argument, so a stray .map() cannot inject a depth", () => {
+    // `xs.map(sortKeysDeep)` passes the array INDEX as the second argument. If
+    // the export forwarded it as the depth, element 513 would start throwing
+    // max_depth_exceeded on values that are barely nested at all.
+    //
+    // The first version of this test asserted `sortKeysDeep.length === 1`,
+    // which the mutation battery showed is NOT discriminating: Function.length
+    // does not count a parameter with a default, and `(value, _d = 0)` is
+    // exactly the shape the footgun takes. Test the behaviour instead.
+    // Shallow enough to be fine on its own (100 << 512), but 600 + 100 would
+    // blow the budget if the second argument were honoured as a starting depth.
+    const nested = JSON.parse("[".repeat(100) + "1" + "]".repeat(100));
+    expect(() => (sortKeysDeep as (v: unknown, d?: number) => unknown)(nested, 600)).not.toThrow();
+    expect(
+      JSON.stringify((sortKeysDeep as (v: unknown, d?: number) => unknown)(nested, 600)),
+    ).toBe(JSON.stringify(sortKeysDeep(nested)));
+
+    // And the real call shape, at an index past the budget.
     const many = Array.from({ length: 600 }, (_, i) => ({ b: i, a: i }));
     expect(() => many.map(sortKeysDeep)).not.toThrow();
   });

--- a/apps/api/src/lib/canonical/jcs.test.ts
+++ b/apps/api/src/lib/canonical/jcs.test.ts
@@ -300,11 +300,22 @@ describe("properties JavaScript treats specially", () => {
     }
   });
 
-  it("inherited properties are excluded; only own members are canonicalized", () => {
+  it("an object with a populated prototype is refused, not partially serialized", () => {
+    // JSON.stringify emits only the own members, silently discarding whatever
+    // the prototype carried. That is plausible output for an object whose
+    // meaning is incomplete, so the allow-list refuses it instead.
     const proto = { inherited: "must not appear" };
     const child = Object.create(proto) as Record<string, unknown>;
     child.own = 1;
-    expect(canonicalize(child)).toBe('{"own":1}');
+    expect(JSON.stringify(child)).toBe('{"own":1}');
+    let err: unknown;
+    try {
+      canonicalize(child);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+    expect((err as CanonicalizationError).code).toBe("unsupported_type");
   });
 
   it("a null-prototype object canonicalizes like any other", () => {
@@ -322,7 +333,7 @@ describe("properties JavaScript treats specially", () => {
     expect(canonicalize(o)).toBe('{"1":4,"10":1,"2":2,"b":3}');
   });
 
-  it("a toJSON on the PROTOTYPE is ignored, not honoured", () => {
+  it("a class instance is refused before its prototype toJSON can be reached", () => {
     class T {
       a = 1;
       toJSON() {
@@ -330,9 +341,59 @@ describe("properties JavaScript treats specially", () => {
       }
     }
     const inst = new T();
+    // JSON.stringify would let the object choose its own canonical form.
     expect(JSON.stringify({ k: inst })).toBe('{"k":"hijacked"}');
-    // Not an own enumerable member, so it is simply not serialized.
-    expect(canonicalize({ k: inst })).toBe('{"k":{"a":1}}');
+    let err: unknown;
+    try {
+      canonicalize({ k: inst });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+    expect((err as CanonicalizationError).code).toBe("unsupported_type");
+  });
+
+  it("every exotic that JSON.stringify flattens to {} is refused", () => {
+    // Found by probing, and the reason the blocklist became an allow-list:
+    // each of these loses its entire meaning in output that looks like a
+    // legitimate empty object.
+    const exotics: Array<[string, unknown]> = [
+      ["Error", new Error("boom")],
+      ["Promise", Promise.resolve(1)],
+      ["WeakMap", new WeakMap()],
+      ["WeakSet", new WeakSet()],
+      ["ArrayBuffer", new ArrayBuffer(8)],
+      ["Map", new Map([["a", 1]])],
+      ["Set", new Set([1])],
+      ["Date", new Date(0)],
+      ["RegExp", /x/],
+      ["Uint8Array", new Uint8Array([1])],
+    ];
+    for (const [label, value] of exotics) {
+      expect(JSON.stringify({ k: value }), `${label} baseline`).toMatch(/^\{"k":(\{|")/);
+      let err: unknown;
+      try {
+        canonicalize({ k: value });
+      } catch (e) {
+        err = e;
+      }
+      expect(err, `${label} was not refused`).toBeInstanceOf(CanonicalizationError);
+    }
+  });
+
+  it("an array carrying non-index own properties is refused", () => {
+    // `const a = [1]; a.extra = 2` serializes as `[1]`, losing `extra`.
+    const arr: unknown[] & { extra?: string } = [1, 2];
+    arr.extra = "dropped by JSON.stringify";
+    expect(JSON.stringify(arr)).toBe("[1,2]");
+    let err: unknown;
+    try {
+      canonicalize(arr);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+    expect((err as CanonicalizationError).code).toBe("sparse_or_exotic_array");
   });
 
   it("symbol keys and non-enumerable properties are excluded, as JSON requires", () => {

--- a/apps/api/src/lib/canonical/jcs.test.ts
+++ b/apps/api/src/lib/canonical/jcs.test.ts
@@ -621,6 +621,36 @@ describe("differential fuzz against both references", () => {
     return obj;
   }
 
+  it("PINNED: json-canonicalize is WRONG on a non-null toJSON property — we are not", () => {
+    // serializer.ts:29-33 routes any object whose `toJSON` PROPERTY is non-null
+    // straight to JSON.stringify, skipping the sort. A plain data value under
+    // that key is enough; `{"toJSON": null}` dodges the guard.
+    //
+    // Pinned rather than worked around, because the fuzz below asserts
+    // `ours === refB(value)` and its key alphabet deliberately omits "toJSON".
+    // Add it and the suite goes red with the message "reference
+    // `json-canonicalize` disagrees" — pointing at the wrong culprit and
+    // inviting someone to "fix" correct code. This test is the note they will
+    // find instead.
+    const value = JSON.parse('{"toJSON": 1, "-1": 2}');
+
+    expect(canonicalize(value)).toBe('{"-1":2,"toJSON":1}'); // RFC 8785 §3.2.3
+    expect(refA(value as never)).toBe('{"-1":2,"toJSON":1}'); // agrees with us
+    expect(refB(value)).toBe('{"toJSON":1,"-1":2}'); // unsorted — the bug
+
+    // And the guard really is the non-null check.
+    const nulled = JSON.parse('{"toJSON": null, "-1": 2}');
+    expect(refB(nulled)).toBe(canonicalize(nulled));
+  });
+
+  it("sortKeysDeep cannot be passed a depth by a stray .map()", () => {
+    // An exported optional depth parameter would make `xs.map(sortKeysDeep)`
+    // pass the array INDEX as the depth, throwing at element 513.
+    expect(sortKeysDeep.length).toBe(1);
+    const many = Array.from({ length: 600 }, (_, i) => ({ b: i, a: i }));
+    expect(() => many.map(sortKeysDeep)).not.toThrow();
+  });
+
   it("2000 random JSON values agree with both references, byte for byte", () => {
     const rnd = makeRng(20260823);
     let compared = 0;

--- a/apps/api/src/lib/canonical/jcs.test.ts
+++ b/apps/api/src/lib/canonical/jcs.test.ts
@@ -632,6 +632,14 @@ describe("differential fuzz against both references", () => {
     // `json-canonicalize` disagrees" — pointing at the wrong culprit and
     // inviting someone to "fix" correct code. This test is the note they will
     // find instead.
+    //
+    // The guard upstream is `!= null`, so every falsy-but-non-null value trips
+    // it too: 0, false, "", {} and [] all skip the sort; only null does not.
+    //
+    // This asserts THIRD-PARTY behaviour, so `json-canonicalize` is pinned to
+    // an exact version (2.0.1) in package.json rather than a caret range. If
+    // someone deliberately bumps it and upstream has fixed the bug, this test
+    // goes red on purpose — delete it and the note together.
     const value = JSON.parse('{"toJSON": 1, "-1": 2}');
 
     expect(canonicalize(value)).toBe('{"-1":2,"toJSON":1}'); // RFC 8785 §3.2.3

--- a/apps/api/src/lib/canonical/jcs.test.ts
+++ b/apps/api/src/lib/canonical/jcs.test.ts
@@ -1,0 +1,296 @@
+/**
+ * RFC 8785 conformance for Strale's own canonicalizer (Phase 3).
+ *
+ * Three kinds of assertion, deliberately separated:
+ *
+ *  1. **Committed vectors** — `jcs-vectors.json`, hand-derived from the RFC's
+ *     rules. A vector generated from the implementation under test proves
+ *     nothing, so none of them were.
+ *  2. **Independent cross-check** — every vector is also run through two
+ *     third-party JCS implementations (`canonicalize`, `json-canonicalize`).
+ *     They are devDependencies and verification references only: nothing here
+ *     imports them at runtime, and if they disagree with us the test fails
+ *     rather than deferring to them.
+ *  3. **Domain refusals** — the values `JSON.stringify` would silently coerce
+ *     or drop. Each is an error here, because silent omission is exactly what
+ *     a closed receipt schema cannot tolerate.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import refA from "canonicalize";
+import { canonicalize as refB } from "json-canonicalize/src/index.ts";
+
+import { canonicalize, canonicalBytes, CanonicalizationError } from "./jcs.js";
+import { DOMAIN_TAGS, domainDigest, digestPreimage } from "./domain-digest.js";
+
+interface Vector {
+  name: string;
+  input: unknown;
+  expected: string;
+}
+
+const VECTORS = JSON.parse(
+  readFileSync(join(import.meta.dirname, "jcs-vectors.json"), "utf8"),
+) as Record<string, Vector[] | unknown>;
+
+const GROUPS = Object.entries(VECTORS).filter(
+  //  is an array of strings, not a vector group. Without this the
+  // suite iterated it and produced seven tests named "undefined".
+  (entry): entry is [string, Vector[]] =>
+    !entry[0].startsWith("_") &&
+    Array.isArray(entry[1]) &&
+    entry[1].every((v) => typeof (v as Vector)?.name === "string"),
+);
+
+function sha256Hex(b: Buffer): string {
+  return createHash("sha256").update(b).digest("hex");
+}
+
+describe("RFC 8785 canonicalization — committed vectors", () => {
+  it("the vector file actually contains vectors", () => {
+    // Guards the whole suite: a rename or a parse slip would otherwise make
+    // every `it.each` below iterate an empty list and report success.
+    const total = GROUPS.reduce((n, [, v]) => n + v.length, 0);
+    expect(GROUPS.length).toBeGreaterThanOrEqual(7);
+    expect(total).toBeGreaterThanOrEqual(40);
+  });
+
+  for (const [group, vectors] of GROUPS) {
+    describe(group, () => {
+      for (const v of vectors) {
+        it(v.name, () => {
+          expect(canonicalize(v.input)).toBe(v.expected);
+        });
+      }
+    });
+  }
+});
+
+describe("independent implementations agree, vector for vector", () => {
+  for (const [group, vectors] of GROUPS) {
+    for (const v of vectors) {
+      it(`${group}: ${v.name}`, () => {
+        const ours = canonicalize(v.input);
+        const a = refA(v.input as never);
+        const b = refB(v.input);
+
+        expect(a, "reference `canonicalize` disagrees with the committed vector").toBe(v.expected);
+        expect(b, "reference `json-canonicalize` disagrees with the committed vector").toBe(
+          v.expected,
+        );
+        expect(ours).toBe(a);
+        expect(ours).toBe(b);
+
+        // The bytes and the digest, not just the string — RFC 8785 is defined
+        // over UTF-8 bytes and that is what we commit to.
+        expect(sha256Hex(canonicalBytes(v.input))).toBe(
+          sha256Hex(Buffer.from(a as string, "utf8")),
+        );
+      });
+    }
+  }
+});
+
+describe("insertion order cannot reach the bytes", () => {
+  it("two objects built in opposite orders produce identical bytes and digest", () => {
+    const forward: Record<string, unknown> = {};
+    forward.alpha = 1;
+    forward.beta = { x: 1, y: 2 };
+    forward.gamma = [1, 2, 3];
+
+    const backward: Record<string, unknown> = {};
+    backward.gamma = [1, 2, 3];
+    backward.beta = {} as Record<string, unknown>;
+    (backward.beta as Record<string, unknown>).y = 2;
+    (backward.beta as Record<string, unknown>).x = 1;
+    backward.alpha = 1;
+
+    // Sanity: they really were built differently, or this test proves nothing.
+    expect(JSON.stringify(forward)).not.toBe(JSON.stringify(backward));
+
+    expect(canonicalize(forward)).toBe(canonicalize(backward));
+    expect(canonicalBytes(forward).equals(canonicalBytes(backward))).toBe(true);
+    expect(domainDigest(DOMAIN_TAGS.executionReceipt, forward)).toBe(
+      domainDigest(DOMAIN_TAGS.executionReceipt, backward),
+    );
+  });
+
+  it("deleting and re-adding a key does not change the digest", () => {
+    const o: Record<string, unknown> = { a: 1, b: 2, c: 3 };
+    const before = domainDigest(DOMAIN_TAGS.executionReceipt, o);
+    delete o.a;
+    o.a = 1; // now last in insertion order
+    expect(domainDigest(DOMAIN_TAGS.executionReceipt, o)).toBe(before);
+  });
+
+  it("a round trip through JSON.parse does not change the digest", () => {
+    const o = { z: [1, { b: 2, a: 3 }], a: "x" };
+    expect(domainDigest(DOMAIN_TAGS.executionReceipt, JSON.parse(JSON.stringify(o)))).toBe(
+      domainDigest(DOMAIN_TAGS.executionReceipt, o),
+    );
+  });
+});
+
+describe("values outside the JSON domain are refused, never coerced", () => {
+  function refusal(value: unknown, code: string) {
+    let err: unknown;
+    try {
+      canonicalize(value);
+    } catch (e) {
+      err = e;
+    }
+    expect(err, "expected a refusal, got a canonical string").toBeInstanceOf(
+      CanonicalizationError,
+    );
+    expect((err as CanonicalizationError).code).toBe(code);
+  }
+
+  it("NaN", () => refusal({ k: NaN }, "non_finite_number"));
+  it("Infinity", () => refusal({ k: Infinity }, "non_finite_number"));
+  it("-Infinity", () => refusal({ k: -Infinity }, "non_finite_number"));
+
+  it("undefined as an object member — the silent-omission case", () => {
+    // JSON.stringify DROPS the property entirely. If this were allowed, a call
+    // site could remove a hashed field just by leaving it undefined, which the
+    // closed schema forbids.
+    expect(JSON.stringify({ a: 1, b: undefined })).toBe('{"a":1}');
+    refusal({ a: 1, b: undefined }, "unsupported_type");
+  });
+
+  it("undefined as an array element — silently becomes null", () => {
+    expect(JSON.stringify([1, undefined])).toBe("[1,null]");
+    refusal([1, undefined], "unsupported_type");
+  });
+
+  it("BigInt", () => refusal({ k: BigInt(1) }, "unsupported_type"));
+  it("function", () => refusal({ k: () => 1 }, "unsupported_type"));
+  it("symbol", () => refusal({ k: Symbol("s") }, "unsupported_type"));
+
+  it("a direct cycle", () => {
+    const o: Record<string, unknown> = { a: 1 };
+    o.self = o;
+    refusal(o, "cyclic_structure");
+  });
+
+  it("an indirect cycle through an array", () => {
+    const a: unknown[] = [];
+    a.push({ back: a });
+    refusal(a, "cyclic_structure");
+  });
+
+  it("shared (non-cyclic) references are NOT a cycle", () => {
+    // A diamond is legal JSON. Refusing it would be over-detection.
+    const shared = { v: 1 };
+    expect(canonicalize({ a: shared, b: shared })).toBe('{"a":{"v":1},"b":{"v":1}}');
+  });
+
+  it("Map and Set — JSON.stringify turns them into {} and loses everything", () => {
+    expect(JSON.stringify({ k: new Map([["a", 1]]) })).toBe('{"k":{}}');
+    refusal({ k: new Map([["a", 1]]) }, "unsupported_type");
+    refusal({ k: new Set([1]) }, "unsupported_type");
+  });
+
+  it("Date — refused rather than silently becoming a string via toJSON", () => {
+    // The call site must convert deliberately. Honouring toJSON would let an
+    // object choose its own canonical form.
+    refusal({ k: new Date(0) }, "unsupported_type");
+  });
+
+  it("a sparse array hole would become null", () => {
+    const sparse = [1, , 3] as unknown[];
+    expect(JSON.stringify(sparse)).toBe("[1,null,3]");
+    refusal(sparse, "sparse_or_exotic_array");
+  });
+
+  it("lone surrogates", () => {
+    refusal({ k: "\ud83d" }, "lone_surrogate");
+    refusal({ k: "\ude00" }, "lone_surrogate");
+    refusal({ "\ud83d": 1 }, "lone_surrogate");
+    // A correctly paired surrogate is fine.
+    expect(canonicalize({ k: "😀" })).toBe('{"k":"😀"}');
+  });
+
+  it("toJSON is ignored, not honoured", () => {
+    const o = { k: { toJSON: () => "hijacked", real: 1 } };
+    // JSON.stringify would emit the hijacked value.
+    expect(JSON.stringify(o)).toBe('{"k":"hijacked"}');
+    // We refuse, because toJSON is a function member.
+    refusal(o, "unsupported_type");
+  });
+});
+
+describe("domain separation", () => {
+  it("the same payload digests differently under different domains", () => {
+    const payload = { a: 1 };
+    expect(domainDigest(DOMAIN_TAGS.executionReceipt, payload)).not.toBe(
+      domainDigest(DOMAIN_TAGS.manifestSnapshot, payload),
+    );
+  });
+
+  it("the preimage is TAG || 0x00 || canonical bytes, exactly", () => {
+    const payload = { a: 1 };
+    const pre = digestPreimage(DOMAIN_TAGS.executionReceipt, payload);
+    const tag = Buffer.from(DOMAIN_TAGS.executionReceipt, "ascii");
+
+    expect(pre.subarray(0, tag.length).equals(tag)).toBe(true);
+    expect(pre[tag.length]).toBe(0x00);
+    expect(pre.subarray(tag.length + 1).equals(canonicalBytes(payload))).toBe(true);
+  });
+
+  it("the tag cannot be forged from payload content", () => {
+    // Without the NUL separator, a payload whose canonical bytes began with the
+    // rest of another tag could collide. The separator makes the boundary
+    // unambiguous, and the tags contain no NUL.
+    for (const tag of Object.values(DOMAIN_TAGS)) {
+      expect(tag).toMatch(/^[\x21-\x7e]+$/);
+      expect(tag.includes(" ")).toBe(false);
+    }
+  });
+
+  it("the digest is the full 256-bit value, hex, prefixed", () => {
+    const d = domainDigest(DOMAIN_TAGS.executionReceipt, { a: 1 });
+    expect(d).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("the digest is over the BYTES, matching an out-of-band recomputation", () => {
+    // What an independent verifier would do with only the published rule.
+    const payload = { b: 2, a: 1 };
+    const independent = createHash("sha256")
+      .update(
+        Buffer.concat([
+          Buffer.from("strale.execution.v1", "ascii"),
+          Buffer.from([0x00]),
+          Buffer.from(refA(payload as never) as string, "utf8"),
+        ]),
+      )
+      .digest("hex");
+    expect(domainDigest(DOMAIN_TAGS.executionReceipt, payload)).toBe(`sha256:${independent}`);
+  });
+});
+
+describe("the UTF-16 code-unit ordering rule specifically", () => {
+  it("sorts by code unit, which differs from code point above the BMP", () => {
+    // U+1F600 == D83D DE00; U+FB00 is a single unit. Code POINT order puts
+    // U+FB00 first; UTF-16 CODE UNIT order puts the emoji first. RFC 8785
+    // mandates the latter.
+    const out = canonicalize({ "ﬀ": 1, "\u{1F600}": 2 });
+    expect(out.indexOf("\u{1F600}")).toBeLessThan(out.indexOf("ﬀ"));
+
+    // And it is not merely "our sort" — the references agree.
+    expect(refA({ "ﬀ": 1, "\u{1F600}": 2 } as never)).toBe(out);
+    expect(refB({ "ﬀ": 1, "\u{1F600}": 2 })).toBe(out);
+  });
+
+  it("differs from a UTF-8 byte sort, so a byte-sorting impl fails here", () => {
+    const keys = ["ﬀ", "\u{1F600}"];
+    const byUtf8 = [...keys].sort((x, y) =>
+      Buffer.from(x, "utf8").compare(Buffer.from(y, "utf8")),
+    );
+    const byCodeUnit = [...keys].sort();
+    expect(byUtf8).not.toEqual(byCodeUnit);
+  });
+});

--- a/apps/api/src/lib/canonical/jcs.test.ts
+++ b/apps/api/src/lib/canonical/jcs.test.ts
@@ -347,6 +347,38 @@ describe("properties JavaScript treats specially", () => {
   });
 });
 
+describe("nesting depth is bounded by us, not by the stack", () => {
+  function nest(depth: number): unknown {
+    return JSON.parse("[".repeat(depth) + "1" + "]".repeat(depth));
+  }
+
+  it("ordinary nesting is unaffected", () => {
+    expect(canonicalize(nest(100))).toContain("[[");
+    expect(() => canonicalize(nest(500))).not.toThrow();
+  });
+
+  it("pathological nesting refuses with OUR error, not a RangeError", () => {
+    // Measured before this bound: depth 5000 parses fine and then throws a bare
+    // `RangeError: Maximum call stack size exceeded` from inside the
+    // serializer. Attacker-reachable on any endpoint taking JSON, and outside
+    // this module's closed error codes.
+    let err: unknown;
+    try {
+      canonicalize(nest(5000));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+    expect((err as CanonicalizationError).code).toBe("max_depth_exceeded");
+    expect(err).not.toBeInstanceOf(RangeError);
+  });
+
+  it("the input that overflows the stack still parses, so the bound is load-bearing", () => {
+    // If JSON.parse refused first, the bound would be unreachable decoration.
+    expect(() => nest(5000)).not.toThrow();
+  });
+});
+
 describe("domain separation", () => {
   it("the same payload digests differently under different domains", () => {
     const payload = { a: 1 };

--- a/apps/api/src/lib/canonical/jcs.test.ts
+++ b/apps/api/src/lib/canonical/jcs.test.ts
@@ -498,6 +498,39 @@ describe("the array branch enforces the same invariant as the object branch", ()
     delete (Sneaky.prototype as unknown as Record<string, unknown>)["0"];
   });
 
+  it("an Array subclass that overrides map() is refused — only the prototype check catches this", () => {
+    // The prototype check has to be load-bearing on its own, and the
+    // prototype-getter case above does NOT isolate it: that value has no own
+    // descriptor at index 0, so the hole check refuses it either way. The
+    // mutation battery caught exactly that — removing the prototype check left
+    // the suite green.
+    //
+    // This value passes the stray check (own key "0") and the hole check (a
+    // real data descriptor), and still serializes misleadingly, because the
+    // serializer reaches the elements through `value.map(...)`.
+    class Evil extends Array {
+      override map(): never[] {
+        return ["hijacked"] as unknown as never[];
+      }
+    }
+    const evil = new Evil();
+    evil.push(1);
+
+    expect(Object.keys(evil)).toEqual(["0"]);
+    expect(Object.getOwnPropertyDescriptor(evil, 0)?.value).toBe(1);
+    expect(JSON.stringify(evil)).toBe("[1]");
+    expect(JSON.stringify(evil.map(() => "x"))).toBe('["hijacked"]');
+
+    let err: unknown;
+    try {
+      canonicalize(evil);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+    expect((err as CanonicalizationError).code).toBe("sparse_or_exotic_array");
+  });
+
   it("ordinary arrays are unaffected", () => {
     expect(canonicalize([1, "a", null, true, [], {}])).toBe('[1,"a",null,true,[],{}]');
     expect(canonicalize([])).toBe("[]");

--- a/apps/api/src/lib/canonical/jcs.test.ts
+++ b/apps/api/src/lib/canonical/jcs.test.ts
@@ -265,6 +265,55 @@ describe("properties JavaScript treats specially", () => {
     expect((err as CanonicalizationError).code).toBe("accessor_property");
   });
 
+  it("a Proxy is refused — it defeats the accessor check and can vary per read", () => {
+    // The getOwnPropertyDescriptor trap reports a plain data descriptor while
+    // the get trap does the varying, so the getter guard never fires.
+    let n = 0;
+    const proxy = new Proxy(
+      { a: 1, k: 0 },
+      { get: (t, p) => (p === "k" ? ++n : (t as Record<string, unknown>)[p as string]) },
+    );
+    let err: unknown;
+    try {
+      canonicalize(proxy);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CanonicalizationError);
+    expect((err as CanonicalizationError).code).toBe("unsupported_type");
+  });
+
+  it("boxed primitives are refused rather than becoming misleading JSON", () => {
+    // Without this they do not throw — they produce something plausible and
+    // wrong. new Number(1) and new Boolean(true) lose their value entirely.
+    expect(JSON.stringify({ k: new Number(1) })).toBe('{"k":1}');
+    for (const boxed of [new String("x"), new Number(1), new Boolean(true)]) {
+      let err: unknown;
+      try {
+        canonicalize({ k: boxed });
+      } catch (e) {
+        err = e;
+      }
+      expect(err, `${boxed.constructor.name} was not refused`).toBeInstanceOf(
+        CanonicalizationError,
+      );
+    }
+  });
+
+  it("inherited properties are excluded; only own members are canonicalized", () => {
+    const proto = { inherited: "must not appear" };
+    const child = Object.create(proto) as Record<string, unknown>;
+    child.own = 1;
+    expect(canonicalize(child)).toBe('{"own":1}');
+  });
+
+  it("a null-prototype object canonicalizes like any other", () => {
+    const np = Object.create(null) as Record<string, unknown>;
+    np.b = 1;
+    np.a = 2;
+    expect(canonicalize(np)).toBe('{"a":2,"b":1}');
+  });
+
   it("integer-like keys sort by code unit, not by JS integer-key order", () => {
     // Object.keys returns integer-like keys first, ascending numerically:
     // ["1","2","10","b"]. RFC 8785 wants "1","10","2","b".

--- a/apps/api/src/lib/canonical/jcs.ts
+++ b/apps/api/src/lib/canonical/jcs.ts
@@ -61,7 +61,8 @@ export type JcsErrorCode =
   | "cyclic_structure"
   | "lone_surrogate"
   | "sparse_or_exotic_array"
-  | "accessor_property";
+  | "accessor_property"
+  | "max_depth_exceeded";
 
 /**
  * The RFC 8785 §3.2.3 ordering rule, defined once.
@@ -110,6 +111,22 @@ export function sortKeysDeep(value: unknown): unknown {
   for (const key of sortJsonKeys(Object.keys(record))) out[key] = sortKeysDeep(record[key]);
   return out;
 }
+
+/**
+ * Deepest nesting we will canonicalize.
+ *
+ * `canonicalize` recurses, and V8's stack gives out somewhere between 1,000 and
+ * 5,000 levels — while `JSON.parse` happily accepts far more. Measured: a
+ * 5,000-deep array parses fine and then throws a bare `RangeError: Maximum call
+ * stack size exceeded` from inside the serializer. That is attacker-reachable
+ * on any endpoint taking JSON, and a `RangeError` is not one of this module's
+ * closed error codes — on the receipt path it would surface as an unexpected
+ * crash rather than a clean, reason-coded refusal.
+ *
+ * 512 is far beyond any real payload (a receipt is five levels deep) and far
+ * below where the stack fails, so the refusal is always ours and never V8's.
+ */
+const MAX_DEPTH = 512;
 
 const CONTROL_ESCAPES: Record<number, string> = {
   0x08: "\\b",
@@ -184,7 +201,14 @@ function serializeNumber(value: number, path: string): string {
   return String(value);
 }
 
-function serialize(value: unknown, path: string, seen: Set<object>): string {
+function serialize(value: unknown, path: string, seen: Set<object>, depth = 0): string {
+  if (depth > MAX_DEPTH) {
+    throw new CanonicalizationError(
+      "max_depth_exceeded",
+      path,
+      `nesting deeper than ${MAX_DEPTH} levels`,
+    );
+  }
   if (value === null) return "null";
 
   const t = typeof value;
@@ -230,7 +254,7 @@ function serialize(value: unknown, path: string, seen: Set<object>): string {
           );
         }
       }
-      const parts = value.map((v, i) => serialize(v, `${path}[${i}]`, seen));
+      const parts = value.map((v, i) => serialize(v, `${path}[${i}]`, seen, depth + 1));
       return `[${parts.join(",")}]`;
     }
 
@@ -305,7 +329,7 @@ function serialize(value: unknown, path: string, seen: Set<object>): string {
       // the whole property. It must be an error, or a call site could remove a
       // hashed field just by leaving it undefined.
       members.push(
-        `${serializeString(key, path)}:${serialize(child, `${path}/${key}`, seen)}`,
+        `${serializeString(key, path)}:${serialize(child, `${path}/${key}`, seen, depth + 1)}`,
       );
     }
     return `{${members.join(",")}}`;

--- a/apps/api/src/lib/canonical/jcs.ts
+++ b/apps/api/src/lib/canonical/jcs.ts
@@ -58,7 +58,8 @@ export type JcsErrorCode =
   | "unsupported_type"
   | "cyclic_structure"
   | "lone_surrogate"
-  | "sparse_or_exotic_array";
+  | "sparse_or_exotic_array"
+  | "accessor_property";
 
 /**
  * The RFC 8785 §3.2.3 ordering rule, defined once.
@@ -93,7 +94,17 @@ export function sortKeysDeep(value: unknown): unknown {
   if (value === null || typeof value !== "object") return value;
   if (Array.isArray(value)) return value.map(sortKeysDeep);
   const record = value as Record<string, unknown>;
-  const out: Record<string, unknown> = {};
+  // NULL PROTOTYPE, deliberately. On an ordinary object literal,
+  // `out["__proto__"] = v` does not create a property — it sets the prototype,
+  // and the key vanishes from the result. `JSON.parse('{"__proto__":1}')`
+  // produces exactly that key as an OWN property, so the member was silently
+  // dropped: two requests differing only in `__proto__` produced the same
+  // idempotency fingerprint and would have replayed each other's result.
+  // Inherited from the private implementation this replaced, found by probing
+  // rather than by review. Measured before changing: 23 historical rows carry
+  // the literal in their input and ZERO live idempotency keys do, so the
+  // fingerprint moves for no key in flight.
+  const out: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   for (const key of sortJsonKeys(Object.keys(record))) out[key] = sortKeysDeep(record[key]);
   return out;
 }
@@ -244,6 +255,21 @@ function serialize(value: unknown, path: string, seen: Set<object>): string {
 
     const members: string[] = [];
     for (const key of keys) {
+      // An accessor is not a value. A getter may return something different on
+      // every read, which would make the digest non-deterministic — the same
+      // object canonicalizing to two different commitments. Found by probing:
+      // `{ get k() { return ++n; } }` produced `{"a":1,"k":1}` then
+      // `{"a":1,"k":2}`. Unreachable from JSON.parse, which is the only source
+      // in the receipt path, so this is a guard rather than a fix for a live
+      // bug — but a commitment primitive must not depend on that staying true.
+      const descriptor = Object.getOwnPropertyDescriptor(record, key);
+      if (descriptor && typeof descriptor.get === "function") {
+        throw new CanonicalizationError(
+          "accessor_property",
+          `${path}/${key}`,
+          "a getter can return a different value on each read, so it has no stable canonical form",
+        );
+      }
       const child = record[key];
       // An `undefined` MEMBER is the silent-omission case: JSON.stringify drops
       // the whole property. It must be an error, or a call site could remove a

--- a/apps/api/src/lib/canonical/jcs.ts
+++ b/apps/api/src/lib/canonical/jcs.ts
@@ -40,6 +40,8 @@
  * bytes, so anything that digests must go through `canonicalBytes`.
  */
 
+import { types as nodeTypes } from "node:util";
+
 export class CanonicalizationError extends Error {
   readonly code: JcsErrorCode;
   /** JSON Pointer-ish path to the offending value, for a usable message. */
@@ -230,6 +232,34 @@ function serialize(value: unknown, path: string, seen: Set<object>): string {
       }
       const parts = value.map((v, i) => serialize(v, `${path}[${i}]`, seen));
       return `[${parts.join(",")}]`;
+    }
+
+    // A Proxy can vary what it returns on every read, exactly like a getter —
+    // and it defeats the accessor check below, because its
+    // getOwnPropertyDescriptor trap reports a plain DATA descriptor while the
+    // `get` trap does the varying. Found by probing: the same Proxy
+    // canonicalized to {"a":1,"k":1} then {"a":1,"k":2}. Unreachable from
+    // JSON.parse, but a commitment primitive must not rest on that.
+    if (nodeTypes.isProxy(obj)) {
+      throw new CanonicalizationError(
+        "unsupported_type",
+        path,
+        "a Proxy can return a different value on each read, so it has no stable canonical form",
+      );
+    }
+
+    // Boxed primitives serialize into MISLEADING JSON rather than failing:
+    // `new Number(1)` and `new Boolean(true)` both become `{}` — the value
+    // disappears entirely — and `new String("x")` becomes `{"0":"x"}`, an
+    // index map. This is the one place we deliberately diverge from
+    // JSON.stringify, which unwraps them; unwrapping silently would let two
+    // different JS values share a commitment.
+    if (obj instanceof String || obj instanceof Number || obj instanceof Boolean) {
+      throw new CanonicalizationError(
+        "unsupported_type",
+        path,
+        `${obj.constructor.name} object: pass the primitive, not its wrapper`,
+      );
     }
 
     // Reject the exotic objects JSON.stringify would happily mangle. Map and

--- a/apps/api/src/lib/canonical/jcs.ts
+++ b/apps/api/src/lib/canonical/jcs.ts
@@ -242,9 +242,42 @@ function serialize(value: unknown, path: string, seen: Set<object>, depth = 0): 
   }
   seen.add(obj);
   try {
+    // ── ALLOW-LIST, not a blocklist ──────────────────────────────────────
+    //
+    // The blocklist this replaced named Map, Set, Date, RegExp, typed arrays
+    // and boxed primitives, and was still incomplete: probing found Error,
+    // Promise, WeakMap, WeakSet and ArrayBuffer all serializing to `{}` — the
+    // object's entire meaning gone, silently, in output that looks like a
+    // legitimate empty object. Each was found one at a time, which is the
+    // wrong shape of defence for a commitment primitive.
+    //
+    // Only two things have a faithful JSON form: a plain object and a plain
+    // array. Everything else is refused by construction, so a value type
+    // nobody has thought of yet fails closed instead of being committed to.
+    if (nodeTypes.isProxy(obj)) {
+      // A Proxy of a plain object passes the prototype check below, because
+      // getPrototypeOf forwards to the target — and its `get` trap can return
+      // a different value on every read. Checked before, not after.
+      throw new CanonicalizationError(
+        "unsupported_type",
+        path,
+        "a Proxy can return a different value on each read, so it has no stable canonical form",
+      );
+    }
+
     if (Array.isArray(value)) {
-      // A sparse array's holes would serialize as null under JSON.stringify —
-      // another silent coercion. Refuse instead.
+      // An array's own non-index properties are dropped by JSON.stringify:
+      // `const a = [1]; a.extra = 2` serializes as `[1]`, losing `extra`
+      // without a word.
+      const stray = Object.keys(obj).filter((k) => String(Number(k)) !== k);
+      if (stray.length > 0) {
+        throw new CanonicalizationError(
+          "sparse_or_exotic_array",
+          path,
+          `array carries non-index own propert${stray.length === 1 ? "y" : "ies"} ` +
+            `(${stray.join(", ")}) that JSON.stringify would silently drop`,
+        );
+      }
       for (let i = 0; i < value.length; i++) {
         if (!(i in value)) {
           throw new CanonicalizationError(
@@ -258,48 +291,13 @@ function serialize(value: unknown, path: string, seen: Set<object>, depth = 0): 
       return `[${parts.join(",")}]`;
     }
 
-    // A Proxy can vary what it returns on every read, exactly like a getter —
-    // and it defeats the accessor check below, because its
-    // getOwnPropertyDescriptor trap reports a plain DATA descriptor while the
-    // `get` trap does the varying. Found by probing: the same Proxy
-    // canonicalized to {"a":1,"k":1} then {"a":1,"k":2}. Unreachable from
-    // JSON.parse, but a commitment primitive must not rest on that.
-    if (nodeTypes.isProxy(obj)) {
+    const proto = Object.getPrototypeOf(obj);
+    if (proto !== Object.prototype && proto !== null) {
       throw new CanonicalizationError(
         "unsupported_type",
         path,
-        "a Proxy can return a different value on each read, so it has no stable canonical form",
-      );
-    }
-
-    // Boxed primitives serialize into MISLEADING JSON rather than failing:
-    // `new Number(1)` and `new Boolean(true)` both become `{}` — the value
-    // disappears entirely — and `new String("x")` becomes `{"0":"x"}`, an
-    // index map. This is the one place we deliberately diverge from
-    // JSON.stringify, which unwraps them; unwrapping silently would let two
-    // different JS values share a commitment.
-    if (obj instanceof String || obj instanceof Number || obj instanceof Boolean) {
-      throw new CanonicalizationError(
-        "unsupported_type",
-        path,
-        `${obj.constructor.name} object: pass the primitive, not its wrapper`,
-      );
-    }
-
-    // Reject the exotic objects JSON.stringify would happily mangle. Map and
-    // Set stringify as `{}`, losing every entry without complaint.
-    if (
-      obj instanceof Map ||
-      obj instanceof Set ||
-      obj instanceof Date ||
-      obj instanceof RegExp ||
-      ArrayBuffer.isView(obj)
-    ) {
-      throw new CanonicalizationError(
-        "unsupported_type",
-        path,
-        `${obj.constructor?.name ?? "exotic object"} has no canonical JSON form; ` +
-          "convert it deliberately at the call site",
+        `${obj.constructor?.name ?? "non-plain object"} has no faithful JSON form; ` +
+          "convert it to a plain object at the call site",
       );
     }
 

--- a/apps/api/src/lib/canonical/jcs.ts
+++ b/apps/api/src/lib/canonical/jcs.ts
@@ -60,6 +60,44 @@ export type JcsErrorCode =
   | "lone_surrogate"
   | "sparse_or_exotic_array";
 
+/**
+ * The RFC 8785 §3.2.3 ordering rule, defined once.
+ *
+ * Sorting is by UTF-16 code unit, which is exactly what
+ * `Array.prototype.sort`'s default comparator does — so this function is thin
+ * on purpose. It exists so the RULE has one home: `idempotency-fingerprint.ts`
+ * grew its own recursive key-sort independently, and two implementations of an
+ * ordering rule is how they drift. Anything needing "JSON keys in canonical
+ * order" calls this.
+ *
+ * Deliberately NOT code-point order and NOT UTF-8 byte order. Those three
+ * disagree above the BMP: U+1F600 (surrogates D83D DE00) sorts before U+FB00
+ * by code unit and after it by the other two.
+ */
+export function sortJsonKeys(keys: readonly string[]): string[] {
+  return [...keys].sort();
+}
+
+/**
+ * Recursively reorder an object's keys without serializing.
+ *
+ * A shape normalizer, **not** a canonicalizer — it performs §3.2.3 and nothing
+ * else, so the result still has to be serialized by something. It exists so the
+ * one caller that must keep its legacy `JSON.stringify` bytes
+ * (`computeIdempotencyFingerprint`) shares this module's ordering rule instead
+ * of keeping a private copy.
+ *
+ * New code should use `canonicalize` instead.
+ */
+export function sortKeysDeep(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  const record = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of sortJsonKeys(Object.keys(record))) out[key] = sortKeysDeep(record[key]);
+  return out;
+}
+
 const CONTROL_ESCAPES: Record<number, string> = {
   0x08: "\\b",
   0x09: "\\t",
@@ -200,10 +238,9 @@ function serialize(value: unknown, path: string, seen: Set<object>): string {
       );
     }
 
-    // RFC 8785 §3.2.3: sort by UTF-16 code unit. Array.prototype.sort's default
-    // comparator is exactly that, so it is used deliberately, not by accident.
+    // RFC 8785 §3.2.3, via the single definition of the ordering rule.
     const record = obj as Record<string, unknown>;
-    const keys = Object.keys(record).sort();
+    const keys = sortJsonKeys(Object.keys(record));
 
     const members: string[] = [];
     for (const key of keys) {

--- a/apps/api/src/lib/canonical/jcs.ts
+++ b/apps/api/src/lib/canonical/jcs.ts
@@ -93,7 +93,15 @@ export function sortJsonKeys(keys: readonly string[]): string[] {
  *
  * New code should use `canonicalize` instead.
  */
-export function sortKeysDeep(value: unknown, depth = 0): unknown {
+export function sortKeysDeep(value: unknown): unknown {
+  // The recursion carries depth internally. It is deliberately NOT a second
+  // parameter on the exported function: `xs.map(sortKeysDeep)` would then pass
+  // the ARRAY INDEX as the depth and start throwing max_depth_exceeded at
+  // element 513. No such call site exists, and now none can.
+  return sortKeysDeepAt(value, 0);
+}
+
+function sortKeysDeepAt(value: unknown, depth: number): unknown {
   // THE BOUND HAS TO BE HERE TOO, and this is the one that mattered.
   //
   // MAX_DEPTH was added to `canonicalize` — which no production path calls.
@@ -112,7 +120,7 @@ export function sortKeysDeep(value: unknown, depth = 0): unknown {
     );
   }
   if (value === null || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map((v) => sortKeysDeep(v, depth + 1));
+  if (Array.isArray(value)) return value.map((v) => sortKeysDeepAt(v, depth + 1));
   const record = value as Record<string, unknown>;
   // NULL PROTOTYPE, deliberately. On an ordinary object literal,
   // `out["__proto__"] = v` does not create a property — it sets the prototype,
@@ -125,7 +133,8 @@ export function sortKeysDeep(value: unknown, depth = 0): unknown {
   // the literal in their input and ZERO live idempotency keys do, so the
   // fingerprint moves for no key in flight.
   const out: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-  for (const key of sortJsonKeys(Object.keys(record))) out[key] = sortKeysDeep(record[key], depth + 1);
+  for (const key of sortJsonKeys(Object.keys(record)))
+    out[key] = sortKeysDeepAt(record[key], depth + 1);
   return out;
 }
 

--- a/apps/api/src/lib/canonical/jcs.ts
+++ b/apps/api/src/lib/canonical/jcs.ts
@@ -1,0 +1,238 @@
+/**
+ * RFC 8785 — JSON Canonicalization Scheme (JCS), implemented inside Strale.
+ *
+ * No third-party runtime dependency, by design: this produces the bytes a
+ * customer's execution receipt is committed to, so the rule has to be ours and
+ * has to be readable here. Independent implementations are used in tests as
+ * cross-check references only — never at runtime, never as the authority.
+ *
+ * ## Why this is short
+ *
+ * RFC 8785 was written around ECMAScript semantics, so a correct JS
+ * implementation is mostly *restriction*, not reimplementation:
+ *
+ *  - **Numbers.** RFC 8785 §3.2.2.3 specifies ECMAScript `Number::toString`,
+ *    which is exactly what `JSON.stringify` emits for a number. Shortest
+ *    round-tripping form, exponent normalisation, `1.0` → `1`, `1e2` → `100`,
+ *    `-0` → `0`: all already correct.
+ *  - **Strings.** RFC 8785 §3.2.2.2 specifies the same minimal escaping
+ *    `JSON.stringify` performs — `"` `\` and the C0 controls, using the short
+ *    forms `\b \t \n \f \r` where they exist and `\u00xx` otherwise, with
+ *    non-ASCII left as literal UTF-8.
+ *
+ * What JS does NOT do, and this module must:
+ *
+ *  1. **Sort object properties** by UTF-16 code unit, recursively (§3.2.3).
+ *  2. **Refuse everything outside the JSON domain.** `JSON.stringify` silently
+ *     drops `undefined`/function/symbol object members and turns them into
+ *     `null` inside arrays. Silent omission is precisely what the receipt
+ *     schema forbids, so these are errors here, not quiet coercions.
+ *  3. **Refuse `NaN`, `Infinity`, `BigInt`, cycles, and lone surrogates.**
+ *  4. **Ignore `toJSON`.** `JSON.stringify` would call it, letting an object
+ *     choose its own canonical form — a call site selecting what gets hashed,
+ *     which the schema forbids. A `Date` therefore does not silently become a
+ *     string here; the caller must convert it deliberately.
+ *
+ * ## Output
+ *
+ * `canonicalize()` returns a `string`; `canonicalBytes()` returns the UTF-8
+ * encoding of it, which is what gets hashed. RFC 8785 is defined over the UTF-8
+ * bytes, so anything that digests must go through `canonicalBytes`.
+ */
+
+export class CanonicalizationError extends Error {
+  readonly code: JcsErrorCode;
+  /** JSON Pointer-ish path to the offending value, for a usable message. */
+  readonly path: string;
+
+  constructor(code: JcsErrorCode, path: string, detail: string) {
+    super(`${code} at ${path || "<root>"}: ${detail}`);
+    this.name = "CanonicalizationError";
+    this.code = code;
+    this.path = path;
+  }
+}
+
+export type JcsErrorCode =
+  | "non_finite_number"
+  | "unsupported_type"
+  | "cyclic_structure"
+  | "lone_surrogate"
+  | "sparse_or_exotic_array";
+
+const CONTROL_ESCAPES: Record<number, string> = {
+  0x08: "\\b",
+  0x09: "\\t",
+  0x0a: "\\n",
+  0x0c: "\\f",
+  0x0d: "\\r",
+};
+
+/**
+ * Serialize one string per RFC 8785 §3.2.2.2.
+ *
+ * Written out rather than delegated to `JSON.stringify` for two reasons: it
+ * makes the escaping rule auditable in the file that claims to implement it,
+ * and it lets lone surrogates be an error instead of being silently replaced
+ * with `�`-style escapes by the engine's well-formed-stringify behaviour.
+ */
+function serializeString(value: string, path: string): string {
+  let out = '"';
+  for (let i = 0; i < value.length; i++) {
+    const cp = value.charCodeAt(i);
+
+    if (cp === 0x22) {
+      out += '\\"';
+    } else if (cp === 0x5c) {
+      out += "\\\\";
+    } else if (cp < 0x20) {
+      out += CONTROL_ESCAPES[cp] ?? `\\u${cp.toString(16).padStart(4, "0")}`;
+    } else if (cp >= 0xd800 && cp <= 0xdbff) {
+      // High surrogate: must be followed by a low surrogate.
+      const next = value.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new CanonicalizationError(
+          "lone_surrogate",
+          path,
+          `unpaired high surrogate U+${cp.toString(16).toUpperCase()}`,
+        );
+      }
+      out += value[i] + value[i + 1];
+      i++;
+    } else if (cp >= 0xdc00 && cp <= 0xdfff) {
+      throw new CanonicalizationError(
+        "lone_surrogate",
+        path,
+        `unpaired low surrogate U+${cp.toString(16).toUpperCase()}`,
+      );
+    } else {
+      out += value[i];
+    }
+  }
+  return out + '"';
+}
+
+/**
+ * Serialize one number per RFC 8785 §3.2.2.3 (ECMAScript `Number::toString`).
+ *
+ * `String(n)` is that algorithm. The only adjustment is `-0`, which RFC 8785
+ * requires to serialize as `0` and which `String(-0)` already gives — asserted
+ * explicitly below so the behaviour is pinned rather than assumed.
+ */
+function serializeNumber(value: number, path: string): string {
+  if (!Number.isFinite(value)) {
+    throw new CanonicalizationError(
+      "non_finite_number",
+      path,
+      Number.isNaN(value) ? "NaN is outside the JSON domain" : `${value} is outside the JSON domain`,
+    );
+  }
+  // Object.is distinguishes -0 from 0; String() already collapses it, and this
+  // makes that dependence visible instead of incidental.
+  if (Object.is(value, -0)) return "0";
+  return String(value);
+}
+
+function serialize(value: unknown, path: string, seen: Set<object>): string {
+  if (value === null) return "null";
+
+  const t = typeof value;
+
+  if (t === "boolean") return value ? "true" : "false";
+  if (t === "number") return serializeNumber(value as number, path);
+  if (t === "string") return serializeString(value as string, path);
+
+  if (t === "undefined") {
+    throw new CanonicalizationError(
+      "unsupported_type",
+      path,
+      "undefined is not a JSON value; JSON.stringify would silently drop it",
+    );
+  }
+  if (t === "bigint") {
+    throw new CanonicalizationError(
+      "unsupported_type",
+      path,
+      "BigInt cannot be represented as an IEEE 754 double",
+    );
+  }
+  if (t === "function" || t === "symbol") {
+    throw new CanonicalizationError("unsupported_type", path, `${t} is not a JSON value`);
+  }
+
+  // Objects and arrays.
+  const obj = value as object;
+  if (seen.has(obj)) {
+    throw new CanonicalizationError("cyclic_structure", path, "value refers to itself");
+  }
+  seen.add(obj);
+  try {
+    if (Array.isArray(value)) {
+      // A sparse array's holes would serialize as null under JSON.stringify —
+      // another silent coercion. Refuse instead.
+      for (let i = 0; i < value.length; i++) {
+        if (!(i in value)) {
+          throw new CanonicalizationError(
+            "sparse_or_exotic_array",
+            `${path}[${i}]`,
+            "sparse array hole would silently become null",
+          );
+        }
+      }
+      const parts = value.map((v, i) => serialize(v, `${path}[${i}]`, seen));
+      return `[${parts.join(",")}]`;
+    }
+
+    // Reject the exotic objects JSON.stringify would happily mangle. Map and
+    // Set stringify as `{}`, losing every entry without complaint.
+    if (
+      obj instanceof Map ||
+      obj instanceof Set ||
+      obj instanceof Date ||
+      obj instanceof RegExp ||
+      ArrayBuffer.isView(obj)
+    ) {
+      throw new CanonicalizationError(
+        "unsupported_type",
+        path,
+        `${obj.constructor?.name ?? "exotic object"} has no canonical JSON form; ` +
+          "convert it deliberately at the call site",
+      );
+    }
+
+    // RFC 8785 §3.2.3: sort by UTF-16 code unit. Array.prototype.sort's default
+    // comparator is exactly that, so it is used deliberately, not by accident.
+    const record = obj as Record<string, unknown>;
+    const keys = Object.keys(record).sort();
+
+    const members: string[] = [];
+    for (const key of keys) {
+      const child = record[key];
+      // An `undefined` MEMBER is the silent-omission case: JSON.stringify drops
+      // the whole property. It must be an error, or a call site could remove a
+      // hashed field just by leaving it undefined.
+      members.push(
+        `${serializeString(key, path)}:${serialize(child, `${path}/${key}`, seen)}`,
+      );
+    }
+    return `{${members.join(",")}}`;
+  } finally {
+    seen.delete(obj);
+  }
+}
+
+/**
+ * Canonicalize a JSON value to its RFC 8785 string form.
+ *
+ * Throws `CanonicalizationError` rather than coercing. Every refusal is a case
+ * where `JSON.stringify` would have produced *something*, quietly, and that
+ * something would have been committed to.
+ */
+export function canonicalize(value: unknown): string {
+  return serialize(value, "", new Set<object>());
+}
+
+/** The UTF-8 bytes RFC 8785 is defined over. Digest these, never the string. */
+export function canonicalBytes(value: unknown): Buffer {
+  return Buffer.from(canonicalize(value), "utf8");
+}

--- a/apps/api/src/lib/canonical/jcs.ts
+++ b/apps/api/src/lib/canonical/jcs.ts
@@ -93,9 +93,26 @@ export function sortJsonKeys(keys: readonly string[]): string[] {
  *
  * New code should use `canonicalize` instead.
  */
-export function sortKeysDeep(value: unknown): unknown {
+export function sortKeysDeep(value: unknown, depth = 0): unknown {
+  // THE BOUND HAS TO BE HERE TOO, and this is the one that mattered.
+  //
+  // MAX_DEPTH was added to `canonicalize` — which no production path calls.
+  // The only production consumer of this module is `sortKeysDeep`, through
+  // `computeIdempotencyFingerprint`, which `do.ts` invokes on the raw parsed
+  // body before input validation. So the guard protected code with no call
+  // site while the reachable path stayed unbounded: a ~6 KB body nested 3,000
+  // deep, well inside the 1 MB limit, produced a bare RangeError and a 500.
+  // Reviewer-found. Measured first: across 606,399 production inputs the
+  // deepest carries 42 opening brackets, so 512 cannot reach real traffic.
+  if (depth > MAX_DEPTH) {
+    throw new CanonicalizationError(
+      "max_depth_exceeded",
+      "",
+      `nesting deeper than ${MAX_DEPTH} levels`,
+    );
+  }
   if (value === null || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (Array.isArray(value)) return value.map((v) => sortKeysDeep(v, depth + 1));
   const record = value as Record<string, unknown>;
   // NULL PROTOTYPE, deliberately. On an ordinary object literal,
   // `out["__proto__"] = v` does not create a property — it sets the prototype,
@@ -108,7 +125,7 @@ export function sortKeysDeep(value: unknown): unknown {
   // the literal in their input and ZERO live idempotency keys do, so the
   // fingerprint moves for no key in flight.
   const out: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
-  for (const key of sortJsonKeys(Object.keys(record))) out[key] = sortKeysDeep(record[key]);
+  for (const key of sortJsonKeys(Object.keys(record))) out[key] = sortKeysDeep(record[key], depth + 1);
   return out;
 }
 
@@ -127,6 +144,19 @@ export function sortKeysDeep(value: unknown): unknown {
  * below where the stack fails, so the refusal is always ours and never V8's.
  */
 const MAX_DEPTH = 512;
+
+/**
+ * Is `key` a canonical array index that the serializer will actually visit?
+ *
+ * Digits only, no leading zeros, and inside the array's length. Everything
+ * else — "-1", "1.5", "NaN", "Infinity", "01", "1e+21", 2^32 and beyond — is a
+ * member `JSON.stringify` drops without a word.
+ */
+function isCanonicalArrayIndex(key: string, length: number): boolean {
+  if (!/^(0|[1-9][0-9]*)$/.test(key)) return false;
+  const n = Number(key);
+  return Number.isSafeInteger(n) && n < length;
+}
 
 const CONTROL_ESCAPES: Record<number, string> = {
   0x08: "\\b",
@@ -266,27 +296,62 @@ function serialize(value: unknown, path: string, seen: Set<object>, depth = 0): 
     }
 
     if (Array.isArray(value)) {
-      // An array's own non-index properties are dropped by JSON.stringify:
-      // `const a = [1]; a.extra = 2` serializes as `[1]`, losing `extra`
-      // without a word.
-      const stray = Object.keys(obj).filter((k) => String(Number(k)) !== k);
-      if (stray.length > 0) {
+      // The SAME three-part invariant the object branch enforces, applied here.
+      // An earlier version checked only strays and holes, which left three
+      // holes of exactly the class the object branch had just closed:
+      // an accessor at an index, a bogus "index" key, and a subclass whose
+      // prototype supplies the index. Reviewer-found, in one pass, by checking
+      // both branches against the invariant instead of against a type list.
+      //
+      // The invariant: every value read during serialization must be an own
+      // DATA property of a PLAIN container, and no member may exist that the
+      // reader will not visit.
+
+      // 1. Plain container. An Array subclass can put an index on its
+      //    prototype, where `in` finds it, `Object.keys` does not, and
+      //    `Array.prototype.map` still reads it.
+      if (Object.getPrototypeOf(value) !== Array.prototype) {
         throw new CanonicalizationError(
           "sparse_or_exotic_array",
           path,
-          `array carries non-index own propert${stray.length === 1 ? "y" : "ies"} ` +
-            `(${stray.join(", ")}) that JSON.stringify would silently drop`,
+          `${(value as object).constructor?.name ?? "array subclass"} is not a plain array`,
         );
       }
+
+      // 2. No member the reader will not visit. `String(Number(k)) !== k` was
+      //    not an index test: it admitted "-1", "1.5", "NaN", "Infinity",
+      //    "1e+21" and out-of-range integers, every one of which
+      //    JSON.stringify silently drops.
+      for (const key of Object.keys(value)) {
+        if (!isCanonicalArrayIndex(key, value.length)) {
+          throw new CanonicalizationError(
+            "sparse_or_exotic_array",
+            `${path}/${key}`,
+            `array carries the non-index own property "${key}", which ` +
+              "JSON.stringify would silently drop",
+          );
+        }
+      }
+
+      // 3. Own data properties only — no holes, no accessors at an index.
       for (let i = 0; i < value.length; i++) {
-        if (!(i in value)) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, i);
+        if (!descriptor) {
           throw new CanonicalizationError(
             "sparse_or_exotic_array",
             `${path}[${i}]`,
             "sparse array hole would silently become null",
           );
         }
+        if (typeof descriptor.get === "function") {
+          throw new CanonicalizationError(
+            "accessor_property",
+            `${path}[${i}]`,
+            "a getter can return a different value on each read, so it has no stable canonical form",
+          );
+        }
       }
+
       const parts = value.map((v, i) => serialize(v, `${path}[${i}]`, seen, depth + 1));
       return `[${parts.join(",")}]`;
     }

--- a/apps/api/src/lib/idempotency-fingerprint.ts
+++ b/apps/api/src/lib/idempotency-fingerprint.ts
@@ -26,6 +26,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { sortKeysDeep } from "./canonical/jcs.js";
 
 /**
  * Stable across key order, so `{a:1,b:2}` and `{b:2,a:1}` are one request.
@@ -35,15 +36,6 @@ import { createHash } from "node:crypto";
  * retry — which is exactly when idempotency matters. Sorting recursively means
  * a retry that differs only in serialisation still replays instead of 409ing.
  */
-function canonicalize(value: unknown): unknown {
-  if (value === null || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map(canonicalize);
-  const obj = value as Record<string, unknown>;
-  const out: Record<string, unknown> = {};
-  for (const key of Object.keys(obj).sort()) out[key] = canonicalize(obj[key]);
-  return out;
-}
-
 /**
  * Bind a key to the work it was issued for.
  *
@@ -51,6 +43,25 @@ function canonicalize(value: unknown): unknown {
  * `capability_slug` are alternative ways of selecting what runs, and a key
  * reused across two different capabilities is precisely the case that returned
  * the wrong capability's output.
+ */
+/*
+ * WHY THIS STILL USES JSON.stringify RATHER THAN THE RFC 8785 CANONICALIZER.
+ *
+ * The ordering rule is now shared (`sortKeysDeep`), so there is one definition
+ * of canonical key order in the codebase. The SERIALIZATION is deliberately
+ * left alone.
+ *
+ * Moving this digest to `canonicalize()` would change its bytes — the fixed
+ * literal below is emitted in declaration order, while JCS would sort those six
+ * members too. Different bytes mean different fingerprints, and `isReplayable`
+ * returns false on a mismatch, so every idempotency key in flight across the
+ * deploy would 409 on a legitimate retry. That is precisely the failure this
+ * module's own comment calls "a worse failure than the one this package fixes".
+ *
+ * Full adoption therefore needs a dual-accept window (compute both, accept
+ * either, retire the old form once keys have aged out). That is receipt-
+ * integration work, not canonicalizer work, and it is recorded in the Phase 2
+ * spec rather than smuggled in here.
  */
 export function computeIdempotencyFingerprint(params: {
   task?: string | null;
@@ -77,7 +88,7 @@ export function computeIdempotencyFingerprint(params: {
     rail: params.rail ?? "capability",
     task: params.task ?? null,
     capability_slug: params.capabilitySlug ?? null,
-    inputs: canonicalize(params.inputs ?? null),
+    inputs: sortKeysDeep(params.inputs ?? null),
     dry_run: params.dryRun === true,
     require_fresh: params.requireFresh === true,
   });

--- a/docs/company/LESSONS.md
+++ b/docs/company/LESSONS.md
@@ -482,6 +482,53 @@ would have needed for `close_stranded_executing_rows` and confirm it is refused
 
 ---
 
+### F11 · Destroying uncommitted work to run a fail-before check — **THE GUARD ALREADY EXISTED**
+
+> Writing a fix, mutating it to prove a test discriminates, then "restoring"
+> with `git checkout -- <file>` — which does not restore uncommitted work, it
+> discards it.
+
+**Count: 6.** Four during the 2026-08-21 remediation program, which is what
+caused `apps/api/scripts/mutation-test.mjs` to be written. Then twice more on
+2026-08-23, in WP10 and in the execution-receipt package, by a session that had
+not reached for it.
+
+**What makes this family different from the others here: the repair already
+shipped, and the recurrence happened anyway.** The guard enforces exactly the
+right protocol — clean tree, baseline green, mutate, red, restore, green again,
+clean tree — and its own docstring opens with "`git checkout -- <file>`
+destroyed uncommitted work FOUR times". It was sitting in the repo, correct and
+sufficient, through both new incidents.
+
+So the defect is not missing tooling. **A tool nobody reaches for is not a
+control.** Both 2026-08-23 incidents came from hand-rolling `python -c` mutation
+scripts and `cp /tmp/backup` restores in a shell loop, which is faster to type
+than looking for whether a tool exists — and it works right up until the restore
+targets a file whose changes were never committed.
+
+Worth recording precisely, because the near-miss is the instructive part: in the
+WP10 case the mutation went into a **commit** (`7b1185d` shipped a reviewer's
+mutation as if it were the fix, under a message describing the opposite). In the
+receipt case the loss was caught within seconds only because the restored file
+left a dangling import that failed typecheck. Neither was caught by a control.
+
+**Local fix, applied 2026-08-23:** every fail-before check in the execution-
+receipt package now runs through `mutation-test.mjs`. Re-running the nine Phase 3
+mutations through it reproduced all nine as CAUGHT, with clean-tree enforcement
+and a verified-green baseline on both sides — which the hand-rolled version could
+not assert, and which is the difference between "the suite went red" and "the
+suite went red *because of the mutation*".
+
+**State: OPEN.** No new tooling is owed — the existing guard is sufficient and
+that is the finding. What is owed is the thing this file asks of every family: a
+discriminating control, and there is currently none that makes the *unguarded*
+path harder than the guarded one. A pre-commit or PostToolUse check that notices
+a mutation-shaped edit against a dirty tree would be one; deciding whether that
+is worth the friction is the open question, and it should not be answered by
+bolting it onto an unrelated PR.
+
+---
+
 ## How this file is maintained
 
 - Any session may add an incident to a family. No approval, no ceremony — one

--- a/docs/design/execution-receipt/PHASE-1-CURRENT-TRUTH.md
+++ b/docs/design/execution-receipt/PHASE-1-CURRENT-TRUTH.md
@@ -1,0 +1,177 @@
+# Execution receipt, Phase 1 — what the integrity substrate actually binds today
+
+**Method:** read from implementation and tests on `origin/main` at `933c1e4`, and
+from production read-only. Nothing here is taken from a design document, a
+marketing page, or a code comment that the code does not support. Where a claim
+elsewhere in the repo is contradicted by the implementation, that is recorded as
+a finding rather than smoothed over.
+
+---
+
+## 1. The one thing that is genuinely a cryptographic commitment
+
+`apps/api/src/lib/integrity-hash.ts` → `computeIntegrityHash(record, previousHash)`.
+
+SHA-256 over `JSON.stringify` of a **fixed object literal**, with these members
+and no others:
+
+| bound | field |
+|---|---|
+| identity | `id`, `userId` |
+| outcome | `status`, `error` |
+| **request** | `input` |
+| **result** | `output` |
+| commercial | `priceCents` |
+| timing | `latencyMs`, `createdAt`, `completedAt` (each coerced through `new Date(x).toISOString()`) |
+| context | `provenance`, `auditTrail`, `transparencyMarker`, `dataJurisdiction` |
+| chain | `previousHash` |
+
+So the substrate **does** already commit to the request and the result. That is
+the single most important true thing to establish, because it means the new
+receipt is a *canonicalisation and identity* problem, not a "we never hashed the
+result" problem.
+
+Chain shape: per-day linkage, `previous_hash` + a monotonic `chain_seq` assigned
+at hash time, anchored at `GENESIS_HASH = sha256("strale-genesis-v1")`. Hashing
+is two-phase — the row commits first, a worker (`jobs/integrity-hash-retry.ts`)
+fills the chain afterwards. Fork detection, head selection and out-of-order
+completion are covered by `integrity-hash-chain.integration.test.ts` (8 tests,
+including one that PINS a known bug: nothing prevents two rows sharing a parent).
+
+## 2. `compliance_hash` does not exist
+
+There is no `compliance_hash` column, function, or value anywhere in `apps/api/src`.
+
+What exists is `compliance_hash_state` — a `varchar(16)` **state label**
+(`pending` → `complete` / `failed` / `excluded` / `deferred`) written only by
+`jobs/integrity-hash-retry.ts` to track whether the integrity hash has been
+computed yet. It is a workflow status, not a digest.
+
+Adjacent trap: `integrity_hash_status` is **not** an integrity field despite the
+name. `db/schema.ts:389-392` records it as externally managed by an untracked
+workflow that tags rows `customer` / `test` for analytics, with an explicit "do
+NOT read, write, or modify from API code".
+
+Anything asserting a "compliance hash" is describing something the code does not
+have.
+
+## 3. There is no signed receipt on any rail today
+
+The only signature in the x402 path is the **payer's** signed
+`TransferWithAuthorization`, verified inbound by the facilitator
+(`lib/x402-gateway.ts`). It is a payment authorisation. Strale signs nothing
+about the result, on any rail. `x402_settlement_id` and `x402_payer_hash` are
+settlement bookkeeping, not attestations.
+
+So "x402 signed receipt if present" resolves to: **not present**. There is no
+existing artifact to preserve compatibility with.
+
+## 4. Three separate, mutually inconsistent hashes over the same material
+
+This is the defect that makes Phase 4's single authority necessary.
+
+| # | site | input | canonicalisation | width |
+|---|---|---|---|---|
+| 1 | `computeIntegrityHash` (`lib/integrity-hash.ts:90`) | fixed literal incl. `input`, `output` | **none for nested values** — top-level order fixed by the literal, but `input`/`output`/`provenance`/`auditTrail` are stringified in insertion order | 64 hex |
+| 2 | `hashInput` (`routes/do.ts:2818`) → `audit_trail.input_hash` | request inputs only | **none** — bare `JSON.stringify(input)` | 64 hex |
+| 3 | `computeIdempotencyFingerprint` (`lib/idempotency-fingerprint.ts:76`) | rail, task, slug, inputs, dry_run, require_fresh | **partial** — a private recursive key-sort (`canonicalize`, line 46) | **32 hex (truncated)** |
+
+Consequences, all provable by construction:
+
+- **Two semantically identical requests can produce different digests** in (1)
+  and (2), because JavaScript object key order is insertion order and nothing
+  normalises it. `{"a":1,"b":2}` and `{"b":2,"a":1}` hash differently.
+- (3) sorts keys but is not RFC 8785: no number normalisation (`1.0` vs `1`, `1e2`
+  vs `100`), no `-0` handling, no Unicode normalisation, no escaping rules.
+- (3) is truncated to 128 bits and is a **replay key**, not a commitment.
+- Nothing cross-checks the three against each other.
+
+## 5. What the chain does NOT bind
+
+Against the fields the receipt spec must cover:
+
+| required by spec | bound today? | where |
+|---|---|---|
+| transaction id | **yes** | `id` |
+| semantic input | **yes** | `input` |
+| semantic returned result | **yes** | `output` |
+| capability identity | **indirectly** | only via `auditTrail.capability` (the slug), which is inside the hashed `auditTrail` blob — not a first-class hashed field |
+| **capability version / implementation identity** | **NO** | *no version concept exists anywhere in the codebase* — `grep capabilityVersion\|capability_version` across `src/` returns nothing |
+| endpoint / execution rail | **partially** | `auditTrail.execution_mode` is `sync`/`async`; the RAIL (`/v1/do` vs x402 vs solution step vs MCP vs A2A) is not recorded as such |
+| execution method | **partially** | `transparencyMarker` and `auditTrail.ai_description` approximate it |
+| data vintage / source observation time | **partially** | `provenance.fetched_at` where the executor supplies it; `validateProvenanceAtBoundary` warns but does **not** block on absence |
+| receipt version | **NO** | no versioning of the hashed shape exists; changing the payload silently changes every future digest with nothing recording which rule produced which |
+
+The last row is the most consequential for Phase 2: because there is no version
+field, the existing chain cannot distinguish "hash computed under the old rule"
+from "hash is wrong". Any change to the hashed payload is therefore
+unversioned today, which is precisely what a `strale.execution.v1` identifier
+fixes.
+
+## 6. Call sites can already vary what gets hashed
+
+`buildFullAudit` (`routes/do.ts:2896`) takes `outputSchema?` and `provenance?` as
+**optional** parameters, and `schema_validated` falls back to `false` when the
+schema is absent. The audit body — which is inside the integrity hash — therefore
+differs in content depending on what the call site happened to pass. This is the
+"no call site may select or omit hashed fields" requirement failing today, in the
+one composer that feeds the chain.
+
+## 7. Legacy honesty constraint
+
+`routes/audit.ts:110` already acknowledges "legacy rows pre-`buildFullAudit`
+(informational, not hash-protected)". Measured in production, 2026-08-23:
+
+| population | rows |
+|---|---|
+| transactions, total | 921,259 |
+| with an `integrity_hash` | 883,296 |
+| **without** one | 37,963 |
+| `redacted_at` set (content cleared in place) | 316,198 |
+| **hashed, but the hashed content is now gone** | **278,247** |
+
+Also confirmed against `information_schema`: `transactions.compliance_hash`
+column count = **0**. It does not exist.
+
+Those 278,247 rows are the hard constraint on Phase 5. They carry a valid chain
+hash computed over `input`/`output` that retention (90 days) or account closure
+(WP11) has since cleared in place — deliberately, and provably, since 0103's
+trigger makes redaction irreversible. **The originally-hashed material no longer
+exists for them, so no receipt can ever be reconstructed.** They must be labelled
+legacy and left alone; any backfill that "recomputed" a receipt for them would be
+fabricating a commitment to content nobody can produce. The 37,963 unhashed rows
+are a separate, pre-existing population and are not this package's to fix.
+
+---
+
+## What this means for Phases 2–7
+
+1. The receipt is **not** a new integrity system. The chain already binds request
+   and result; the receipt makes that commitment *canonical, versioned, and
+   independently recomputable*, and binds it into the existing chain material
+   (spec Phase 4) rather than alongside it.
+2. **RFC 8785 is the substantive change.** Today's three hashes are
+   insertion-order dependent (two of them entirely). Without canonicalisation, an
+   independent party cannot recompute a digest from the same semantic values.
+3. **Capability version identity has to be invented**, not wired up. Nothing in
+   the codebase identifies which implementation produced a result. This is the
+   one place the spec requires a genuinely new concept, and it needs a decision
+   on what constitutes a version (executor content hash? manifest digest?
+   deploy commit?) before Phase 2 can be finalised.
+4. **One authority, called by every rail.** Today `/v1/do` hashes inputs one way,
+   idempotency another, and the chain a third. Phase 4's builder replaces all
+   three call-site-local schemes; the idempotency fingerprint stays a separate
+   *replay key* but must stop being a second, divergent canonicaliser.
+5. **Nothing to keep compatible with on x402.** No signed receipt exists, so the
+   wire format is unconstrained by history — which also means there is no
+   pressure to imitate any external proposal.
+
+### Open decision for Phase 2 (mine to make, recorded before I make it)
+
+What identifies "the implementation that ran". Candidates: the deployed commit
+SHA (already served at `/health`, coarse — changes for unrelated deploys); a
+content hash of the executor module (precise, but rebuild-sensitive); the
+capability's manifest digest (stable and semantically meaningful, but does not
+change when executor code changes). My inclination is a composite —
+`{deploy_commit, manifest_digest}` — so the receipt records both what was
+declared and what was deployed, and neither alone has to carry the weight.

--- a/docs/design/execution-receipt/PHASE-2-SPEC.md
+++ b/docs/design/execution-receipt/PHASE-2-SPEC.md
@@ -159,6 +159,31 @@ property of the current code rather than something the type system enforces.
   Those are interpretations, they change, and a receipt that moves when an
   interpretation moves is worthless.
 
+### 3.1 Limits inherited from RFC 8785 itself (found in Phase 3)
+
+None of these forced a schema change, but each is a real limit on what "the same
+request" means, and a verifier deserves to know them:
+
+- **`-0` and `0` are the same JSON number.** RFC 8785 §3.2.2.3 collapses negative
+  zero. If a customer sends `-0` in `inputs`, the receipt is identical to one for
+  `0`. The receipt cannot distinguish them, and no amount of care at our end
+  changes that.
+- **Unicode is NOT normalized.** `"é"` precomposed (U+00E9) and decomposed
+  (`e` + U+0301) are visually identical and produce **different digests**. Two
+  requests a human would call the same are, to the receipt, different. Applying
+  NFC would be a deviation from the RFC and would silently fold inputs the
+  customer distinguished, so the honest choice is to leave it and say so.
+- **Integers beyond 2^53 do not round-trip.** They are already lossy at
+  `JSON.parse`, before the canonicalizer sees them. A large numeric identifier
+  sent as a JSON number is committed to at its double precision, not its literal
+  spelling. Send such identifiers as strings.
+- **The canonicalizer ENFORCES the closed schema**, which is stronger than §1
+  claimed. `undefined` is refused rather than dropped, so a call site cannot omit
+  a hashed field by leaving it undefined; `Date` is refused rather than silently
+  becoming a string through `toJSON`, so an object cannot choose its own
+  canonical form. The closed-schema rule is now a property of the primitive, not
+  a convention the builder has to remember.
+
 ---
 
 ## 4. Manifest / implementation identity

--- a/docs/design/execution-receipt/PHASE-2-SPEC.md
+++ b/docs/design/execution-receipt/PHASE-2-SPEC.md
@@ -1,6 +1,8 @@
 # `strale.execution.v1` — specification
 
-**Status:** SPEC, not implemented. Phase 3 does not begin until this is agreed.
+**Status:** APPROVED WITH AMENDMENTS (2026-08-23). Amendments 1-6 are folded in
+below and marked. Phase 3 (canonicalisation primitive) proceeds; receipt
+integration does not.
 **Depends on:** `PHASE-1-CURRENT-TRUTH.md` (accepted).
 **Owner:** Strale. No external provenance package is a runtime dependency or an
 authority for any part of this.
@@ -196,9 +198,20 @@ execution_manifest_snapshots
 - One row per distinct declaration, not per transaction. The catalogue is ~330
   capabilities and ~100 solutions; snapshots accumulate only when a declaration
   actually changes.
-- **Retention must never prune it.** A snapshot outlives the transactions that
-  reference it, because a receipt is unverifiable without it. This is an explicit
-  exception to the retention policy and must be recorded there, not assumed.
+- **Permanence is structural, not a convention** (amendment 6). A snapshot
+  outlives every transaction that references it, because a receipt is
+  unverifiable without it. Three mechanisms, because the risk is that a future
+  author prunes it without ever learning why they should not:
+  1. **A `BEFORE DELETE` trigger** that raises. Generic retention cannot silently
+     destroy verification material; it gets a loud error instead of a row count.
+  2. **An explicit denylist entry** in `db-retention.ts`, asserted by a test:
+     the table must never appear in `RETENTION_RULES`, and adding it turns that
+     test red.
+  3. **A comment at the table definition** naming the consequence — every receipt
+     older than the pruning window becomes unverifiable, with no error anywhere.
+
+  Mechanisms 1 and 2 are load-bearing; 3 exists so the next reader understands 1
+  and 2 rather than working around them.
 
 **What is in the normalized declaration** — the execution-semantic contract:
 
@@ -312,7 +325,26 @@ receipt asserting the wrong rail is worse than no receipt, and a permissive
 The receipt does not create a parallel integrity system. It becomes an input to
 the one that exists.
 
-1. Build the receipt payload → RFC 8785 → SHA-256 → full 64-hex digest.
+0. **Domain separation** (amendment 5). Every digest in this system is taken
+   over a domain-tagged, versioned preimage, never over bare canonical bytes:
+
+   ```
+   digest = SHA-256( DOMAIN_TAG || 0x00 || RFC8785(payload) )
+   ```
+
+   | material | `DOMAIN_TAG` |
+   |---|---|
+   | execution receipt | `strale.execution.v1` |
+   | manifest snapshot | `strale.manifest-snapshot.v1` |
+
+   The tag is US-ASCII and contains no NUL, so the `0x00` separator is
+   unambiguous. Two different kinds of material can therefore never collide, and
+   a payload that is valid under one schema cannot be replayed as the other. The
+   version lives in the tag as well as inside the receipt body, so the preimage
+   itself changes when the schema does.
+
+1. Build the receipt payload → RFC 8785 → domain-tagged preimage → SHA-256 →
+   full 64-hex digest.
 2. Persist on the transaction: `receipt_version`, `receipt_canonicalization`
    (`"RFC8785"`), `receipt_digest_alg` (`"sha256"`), `receipt_digest`.
 3. `computeIntegrityHash`'s payload gains `receiptDigest`, so the chain covers
@@ -323,6 +355,28 @@ the one that exists.
 4. The chain payload itself becomes versioned (`integrity_payload_version`),
    closing the Phase 1 finding that payload changes are currently
    indistinguishable from corruption.
+
+### 8.1 Chain version transition (amendment 4)
+
+Two payload versions coexist permanently. This is a transition, not a migration:
+no historical hash is ever recomputed.
+
+| | chain v1 | chain v2 |
+|---|---|---|
+| rows | pre-epoch | post-epoch |
+| payload | today's 15 members, unchanged | the same members **plus `receiptDigest`** |
+| `integrity_payload_version` | `NULL` (absent = v1, by definition) | `2` |
+| verification | must remain verifiable forever, under the v1 rule | verified under the v2 rule |
+
+The verifier selects the rule from the row's own
+`integrity_payload_version`, so a v1 row verifies with the v1 payload and a v2
+row with the v2 payload. **Linkage crosses the boundary unchanged**: a v2 row's
+`previous_hash` points at the last v1 hash exactly as any other link, so the
+chain is continuous across the epoch and `reaches_genesis` still holds.
+
+The one-way property this buys: because `receiptDigest` is inside the v2 payload,
+swapping a receipt digest on a post-epoch row invalidates that row's chain hash
+and therefore every row after it.
 
 **Ordering constraint.** Hashing is two-phase today: the row commits, then
 `jobs/integrity-hash-retry.ts` chains it. The receipt must be built and persisted
@@ -339,21 +393,72 @@ than silently wrong.
 
 - Receipts begin at a **defined deployment epoch**: the merge commit that ships
   Phase 4. Recorded in the package record and in a `platform_facts` entry.
-- **No backfill, ever.** Phase 1 measured 278,247 production rows whose hashed
-  `input`/`output` have been irreversibly cleared by retention or account
-  closure; their original material provably no longer exists. Reconstructing a
-  receipt for them would fabricate a commitment. The other pre-epoch rows are not
-  backfilled either, because their `manifest_digest` and `deploy_commit` are not
-  recoverable — a receipt is only honest when *every* required field comes from
-  execution-time material.
+- **No backfill, ever — including rows whose `input`/`output` still exist**
+  (amendment 1). The temptation is real: 605,215 rows still carry their content.
+  But content is not the whole receipt. Their `manifest_digest` and
+  `deploy_commit` are not recoverable at any price, because nothing recorded the
+  declaration or the build in force at the time. A "receipt" assembled from
+  surviving content plus reconstructed implementation identity would assert
+  something nobody measured. One epoch, one rule, no exceptions to argue about
+  later. Phase 1 separately measured 278,247 rows whose content is irreversibly
+  gone; they are the same answer for a stronger reason.
 - Pre-epoch rows report `receipt: { "status": "legacy_unavailable", "reason": … }`
   on the verify/audit surfaces. Not an error, not an empty object, not a null
   that reads like a bug.
-- **Refusal beats fabrication.** Receipt construction refuses — recording no
-  receipt rather than a wrong one — when: `rail` cannot be mapped to the enum; a
-  production `deploy_commit` is null; a `manifest_digest` cannot be resolved; or
-  `subject.slug` is absent. Refusals are counted and surfaced, so a systematic
-  refusal is visible rather than quietly degrading coverage.
+### 9.1 Post-epoch receipt lifecycle (amendment 2)
+
+A post-epoch transaction may not silently lack a receipt. `legacy_unavailable`
+is **forbidden** post-epoch — it is a statement about history, and using it for a
+present-day failure would disguise a defect as a policy.
+
+`transactions.receipt_status`, a closed enum, NOT NULL for post-epoch rows:
+
+| status | meaning |
+|---|---|
+| `complete` | digest computed and persisted |
+| `pending` | row committed, receipt not yet built — the expected transient state, since the money path must never wait on receipt construction |
+| `failed` | construction was attempted and could not honestly complete; `receipt_failure_reason` says why |
+
+Closed reason codes on `failed` / `pending`:
+`unmapped_rail`, `missing_deploy_identity`, `unresolvable_manifest`,
+`missing_subject`, `snapshot_write_failed`, `canonicalization_error`,
+`internal_error`.
+
+**Retry.** A `pending` row is retried by the same worker that chains it
+(`jobs/integrity-hash-retry.ts`) — one place already owns "finish what the
+request path could not". Retries are bounded and back off; on exhaustion the row
+moves to `failed` with the last reason. A `failed` row is terminal and is never
+silently retried into `complete`, because the material that made it fail is not
+expected to reappear.
+
+**Monitoring.** `pending` older than one chain cycle, and any `failed`, are
+surfaced as counts by reason code. A non-zero `failed` count is an alert, not a
+dashboard curiosity: it means executions are happening that cannot be committed
+to.
+
+### 9.2 Invariant failures, not ordinary absence (amendment 3)
+
+Three conditions are **invariant failures**, not missing-data cases:
+
+1. `rail` not in the closed enum;
+2. `deploy_commit` absent in production;
+3. `manifest_digest` unresolvable.
+
+Each records `receipt_status = 'failed'` with its reason code AND raises an
+error-level signal. They are bugs — a rail nobody mapped, a deploy that lost its
+identity, a declaration that vanished — and none of them is a thing that
+legitimately happens.
+
+**Deploy identity is required at production boot.** `RAILWAY_GIT_COMMIT_SHA`
+becomes a startup assertion: in production, a missing or non-40-hex value aborts
+boot, in the same position as the existing schema-validation and cost-class
+gates. Every receipt from a booted process then has a real commit by
+construction, so `missing_deploy_identity` should be unreachable in production
+and its appearance is itself the alarm.
+
+Local and test environments are exempt and record the literal
+`"unknown-local-build"`, which is a *defined* representation and can never be
+mistaken for a real 40-hex SHA.
 
 ---
 

--- a/docs/design/execution-receipt/PHASE-2-SPEC.md
+++ b/docs/design/execution-receipt/PHASE-2-SPEC.md
@@ -1,0 +1,425 @@
+# `strale.execution.v1` — specification
+
+**Status:** SPEC, not implemented. Phase 3 does not begin until this is agreed.
+**Depends on:** `PHASE-1-CURRENT-TRUTH.md` (accepted).
+**Owner:** Strale. No external provenance package is a runtime dependency or an
+authority for any part of this.
+
+---
+
+## 0. What this is, in one paragraph
+
+A **closed, versioned, canonical payload** that commits a specific request to the
+specific result Strale returned for it. It is RFC 8785 canonicalised, SHA-256
+digested, stored as a full digest, and folded into the existing integrity chain.
+A party who already holds the disclosed request and result can recompute the
+digest offline and compare. It is **not** a signature, **not** a new integrity
+system, and **not** a compliance claim.
+
+---
+
+## 1. The payload
+
+Exactly these keys, always, in every receipt. The schema is closed: a call site
+may neither omit a key nor add one. Values that do not apply take the defined
+representation given below — they never disappear.
+
+```json
+{
+  "version": "strale.execution.v1",
+  "transaction_id": "8f1c…",
+  "subject": {
+    "kind": "capability",
+    "slug": "vat-validate"
+  },
+  "implementation": {
+    "deploy_commit": "ce5e63f091863f56764829b498525211cd2ab234",
+    "manifest_digest": "sha256:9a3f…",
+    "steps": null
+  },
+  "request": {
+    "rail": "v1_do",
+    "inputs": { "vat_number": "SE556677889901" }
+  },
+  "response": {
+    "status": "completed",
+    "result": { "valid": true, "name": "…" },
+    "error": null
+  },
+  "execution": {
+    "method": "algorithmic",
+    "source_observation": { "kind": "live_fetch", "observed_at": "2026-08-23T09:14:50.311Z" }
+  }
+}
+```
+
+### Departures from the illustrative sketch, and why
+
+| change | reason |
+|---|---|
+| `response.error` added | Decision 6 requires failures to be executions. A failed receipt with only `result: null` would not bind *what the caller was told*. |
+| `implementation.steps` added | Decision on solutions (§5). Always present; `null` for capabilities. |
+| `source_observation` is always a tagged object, never bare `null` | Decision 5 requires a *defined representation*, and Decision 9 warns against forcing one scalar. A bare `null` conflates "no source applies" with "we failed to record one" — two facts a verifier must be able to tell apart. §6. |
+| no `price_cents`, no compliance block, no badges/scores | Decision 7. The chain already binds `priceCents`; a verifier recomputing a receipt holds the request and result, not the invoice. Putting price in would force disclosing commercial terms to verify a result. |
+
+---
+
+## 2. Field-by-field semantics
+
+### `version` — `"strale.execution.v1"`
+Literal. Names the canonicalisation rules, the key set, and the digest algorithm
+together. Any change to any of the three requires a new version string. Phase 1
+found that today's chain payload is unversioned, so a payload change is
+indistinguishable from a broken hash; this field is the fix.
+
+### `subject` — what was asked for
+- `kind`: closed enum `"capability" | "solution"`.
+- `slug`: the capability or solution slug as routed. Not a display name.
+
+The routing *decision* (task text → slug) is deliberately not bound: the receipt
+commits to what ran, not to how it was selected. The idempotency fingerprint
+already covers `task` for replay purposes, and that is a different question.
+
+### `implementation` — what code and what declaration
+- `deploy_commit`: the **full 40-hex** git SHA the serving process was built
+  from (`RAILWAY_GIT_COMMIT_SHA`, untruncated — `/health` shows 12 for display
+  only). `null` when unset, which is local development and never production; a
+  production receipt with a null commit is a defect, and §9 makes it refusable.
+- `manifest_digest`: `sha256:<64 hex>` over the RFC 8785 bytes of the normalized
+  declaration snapshot in force at execution. §4.
+- `steps`: `null` for capabilities; for solutions, the ordered step identity
+  array of §5.
+
+There is deliberately **no semantic `capability_version`**. A hand-maintained
+version integer is a claim someone has to remember to update; `deploy_commit` and
+`manifest_digest` are both derived from material that exists anyway.
+
+### `request` — what was asked
+- `rail`: closed Strale-owned enum, §7.
+- `inputs`: the **semantic** request object — the validated inputs the executor
+  was invoked with, not the raw HTTP body. Headers, idempotency keys, budget
+  knobs (`max_price_cents`, `timeout_seconds`), and transport framing are
+  excluded: they do not change what was computed, and binding them would make a
+  receipt unverifiable by anyone who did not observe the original HTTP call.
+
+### `response` — what was returned
+- `status`: closed enum `"completed" | "failed"`.
+- `result`: the semantic result **as the caller received it**, or `null` when
+  `status = "failed"`.
+- `error`: `null` on success; on failure, `{ "code": "…", "message": "…" }` — the
+  **sanitised, caller-visible** error, not the internal exception. Production
+  redacts URLs and internal detail from error strings before they leave the
+  process; binding the internal form would commit to a string the caller never
+  saw and could not reproduce.
+
+Decision 4 is satisfied by construction on every current rail. Verified in
+Phase 1: `/v1/do` returns `output: capResult.output` — the same object stored —
+so the stored value and the caller-visible value are identical, with no later
+transformation. §9 records this as an invariant a test must pin, because it is a
+property of the current code rather than something the type system enforces.
+
+### `execution` — how it was produced
+- `method`: closed enum `"algorithmic" | "ai_generated" | "mixed"`, taken from
+  the capability's declared `transparency_tag`. An execution fact (was a model
+  involved), not a compliance interpretation.
+- `source_observation`: §6.
+
+---
+
+## 3. What the receipt proves, and what it does not
+
+**Proves**, to anyone holding the disclosed request and result:
+
+- These exact inputs produced exactly this result, on this transaction.
+- Under this deployed code (`deploy_commit`) and this capability declaration
+  (`manifest_digest`).
+- Over this rail, by this method, with this recorded source observation.
+- Including failures — a failed execution has a receipt too.
+- That the record has not been altered since, **when combined with the chain**
+  (§8): the digest is inside the chain payload, so changing a receipt breaks the
+  chain from that point forward.
+
+**Does not prove:**
+
+- **That the result is correct.** It commits to what Strale returned, not to
+  whether the upstream source was right. A receipt over wrong data is a valid
+  receipt.
+- **That Strale attests to it.** There is no signature. A digest binds content;
+  it does not authenticate an issuer. Anyone able to write the database could
+  compute a consistent receipt. Signing is a possible v2 and is deliberately out
+  of scope — Phase 1 established there is no signed receipt today, so nothing
+  regresses by not adding one now.
+- **That the upstream source said this at the time.** `source_observation`
+  records what the executor declared it observed. It is Strale's assertion about
+  provenance, not the source's.
+- **Anything about rows outside the epoch** (§9).
+- **Regulatory conformance.** No badge, score, or framework mapping is bound.
+  Those are interpretations, they change, and a receipt that moves when an
+  interpretation moves is worthless.
+
+---
+
+## 4. Manifest / implementation identity
+
+This is the part that fails if done naively, and Decision 2 names the failure
+exactly: hashing a mutable current row does not prove historical configuration.
+
+**The problem, concretely.** `capabilities.onboarding_manifest` is a `jsonb`
+column, and four scripts write to it (`sync-manifest-canonical-to-db.ts`,
+`sync-manifest-text-to-db.ts`, `sweep-manifest-drift.ts`, plus `onboard.ts`).
+The YAML in `manifests/` is immutably addressable by git commit, but the
+executor does not read YAML at runtime — it reads the database row. So the
+material actually in force is the mutable one, and it can and does drift from
+git.
+
+**The design: a content-addressed, insert-only snapshot table.**
+
+```
+execution_manifest_snapshots
+  digest        text PRIMARY KEY        -- 'sha256:<64 hex>' of the RFC 8785 bytes below
+  subject_kind  varchar(16)  NOT NULL   -- 'capability' | 'solution'
+  subject_slug  text         NOT NULL
+  snapshot      jsonb        NOT NULL   -- the exact normalized declaration
+  first_seen_at timestamptz  NOT NULL DEFAULT now()
+```
+
+- At execution, the coordinator normalizes the declaration in force, canonicalises
+  it (RFC 8785), digests it, and `INSERT … ON CONFLICT (digest) DO NOTHING`. The
+  receipt carries the digest.
+- **Immutably addressable because it is content-addressed**: the digest is the
+  address, and the address is a function of the content. A snapshot cannot change
+  without changing its own primary key.
+- A `BEFORE UPDATE` trigger blocks any change to `digest`, `snapshot`,
+  `subject_kind`, or `subject_slug` — the same shape as migration 0103's
+  redaction trigger, and load-bearing for the same reason: without it, "immutable"
+  is a convention rather than a property.
+- One row per distinct declaration, not per transaction. The catalogue is ~330
+  capabilities and ~100 solutions; snapshots accumulate only when a declaration
+  actually changes.
+- **Retention must never prune it.** A snapshot outlives the transactions that
+  reference it, because a receipt is unverifiable without it. This is an explicit
+  exception to the retention policy and must be recorded there, not assumed.
+
+**What is in the normalized declaration** — the execution-semantic contract:
+
+| included | excluded, and why |
+|---|---|
+| `slug` | `is_active`, `x402_enabled`, `visible`, `lifecycle_state` — routing and eligibility, not declaration; they change constantly and would churn the digest without changing what runs |
+| `input_schema`, `output_schema` | `price_cents` — commercial; already bound by the chain, and binding it here would force disclosing terms to verify a result |
+| `transparency_tag` | `avg_latency_ms`, quality scores, health — observational, not declared |
+| `data_source`, `data_source_type` | `limitations`, descriptions, SEO text — disclosure prose; changing a sentence must not invalidate a result's identity |
+| `freshness_category` | badges, framework mappings — Decision 7 |
+| `output_field_reliability` | |
+| `processes_personal_data`, `personal_data_categories` | |
+| `gdpr_art_22_classification` | |
+
+The rule behind the split: **if changing the field changes what a correct
+execution would produce or how it must be interpreted, it is in; if it changes
+only how the capability is sold, listed, or measured, it is out.**
+
+---
+
+## 5. Solution identity
+
+Decision: a solution receipt that binds only the solution slug is
+under-specified, because swapping a constituent capability's implementation
+changes what ran while leaving the receipt identical.
+
+`implementation.steps` is therefore, for `subject.kind = "solution"`, an
+**ordered array** — order is part of the identity, since the same steps in a
+different order are a different computation:
+
+```json
+"steps": [
+  { "step_order": 1, "slug": "vat-validate",     "manifest_digest": "sha256:…" },
+  { "step_order": 2, "slug": "sanctions-check",  "manifest_digest": "sha256:…" }
+]
+```
+
+- `manifest_digest` per step is resolved from the same snapshot table, at
+  execution, for the declaration each step actually ran under.
+- `implementation.manifest_digest` at the top level is the **solution's own**
+  declaration digest (its step list, gates, ordering) — so both the recipe and
+  every ingredient are bound.
+- A step that did not run (short-circuited by a gate) still appears, with
+  `"manifest_digest": null` and the absence recorded — omitting it would let two
+  different executions share a receipt shape.
+
+**Explicitly out of scope for v1:** per-step receipts. Phase 1 confirmed a
+solution execution writes one transaction with `capability_id = NULL` and the
+step results inside `output.steps`; steps have no transaction rows of their own.
+Giving steps their own receipts means giving them their own identity in the
+chain, which is a larger change than this package. The solution receipt binds
+step identity; it does not produce a separately verifiable per-step artifact.
+
+---
+
+## 6. `source_observation`
+
+Decision 9 is right that one scalar timestamp is dishonest across the catalogue —
+a live registry lookup, a bulk dataset, and a pure computation have genuinely
+different vintage semantics, and forcing them into one field produces a
+fabricated timestamp for two of the three.
+
+Always present, always exactly one of these closed shapes:
+
+```json
+{ "kind": "live_fetch", "observed_at": "2026-08-23T09:14:50.311Z" }
+{ "kind": "dataset",    "dataset_version": "2026-08-01", "observed_at": "2026-08-23T09:14:50.311Z" }
+{ "kind": "computed" }
+{ "kind": "none_declared" }
+```
+
+- `live_fetch` — the executor contacted a source during this execution and
+  declared when. Sourced from `provenance.fetched_at`.
+- `dataset` — the answer came from a versioned corpus; `dataset_version`
+  identifies it, `observed_at` is when this execution read it.
+- `computed` — no external source (validators, format checks, arithmetic).
+  Positively asserted, not inferred from absence.
+- `none_declared` — the executor declared nothing. **This is the honest
+  representation of missing information**, and it is deliberately distinguishable
+  from `computed`. Phase 1 found `validateProvenanceAtBoundary` warns but does not
+  block on absent provenance, so this case exists today and pretending otherwise
+  would put a false vintage into a commitment.
+
+`none_declared` is expected to be common at the epoch and should shrink. Its
+count is a measurable quality signal, which is a better outcome than a
+uniformly-populated field nobody can trust.
+
+---
+
+## 7. Rail identity
+
+Closed, Strale-owned, derived from which interface the caller used — never from
+raw HTTP noise (no `User-Agent`, no `Referer`, no header sniffing):
+
+| value | meaning |
+|---|---|
+| `v1_do` | `POST /v1/do`, wallet-billed or free-tier |
+| `x402` | the x402 gateway, payment-as-auth |
+| `mcp` | the MCP server tool surface |
+| `a2a` | the A2A protocol surface |
+| `internal` | platform-originated execution (test harness, sweeps) |
+
+Unknown or unmapped callers are a **refusal**, not a fallback value (§9). A
+receipt asserting the wrong rail is worse than no receipt, and a permissive
+`"other"` bucket is how the wrong rail gets asserted.
+
+---
+
+## 8. Composition with the existing integrity chain
+
+The receipt does not create a parallel integrity system. It becomes an input to
+the one that exists.
+
+1. Build the receipt payload → RFC 8785 → SHA-256 → full 64-hex digest.
+2. Persist on the transaction: `receipt_version`, `receipt_canonicalization`
+   (`"RFC8785"`), `receipt_digest_alg` (`"sha256"`), `receipt_digest`.
+3. `computeIntegrityHash`'s payload gains `receiptDigest`, so the chain covers
+   it. Swapping a receipt digest without recomputing the chain breaks
+   verification at that row and every row after it — which is the property
+   Decision "a receipt digest cannot be swapped without invalidating the chain"
+   asks for.
+4. The chain payload itself becomes versioned (`integrity_payload_version`),
+   closing the Phase 1 finding that payload changes are currently
+   indistinguishable from corruption.
+
+**Ordering constraint.** Hashing is two-phase today: the row commits, then
+`jobs/integrity-hash-retry.ts` chains it. The receipt must be built and persisted
+**in the transaction that writes the row**, before chaining, so the chain worker
+finds a digest already present. Receipt construction must never block or fail the
+money path — if it cannot be built, the transaction still commits with
+`receipt_version = NULL` and the chain payload records `receiptDigest: null`.
+That is a defined representation, and such rows are visibly receipt-less rather
+than silently wrong.
+
+---
+
+## 9. Epoch and legacy behaviour
+
+- Receipts begin at a **defined deployment epoch**: the merge commit that ships
+  Phase 4. Recorded in the package record and in a `platform_facts` entry.
+- **No backfill, ever.** Phase 1 measured 278,247 production rows whose hashed
+  `input`/`output` have been irreversibly cleared by retention or account
+  closure; their original material provably no longer exists. Reconstructing a
+  receipt for them would fabricate a commitment. The other pre-epoch rows are not
+  backfilled either, because their `manifest_digest` and `deploy_commit` are not
+  recoverable — a receipt is only honest when *every* required field comes from
+  execution-time material.
+- Pre-epoch rows report `receipt: { "status": "legacy_unavailable", "reason": … }`
+  on the verify/audit surfaces. Not an error, not an empty object, not a null
+  that reads like a bug.
+- **Refusal beats fabrication.** Receipt construction refuses — recording no
+  receipt rather than a wrong one — when: `rail` cannot be mapped to the enum; a
+  production `deploy_commit` is null; a `manifest_digest` cannot be resolved; or
+  `subject.slug` is absent. Refusals are counted and surfaced, so a systematic
+  refusal is visible rather than quietly degrading coverage.
+
+---
+
+## 10. The four hashes, resolved
+
+Phase 1 found three overlapping hashes. The target is three **roles**, one
+canonicaliser, and no new permanent hash.
+
+| hash | fate |
+|---|---|
+| **idempotency fingerprint** | **Keep**, narrowed to operational deduplication only. Its private recursive key-sort is replaced by the shared RFC 8785 canonicaliser — one canonicalisation implementation, not two. Stays truncated to 128 bits: it is a replay key, and it should not look like a commitment. |
+| **execution receipt digest** | **New.** The canonical, portable request/result commitment. Full 256-bit digest. |
+| **integrity chain hash** | **Keep** as tamper-evident anchoring and ordering, now including the receipt digest, and now versioned. |
+| **`audit_trail.input_hash`** | **Deprecate on a disclosed timeline — NOT a silent removal.** It is a weaker, non-canonical duplicate of what the receipt now binds, and nothing in this codebase reads it back (the frontend `AuditRecord` contract does not carry it). **But it is externally visible:** `routes/transactions.ts:105` emits the raw `audit_trail` blob, `input_hash` included, on `GET /v1/transactions/:id`. Removing it is therefore a breaking change to a served response, not an internal cleanup. Path: ship the receipt first; leave `input_hash` in place and unchanged; announce; remove in a later versioned step that also changes the chain payload (§8.4). |
+
+Net effect **+1 now, −1 later**: the receipt digest arrives in this package;
+`input_hash` leaves only after a disclosed deprecation, because it is on a public
+response shape. No fourth permanent hash is created either way.
+
+I originally wrote this row as a clean internal deprecation, having checked only
+that nothing *reads* the field. That was wrong in the direction that matters:
+a field nobody reads internally can still be one a customer depends on, and
+`GET /v1/transactions/:id` has been handing it out.
+
+---
+
+## 11. Unresolved design risks
+
+1. **`manifest_digest` requires the snapshot table to be perfect on the write
+   path.** If the snapshot insert fails, the receipt must refuse (§9), so a
+   database hiccup silently reduces receipt coverage. Mitigation: refusals are
+   counted; a refusal rate above zero is a monitored signal. Residual: coverage
+   is only as good as that write.
+2. **The snapshot table is exempt from retention, permanently.** It holds
+   declarations, not customer data, so no GDPR conflict — but it is an
+   append-only table that only grows, and the exemption must be written into the
+   retention rules rather than assumed. If someone later adds it to
+   `db-retention.ts`, every receipt older than the window becomes unverifiable
+   with no error anywhere.
+3. **Normalization scope is a judgement call.** §4's include/exclude split is
+   defensible but not forced by the code. Getting it wrong in the *inclusive*
+   direction churns digests on cosmetic edits; wrong in the *exclusive* direction
+   means two materially different declarations share a digest. I lean exclusive
+   and expect to revisit.
+4. **`deploy_commit` granularity is coarse.** It changes for every deploy,
+   including ones that touch nothing relevant to a given capability. Two receipts
+   for identical executions across an unrelated deploy will differ in
+   `implementation`, which is correct but will surprise anyone who expects
+   receipt stability. Documented, not fixed — the alternative (per-executor
+   content hashing) is rebuild-sensitive and worse.
+5. **No signature means no issuer authentication.** Stated plainly in §3. If the
+   goal later becomes third-party attestation rather than self-consistency, this
+   needs a key, and key management is a materially larger commitment.
+6. **Decision 4 holds by construction, not by enforcement.** Stored output equals
+   caller-visible output on every rail today. Nothing in the type system prevents
+   a future rail from transforming the result after the receipt is built. Phase 6
+   must pin this with a test per rail, and that test is the only thing standing
+   between the invariant and a silent regression.
+7. **Solution step receipts do not exist** (§5). Bound identity is not the same
+   as an independently verifiable per-step artifact, and a customer may
+   reasonably expect the latter.
+8. **Deprecating `input_hash` needs a consumer story I do not have.** It is
+   emitted on `GET /v1/transactions/:id` and has been for some time. Nobody has
+   measured whether any customer parses it, and the platform has no deprecation
+   channel for response fields. Until both exist, the removal step in §10 is a
+   plan, not a schedule.
+9. **`none_declared` may dominate at the epoch.** If most executions cannot
+   declare a source observation, the field's value is mostly that it exposes the
+   gap. That is honest but is not the same as being useful on day one.

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "canonicalize": "^2.1.0",
         "drizzle-kit": "^0.30.6",
         "js-yaml": "^4.1.1",
-        "json-canonicalize": "^2.0.0",
+        "json-canonicalize": "2.0.1",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3",
         "vitest": "^4.1.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,8 +58,10 @@
         "@types/jsdom": "^28.0.1",
         "@types/node": "^22.12.0",
         "@types/turndown": "^5.0.6",
+        "canonicalize": "^2.1.0",
         "drizzle-kit": "^0.30.6",
         "js-yaml": "^4.1.1",
+        "json-canonicalize": "^2.0.0",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3",
         "vitest": "^4.1.4"
@@ -513,7 +515,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -560,7 +561,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2977,7 +2977,6 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/addresses": "5.5.1",
@@ -3709,7 +3708,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4169,7 +4167,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
       "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4937,6 +4934,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
       }
     },
     "node_modules/cargo-cp-artifact": {
@@ -6276,7 +6283,6 @@
       "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6433,7 +6439,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7170,7 +7175,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7816,7 +7820,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",
@@ -7850,6 +7853,18 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/json-canonicalize": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/json-canonicalize/-/json-canonicalize-2.0.1.tgz",
+      "integrity": "sha512-TuGrLM400c1VN8bQsSOiyDEEmRjIVgFvcSehWC+0JJaV4BGl1vYNxHBPVsN5ADUZIcWp75IN1yf+vCZyDjPt1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.5",
+        "npm": ">=6.0",
+        "yarn": "^1.0"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -9137,7 +9152,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9171,7 +9185,6 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
       "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
@@ -9357,7 +9370,6 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
       "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
       "license": "Unlicense",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10829,7 +10841,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10965,7 +10976,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11209,7 +11219,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11552,7 +11561,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11601,7 +11609,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -11634,7 +11641,7 @@
     },
     "packages/mcp-server": {
       "name": "strale-mcp",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",


### PR DESCRIPTION
## Execution receipt, Phases 1–3

Groundwork for a Strale-owned execution receipt. **No receipt is built, persisted, or served by this PR** — it establishes the truth, the specification, and the cryptographic primitive, and stops there. Phase 4 (receipt builder, manifest snapshot table, migrations, call-site integration, chain-v2 wiring) is deliberately **not** in scope.

No third-party provenance package is a runtime dependency or an authority for any part of this.

---

### Phase 1 — what the integrity substrate actually binds

Read from implementation, tests, and production read-only. Not from documentation. Four findings changed the shape of the work:

- **The chain already commits to request and result.** `computeIntegrityHash` binds `input` and `output`, so this is a *canonicalisation and identity* problem, not a "we never hashed the result" problem.
- **`compliance_hash` does not exist** — no column, no function, no value; `information_schema` count is 0. What exists is `compliance_hash_state`, a workflow status label. And `integrity_hash_status`, despite the name, is externally-managed analytics tagging the schema forbids API code from touching.
- **No signed receipt exists on any rail.** The only x402 signature is the payer's inbound `TransferWithAuthorization`. Nothing to stay compatible with.
- **Three mutually inconsistent hashes** already cover the same material: the chain hash (no canonicalisation of nested values), `audit_trail.input_hash` (bare `JSON.stringify`), and the idempotency fingerprint (partial key-sort, truncated to 128 bits). Two of three are insertion-order dependent — `{"a":1,"b":2}` and `{"b":2,"a":1}` already hash differently today.

Plus: **no capability version identity exists anywhere**, and **278,247 production rows** are hashed over content that retention or account closure has irreversibly cleared.

### Phase 2 — the `strale.execution.v1` specification

Closed, versioned payload binding a request to the result actually returned, with amendments 1–6 folded in. Highlights of the design decisions:

- **`implementation = {deploy_commit, manifest_digest}`**, no semantic `capability_version`.
- **Manifest identity is content-addressed.** The executor reads a *mutable* `capabilities.onboarding_manifest` row that four scripts write to, so hashing it would not prove historical configuration. A snapshot table keyed by its own digest, with an immutability trigger, and permanence made structural (delete trigger + retention denylist assertion + a comment explaining both).
- **Solutions bind an ordered step array** plus the solution's own declaration digest, so swapping a constituent implementation cannot leave the receipt unchanged.
- **`source_observation` is a closed tagged union** (`live_fetch` / `dataset` / `computed` / `none_declared`), not a scalar timestamp — and `none_declared` is deliberately distinguishable from `computed`.
- **Failures are executions**, binding the caller-visible sanitised error.
- **Post-epoch receipts have an explicit lifecycle** (`pending` / `complete` / `failed`) with closed reason codes and bounded retry; `legacy_unavailable` is forbidden post-epoch.
- **Domain-separated digests**: `SHA-256(TAG ‖ 0x00 ‖ RFC8785(payload))`.
- **No backfill, ever** — including the 605,215 rows whose content survives, because their `manifest_digest` and `deploy_commit` are unrecoverable at any price.

The spec states plainly what a receipt does **not** prove: not that the result is correct, and — since there is no signature — **not that Strale attests to it**. Anyone who can write the database can compute a consistent receipt.

### Phase 3 — RFC 8785 and the digest primitive

`jcs.ts` is mostly *restriction*, not reimplementation: RFC 8785 was written around ECMAScript, so number serialisation and string escaping are already what JS does. What it adds is recursive UTF-16 code-unit sorting, and refusal of everything `JSON.stringify` would silently coerce.

**The defence is an allow-list, not a blocklist.** Only a plain object (prototype `Object.prototype` or `null`) and a plain array (own keys are canonical indices, own data descriptors only) have a faithful JSON form. Both branches enforce the same invariant: *every value read must be an own DATA property of a plain container, with no member the reader will not visit.*

That framing arrived late and it is the important part of this PR. Five separate fixes preceded it, each a single exotic type found by probing — and the blocklist was still incomplete when the sixth review found three more holes in one pass by checking both branches against the invariant instead of against a type list.

**49 committed conformance vectors**, hand-derived from the RFC. The discriminating one is Unicode ordering: U+1F600 vs U+FB00 sort differently under UTF-16 code units than under code points *or* UTF-8 bytes.

### Independent verification

Two third-party JCS implementations (`canonicalize`, `json-canonicalize`) are **devDependencies used as test references only** — verified unreachable from `src/index.ts` (236 modules on the graph, zero reference modules).

Reference independence was proved by construction: the reviewer mutated the sort to UTF-8 byte order, **regenerated the vector file from the mutant**, and ran the suite. The committed-vector block went green (echoing the mutant, proving vectors alone prove nothing); the reference block went red. A vector that merely echoes the implementation cannot survive.

A **known bug in one reference is pinned as a test**: `json-canonicalize` routes any object with a non-null `toJSON` *property* straight to `JSON.stringify`, skipping the sort. Our output is right and the other reference agrees. Pinned so that whoever extends the fuzz alphabet finds the note instead of a red suite blaming the wrong culprit.

### Verification performed

| area | evidence |
|---|---|
| Numbers | 699,777 comparisons against both references plus round-trip checks — zero disagreements |
| Strings | all 63,488 non-surrogate BMP code units, as value *and* key; 16,384 astral code points; 20,000 random — zero divergences |
| Surrogates | lone high/low, split pairs, end-of-string — all refused; no U+FFFD anywhere |
| Domain separation | canonical bytes provably NUL-free across all BMP code units, so the first NUL always splits at the tag boundary; 12 forgery attempts → 12 distinct digests |
| Hostile values | 69-construction battery: 55 refused, 14 accepted, none unstable, all fixed points |
| Over-detection | 30,000 random `JSON.parse` values — zero refusals, all byte-identical to both references |
| Idempotency neutrality | 70,000 generated requests against the pre-refactor module extracted verbatim from git object `42c0b7c` — zero divergence |

### Idempotency: consolidated, and deliberately incomplete

The ordering rule now has one home; `idempotency-fingerprint.ts` no longer keeps a private key-sort.

Its **serialisation is deliberately unchanged**. Moving that digest to JCS would sort the six outer members too — different bytes, different fingerprints, and `isReplayable` returns false on mismatch, so **every idempotency key in flight across the deploy would 409 on a legitimate retry**. Full adoption needs a dual-accept window and belongs to receipt integration.

One bug was fixed there: `sortKeysDeep` built its result on an ordinary object literal, so `out["__proto__"] = v` set the *prototype* and the key vanished — two requests differing only in `__proto__` produced the **same fingerprint** and would have replayed each other's result. Inherited verbatim from the code it replaced, which is why byte-neutrality did not catch it: both sides were wrong identically. Measured before changing it: 23 historical rows carry the literal, **zero live idempotency keys do**. The failure mode if that scoping were wrong is a 409, not a silent mis-replay — it fails safe.

### Residual RFC 8785 limitations

None forced a schema change, but each bounds what "the same request" means:

- **`-0` collapses to `0`** — two different inputs, one receipt.
- **Unicode is not normalised** — `"é"` precomposed and decomposed digest differently despite looking identical. Applying NFC would deviate from the RFC and silently fold inputs the customer distinguished.
- **Integers beyond 2^53** are lossy before the canonicaliser sees them. Send large identifiers as strings.
- **Depth is bounded at 512.** Production's deepest input carries 42 opening brackets, so this cannot reach real traffic — but a deeper payload is refused rather than canonicalised.

### No production call site uses the primitive

Verified by import graph, and stated precisely because the blanket claim would be false:

| symbol | production references |
|---|---|
| `canonicalize`, `canonicalBytes`, `domainDigest`, `digestPreimage`, `DOMAIN_TAGS`, `sortJsonKeys` | **0** |
| `sortKeysDeep` | 3, all in `idempotency-fingerprint.ts` — **by design**, and byte-neutral |

The canonicaliser and the digest are reached by nothing. The shared ordering rule is on a production path deliberately.

### Process note

Every fail-before check in this PR ran through the repo's own `apps/api/scripts/mutation-test.mjs`, which enforces clean tree → green baseline → mutate → red → restore → green.

That guard already existed, and its docstring opens by describing the exact failure mode I then repeated twice. Recorded as **LESSONS family F11**: the defect is not missing tooling — a tool nobody reaches for is not a control. No new tooling is added here; that would be the wrong response and the wrong PR.

The battery found **four hollow guards of my own**, three of which review had not: a test asserting SQL text, an array-prototype test that the hole check satisfied anyway, and a footgun test asserting `Function.length` — which cannot see a defaulted parameter, precisely the shape being guarded against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
