### PR TITLE
Execution receipt Phase 4: receipt authority, immutable manifest snapshots, chain v2

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -383,6 +383,35 @@ export const transactions = pgTable(
     // NOT called integrity_hash_status — that column exists on prod and is
     // owned by a separate, untracked workflow that tags 'customer' / 'test'.
     // See PHASE_C_COLUMN_INVESTIGATION.md.
+    // ── Execution receipt (strale.execution.v1), Phase 4 ──────────────────
+    //
+    // NULL receipt_status means PRE-EPOCH: the row predates receipts and is
+    // reported as legacy_unavailable. Post-epoch rows always carry a status,
+    // enforced by a CHECK in migration 0107 — a post-epoch row cannot
+    // masquerade as legacy by leaving the column null.
+    /** 'complete' | 'pending' | 'failed'; NULL only for pre-epoch rows. */
+    receiptStatus: varchar("receipt_status", { length: 16 }),
+    /** Closed reason code, set when status is 'pending' or 'failed'. */
+    receiptFailureReason: varchar("receipt_failure_reason", { length: 40 }),
+    /** 'strale.execution.v1' */
+    receiptVersion: varchar("receipt_version", { length: 32 }),
+    /** 'RFC8785' — named so a verifier need not infer it. */
+    receiptCanonicalization: varchar("receipt_canonicalization", { length: 16 }),
+    /** 'sha256' */
+    receiptDigestAlg: varchar("receipt_digest_alg", { length: 16 }),
+    /** , the full 256-bit digest. Never truncated. */
+    receiptDigest: varchar("receipt_digest", { length: 71 }),
+    /** The snapshot this receipt's implementation identity resolved to. */
+    receiptManifestDigest: varchar("receipt_manifest_digest", { length: 71 }),
+    /** Retry bookkeeping for the pending -> complete path. */
+    receiptAttempts: integer("receipt_attempts").notNull().default(0),
+    /**
+     * Which integrity-chain payload rule hashed this row.
+     * NULL = v1 (pre-epoch, by definition). 2 = v2, which anchors
+     * receipt_digest. The verifier selects the algorithm from THIS column, so
+     * historical rows keep verifying under the rule that produced them.
+     */
+    integrityPayloadVersion: integer("integrity_payload_version"),
     complianceHashState: varchar("compliance_hash_state", { length: 16 })
       .notNull()
       .default("pending"),
@@ -1374,4 +1403,42 @@ export const jobSchedule = pgTable("job_schedule", {
   /** Drives retry backoff. Reset to 0 on success. */
   consecutiveFailures: integer("consecutive_failures").notNull().default(0),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// ─── Execution receipts (strale.execution.v1) ───────────────────────────────
+//
+// Phase 4 of the execution-receipt design. Spec:
+// docs/design/execution-receipt/PHASE-2-SPEC.md.
+
+/**
+ * Content-addressed, INSERT-ONLY snapshots of the declaration in force at
+ * execution time.
+ *
+ * The problem this exists for: the executor reads `capabilities`, which is a
+ * MUTABLE row that four scripts write to (`sync-manifest-canonical-to-db.ts`,
+ * `sync-manifest-text-to-db.ts`, `sweep-manifest-drift.ts`, `onboard.ts`).
+ * Hashing that row later would prove what the declaration says TODAY, not what
+ * it said when the call ran — so a receipt derived from it would assert
+ * something nobody measured.
+ *
+ * Immutability is structural, not conventional:
+ *   - the digest IS the primary key, and it is a function of `snapshot`, so a
+ *     snapshot cannot change without changing its own identity;
+ *   - a BEFORE UPDATE trigger refuses every update (migration 0106);
+ *   - a BEFORE DELETE trigger refuses every delete, so generic retention gets
+ *     a loud error rather than a row count;
+ *   - `db-retention.ts` is asserted never to list this table.
+ *
+ * Deleting a snapshot makes every receipt that references it unverifiable, with
+ * no error anywhere. That is why the refusal is in the database.
+ */
+export const executionManifestSnapshots = pgTable("execution_manifest_snapshots", {
+  /** `sha256:<64 hex>` over the domain-tagged RFC 8785 bytes of `snapshot`. */
+  digest: varchar("digest", { length: 71 }).primaryKey(),
+  /** 'capability' | 'solution' */
+  subjectKind: varchar("subject_kind", { length: 16 }).notNull(),
+  subjectSlug: text("subject_slug").notNull(),
+  /** The exact normalized declaration these bytes were taken over. */
+  snapshot: jsonb("snapshot").notNull(),
+  firstSeenAt: timestamp("first_seen_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/apps/api/src/jobs/integrity-hash-retry.ts
+++ b/apps/api/src/jobs/integrity-hash-retry.ts
@@ -170,6 +170,38 @@ async function runOnce(): Promise<void> {
           ),
         );
 
+      // ROWS THE ADMISSION PREDICATE CANNOT SEE.
+      //
+      // `staleCount` counts rows the batch SELECTED. A row excluded because its
+      // receipt is still pending is never selected, so it would age out of the
+      // chain in complete silence — and the retry sweeper that would settle its
+      // receipt is deferred to the rail PR. Counted separately rather than
+      // folded into staleCount, because the two mean different things: one says
+      // the worker is behind, this says rows are waiting on something the
+      // worker does not control.
+      const [receiptBlocked] = (await tx.execute(sql`
+        SELECT count(*)::int AS n
+          FROM transactions
+         WHERE compliance_hash_state = 'pending'
+           AND receipt_status = 'pending'
+           AND created_at < ${new Date(Date.now() - STALE_WARN_MS).toISOString()}::timestamptz
+      `)) as unknown as Array<{ n: number }>;
+      const receiptBlockedCount = Number(receiptBlocked?.n ?? 0);
+      if (receiptBlockedCount > 0) {
+        logWarn(
+          "integrity-hash-receipt-blocked",
+          `${receiptBlockedCount} transactions excluded from the chain for > 5 min because ` +
+            "their receipt is still pending; they will never chain until it settles",
+          { receiptBlockedCount },
+        );
+        await logHealthEvent({
+          eventType: "integrity_hash_receipt_blocked",
+          tier: 1,
+          actionTaken: "alert",
+          details: { count: receiptBlockedCount, stale_warn_ms: STALE_WARN_MS },
+        }).catch(() => undefined);
+      }
+
       if (pending.length === 0) return;
 
       let staleCount = 0;

--- a/apps/api/src/jobs/integrity-hash-retry.ts
+++ b/apps/api/src/jobs/integrity-hash-retry.ts
@@ -36,7 +36,13 @@
 import { sql, eq, and, lt, asc } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { transactions } from "../db/schema.js";
-import { computeIntegrityHash, getPreviousHash } from "../lib/integrity-hash.js";
+import {
+  computeIntegrityHashVersioned,
+  getPreviousHash,
+  CHAIN_PAYLOAD_V1,
+  CHAIN_PAYLOAD_V2,
+  type ChainPayloadVersion,
+} from "../lib/integrity-hash.js";
 import { log, logError, logWarn } from "../lib/log.js";
 import { logHealthEvent } from "../lib/health-monitor.js";
 import { isShuttingDown } from "../lib/shutdown.js";
@@ -117,6 +123,28 @@ async function runOnce(): Promise<void> {
             lt(transactions.createdAt, pendingCutoff),
             sql`${transactions.completedAt} IS NOT NULL`,
             sql`${transactions.status} IN ('completed', 'failed')`,
+            // A row whose RECEIPT is still pending must not be chained.
+            //
+            // Chain v2 anchors the receipt digest. Hashing a row while its
+            // receipt is unbuilt would anchor `null` and the real digest would
+            // arrive afterwards — the stored hash would then describe a receipt
+            // state the row no longer has, and completing the receipt would
+            // require rewriting an already-chained fact. Reviewer-found; the
+            // hazard is guaranteed rather than theoretical, because retries are
+            // owned by THIS worker, so any row needing one would be chained
+            // while pending and completed after.
+            //
+            // 'complete' and 'failed' are both admissible and both terminal.
+            // A failed receipt enters the chain with a null digest, and the
+            // chain then commits to "at chain time this row had no
+            // recomputable receipt" — permanently true, because failed never
+            // recovers. Excluding failures instead would leave a real, billed
+            // transaction outside the tamper-evident record, which is worse.
+            //
+            // NULL is admissible too: that is a pre-epoch row, or a row from a
+            // rail not yet wired. Those chain under v1, exactly as before.
+            sql`(${transactions.receiptStatus} IS NULL
+                 OR ${transactions.receiptStatus} IN ('complete', 'failed'))`,
           ),
         )
         .orderBy(asc(transactions.completedAt), asc(transactions.id))
@@ -168,7 +196,21 @@ async function runOnce(): Promise<void> {
         }
 
         try {
-          const hash = computeIntegrityHash(
+          // WHICH RULE HASHES THIS ROW, decided here and recorded here.
+          //
+          // The version column says which payload rule produced the hash, so
+          // only this site may write it. The lifecycle module used to stamp
+          // v2 independently, which produced rows hashed under v1 while
+          // declaring v2 — they verified only because nothing had yet
+          // implemented the documented rule.
+          //
+          // A row with receipt state is v2; a row without is v1. There is no
+          // third case, because the admission predicate above already excluded
+          // 'pending'.
+          const chainVersion: ChainPayloadVersion =
+            txn.receiptStatus === null ? CHAIN_PAYLOAD_V1 : CHAIN_PAYLOAD_V2;
+
+          const hash = computeIntegrityHashVersioned(
             {
               id: txn.id,
               userId: txn.userId,
@@ -184,8 +226,12 @@ async function runOnce(): Promise<void> {
               dataJurisdiction: txn.dataJurisdiction,
               createdAt: txn.createdAt,
               completedAt: txn.completedAt,
+              // v1 ignores this member entirely, so passing it is harmless
+              // there and load-bearing here.
+              receiptDigest: txn.receiptDigest ?? null,
             },
             currentPrevious,
+            chainVersion,
           );
 
           await tx
@@ -200,6 +246,11 @@ async function runOnce(): Promise<void> {
               // hashed without taking a position or take one without being
               // hashed.
               chainSeq: sql`nextval('transactions_chain_seq')`,
+              // Same UPDATE as the hash, for the same reason chain_seq is:
+              // a row cannot be hashed without recording which rule hashed it,
+              // and cannot record a rule without being hashed.
+              integrityPayloadVersion:
+                chainVersion === CHAIN_PAYLOAD_V2 ? CHAIN_PAYLOAD_V2 : null,
             })
             .where(eq(transactions.id, txn.id));
           currentPrevious = hash;

--- a/apps/api/src/lib/integrity-hash.ts
+++ b/apps/api/src/lib/integrity-hash.ts
@@ -224,10 +224,15 @@ export async function getPreviousHash(): Promise<string> {
  * Verify a single transaction's integrity hash.
  */
 export function verifyIntegrityHash(
-  record: Parameters<typeof computeIntegrityHash>[0],
+  record: IntegrityHashRecord,
   storedHash: string,
   previousHash: string,
+  storedVersion: number | null | undefined,
 ): { verified: boolean } {
-  const computed = computeIntegrityHash(record, previousHash);
+  const computed = computeIntegrityHashVersioned(
+    record,
+    previousHash,
+    chainVersionOf(storedVersion),
+  );
   return { verified: computed === storedHash };
 }

--- a/apps/api/src/lib/integrity-hash.ts
+++ b/apps/api/src/lib/integrity-hash.ts
@@ -51,26 +51,86 @@ function toCanonicalIso(value: string | Date | null | undefined): string | null 
  * Compute the integrity hash for a transaction record.
  * Includes all compliance-relevant fields + the previous hash.
  */
-export function computeIntegrityHash(
-  record: {
-    id: string;
-    userId: string | null;
-    status: string;
-    input: unknown;
-    output: unknown;
-    error: string | null;
-    priceCents: number;
-    latencyMs: number | null;
-    provenance: unknown;
-    auditTrail: unknown;
-    transparencyMarker: string;
-    dataJurisdiction: string;
-    createdAt: string | Date;
-    completedAt: string | Date | null;
-  },
+export interface IntegrityHashRecord {
+  id: string;
+  userId: string | null;
+  status: string;
+  input: unknown;
+  output: unknown;
+  error: string | null;
+  priceCents: number;
+  latencyMs: number | null;
+  provenance: unknown;
+  auditTrail: unknown;
+  transparencyMarker: string;
+  dataJurisdiction: string;
+  createdAt: string | Date;
+  completedAt: string | Date | null;
+  /**
+   * Chain v2 only: the execution receipt digest this row anchors.
+   *
+   * `null` is a legitimate v2 value — a post-epoch row whose receipt could not
+   * be built still chains, and records `receipt_status = 'failed'` alongside.
+   * What must never happen is the KEY going missing, which is why v2 always
+   * writes it.
+   */
+  receiptDigest?: string | null;
+}
+
+/**
+ * Which payload rule hashed a row.
+ *
+ * v1 is every row written before the receipt epoch. It is `null` in the
+ * database — absent MEANS v1, by definition — so no historical row had to be
+ * touched to introduce versioning, and none was.
+ */
+export const CHAIN_PAYLOAD_V1 = 1;
+export const CHAIN_PAYLOAD_V2 = 2;
+export type ChainPayloadVersion = typeof CHAIN_PAYLOAD_V1 | typeof CHAIN_PAYLOAD_V2;
+
+/** A stored `integrity_payload_version` to the rule that produced the hash. */
+export function chainVersionOf(stored: number | null | undefined): ChainPayloadVersion {
+  return stored === CHAIN_PAYLOAD_V2 ? CHAIN_PAYLOAD_V2 : CHAIN_PAYLOAD_V1;
+}
+
+/**
+ * Compute the integrity hash under an explicit payload version.
+ *
+ * ## Why two rules coexist permanently
+ *
+ * This is a transition, not a migration. **No historical hash is ever
+ * recomputed**, so a v1 row must keep verifying under the v1 payload forever —
+ * otherwise 883,296 production rows would appear corrupt the moment v2 shipped,
+ * which is the single worst outcome available here.
+ *
+ * The verifier picks the rule from the row's own `integrity_payload_version`.
+ * Linkage crosses the boundary unchanged: a v2 row's `previous_hash` points at
+ * the last v1 hash exactly like any other link, so the chain stays continuous
+ * and `reaches_genesis` still holds.
+ *
+ * ## What v2 adds, and why only that
+ *
+ * One member: `receiptDigest`. Because it is inside the hashed payload,
+ * swapping a receipt digest on a post-epoch row invalidates that row's chain
+ * hash and therefore every row after it — which is the property "a receipt
+ * digest cannot be swapped without invalidating the chain" asks for.
+ *
+ * Nothing else changes. v2 is v1 plus one member, so a reader comparing them
+ * can see the entire difference at once.
+ *
+ * `JSON.stringify` over a fixed literal is retained deliberately rather than
+ * switched to RFC 8785: changing the serialization would change every future
+ * chain hash for reasons unrelated to the receipt, and the nested-value
+ * canonicalization gap it carries is documented in PHASE-1-CURRENT-TRUTH.md
+ * as a separate, known limitation of the chain — not something this phase
+ * quietly fixes while doing something else.
+ */
+export function computeIntegrityHashVersioned(
+  record: IntegrityHashRecord,
   previousHash: string,
+  version: ChainPayloadVersion,
 ): string {
-  const payload = JSON.stringify({
+  const base = {
     id: record.id,
     userId: record.userId,
     status: record.status,
@@ -86,8 +146,32 @@ export function computeIntegrityHash(
     createdAt: toCanonicalIso(record.createdAt),
     completedAt: toCanonicalIso(record.completedAt),
     previousHash,
-  });
+  };
+
+  // v2 appends one member. The key is ALWAYS present in v2 — a conditional
+  // spread would make the payload shape depend on the value, which is the
+  // call-site-varies-what-is-hashed defect this program exists to remove.
+  const payload =
+    version === CHAIN_PAYLOAD_V2
+      ? JSON.stringify({ ...base, receiptDigest: record.receiptDigest ?? null })
+      : JSON.stringify(base);
+
   return createHash("sha256").update(payload).digest("hex");
+}
+
+/**
+ * The v1 entry point, unchanged in behaviour.
+ *
+ * Kept as its own export so every existing caller and every existing test
+ * keeps hashing exactly what it hashed before. A default parameter on the
+ * versioned function would have been terser and would have made a v1/v2 mixup
+ * a one-character mistake.
+ */
+export function computeIntegrityHash(
+  record: IntegrityHashRecord,
+  previousHash: string,
+): string {
+  return computeIntegrityHashVersioned(record, previousHash, CHAIN_PAYLOAD_V1);
 }
 
 /**

--- a/apps/api/src/lib/integrity-hash.ts
+++ b/apps/api/src/lib/integrity-hash.ts
@@ -90,7 +90,16 @@ export type ChainPayloadVersion = typeof CHAIN_PAYLOAD_V1 | typeof CHAIN_PAYLOAD
 
 /** A stored `integrity_payload_version` to the rule that produced the hash. */
 export function chainVersionOf(stored: number | null | undefined): ChainPayloadVersion {
-  return stored === CHAIN_PAYLOAD_V2 ? CHAIN_PAYLOAD_V2 : CHAIN_PAYLOAD_V1;
+  if (stored === null || stored === undefined) return CHAIN_PAYLOAD_V1;
+  if (stored === CHAIN_PAYLOAD_V2) return CHAIN_PAYLOAD_V2;
+  // FAIL CLOSED. The first version returned v1 for anything unrecognised, so a
+  // stored 3 or 0 would be verified under the wrong rule and reported as
+  // corruption rather than as a version we do not understand. The CHECK on the
+  // column bounds this today; the function should not depend on that.
+  throw new Error(
+    `unknown integrity_payload_version ${stored}: refusing to guess which rule ` +
+      `hashed this row. A version this code does not know is not a v1 row.`,
+  );
 }
 
 /**

--- a/apps/api/src/lib/receipt/deploy-identity.ts
+++ b/apps/api/src/lib/receipt/deploy-identity.ts
@@ -1,0 +1,98 @@
+/**
+ * The authoritative runtime source of `deploy_commit` (Phase 4 §D).
+ *
+ * ## Where it comes from
+ *
+ * `RAILWAY_GIT_COMMIT_SHA`, **untruncated**. `/health` slices it to 12
+ * characters for display; a receipt records the full 40, because 12 hex is a
+ * display convenience and 40 is an identity.
+ *
+ * ## Why production refuses to start without it
+ *
+ * A receipt whose `implementation.deploy_commit` is missing cannot answer the
+ * question it exists to answer — which code produced this result. Phase 2 §9.2
+ * classifies that as an invariant failure rather than an absence, and the only
+ * way for `missing_deploy_identity` to be genuinely unreachable in a booted
+ * process is for the process to refuse to boot without it.
+ *
+ * So this is a startup assertion, in the same position as the existing
+ * schema-validation and cost-class gates: a production process that cannot
+ * identify its serving commit does not become ready. That is deliberately
+ * stronger than degrading — a process serving receipts with no implementation
+ * identity is producing commitments nobody can interpret, and it would do so
+ * silently.
+ *
+ * ## Why dev and test are exempt
+ *
+ * They have no `RAILWAY_GIT_COMMIT_SHA` and never will. They record the
+ * literal `unknown-local-build`, which is a DEFINED representation — it can
+ * never be mistaken for a real commit, and it cannot be produced accidentally
+ * in production because production takes the refusal path instead.
+ *
+ * The exemption is keyed on `NODE_ENV === "production"` alone. Anything more
+ * clever (a Railway-specific variable, a hostname check) would make the gate
+ * depend on a signal that can disappear for reasons unrelated to correctness.
+ */
+
+import { LOCAL_BUILD_SENTINEL, requiresDeployIdentity } from "./execution-receipt.js";
+
+export { LOCAL_BUILD_SENTINEL };
+
+const FULL_SHA = /^[0-9a-f]{40}$/;
+
+export class DeployIdentityError extends Error {
+  constructor(detail: string) {
+    super(detail);
+    this.name = "DeployIdentityError";
+  }
+}
+
+/**
+ * The commit this process is serving.
+ *
+ * Returns the full SHA in production, or the sentinel outside it. Throws in
+ * production when the value is missing or malformed — callers on the request
+ * path should not be reaching for this before boot has asserted it, and if
+ * they do, throwing is better than handing back a value that looks real.
+ */
+export function resolveDeployCommit(env = process.env): string {
+  const raw = env.RAILWAY_GIT_COMMIT_SHA?.trim();
+
+  if (requiresDeployIdentity(env)) {
+    if (!raw) {
+      throw new DeployIdentityError(
+        "RAILWAY_GIT_COMMIT_SHA is unset in production. Every execution receipt " +
+          "records which code produced the result; without it, receipts would " +
+          "carry no implementation identity and could not be interpreted later.",
+      );
+    }
+    if (!FULL_SHA.test(raw)) {
+      throw new DeployIdentityError(
+        `RAILWAY_GIT_COMMIT_SHA is not a full 40-hex commit (got ${JSON.stringify(raw)}). ` +
+          "A truncated or decorated value is not an identity — /health truncates for " +
+          "display, but a receipt must record the whole thing.",
+      );
+    }
+    return raw;
+  }
+
+  // Outside production: use a real commit when one happens to be present (CI
+  // often has it), otherwise the sentinel.
+  return raw && FULL_SHA.test(raw) ? raw : LOCAL_BUILD_SENTINEL;
+}
+
+/**
+ * Boot gate. Call before the server listens.
+ *
+ * Deliberately narrow: it asserts and returns, so the caller decides what
+ * "refuse to become ready" means in its own context. Throwing from here would
+ * couple this module to the process lifecycle.
+ */
+export function assertDeployIdentity(env = process.env): {
+  deployCommit: string;
+  enforced: boolean;
+} {
+  const enforced = requiresDeployIdentity(env);
+  const deployCommit = resolveDeployCommit(env); // throws in production if absent
+  return { deployCommit, enforced };
+}

--- a/apps/api/src/lib/receipt/execution-receipt.integration.test.ts
+++ b/apps/api/src/lib/receipt/execution-receipt.integration.test.ts
@@ -1,0 +1,692 @@
+/**
+ * Phase 4 against a real Postgres — the properties from §H.
+ *
+ * Real rows because every load-bearing property here is a property of the
+ * database: a trigger that refuses UPDATE, a CHECK that refuses a 'complete'
+ * row with no digest, an `ON CONFLICT` that deduplicates by digest. A mocked
+ * db module would assert the shape of a query and prove none of it.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { sql } from "drizzle-orm";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
+
+import { useTestDatabase } from "../../test-support/integration-db.js";
+import {
+  normalizeCapabilityDeclaration,
+  normalizeSolutionDeclaration,
+  recordManifestSnapshot,
+  readManifestSnapshot,
+  declarationDigest,
+  declarationCanonicalBytes,
+  type CapabilityDeclarationSource,
+} from "./manifest-snapshot.js";
+import {
+  buildExecutionReceipt,
+  LOCAL_BUILD_SENTINEL,
+  type ReceiptInput,
+} from "./execution-receipt.js";
+import {
+  markReceiptComplete,
+  markReceiptFailed,
+  markReceiptPending,
+  selectPendingReceipts,
+  receiptHealthCounts,
+  describeReceiptState,
+} from "./receipt-lifecycle.js";
+import {
+  computeIntegrityHashVersioned,
+  CHAIN_PAYLOAD_V1,
+  CHAIN_PAYLOAD_V2,
+  chainVersionOf,
+  type IntegrityHashRecord,
+} from "../integrity-hash.js";
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+const BASE_DECL: CapabilityDeclarationSource = {
+  slug: "vat-validate",
+  inputSchema: { type: "object", properties: { vat_number: { type: "string" } } },
+  outputSchema: { type: "object", properties: { valid: { type: "boolean" } } },
+  transparencyTag: "algorithmic",
+  dataSource: "VIES",
+  capabilityType: "stable_api",
+  freshnessCategory: "live-fetch",
+  outputFieldReliability: { valid: "guaranteed" },
+  processesPersonalData: false,
+  personalDataCategories: [],
+  gdprArt22Classification: "data_lookup",
+};
+
+function baseReceipt(overrides: Partial<ReceiptInput> = {}): ReceiptInput {
+  return {
+    transactionId: "8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f",
+    subjectKind: "capability",
+    subjectSlug: "vat-validate",
+    deployCommit: "ce5e63f091863f56764829b498525211cd2ab234",
+    manifestDigest: `sha256:${"a".repeat(64)}`,
+    steps: null,
+    rail: "v1_do",
+    inputs: { vat_number: "SE556677889901" },
+    status: "completed",
+    result: { valid: true },
+    error: null,
+    method: "algorithmic",
+    sourceObservation: { kind: "live_fetch", observed_at: "2026-08-23T09:14:50.311Z" },
+    ...overrides,
+  };
+}
+
+function digestOf(input: ReceiptInput): string {
+  const r = buildExecutionReceipt(input, { NODE_ENV: "test" } as NodeJS.ProcessEnv);
+  if (r.outcome !== "complete") throw new Error(`expected complete, got ${r.reason}`);
+  return r.digest;
+}
+
+describeMaybe("execution receipts against a real database", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+
+  const snapshots = new Set<string>();
+  const txns = new Set<string>();
+  let userId = "";
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 6 });
+    db = drizzle(client);
+    userId = randomUUID();
+    await db.execute(sql`
+      INSERT INTO users (id, email, api_key_hash, key_prefix)
+      VALUES (${userId}::uuid, ${`receipt-${userId}@test.local`}, ${randomUUID()}, 'sk_test_')
+    `);
+  });
+
+  afterAll(async () => {
+    for (const id of txns) await db.execute(sql`DELETE FROM transactions WHERE id = ${id}::uuid`);
+    await db.execute(sql`DELETE FROM users WHERE id = ${userId}::uuid`);
+    // Snapshots cannot be deleted — that is the point. They are left behind,
+    // which is correct: a real deployment never removes them either.
+    await client.end();
+  });
+
+  afterEach(async () => {
+    for (const id of txns) await db.execute(sql`DELETE FROM transactions WHERE id = ${id}::uuid`);
+    txns.clear();
+  });
+
+  async function newTransaction(): Promise<string> {
+    const id = randomUUID();
+    txns.add(id);
+    await db.execute(sql`
+      INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
+                                data_jurisdiction, input)
+      VALUES (${id}::uuid, ${userId}::uuid, 'completed', 5, 'algorithmic', 'EU', '{}'::jsonb)
+    `);
+    return id;
+  }
+
+  async function store(decl: Record<string, unknown>): Promise<string> {
+    const d = await recordManifestSnapshot(db, decl);
+    snapshots.add(d);
+    return d;
+  }
+
+  // ── A. Manifest snapshot authority ───────────────────────────────────────
+
+  it("identical declarations deduplicate to exactly one snapshot", async () => {
+    const decl = normalizeCapabilityDeclaration(BASE_DECL);
+    const first = await store(decl);
+    const second = await store({ ...decl }); // different object, same content
+    expect(second).toBe(first);
+
+    const rows = await db.execute(
+      sql`SELECT count(*)::int AS n FROM execution_manifest_snapshots WHERE digest = ${first}`,
+    );
+    expect(Number((rows as unknown as Array<{ n: number }>)[0].n)).toBe(1);
+  });
+
+  it("changing any EXECUTION-RELEVANT declaration field changes the digest", async () => {
+    const base = declarationDigest(normalizeCapabilityDeclaration(BASE_DECL));
+    const mutations: Array<[string, Partial<CapabilityDeclarationSource>]> = [
+      ["slug", { slug: "iban-validate" }],
+      ["input_schema", { inputSchema: { type: "object", properties: { other: {} } } }],
+      ["output_schema", { outputSchema: { type: "object", properties: { other: {} } } }],
+      ["transparency_tag", { transparencyTag: "ai_generated" }],
+      ["data_source", { dataSource: "Some Other Registry" }],
+      ["capability_type", { capabilityType: "scraping" }],
+      ["freshness_category", { freshnessCategory: "reference-data" }],
+      ["output_field_reliability", { outputFieldReliability: { valid: "common" } }],
+      ["processes_personal_data", { processesPersonalData: true }],
+      ["personal_data_categories", { personalDataCategories: ["name"] }],
+      ["gdpr_art_22_classification", { gdprArt22Classification: "screening_signal" }],
+    ];
+    for (const [label, patch] of mutations) {
+      const moved = declarationDigest(normalizeCapabilityDeclaration({ ...BASE_DECL, ...patch }));
+      expect(moved, `${label} did not move the digest`).not.toBe(base);
+    }
+  });
+
+  it("changing sale/listing metadata the spec EXCLUDES does not change the digest", async () => {
+    // The rule: if it changes what a correct execution produces, it is in. If
+    // it changes only how the capability is sold, listed or measured, it is
+    // out. These are all "out", and the normalizer never reads them — proven
+    // by handing them to it and getting the same digest.
+    const base = declarationDigest(normalizeCapabilityDeclaration(BASE_DECL));
+    const withNoise = {
+      ...BASE_DECL,
+      // Fields that exist on the capabilities row but are deliberately not
+      // part of the declaration.
+      isActive: false,
+      x402Enabled: true,
+      visible: false,
+      lifecycleState: "deactivated",
+      priceCents: 999,
+      avgLatencyMs: 12345,
+      description: "a completely rewritten description",
+      name: "Renamed Capability",
+    } as unknown as CapabilityDeclarationSource;
+    expect(declarationDigest(normalizeCapabilityDeclaration(withNoise))).toBe(base);
+  });
+
+  it("a stored snapshot cannot be UPDATED", async () => {
+    const digest = await store(normalizeCapabilityDeclaration(BASE_DECL));
+    await expect(
+      db.execute(sql`
+        UPDATE execution_manifest_snapshots SET snapshot = '{"tampered":true}'::jsonb
+         WHERE digest = ${digest}
+      `),
+    ).rejects.toThrow(/insert-only/i);
+
+    // And the content is genuinely unchanged, not merely the statement refused.
+    const back = await readManifestSnapshot(db, digest);
+    expect((back as Record<string, unknown>).slug).toBe("vat-validate");
+  });
+
+  it("a stored snapshot cannot be DELETED, so retention cannot silently remove it", async () => {
+    const digest = await store(normalizeCapabilityDeclaration(BASE_DECL));
+    await expect(
+      db.execute(sql`DELETE FROM execution_manifest_snapshots WHERE digest = ${digest}`),
+    ).rejects.toThrow(/insert-only/i);
+    expect(await readManifestSnapshot(db, digest)).not.toBeNull();
+  });
+
+  it("a blanket DELETE — what generic retention would issue — is refused too", async () => {
+    await store(normalizeCapabilityDeclaration(BASE_DECL));
+    await expect(
+      db.execute(sql`DELETE FROM execution_manifest_snapshots WHERE first_seen_at < now()`),
+    ).rejects.toThrow(/insert-only/i);
+  });
+
+  it("db-retention.ts does not, and must never, list this table", async () => {
+    // The trigger is the real defence; this is the second one, because the
+    // failure it prevents is silent and permanent. If someone adds the table
+    // to the retention rules, they meet this test before production meets the
+    // trigger.
+    const { readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const src = readFileSync(
+      join(import.meta.dirname, "..", "..", "jobs", "db-retention.ts"),
+      "utf8",
+    );
+    expect(src).not.toContain("execution_manifest_snapshots");
+  });
+
+  it("the snapshot round-trips, so a receipt stays recomputable years later", async () => {
+    const decl = normalizeCapabilityDeclaration(BASE_DECL);
+    const digest = await store(decl);
+    const back = await readManifestSnapshot(db, digest);
+    expect(back).toEqual(decl);
+    // And the digest is reproducible from what was stored.
+    expect(declarationDigest(back as Record<string, unknown>)).toBe(digest);
+    expect(declarationCanonicalBytes(back as Record<string, unknown>)).toBe(
+      declarationCanonicalBytes(decl),
+    );
+  });
+
+  it("a mutation to the CURRENT capability row cannot rewrite an old receipt's meaning", async () => {
+    // The whole reason snapshots exist. Execution happens under declaration A;
+    // the capabilities row later changes to B; the receipt must still resolve
+    // to A's bytes.
+    const declA = normalizeCapabilityDeclaration(BASE_DECL);
+    const digestA = await store(declA);
+
+    const declB = normalizeCapabilityDeclaration({ ...BASE_DECL, transparencyTag: "ai_generated" });
+    const digestB = await store(declB);
+    expect(digestB).not.toBe(digestA);
+
+    // The old digest still resolves to the old bytes.
+    const back = await readManifestSnapshot(db, digestA);
+    expect((back as Record<string, unknown>).transparency_tag).toBe("algorithmic");
+  });
+
+  // ── Solutions ────────────────────────────────────────────────────────────
+
+  it("solution identity binds ordered step identities, so swapping a step moves the digest", async () => {
+    const stepA = { step_order: 1, slug: "vat-validate", manifest_digest: `sha256:${"1".repeat(64)}` };
+    const stepB = { step_order: 2, slug: "sanctions-check", manifest_digest: `sha256:${"2".repeat(64)}` };
+
+    const base = declarationDigest(
+      normalizeSolutionDeclaration({ slug: "kyb-essentials-se", steps: [stepA, stepB] }),
+    );
+
+    // Same slugs, different step ORDER.
+    const reordered = declarationDigest(
+      normalizeSolutionDeclaration({
+        slug: "kyb-essentials-se",
+        steps: [
+          { ...stepA, step_order: 2 },
+          { ...stepB, step_order: 1 },
+        ],
+      }),
+    );
+    expect(reordered).not.toBe(base);
+
+    // Same slugs and order, one step's IMPLEMENTATION changed.
+    const reimplemented = declarationDigest(
+      normalizeSolutionDeclaration({
+        slug: "kyb-essentials-se",
+        steps: [stepA, { ...stepB, manifest_digest: `sha256:${"3".repeat(64)}` }],
+      }),
+    );
+    expect(reimplemented).not.toBe(base);
+  });
+
+  it("a skipped step is represented explicitly, not omitted", async () => {
+    const withSkip = normalizeSolutionDeclaration({
+      slug: "kyb-essentials-se",
+      steps: [
+        { step_order: 1, slug: "vat-validate", manifest_digest: `sha256:${"1".repeat(64)}` },
+        { step_order: 2, slug: "sanctions-check", manifest_digest: null },
+      ],
+    });
+    const omitted = normalizeSolutionDeclaration({
+      slug: "kyb-essentials-se",
+      steps: [{ step_order: 1, slug: "vat-validate", manifest_digest: `sha256:${"1".repeat(64)}` }],
+    });
+    // Omitting the step would let two different executions share a shape.
+    expect(declarationDigest(withSkip)).not.toBe(declarationDigest(omitted));
+    expect((withSkip.steps as unknown[]).length).toBe(2);
+  });
+
+  // ── B. The receipt builder ───────────────────────────────────────────────
+
+  it("changing the input changes the receipt digest", () => {
+    expect(digestOf(baseReceipt({ inputs: { vat_number: "SE999999999999" } }))).not.toBe(
+      digestOf(baseReceipt()),
+    );
+  });
+
+  it("changing the caller-visible result changes the receipt digest", () => {
+    expect(digestOf(baseReceipt({ result: { valid: false } }))).not.toBe(digestOf(baseReceipt()));
+  });
+
+  it("changing the caller-visible error changes the receipt digest", () => {
+    const failed = baseReceipt({
+      status: "failed",
+      result: null,
+      error: { code: "invalid_input", message: "vat_number is malformed" },
+    });
+    const other = baseReceipt({
+      status: "failed",
+      result: null,
+      error: { code: "invalid_input", message: "vat_number is empty" },
+    });
+    expect(digestOf(other)).not.toBe(digestOf(failed));
+    // And a failure is genuinely a different receipt from a success.
+    expect(digestOf(failed)).not.toBe(digestOf(baseReceipt()));
+  });
+
+  it("changing the deploy commit changes the receipt digest", () => {
+    expect(
+      digestOf(baseReceipt({ deployCommit: "0".repeat(40) })),
+    ).not.toBe(digestOf(baseReceipt()));
+  });
+
+  it("changing the manifest digest changes the receipt digest", () => {
+    expect(digestOf(baseReceipt({ manifestDigest: `sha256:${"b".repeat(64)}` }))).not.toBe(
+      digestOf(baseReceipt()),
+    );
+  });
+
+  it("changing the rail, method or source observation changes the receipt digest", () => {
+    const base = digestOf(baseReceipt());
+    expect(digestOf(baseReceipt({ rail: "x402" }))).not.toBe(base);
+    expect(digestOf(baseReceipt({ method: "ai_generated" }))).not.toBe(base);
+    expect(digestOf(baseReceipt({ sourceObservation: { kind: "computed" } }))).not.toBe(base);
+    // none_declared must be distinguishable from computed.
+    expect(digestOf(baseReceipt({ sourceObservation: { kind: "none_declared" } }))).not.toBe(
+      digestOf(baseReceipt({ sourceObservation: { kind: "computed" } })),
+    );
+  });
+
+  it("changing solution step order or identity changes the receipt digest", () => {
+    const s1 = { step_order: 1, slug: "a", manifest_digest: `sha256:${"1".repeat(64)}` };
+    const s2 = { step_order: 2, slug: "b", manifest_digest: `sha256:${"2".repeat(64)}` };
+    const sol = baseReceipt({ subjectKind: "solution", subjectSlug: "kyb-essentials-se", steps: [s1, s2] });
+    const base = digestOf(sol);
+
+    expect(
+      digestOf(baseReceipt({
+        subjectKind: "solution", subjectSlug: "kyb-essentials-se",
+        steps: [{ ...s1, step_order: 2 }, { ...s2, step_order: 1 }],
+      })),
+    ).not.toBe(base);
+
+    expect(
+      digestOf(baseReceipt({
+        subjectKind: "solution", subjectSlug: "kyb-essentials-se",
+        steps: [s1, { ...s2, manifest_digest: `sha256:${"9".repeat(64)}` }],
+      })),
+    ).not.toBe(base);
+  });
+
+  it("call-site key insertion order cannot change the receipt digest", () => {
+    const forward = baseReceipt({ inputs: { a: 1, b: 2 } });
+    const backward = baseReceipt({ inputs: JSON.parse('{"b":2,"a":1}') });
+    expect(digestOf(backward)).toBe(digestOf(forward));
+  });
+
+  it("an incomplete fixed point REFUSES rather than omitting a member", () => {
+    const cases: Array<[string, Partial<ReceiptInput>, string]> = [
+      ["unknown rail", { rail: "graphql" }, "unmapped_rail"],
+      ["missing subject", { subjectSlug: "" }, "missing_subject"],
+      ["missing manifest digest", { manifestDigest: null }, "unresolvable_manifest"],
+      ["missing deploy identity", { deployCommit: null }, "missing_deploy_identity"],
+      ["solution without steps", { subjectKind: "solution", steps: null }, "unresolvable_manifest"],
+      ["capability WITH steps", { steps: [] }, "internal_error"],
+      ["failed without an error", { status: "failed", result: null, error: null }, "internal_error"],
+    ];
+    for (const [label, patch, reason] of cases) {
+      const r = buildExecutionReceipt(baseReceipt(patch), { NODE_ENV: "test" } as NodeJS.ProcessEnv);
+      expect(r.outcome, `${label} should refuse`).toBe("failed");
+      if (r.outcome === "failed") expect(r.reason, label).toBe(reason);
+    }
+  });
+
+  it("production refuses a receipt without a full 40-hex deploy commit", () => {
+    const prod = { NODE_ENV: "production" } as NodeJS.ProcessEnv;
+    for (const bad of [null, LOCAL_BUILD_SENTINEL, "ce5e63f09186", "ce5e63f091863f56764829b498525211cd2ab23Z"]) {
+      const r = buildExecutionReceipt(baseReceipt({ deployCommit: bad }), prod);
+      expect(r.outcome).toBe("failed");
+      if (r.outcome === "failed") expect(r.reason).toBe("missing_deploy_identity");
+    }
+    expect(buildExecutionReceipt(baseReceipt(), prod).outcome).toBe("complete");
+  });
+
+  it("the digest is the full 256 bits, over the exact canonical bytes", () => {
+    const r = buildExecutionReceipt(baseReceipt(), { NODE_ENV: "test" } as NodeJS.ProcessEnv);
+    expect(r.outcome).toBe("complete");
+    if (r.outcome !== "complete") return;
+
+    expect(r.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    // Recomputed the way an independent verifier would, from the published rule.
+    const independent = createHash("sha256")
+      .update(
+        Buffer.concat([
+          Buffer.from("strale.execution.v1", "utf8"),
+          Buffer.from([0x00]),
+          r.canonicalBytes,
+        ]),
+      )
+      .digest("hex");
+    expect(r.digest).toBe(`sha256:${independent}`);
+  });
+
+  // ── C. Lifecycle ─────────────────────────────────────────────────────────
+
+  it("a successful execution whose receipt FAILED is not recorded as complete", async () => {
+    const id = await newTransaction();
+    await markReceiptPending(db, id);
+    const { status } = await markReceiptFailed(db, id, "unmapped_rail");
+    expect(status).toBe("failed");
+
+    const rows = await db.execute(sql`
+      SELECT status, receipt_status, receipt_failure_reason, receipt_digest
+        FROM transactions WHERE id = ${id}::uuid
+    `);
+    const row = (rows as unknown as Array<Record<string, unknown>>)[0];
+    // The business execution still succeeded and is still billable.
+    expect(row.status).toBe("completed");
+    // The receipt state says otherwise, visibly.
+    expect(row.receipt_status).toBe("failed");
+    expect(row.receipt_failure_reason).toBe("unmapped_rail");
+    expect(row.receipt_digest).toBeNull();
+  });
+
+  it("the database refuses a 'complete' receipt with no digest", async () => {
+    const id = await newTransaction();
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_status = 'complete' WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/transactions_receipt_complete_is_complete/);
+  });
+
+  it("the database refuses a pending/failed row with no reason", async () => {
+    const id = await newTransaction();
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_status = 'failed' WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/transactions_receipt_reason_required/);
+  });
+
+  it("the database refuses a truncated receipt digest", async () => {
+    const id = await newTransaction();
+    await expect(
+      db.execute(sql`
+        UPDATE transactions
+           SET receipt_status = 'complete', receipt_digest = 'sha256:abc',
+               receipt_version = 'strale.execution.v1', receipt_canonicalization = 'RFC8785',
+               receipt_digest_alg = 'sha256'
+         WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/transactions_receipt_digest_shape/);
+  });
+
+  it("a retryable reason stays pending and is picked up; a terminal one does not", async () => {
+    const retryable = await newTransaction();
+    await markReceiptPending(db, retryable);
+    const r1 = await markReceiptFailed(db, retryable, "snapshot_write_failed");
+    expect(r1.status).toBe("pending");
+    expect(r1.attempts).toBe(1);
+
+    const terminal = await newTransaction();
+    await markReceiptPending(db, terminal);
+    const t1 = await markReceiptFailed(db, terminal, "unresolvable_manifest");
+    expect(t1.status).toBe("failed");
+
+    const pending = await selectPendingReceipts(db, 100);
+    const ids = pending.map((p) => p.id);
+    expect(ids).toContain(retryable);
+    expect(ids).not.toContain(terminal);
+  });
+
+  it("a retryable reason becomes failed once the attempt budget is spent", async () => {
+    const id = await newTransaction();
+    await markReceiptPending(db, id);
+    let last = { status: "pending" as string, attempts: 0 };
+    for (let i = 0; i < 5; i++) last = await markReceiptFailed(db, id, "snapshot_write_failed");
+    expect(last.status).toBe("failed");
+    expect(last.attempts).toBe(5);
+    // Exhaustion is visible, not a stall.
+    expect((await selectPendingReceipts(db, 100)).map((p) => p.id)).not.toContain(id);
+  });
+
+  it("monitoring can see pending and failed receipts by reason", async () => {
+    const a = await newTransaction();
+    const b = await newTransaction();
+    await markReceiptPending(db, a);
+    await markReceiptFailed(db, a, "snapshot_write_failed");
+    await markReceiptPending(db, b);
+    await markReceiptFailed(db, b, "unmapped_rail");
+
+    const counts = await receiptHealthCounts(db);
+    expect(counts.some((c) => c.status === "pending" && c.reason === "snapshot_write_failed")).toBe(true);
+    expect(counts.some((c) => c.status === "failed" && c.reason === "unmapped_rail")).toBe(true);
+  });
+
+  it("a complete receipt records everything needed to recompute it", async () => {
+    const id = await newTransaction();
+    const built = buildExecutionReceipt(baseReceipt({ transactionId: id }), {
+      NODE_ENV: "test",
+    } as NodeJS.ProcessEnv);
+    expect(built.outcome).toBe("complete");
+    if (built.outcome !== "complete") return;
+    await markReceiptComplete(db, id, built);
+
+    const rows = await db.execute(sql`
+      SELECT receipt_status, receipt_version, receipt_canonicalization, receipt_digest_alg,
+             receipt_digest, receipt_manifest_digest, integrity_payload_version
+        FROM transactions WHERE id = ${id}::uuid
+    `);
+    const row = (rows as unknown as Array<Record<string, unknown>>)[0];
+    expect(row.receipt_status).toBe("complete");
+    expect(row.receipt_version).toBe("strale.execution.v1");
+    expect(row.receipt_canonicalization).toBe("RFC8785");
+    expect(row.receipt_digest_alg).toBe("sha256");
+    expect(row.receipt_digest).toBe(built.digest);
+    expect(Number(row.integrity_payload_version)).toBe(2);
+  });
+
+  // ── F. Epoch ─────────────────────────────────────────────────────────────
+
+  it("a pre-epoch row reads as legacy_unavailable, and post-epoch cannot masquerade as it", async () => {
+    const legacy = await newTransaction(); // no receipt columns written
+    const rows = await db.execute(sql`
+      SELECT receipt_status, receipt_failure_reason, receipt_digest, integrity_payload_version
+        FROM transactions WHERE id = ${legacy}::uuid
+    `);
+    const row = (rows as unknown as Array<Record<string, unknown>>)[0];
+    expect(row.receipt_status).toBeNull();
+    expect(row.integrity_payload_version).toBeNull();
+
+    const described = describeReceiptState({
+      receiptStatus: row.receipt_status as string | null,
+      receiptFailureReason: row.receipt_failure_reason as string | null,
+      receiptDigest: row.receipt_digest as string | null,
+    });
+    expect(described.status).toBe("legacy_unavailable");
+
+    // A v2 row cannot leave receipt_status null and read as legacy.
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET integrity_payload_version = 2 WHERE id = ${legacy}::uuid
+      `),
+    ).rejects.toThrow(/transactions_chain_v2_has_receipt_state/);
+  });
+
+  it("no historical row was given a receipt", async () => {
+    // The epoch rule, checked against the table rather than asserted: this
+    // suite's own rows are the only ones carrying receipt state.
+    const rows = await db.execute(sql`
+      SELECT count(*)::int AS n FROM transactions
+       WHERE receipt_status IS NOT NULL AND user_id <> ${userId}::uuid
+    `);
+    expect(Number((rows as unknown as Array<{ n: number }>)[0].n)).toBe(0);
+  });
+
+  // ── E. Chain v2 ──────────────────────────────────────────────────────────
+
+  const chainRecord: IntegrityHashRecord = {
+    id: "8f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f",
+    userId: "u1",
+    status: "completed",
+    input: { a: 1 },
+    output: { b: 2 },
+    error: null,
+    priceCents: 5,
+    latencyMs: 120,
+    provenance: { source: "VIES" },
+    auditTrail: { capability: "vat-validate" },
+    transparencyMarker: "algorithmic",
+    dataJurisdiction: "EU",
+    createdAt: "2026-08-23T09:00:00.000Z",
+    completedAt: "2026-08-23T09:00:01.000Z",
+  };
+
+  it("a v1 row hashes exactly as it did before v2 existed", () => {
+    // The frozen expectation: v1 must not move, or 883,296 production rows
+    // become apparently corrupt.
+    const v1 = computeIntegrityHashVersioned(chainRecord, "prev", CHAIN_PAYLOAD_V1);
+    const expected = createHash("sha256")
+      .update(
+        JSON.stringify({
+          id: chainRecord.id,
+          userId: chainRecord.userId,
+          status: chainRecord.status,
+          input: chainRecord.input,
+          output: chainRecord.output,
+          error: chainRecord.error,
+          priceCents: chainRecord.priceCents,
+          latencyMs: chainRecord.latencyMs,
+          provenance: chainRecord.provenance,
+          auditTrail: chainRecord.auditTrail,
+          transparencyMarker: chainRecord.transparencyMarker,
+          dataJurisdiction: chainRecord.dataJurisdiction,
+          createdAt: "2026-08-23T09:00:00.000Z",
+          completedAt: "2026-08-23T09:00:01.000Z",
+          previousHash: "prev",
+        }),
+      )
+      .digest("hex");
+    expect(v1).toBe(expected);
+  });
+
+  it("a receipt digest present on a v1 row does NOT change its hash", () => {
+    // v1 must be blind to the new member, or historical rows would shift.
+    expect(
+      computeIntegrityHashVersioned(
+        { ...chainRecord, receiptDigest: `sha256:${"f".repeat(64)}` },
+        "prev",
+        CHAIN_PAYLOAD_V1,
+      ),
+    ).toBe(computeIntegrityHashVersioned(chainRecord, "prev", CHAIN_PAYLOAD_V1));
+  });
+
+  it("v2 anchors the receipt digest — swapping it invalidates the chain hash", () => {
+    const withA = computeIntegrityHashVersioned(
+      { ...chainRecord, receiptDigest: `sha256:${"a".repeat(64)}` },
+      "prev",
+      CHAIN_PAYLOAD_V2,
+    );
+    const withB = computeIntegrityHashVersioned(
+      { ...chainRecord, receiptDigest: `sha256:${"b".repeat(64)}` },
+      "prev",
+      CHAIN_PAYLOAD_V2,
+    );
+    expect(withB).not.toBe(withA);
+    // And v2 differs from v1 for the same record — the versions are distinct rules.
+    expect(withA).not.toBe(computeIntegrityHashVersioned(chainRecord, "prev", CHAIN_PAYLOAD_V1));
+  });
+
+  it("a v2 row with no receipt still hashes deterministically, with the key present", () => {
+    const a = computeIntegrityHashVersioned({ ...chainRecord, receiptDigest: null }, "p", CHAIN_PAYLOAD_V2);
+    const b = computeIntegrityHashVersioned(chainRecord, "p", CHAIN_PAYLOAD_V2);
+    // Omitting the field and passing null must be the same — the key is always written.
+    expect(a).toBe(b);
+  });
+
+  it("the verifier selects the rule from the stored version", () => {
+    expect(chainVersionOf(null)).toBe(CHAIN_PAYLOAD_V1);
+    expect(chainVersionOf(undefined)).toBe(CHAIN_PAYLOAD_V1);
+    expect(chainVersionOf(2)).toBe(CHAIN_PAYLOAD_V2);
+  });
+
+  it("linkage crosses the epoch unchanged, so the chain stays continuous", () => {
+    // A v2 row's previous_hash points at a v1 hash exactly like any other link.
+    const v1Hash = computeIntegrityHashVersioned(chainRecord, "genesis", CHAIN_PAYLOAD_V1);
+    const v2Hash = computeIntegrityHashVersioned(
+      { ...chainRecord, id: "next", receiptDigest: `sha256:${"c".repeat(64)}` },
+      v1Hash,
+      CHAIN_PAYLOAD_V2,
+    );
+    expect(v2Hash).toMatch(/^[0-9a-f]{64}$/);
+    // Recomputing the v1 link under v1 still reproduces it.
+    expect(computeIntegrityHashVersioned(chainRecord, "genesis", CHAIN_PAYLOAD_V1)).toBe(v1Hash);
+  });
+});

--- a/apps/api/src/lib/receipt/execution-receipt.integration.test.ts
+++ b/apps/api/src/lib/receipt/execution-receipt.integration.test.ts
@@ -266,8 +266,8 @@ describeMaybe("execution receipts against a real database", () => {
   // ── Solutions ────────────────────────────────────────────────────────────
 
   it("solution identity binds ordered step identities, so swapping a step moves the digest", async () => {
-    const stepA = { step_order: 1, slug: "vat-validate", manifest_digest: `sha256:${"1".repeat(64)}` };
-    const stepB = { step_order: 2, slug: "sanctions-check", manifest_digest: `sha256:${"2".repeat(64)}` };
+    const stepA = { step_order: 1, slug: "vat-validate", disposition: "ran" as const, manifest_digest: `sha256:${"1".repeat(64)}` };
+    const stepB = { step_order: 2, slug: "sanctions-check", disposition: "ran" as const, manifest_digest: `sha256:${"2".repeat(64)}` };
 
     const base = declarationDigest(
       normalizeSolutionDeclaration({ slug: "kyb-essentials-se", steps: [stepA, stepB] }),
@@ -299,13 +299,13 @@ describeMaybe("execution receipts against a real database", () => {
     const withSkip = normalizeSolutionDeclaration({
       slug: "kyb-essentials-se",
       steps: [
-        { step_order: 1, slug: "vat-validate", manifest_digest: `sha256:${"1".repeat(64)}` },
-        { step_order: 2, slug: "sanctions-check", manifest_digest: null },
+        { step_order: 1, slug: "vat-validate", disposition: "ran" as const, manifest_digest: `sha256:${"1".repeat(64)}` },
+        { step_order: 2, slug: "sanctions-check", disposition: "skipped" as const, manifest_digest: null },
       ],
     });
     const omitted = normalizeSolutionDeclaration({
       slug: "kyb-essentials-se",
-      steps: [{ step_order: 1, slug: "vat-validate", manifest_digest: `sha256:${"1".repeat(64)}` }],
+      steps: [{ step_order: 1, slug: "vat-validate", disposition: "ran" as const, manifest_digest: `sha256:${"1".repeat(64)}` }],
     });
     // Omitting the step would let two different executions share a shape.
     expect(declarationDigest(withSkip)).not.toBe(declarationDigest(omitted));
@@ -364,8 +364,8 @@ describeMaybe("execution receipts against a real database", () => {
   });
 
   it("changing solution step order or identity changes the receipt digest", () => {
-    const s1 = { step_order: 1, slug: "a", manifest_digest: `sha256:${"1".repeat(64)}` };
-    const s2 = { step_order: 2, slug: "b", manifest_digest: `sha256:${"2".repeat(64)}` };
+    const s1 = { step_order: 1, slug: "a", disposition: "ran" as const, manifest_digest: `sha256:${"1".repeat(64)}` };
+    const s2 = { step_order: 2, slug: "b", disposition: "ran" as const, manifest_digest: `sha256:${"2".repeat(64)}` };
     const sol = baseReceipt({ subjectKind: "solution", subjectSlug: "kyb-essentials-se", steps: [s1, s2] });
     const base = digestOf(sol);
 
@@ -391,8 +391,8 @@ describeMaybe("execution receipts against a real database", () => {
     //
     // Here step_order is IDENTICAL and only the array order differs. Sorted,
     // the two are the same computation and must agree. Unsorted, they do not.
-    const s1 = { step_order: 1, slug: "a", manifest_digest: `sha256:${"1".repeat(64)}` };
-    const s2 = { step_order: 2, slug: "b", manifest_digest: `sha256:${"2".repeat(64)}` };
+    const s1 = { step_order: 1, slug: "a", disposition: "ran" as const, manifest_digest: `sha256:${"1".repeat(64)}` };
+    const s2 = { step_order: 2, slug: "b", disposition: "ran" as const, manifest_digest: `sha256:${"2".repeat(64)}` };
 
     const inOrder = digestOf(
       baseReceipt({ subjectKind: "solution", subjectSlug: "kyb", steps: [s1, s2] }),
@@ -476,7 +476,7 @@ describeMaybe("execution receipts against a real database", () => {
     expect(row.receipt_digest).toBeNull();
   });
 
-  it("a receipt that later FAILS has its success metadata cleared, not left stale", async () => {
+  it("a COMPLETE receipt cannot be withdrawn — complete is absorbing", async () => {
     // The previous test asserts receipt_digest is null after a failure — but
     // that row never had a digest, so it was null either way. The mutation
     // battery caught it. This one sets a real complete receipt FIRST, so the
@@ -486,6 +486,7 @@ describeMaybe("execution receipts against a real database", () => {
       NODE_ENV: "test",
     } as NodeJS.ProcessEnv);
     if (built.outcome !== "complete") throw new Error("fixture must build");
+    await markReceiptPending(db, id);
     await markReceiptComplete(db, id, built);
 
     const before = await db.execute(
@@ -495,7 +496,10 @@ describeMaybe("execution receipts against a real database", () => {
       built.digest,
     );
 
-    await markReceiptFailed(db, id, "unresolvable_manifest");
+    // complete is absorbing now, so a late failure is REFUSED rather than
+    // clearing the digest. That is the stronger guarantee: an anchored receipt
+    // cannot be withdrawn.
+    await expect(markReceiptFailed(db, id, "unresolvable_manifest")).rejects.toThrow();
 
     const after = await db.execute(sql`
       SELECT receipt_status, receipt_digest, receipt_version, receipt_canonicalization,
@@ -503,13 +507,8 @@ describeMaybe("execution receipts against a real database", () => {
         FROM transactions WHERE id = ${id}::uuid
     `);
     const row = (after as unknown as Array<Record<string, unknown>>)[0];
-    expect(row.receipt_status).toBe("failed");
-    // A stale digest on a failed row would be a commitment to a receipt that
-    // was withdrawn — worse than no digest at all.
-    expect(row.receipt_digest).toBeNull();
-    expect(row.receipt_version).toBeNull();
-    expect(row.receipt_canonicalization).toBeNull();
-    expect(row.receipt_digest_alg).toBeNull();
+    expect(row.receipt_status).toBe("complete");
+    expect(row.receipt_digest).toBe(built.digest);
   });
 
   it("the database refuses a 'complete' receipt with no digest", async () => {
@@ -592,6 +591,7 @@ describeMaybe("execution receipts against a real database", () => {
     } as NodeJS.ProcessEnv);
     expect(built.outcome).toBe("complete");
     if (built.outcome !== "complete") return;
+    await markReceiptPending(db, id);
     await markReceiptComplete(db, id, built);
 
     const rows = await db.execute(sql`
@@ -605,7 +605,12 @@ describeMaybe("execution receipts against a real database", () => {
     expect(row.receipt_canonicalization).toBe("RFC8785");
     expect(row.receipt_digest_alg).toBe("sha256");
     expect(row.receipt_digest).toBe(built.digest);
-    expect(Number(row.integrity_payload_version)).toBe(2);
+
+    // The lifecycle must NOT set the chain version. That column records which
+    // rule produced the integrity hash, so only the site that computes the hash
+    // may write it — writing it here produced rows hashed under v1 while
+    // declaring v2, which is the defect this round fixes.
+    expect(row.integrity_payload_version).toBeNull();
   });
 
   // ── F. Epoch ─────────────────────────────────────────────────────────────

--- a/apps/api/src/lib/receipt/execution-receipt.integration.test.ts
+++ b/apps/api/src/lib/receipt/execution-receipt.integration.test.ts
@@ -384,6 +384,25 @@ describeMaybe("execution receipts against a real database", () => {
     ).not.toBe(base);
   });
 
+  it("the same steps in a different ARRAY order produce the SAME digest", () => {
+    // This is what isolates the sort. The reordering test above changes
+    // step_order values, so the digest moves whether or not the builder sorts
+    // — it passed for the wrong reason and the mutation battery caught it.
+    //
+    // Here step_order is IDENTICAL and only the array order differs. Sorted,
+    // the two are the same computation and must agree. Unsorted, they do not.
+    const s1 = { step_order: 1, slug: "a", manifest_digest: `sha256:${"1".repeat(64)}` };
+    const s2 = { step_order: 2, slug: "b", manifest_digest: `sha256:${"2".repeat(64)}` };
+
+    const inOrder = digestOf(
+      baseReceipt({ subjectKind: "solution", subjectSlug: "kyb", steps: [s1, s2] }),
+    );
+    const shuffled = digestOf(
+      baseReceipt({ subjectKind: "solution", subjectSlug: "kyb", steps: [s2, s1] }),
+    );
+    expect(shuffled).toBe(inOrder);
+  });
+
   it("call-site key insertion order cannot change the receipt digest", () => {
     const forward = baseReceipt({ inputs: { a: 1, b: 2 } });
     const backward = baseReceipt({ inputs: JSON.parse('{"b":2,"a":1}') });
@@ -455,6 +474,42 @@ describeMaybe("execution receipts against a real database", () => {
     expect(row.receipt_status).toBe("failed");
     expect(row.receipt_failure_reason).toBe("unmapped_rail");
     expect(row.receipt_digest).toBeNull();
+  });
+
+  it("a receipt that later FAILS has its success metadata cleared, not left stale", async () => {
+    // The previous test asserts receipt_digest is null after a failure — but
+    // that row never had a digest, so it was null either way. The mutation
+    // battery caught it. This one sets a real complete receipt FIRST, so the
+    // clearing has something to clear.
+    const id = await newTransaction();
+    const built = buildExecutionReceipt(baseReceipt({ transactionId: id }), {
+      NODE_ENV: "test",
+    } as NodeJS.ProcessEnv);
+    if (built.outcome !== "complete") throw new Error("fixture must build");
+    await markReceiptComplete(db, id, built);
+
+    const before = await db.execute(
+      sql`SELECT receipt_digest FROM transactions WHERE id = ${id}::uuid`,
+    );
+    expect((before as unknown as Array<Record<string, unknown>>)[0].receipt_digest).toBe(
+      built.digest,
+    );
+
+    await markReceiptFailed(db, id, "unresolvable_manifest");
+
+    const after = await db.execute(sql`
+      SELECT receipt_status, receipt_digest, receipt_version, receipt_canonicalization,
+             receipt_digest_alg
+        FROM transactions WHERE id = ${id}::uuid
+    `);
+    const row = (after as unknown as Array<Record<string, unknown>>)[0];
+    expect(row.receipt_status).toBe("failed");
+    // A stale digest on a failed row would be a commitment to a receipt that
+    // was withdrawn — worse than no digest at all.
+    expect(row.receipt_digest).toBeNull();
+    expect(row.receipt_version).toBeNull();
+    expect(row.receipt_canonicalization).toBeNull();
+    expect(row.receipt_digest_alg).toBeNull();
   });
 
   it("the database refuses a 'complete' receipt with no digest", async () => {

--- a/apps/api/src/lib/receipt/execution-receipt.ts
+++ b/apps/api/src/lib/receipt/execution-receipt.ts
@@ -29,7 +29,11 @@
 
 import { canonicalBytes } from "../canonical/jcs.js";
 import { DOMAIN_TAGS, domainDigest } from "../canonical/domain-digest.js";
-import type { SolutionStepIdentity } from "./manifest-snapshot.js";
+import {
+  assertWellFormedSteps,
+  ManifestSnapshotError,
+  type SolutionStepIdentity,
+} from "./manifest-snapshot.js";
 
 export const RECEIPT_VERSION = "strale.execution.v1";
 export const RECEIPT_CANONICALIZATION = "RFC8785";
@@ -214,6 +218,25 @@ export function buildExecutionReceipt(
     };
   }
 
+  // The step rules live in the snapshot authority, and the FIRST fix applied
+  // them only there — so the receipt, which is the artifact the customer holds
+  // and the thing the chain anchors, still accepted duplicate step_order,
+  // negative and fractional orders, and an empty step list, and still dropped
+  // `disposition` from the hashed payload. Reviewer-found: the snapshot is a
+  // side table; the receipt is the claim.
+  if (input.steps !== null) {
+    try {
+      assertWellFormedSteps(input.subjectSlug, input.steps);
+    } catch (err) {
+      return {
+        outcome: "failed",
+        reason: "unresolvable_manifest",
+        detail:
+          err instanceof ManifestSnapshotError ? err.message : String(err),
+      };
+    }
+  }
+
   if (input.status === "failed" && input.error === null) {
     return {
       outcome: "failed",
@@ -249,6 +272,10 @@ export function buildExecutionReceipt(
               .map((s) => ({
                 step_order: s.step_order,
                 slug: s.slug,
+                // Without this, `skipped` and `unresolved` produce an IDENTICAL
+                // receipt digest — the spec's "the absence recorded" left
+                // unimplemented in the one place it is read.
+                disposition: s.disposition,
                 manifest_digest: s.manifest_digest,
               })),
     },

--- a/apps/api/src/lib/receipt/execution-receipt.ts
+++ b/apps/api/src/lib/receipt/execution-receipt.ts
@@ -1,0 +1,296 @@
+/**
+ * The execution receipt authority (Phase 4 §B).
+ *
+ * **Exactly one place builds a `strale.execution.v1` payload.** No rail
+ * constructs its own receipt object, and no call site chooses which members it
+ * fills in — that is the closed-schema rule from Phase 2 §1, and it is enforced
+ * here by requiring every fixed-point member as a named argument rather than
+ * reading whatever a caller happened to pass.
+ *
+ * The pattern this avoids is the one Phase 1 found already present:
+ * `buildFullAudit` takes `outputSchema?` and `provenance?` as optional, so the
+ * audit body — which is inside the integrity hash — differs depending on what
+ * the call site remembered. A receipt built that way would mean different
+ * things on different rails while carrying the same version string.
+ *
+ * ## What this produces
+ *
+ * The canonical bytes, the full 256-bit digest, and the metadata a verifier
+ * needs to recompute it offline. Nothing is truncated and nothing is optional.
+ *
+ * ## What it refuses
+ *
+ * An unknown rail, a missing production deploy identity, an unresolved
+ * manifest digest, and a missing subject are **invariant failures**, not
+ * absences (Phase 2 §9.2). Each returns a `failed` outcome carrying a closed
+ * reason code, so the caller records *why* rather than leaving a null nobody
+ * can interpret.
+ */
+
+import { canonicalBytes } from "../canonical/jcs.js";
+import { DOMAIN_TAGS, domainDigest } from "../canonical/domain-digest.js";
+import type { SolutionStepIdentity } from "./manifest-snapshot.js";
+
+export const RECEIPT_VERSION = "strale.execution.v1";
+export const RECEIPT_CANONICALIZATION = "RFC8785";
+export const RECEIPT_DIGEST_ALG = "sha256";
+
+/**
+ * Semantic rail identity — which interface the caller used.
+ *
+ * Closed, Strale-owned, and never derived from HTTP noise (no `User-Agent`,
+ * no `Referer`). An unmapped caller is a refusal, not an "other" bucket: a
+ * receipt asserting the wrong rail is worse than no receipt, and a permissive
+ * fallback is how the wrong rail gets asserted.
+ */
+export const RAILS = ["v1_do", "x402", "mcp", "a2a", "internal"] as const;
+export type Rail = (typeof RAILS)[number];
+
+export function isRail(value: unknown): value is Rail {
+  return typeof value === "string" && (RAILS as readonly string[]).includes(value);
+}
+
+/** Execution method — an execution fact, not a compliance interpretation. */
+export const EXECUTION_METHODS = ["algorithmic", "ai_generated", "mixed"] as const;
+export type ExecutionMethod = (typeof EXECUTION_METHODS)[number];
+
+/**
+ * Source observation (Phase 2 §6).
+ *
+ * A tagged union rather than a scalar timestamp, because a live registry
+ * lookup, a versioned corpus and a pure computation have genuinely different
+ * vintage semantics — forcing them into one field fabricates a timestamp for
+ * two of the three.
+ *
+ * `none_declared` is deliberately distinguishable from `computed`: the first
+ * says we do not know, the second positively asserts there was no external
+ * source. Collapsing them would put a false vintage into a commitment.
+ */
+export type SourceObservation =
+  | { kind: "live_fetch"; observed_at: string }
+  | { kind: "dataset"; dataset_version: string; observed_at: string | null }
+  | { kind: "computed" }
+  | { kind: "none_declared" };
+
+/** Closed reason codes for a receipt that is not `complete`. */
+export const RECEIPT_FAILURE_REASONS = [
+  "unmapped_rail",
+  "missing_deploy_identity",
+  "unresolvable_manifest",
+  "missing_subject",
+  "snapshot_write_failed",
+  "canonicalization_error",
+  "internal_error",
+] as const;
+export type ReceiptFailureReason = (typeof RECEIPT_FAILURE_REASONS)[number];
+
+/**
+ * Everything the builder needs. Every member is REQUIRED — including the ones
+ * that are frequently null — so a call site cannot omit a hashed field by
+ * forgetting it. `null` is passed explicitly and means something.
+ */
+export interface ReceiptInput {
+  transactionId: string;
+  subjectKind: "capability" | "solution";
+  subjectSlug: string;
+  /** Full 40-hex commit, or the literal `unknown-local-build` outside production. */
+  deployCommit: string | null;
+  /** `sha256:<64 hex>` from the manifest snapshot authority. */
+  manifestDigest: string | null;
+  /** Ordered step identities for a solution; `null` for a capability. */
+  steps: SolutionStepIdentity[] | null;
+  rail: string;
+  /** The validated inputs the executor was invoked with, not the raw HTTP body. */
+  inputs: unknown;
+  status: "completed" | "failed";
+  /** The result AS THE CALLER RECEIVED IT, or null when status is failed. */
+  result: unknown;
+  /** The sanitised, caller-visible error, or null on success. */
+  error: { code: string; message: string } | null;
+  method: ExecutionMethod;
+  sourceObservation: SourceObservation;
+}
+
+export interface ReceiptSuccess {
+  outcome: "complete";
+  /** The exact RFC 8785 bytes the digest was taken over. */
+  canonicalBytes: Buffer;
+  payload: Record<string, unknown>;
+  digest: string;
+  version: string;
+  canonicalization: string;
+  digestAlg: string;
+  manifestDigest: string;
+}
+
+export interface ReceiptRefusal {
+  outcome: "failed";
+  reason: ReceiptFailureReason;
+  detail: string;
+}
+
+export type ReceiptResult = ReceiptSuccess | ReceiptRefusal;
+
+/**
+ * Is this a production process that must know its own commit?
+ *
+ * Kept next to the refusal it drives so the two cannot drift.
+ */
+export function requiresDeployIdentity(env = process.env): boolean {
+  return env.NODE_ENV === "production";
+}
+
+/** The literal recorded outside production. Never mistakable for a real SHA. */
+export const LOCAL_BUILD_SENTINEL = "unknown-local-build";
+
+function isFullCommitSha(value: string): boolean {
+  return /^[0-9a-f]{40}$/.test(value);
+}
+
+/**
+ * Build the receipt. Pure: no database, no clock, no environment reads beyond
+ * the explicit `env` seam, so the same input always produces the same digest.
+ */
+export function buildExecutionReceipt(
+  input: ReceiptInput,
+  env = process.env,
+): ReceiptResult {
+  // ── Invariant failures, checked before anything is hashed ────────────────
+
+  if (!input.subjectSlug || typeof input.subjectSlug !== "string") {
+    return { outcome: "failed", reason: "missing_subject", detail: "subject slug is empty" };
+  }
+
+  if (!isRail(input.rail)) {
+    return {
+      outcome: "failed",
+      reason: "unmapped_rail",
+      detail: `rail ${JSON.stringify(input.rail)} is not one of ${RAILS.join(", ")}`,
+    };
+  }
+
+  const deployCommit = input.deployCommit;
+  if (requiresDeployIdentity(env)) {
+    if (!deployCommit || !isFullCommitSha(deployCommit)) {
+      return {
+        outcome: "failed",
+        reason: "missing_deploy_identity",
+        detail:
+          "production receipts require a full 40-hex deploy commit; " +
+          `got ${JSON.stringify(deployCommit)}`,
+      };
+    }
+  } else if (!deployCommit) {
+    return {
+      outcome: "failed",
+      reason: "missing_deploy_identity",
+      detail: `deploy identity must be a commit or the literal ${LOCAL_BUILD_SENTINEL}`,
+    };
+  }
+
+  if (!input.manifestDigest) {
+    return {
+      outcome: "failed",
+      reason: "unresolvable_manifest",
+      detail: "no manifest snapshot digest was resolved for this execution",
+    };
+  }
+
+  // A solution's step identities are part of its identity; a capability must
+  // not carry them. Both directions are refusals, because either would make
+  // two different executions share a receipt shape.
+  if (input.subjectKind === "solution" && input.steps === null) {
+    return {
+      outcome: "failed",
+      reason: "unresolvable_manifest",
+      detail: "a solution receipt requires its ordered step identities",
+    };
+  }
+  if (input.subjectKind === "capability" && input.steps !== null) {
+    return {
+      outcome: "failed",
+      reason: "internal_error",
+      detail: "a capability receipt must not carry solution step identities",
+    };
+  }
+
+  if (input.status === "failed" && input.error === null) {
+    return {
+      outcome: "failed",
+      reason: "internal_error",
+      detail: "a failed execution must bind the caller-visible error",
+    };
+  }
+  if (input.status === "completed" && input.error !== null) {
+    return {
+      outcome: "failed",
+      reason: "internal_error",
+      detail: "a completed execution must not carry an error",
+    };
+  }
+
+  // ── The fixed point. Every member always present. ────────────────────────
+
+  const payload: Record<string, unknown> = {
+    version: RECEIPT_VERSION,
+    transaction_id: input.transactionId,
+    subject: {
+      kind: input.subjectKind,
+      slug: input.subjectSlug,
+    },
+    implementation: {
+      deploy_commit: deployCommit,
+      manifest_digest: input.manifestDigest,
+      steps:
+        input.steps === null
+          ? null
+          : [...input.steps]
+              .sort((a, b) => a.step_order - b.step_order)
+              .map((s) => ({
+                step_order: s.step_order,
+                slug: s.slug,
+                manifest_digest: s.manifest_digest,
+              })),
+    },
+    request: {
+      rail: input.rail,
+      inputs: input.inputs ?? null,
+    },
+    response: {
+      status: input.status,
+      result: input.status === "failed" ? null : (input.result ?? null),
+      error: input.error,
+    },
+    execution: {
+      method: input.method,
+      source_observation: input.sourceObservation,
+    },
+  };
+
+  let bytes: Buffer;
+  let digest: string;
+  try {
+    bytes = canonicalBytes(payload);
+    digest = domainDigest(DOMAIN_TAGS.executionReceipt, payload);
+  } catch (err) {
+    // Customer inputs and results are arbitrary JSON. A value the canonicalizer
+    // refuses — a lone surrogate, nesting past the bound — is a receipt that
+    // cannot be built, not a receipt that may be built without it.
+    return {
+      outcome: "failed",
+      reason: "canonicalization_error",
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  return {
+    outcome: "complete",
+    canonicalBytes: bytes,
+    payload,
+    digest,
+    version: RECEIPT_VERSION,
+    canonicalization: RECEIPT_CANONICALIZATION,
+    digestAlg: RECEIPT_DIGEST_ALG,
+    manifestDigest: input.manifestDigest,
+  };
+}

--- a/apps/api/src/lib/receipt/manifest-snapshot.ts
+++ b/apps/api/src/lib/receipt/manifest-snapshot.ts
@@ -80,16 +80,29 @@ export interface CapabilityDeclarationSource {
   gdprArt22Classification: string | null;
 }
 
+/**
+ * What happened to a step.
+ *
+ * A null `manifest_digest` used to mean BOTH "a gate skipped it" and "we could
+ * not read its declaration" — two materially different facts producing an
+ * identical digest, so a receipt had two readings. PHASE-2-SPEC §5 requires the
+ * absence to be *recorded*, not merely implied. Reviewer-found.
+ */
+export const STEP_DISPOSITIONS = ["ran", "skipped", "unresolved"] as const;
+export type StepDisposition = (typeof STEP_DISPOSITIONS)[number];
+
 /** One step of a solution, in execution order. */
 export interface SolutionStepIdentity {
+  /** 1-based, strictly increasing across the array. Enforced, not assumed. */
   step_order: number;
   slug: string;
   /**
-   * The step's own snapshot digest, or null when the step did not resolve —
-   * a gate skipped it, or its capability could not be read. Null is a DEFINED
-   * representation: omitting the step entirely would let two different
-   * executions share a receipt shape.
+   * `ran` — executed, and `manifest_digest` is its declaration.
+   * `skipped` — a gate short-circuited it; it never ran, deliberately.
+   * `unresolved` — it should have run but its declaration could not be read.
    */
+  disposition: StepDisposition;
+  /** The step's declaration digest. Non-null exactly when disposition is `ran`. */
   manifest_digest: string | null;
 }
 
@@ -135,6 +148,7 @@ export function normalizeCapabilityDeclaration(
 export function normalizeSolutionDeclaration(
   source: SolutionDeclarationSource,
 ): Record<string, unknown> {
+  assertWellFormedSteps(source.slug, source.steps);
   return {
     subject_kind: "solution",
     slug: source.slug,
@@ -143,9 +157,70 @@ export function normalizeSolutionDeclaration(
       .map((step) => ({
         step_order: step.step_order,
         slug: step.slug,
+        disposition: step.disposition,
         manifest_digest: step.manifest_digest,
       })),
   };
+}
+
+/**
+ * A solution's step list must have exactly one reading.
+ *
+ * `Array.prototype.sort` is stable, so with duplicate `step_order` values the
+ * CALLER'S array order silently becomes load-bearing: `[{1,x},{1,y}]` and
+ * `[{1,y},{1,x}]` declare the same ordering and produce different digests.
+ * Reviewer-found, along with `-3`, `0` and `2.5` all being accepted as orders,
+ * and an empty step list being accepted for a solution.
+ *
+ * Strictly increasing positive integers is the only shape with one reading.
+ */
+export function assertWellFormedSteps(
+  solutionSlug: string,
+  steps: readonly SolutionStepIdentity[],
+): void {
+  if (steps.length === 0) {
+    throw new ManifestSnapshotError(
+      "unresolvable_manifest",
+      `solution ${solutionSlug} has no steps; a solution is its steps`,
+    );
+  }
+
+  const orders = steps.map((s) => s.step_order);
+  for (const o of orders) {
+    if (!Number.isInteger(o) || o < 1) {
+      throw new ManifestSnapshotError(
+        "unresolvable_manifest",
+        `solution ${solutionSlug} has step_order ${o}; must be a positive integer`,
+      );
+    }
+  }
+  const sorted = [...orders].sort((a, b) => a - b);
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] === sorted[i - 1]) {
+      throw new ManifestSnapshotError(
+        "unresolvable_manifest",
+        `solution ${solutionSlug} repeats step_order ${sorted[i]}; ordering would be ` +
+          "decided by array position, which is not part of the declared identity",
+      );
+    }
+  }
+
+  for (const step of steps) {
+    const wantsDigest = step.disposition === "ran";
+    if (wantsDigest && !step.manifest_digest) {
+      throw new ManifestSnapshotError(
+        "unresolvable_manifest",
+        `solution ${solutionSlug} step ${step.slug} ran but carries no manifest digest`,
+      );
+    }
+    if (!wantsDigest && step.manifest_digest) {
+      throw new ManifestSnapshotError(
+        "unresolvable_manifest",
+        `solution ${solutionSlug} step ${step.slug} is ${step.disposition} but carries ` +
+          "a manifest digest; only a step that ran has one",
+      );
+    }
+  }
 }
 
 /** The digest of a normalized declaration. Pure — no database. */
@@ -198,12 +273,30 @@ export async function recordManifestSnapshot(
   }
 
   try {
-    await db.execute(sql`
+    const inserted = await db.execute(sql`
       INSERT INTO execution_manifest_snapshots (digest, subject_kind, subject_slug, snapshot)
       VALUES (${digest}, ${kind}, ${slug}, ${JSON.stringify(normalized)}::jsonb)
       ON CONFLICT (digest) DO NOTHING
+      RETURNING digest
     `);
+
+    // ON CONFLICT DO NOTHING is silent by design, which is what makes dedup
+    // work — and what would also silently discard a DIFFERENT snapshot that
+    // happened to arrive under the same digest. That should be impossible
+    // (the digest is a function of the content) but "should be impossible" is
+    // exactly what a content-addressed table has to check rather than assume.
+    if ((inserted as unknown as Array<unknown>).length === 0) {
+      const stored = await readManifestSnapshot(db, digest); // recomputes
+      if (stored === null || canonicalize(stored) !== canonicalize(normalized)) {
+        throw new ManifestSnapshotError(
+          "snapshot_write_failed",
+          `digest ${digest} already stores different content; refusing to report ` +
+            "success for a snapshot that was not written",
+        );
+      }
+    }
   } catch (err) {
+    if (err instanceof ManifestSnapshotError) throw err;
     throw new ManifestSnapshotError(
       "snapshot_write_failed",
       err instanceof Error ? err.message : String(err),
@@ -225,5 +318,25 @@ export async function readManifestSnapshot(
     SELECT snapshot FROM execution_manifest_snapshots WHERE digest = ${digest}
   `);
   const row = (rows as unknown as Array<{ snapshot: Record<string, unknown> }>)[0];
-  return row?.snapshot ?? null;
+  if (!row) return null;
+
+  // RECOMPUTE BEFORE TRUSTING.
+  //
+  // "Content-addressed" was an assertion, not an enforcement: a direct INSERT
+  // bypassing this module could pair digest A with snapshot B, and it was
+  // accepted. The reviewer did exactly that. The digest-to-content relation
+  // cannot be a database CHECK — Postgres has no RFC 8785 — so the one reader a
+  // verifier depends on is where it has to be checked.
+  //
+  // A mismatch is not a data-quality nit. It means the table's addressing is
+  // broken, and every receipt naming this digest is unverifiable.
+  const actual = declarationDigest(row.snapshot);
+  if (actual !== digest) {
+    throw new ManifestSnapshotError(
+      "unresolvable_manifest",
+      `snapshot stored under ${digest} actually hashes to ${actual}; the table is ` +
+        "mis-addressed and every receipt naming this digest is unverifiable",
+    );
+  }
+  return row.snapshot;
 }

--- a/apps/api/src/lib/receipt/manifest-snapshot.ts
+++ b/apps/api/src/lib/receipt/manifest-snapshot.ts
@@ -1,0 +1,229 @@
+/**
+ * The manifest snapshot authority (Phase 4 §A).
+ *
+ * One place decides what "the declaration in force at execution time" means,
+ * and one place writes it down.
+ *
+ * ## Why a snapshot at all
+ *
+ * The executor reads `capabilities`, a MUTABLE row that four scripts write to.
+ * Deriving implementation identity from it later would prove what the
+ * declaration says *today*, not what it said when the call ran. A receipt
+ * assembled that way asserts something nobody measured — which is exactly the
+ * failure Phase 2 decision 2 names.
+ *
+ * So the declaration is normalized and stored, content-addressed, at execution
+ * time. The digest is the identity; the row is the content; neither can move
+ * (migration 0106 refuses UPDATE and DELETE at the database).
+ *
+ * ## What goes in, and the rule behind it
+ *
+ * **If changing the field changes what a correct execution would produce, or
+ * how its result must be interpreted, it is IN. If it changes only how the
+ * capability is sold, listed, or measured, it is OUT.**
+ *
+ * That rule is the whole of the judgement. Applying it:
+ *
+ *  IN  — slug, input/output schema, transparency tag, data source,
+ *        capability type, freshness category, output field reliability,
+ *        personal-data classification, GDPR Art. 22 classification.
+ *  OUT — is_active, x402_enabled, visible, lifecycle_state (routing and
+ *        eligibility, not declaration; they change constantly without changing
+ *        what runs), price_cents (commercial — already bound by the chain, and
+ *        binding it here would force disclosing terms to verify a result),
+ *        avg_latency_ms and quality scores (observational, not declared),
+ *        limitations and descriptions (disclosure prose; changing a sentence
+ *        must not invalidate a result's identity).
+ *
+ * One naming note, because the spec and the database disagree: the manifest
+ * field is `data_source_type`, but the column actually in force is
+ * `capability_type` — the value the executor's behaviour depends on. The
+ * snapshot records the column, under its own name, so what is hashed is what
+ * was true rather than what the YAML said.
+ */
+
+import { sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+
+import { canonicalize } from "../canonical/jcs.js";
+import { DOMAIN_TAGS, domainDigest } from "../canonical/domain-digest.js";
+
+export type SubjectKind = "capability" | "solution";
+
+/** Thrown when a snapshot cannot be built or stored. Never swallowed. */
+export class ManifestSnapshotError extends Error {
+  readonly reason: "unresolvable_manifest" | "snapshot_write_failed";
+  constructor(reason: ManifestSnapshotError["reason"], detail: string) {
+    super(`${reason}: ${detail}`);
+    this.name = "ManifestSnapshotError";
+    this.reason = reason;
+  }
+}
+
+/**
+ * The capability columns that constitute the declaration.
+ *
+ * Listed explicitly rather than spread from the row, so adding a column to
+ * `capabilities` cannot silently change every future digest.
+ */
+export interface CapabilityDeclarationSource {
+  slug: string;
+  inputSchema: unknown;
+  outputSchema: unknown;
+  transparencyTag: string | null;
+  dataSource: string | null;
+  capabilityType: string | null;
+  freshnessCategory: string | null;
+  outputFieldReliability: unknown;
+  processesPersonalData: boolean;
+  personalDataCategories: string[] | null;
+  gdprArt22Classification: string | null;
+}
+
+/** One step of a solution, in execution order. */
+export interface SolutionStepIdentity {
+  step_order: number;
+  slug: string;
+  /**
+   * The step's own snapshot digest, or null when the step did not resolve —
+   * a gate skipped it, or its capability could not be read. Null is a DEFINED
+   * representation: omitting the step entirely would let two different
+   * executions share a receipt shape.
+   */
+  manifest_digest: string | null;
+}
+
+export interface SolutionDeclarationSource {
+  slug: string;
+  steps: SolutionStepIdentity[];
+}
+
+/**
+ * The normalized capability declaration. Key order is irrelevant — RFC 8785
+ * sorts — but the SET is fixed, and every member is always present.
+ */
+export function normalizeCapabilityDeclaration(
+  source: CapabilityDeclarationSource,
+): Record<string, unknown> {
+  return {
+    subject_kind: "capability",
+    slug: source.slug,
+    input_schema: source.inputSchema ?? null,
+    output_schema: source.outputSchema ?? null,
+    transparency_tag: source.transparencyTag ?? null,
+    data_source: source.dataSource ?? null,
+    capability_type: source.capabilityType ?? null,
+    freshness_category: source.freshnessCategory ?? null,
+    output_field_reliability: source.outputFieldReliability ?? null,
+    processes_personal_data: source.processesPersonalData,
+    personal_data_categories: [...(source.personalDataCategories ?? [])].sort(),
+    gdpr_art_22_classification: source.gdprArt22Classification ?? null,
+  };
+}
+
+/**
+ * The normalized solution declaration.
+ *
+ * Binds the recipe AND every ingredient: the ordered step list with each
+ * step's own manifest digest. Without the per-step digests, swapping a
+ * constituent capability's implementation would change what ran while leaving
+ * the solution receipt identical — the under-specification Phase 2 §5 names.
+ *
+ * Order is part of the identity: the same steps in a different order are a
+ * different computation.
+ */
+export function normalizeSolutionDeclaration(
+  source: SolutionDeclarationSource,
+): Record<string, unknown> {
+  return {
+    subject_kind: "solution",
+    slug: source.slug,
+    steps: [...source.steps]
+      .sort((a, b) => a.step_order - b.step_order)
+      .map((step) => ({
+        step_order: step.step_order,
+        slug: step.slug,
+        manifest_digest: step.manifest_digest,
+      })),
+  };
+}
+
+/** The digest of a normalized declaration. Pure — no database. */
+export function declarationDigest(normalized: Record<string, unknown>): string {
+  return domainDigest(DOMAIN_TAGS.manifestSnapshot, normalized);
+}
+
+/** The exact bytes the digest was taken over, for out-of-band recomputation. */
+export function declarationCanonicalBytes(normalized: Record<string, unknown>): string {
+  return canonicalize(normalized);
+}
+
+/**
+ * Store a normalized declaration, returning its digest.
+ *
+ * Deduplicates by digest: identical declarations converge on one row, so the
+ * table grows only when a declaration actually changes. `ON CONFLICT DO
+ * NOTHING` is the whole dedup mechanism — the digest being the primary key is
+ * what makes it correct rather than merely convenient.
+ *
+ * Failure is an `unresolvable_manifest`/`snapshot_write_failed` refusal, never
+ * a silently-absent digest: a receipt without implementation identity is not a
+ * receipt.
+ */
+export async function recordManifestSnapshot(
+  db: PostgresJsDatabase<Record<string, never>> | PostgresJsDatabase<any>,
+  normalized: Record<string, unknown>,
+): Promise<string> {
+  const kind = normalized.subject_kind;
+  const slug = normalized.slug;
+  if (kind !== "capability" && kind !== "solution") {
+    throw new ManifestSnapshotError(
+      "unresolvable_manifest",
+      `subject_kind must be 'capability' or 'solution', got ${JSON.stringify(kind)}`,
+    );
+  }
+  if (typeof slug !== "string" || slug.length === 0) {
+    throw new ManifestSnapshotError("unresolvable_manifest", "slug is missing or empty");
+  }
+
+  let digest: string;
+  try {
+    digest = declarationDigest(normalized);
+  } catch (err) {
+    // A declaration that cannot be canonicalized cannot be committed to.
+    throw new ManifestSnapshotError(
+      "unresolvable_manifest",
+      `declaration is not canonicalizable: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  try {
+    await db.execute(sql`
+      INSERT INTO execution_manifest_snapshots (digest, subject_kind, subject_slug, snapshot)
+      VALUES (${digest}, ${kind}, ${slug}, ${JSON.stringify(normalized)}::jsonb)
+      ON CONFLICT (digest) DO NOTHING
+    `);
+  } catch (err) {
+    throw new ManifestSnapshotError(
+      "snapshot_write_failed",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  return digest;
+}
+
+/**
+ * Read a snapshot back. This is what makes a receipt independently
+ * recomputable years later — without it, `manifest_digest` is an opaque string.
+ */
+export async function readManifestSnapshot(
+  db: PostgresJsDatabase<Record<string, never>> | PostgresJsDatabase<any>,
+  digest: string,
+): Promise<Record<string, unknown> | null> {
+  const rows = await db.execute(sql`
+    SELECT snapshot FROM execution_manifest_snapshots WHERE digest = ${digest}
+  `);
+  const row = (rows as unknown as Array<{ snapshot: Record<string, unknown> }>)[0];
+  return row?.snapshot ?? null;
+}

--- a/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
@@ -1,0 +1,224 @@
+/**
+ * The junction between the receipt lifecycle and the integrity chain.
+ *
+ * Both halves were tested and their JUNCTION was not, and that gap hid the
+ * worst defect of the review: adding `integrity_payload_version` to the
+ * transition trigger's frozen-column list collided with the chain worker
+ * writing exactly that column. The worker's UPDATE fell through to the terminal
+ * check — which tested `OLD.receipt_status IN ('complete','failed')` rather than
+ * whether the status was *changing* — and was refused.
+ *
+ * The whole tick runs in one transaction, so the RAISE aborted it, every later
+ * statement failed, the per-row catch swallowed them, and the tick rolled back.
+ * **One receipt-bearing row would have halted the tamper-evident chain for
+ * every transaction in the system, permanently**, retrying every 30 seconds,
+ * with `/v1/verify` answering "no integrity hash" and `/v1/audit` answering
+ * "still being computed" forever.
+ *
+ * The full repo suite was green while all of that was true.
+ *
+ * This file drives the real worker over real rows. It is deliberately not
+ * merged into either neighbouring suite: the point is that neither of them
+ * could have caught this, and a test that lives in one of them would suggest
+ * otherwise.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { sql } from "drizzle-orm";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../../test-support/integration-db.js";
+import { buildExecutionReceipt } from "./execution-receipt.js";
+import { markReceiptComplete, markReceiptFailed, markReceiptPending } from "./receipt-lifecycle.js";
+import {
+  computeIntegrityHashVersioned,
+  chainVersionOf,
+  GENESIS_HASH,
+  CHAIN_PAYLOAD_V2,
+} from "../integrity-hash.js";
+import { runMigration0108_receiptStateInvariants } from "../startup-migrations.js";
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+describeMaybe("receipt lifecycle × integrity chain", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let runOnce: () => Promise<void>;
+  const txns = new Set<string>();
+  let userId = "";
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 4 });
+    db = drizzle(client);
+    await runMigration0108_receiptStateInvariants(db as never);
+
+    // Imported after the env is pointed at the test database, because the
+    // worker resolves its connection through getDb() at call time.
+    ({ runIntegrityHashRetryOnce: runOnce } = await import("../../jobs/integrity-hash-retry.js"));
+
+    userId = randomUUID();
+    await db.execute(sql`
+      INSERT INTO users (id, email, api_key_hash, key_prefix)
+      VALUES (${userId}::uuid, ${`jx-${userId}@test.local`}, ${randomUUID()}, 'sk_test_')
+    `);
+  });
+
+  afterAll(async () => {
+    for (const id of txns) await db.execute(sql`DELETE FROM transactions WHERE id = ${id}::uuid`);
+    await db.execute(sql`DELETE FROM users WHERE id = ${userId}::uuid`);
+    await client.end();
+  });
+
+  afterEach(async () => {
+    for (const id of txns) await db.execute(sql`DELETE FROM transactions WHERE id = ${id}::uuid`);
+    txns.clear();
+  });
+
+  /** Old enough to clear the worker's grace window. */
+  async function agedTransaction(): Promise<string> {
+    const id = randomUUID();
+    txns.add(id);
+    await db.execute(sql`
+      INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
+                                data_jurisdiction, input, created_at, completed_at)
+      VALUES (${id}::uuid, ${userId}::uuid, 'completed', 5, 'algorithmic', 'EU', '{}'::jsonb,
+              now() - interval '2 minutes', now() - interval '2 minutes')
+    `);
+    return id;
+  }
+
+  async function row(id: string) {
+    const rows = await db.execute(sql`SELECT * FROM transactions WHERE id = ${id}::uuid`);
+    return (rows as unknown as Array<Record<string, unknown>>)[0];
+  }
+
+  async function completeReceipt(id: string): Promise<string> {
+    const built = buildExecutionReceipt(
+      {
+        transactionId: id, subjectKind: "capability", subjectSlug: "vat-validate",
+        deployCommit: "c".repeat(40), manifestDigest: `sha256:${"a".repeat(64)}`,
+        steps: null, rail: "v1_do", inputs: { vat: "SE1" }, status: "completed",
+        result: { valid: true }, error: null, method: "algorithmic",
+        sourceObservation: { kind: "computed" },
+      },
+      { NODE_ENV: "test" } as NodeJS.ProcessEnv,
+    );
+    if (built.outcome !== "complete") throw new Error(`fixture: ${built.reason}`);
+    await markReceiptPending(db, id);
+    await markReceiptComplete(db, id, built);
+    return built.digest;
+  }
+
+  it("THE JUNCTION: a receipt-complete row is chained as v2 and verifies under its own rule", async () => {
+    const id = await agedTransaction();
+    const digest = await completeReceipt(id);
+
+    await runOnce();
+
+    const r = await row(id);
+    // The row was chained at all — this is what the collision prevented.
+    expect(r.integrity_hash, "the worker did not chain the row").not.toBeNull();
+    expect(Number(r.integrity_payload_version)).toBe(CHAIN_PAYLOAD_V2);
+    expect(r.compliance_hash_state).toBe("complete");
+
+    // And it verifies under the rule it declares.
+    const recomputed = computeIntegrityHashVersioned(
+      {
+        id: r.id as string, userId: r.user_id as string, status: r.status as string,
+        input: r.input, output: r.output, error: r.error as string | null,
+        priceCents: r.price_cents as number, latencyMs: r.latency_ms as number | null,
+        provenance: r.provenance, auditTrail: r.audit_trail,
+        transparencyMarker: r.transparency_marker as string,
+        dataJurisdiction: r.data_jurisdiction as string,
+        createdAt: r.created_at as Date, completedAt: r.completed_at as Date,
+        receiptDigest: r.receipt_digest as string | null,
+      },
+      (r.previous_hash as string) ?? GENESIS_HASH,
+      chainVersionOf(r.integrity_payload_version as number | null),
+    );
+    expect(recomputed).toBe(r.integrity_hash);
+    expect(r.receipt_digest).toBe(digest);
+  });
+
+  it("ONE receipt-bearing row does not stop the rest of the batch being chained", async () => {
+    // The blast radius. The tick is one transaction, so a RAISE on any row
+    // aborted every other row's write too — including plain v1 rows with no
+    // receipt at all.
+    const withReceipt = await agedTransaction();
+    await completeReceipt(withReceipt);
+    const plainV1 = await agedTransaction();
+
+    await runOnce();
+
+    const a = await row(withReceipt);
+    const b = await row(plainV1);
+    expect(a.integrity_hash, "receipt row not chained").not.toBeNull();
+    expect(b.integrity_hash, "innocent neighbour not chained").not.toBeNull();
+    expect(b.integrity_payload_version, "a row with no receipt is v1").toBeNull();
+  });
+
+  it("a receipt-FAILED row is chained as v2 with a null digest", async () => {
+    const id = await agedTransaction();
+    await markReceiptPending(db, id);
+    await markReceiptFailed(db, id, "unmapped_rail");
+
+    await runOnce();
+
+    const r = await row(id);
+    expect(r.integrity_hash).not.toBeNull();
+    expect(Number(r.integrity_payload_version)).toBe(CHAIN_PAYLOAD_V2);
+    // The chain commits to "at chain time this row had no recomputable
+    // receipt" — permanently true, because failed never recovers.
+    expect(r.receipt_digest).toBeNull();
+  });
+
+  it("a receipt-PENDING row is not chained, and does not block the batch", async () => {
+    const pending = await agedTransaction();
+    await markReceiptPending(db, pending);
+    const neighbour = await agedTransaction();
+
+    await runOnce();
+
+    expect((await row(pending)).integrity_hash, "pending must not be chained").toBeNull();
+    expect((await row(neighbour)).integrity_hash, "neighbour must still chain").not.toBeNull();
+  });
+
+  it("a pending row chains once its receipt settles, on a later tick", async () => {
+    const id = await agedTransaction();
+    await markReceiptPending(db, id);
+    await runOnce();
+    expect((await row(id)).integrity_hash).toBeNull();
+
+    const built = buildExecutionReceipt(
+      {
+        transactionId: id, subjectKind: "capability", subjectSlug: "vat-validate",
+        deployCommit: "c".repeat(40), manifestDigest: `sha256:${"a".repeat(64)}`,
+        steps: null, rail: "v1_do", inputs: {}, status: "completed",
+        result: {}, error: null, method: "algorithmic",
+        sourceObservation: { kind: "computed" },
+      },
+      { NODE_ENV: "test" } as NodeJS.ProcessEnv,
+    );
+    if (built.outcome !== "complete") throw new Error("fixture");
+    await markReceiptComplete(db, id, built);
+
+    await runOnce();
+    const r = await row(id);
+    expect(r.integrity_hash).not.toBeNull();
+    expect(Number(r.integrity_payload_version)).toBe(CHAIN_PAYLOAD_V2);
+  });
+
+  it("the worker chains a row exactly once", async () => {
+    const id = await agedTransaction();
+    await completeReceipt(id);
+    await runOnce();
+    const first = await row(id);
+    await runOnce();
+    const second = await row(id);
+    expect(second.integrity_hash).toBe(first.integrity_hash);
+    expect(second.chain_seq).toBe(first.chain_seq);
+  });
+});

--- a/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
@@ -211,6 +211,42 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
     expect(Number(r.integrity_payload_version)).toBe(CHAIN_PAYLOAD_V2);
   });
 
+  it("a receipt-blocked row is COUNTED, not silently excluded forever", async () => {
+    // The failure mode this closes is silence. A pending-receipt row is never
+    // SELECTED by the admission predicate, so the stale-row warning — which
+    // counts only selected rows — cannot see it. With the retry sweeper
+    // deferred to the rail PR, such a row would sit outside the chain forever
+    // with nothing saying so.
+    const id = randomUUID();
+    txns.add(id);
+    await db.execute(sql`
+      INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
+                                data_jurisdiction, input, created_at, completed_at)
+      VALUES (${id}::uuid, ${userId}::uuid, 'completed', 5, 'algorithmic', 'EU', '{}'::jsonb,
+              now() - interval '20 minutes', now() - interval '20 minutes')
+    `);
+    await markReceiptPending(db, id);
+
+    const warnings: string[] = [];
+    const { log } = await import("../log.js");
+    const original = log.warn.bind(log);
+    (log as unknown as { warn: typeof log.warn }).warn = ((obj: unknown, msg?: string) => {
+      const label = (obj as { label?: string })?.label;
+      if (label) warnings.push(label);
+      return original(obj as never, msg as never);
+    }) as typeof log.warn;
+
+    try {
+      await runOnce();
+    } finally {
+      (log as unknown as { warn: typeof log.warn }).warn = original;
+    }
+
+    expect(warnings).toContain("integrity-hash-receipt-blocked");
+    // And it is still, correctly, not chained.
+    expect((await row(id)).integrity_hash).toBeNull();
+  });
+
   it("the worker chains a row exactly once", async () => {
     const id = await agedTransaction();
     await completeReceipt(id);

--- a/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
@@ -439,6 +439,25 @@ describeMaybe("Phase 4 invariants cannot be bypassed", () => {
     ).rejects.toThrow(/subject_matches_content/);
   });
 
+  it("each subject key is checked independently", async () => {
+    // The first version of this test used a snapshot missing BOTH keys, so
+    // either half of the CHECK caught it and neither half was load-bearing —
+    // a mutation removing one stayed green. One key present, one absent.
+    for (const [label, body] of [
+      ["slug present, kind absent", '{"slug":"vat-validate"}'],
+      ["kind present, slug absent", '{"subject_kind":"capability"}'],
+    ] as const) {
+      await expect(
+        db.execute(sql`
+          INSERT INTO execution_manifest_snapshots (digest, subject_kind, subject_slug, snapshot)
+          VALUES (${`sha256:${Math.random().toString(16).slice(2).padEnd(64, "0").slice(0, 64)}`},
+                  'capability', 'vat-validate', ${body}::jsonb)
+        `),
+        label,
+      ).rejects.toThrow(/subject_matches_content/);
+    }
+  });
+
   it("a correctly addressed snapshot still round-trips", async () => {
     const decl = normalizeCapabilityDeclaration(DECL);
     const digest = await recordManifestSnapshot(db, decl);

--- a/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
@@ -1,0 +1,380 @@
+/**
+ * The invariants Phase 4's first cut called structural and enforced nowhere.
+ *
+ * An adversarial review drove 25 attacks at that tree and **every one
+ * succeeded**. Each test here is one of those attacks, now refused. They are
+ * separated from the main suite deliberately: that suite proves the design
+ * works, this one proves the design cannot be bypassed, and the two fail for
+ * different reasons.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { sql } from "drizzle-orm";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../../test-support/integration-db.js";
+import {
+  normalizeCapabilityDeclaration,
+  normalizeSolutionDeclaration,
+  recordManifestSnapshot,
+  readManifestSnapshot,
+  declarationDigest,
+  ManifestSnapshotError,
+  type CapabilityDeclarationSource,
+  type SolutionStepIdentity,
+} from "./manifest-snapshot.js";
+import { buildExecutionReceipt } from "./execution-receipt.js";
+import {
+  markReceiptComplete,
+  markReceiptFailed,
+  markReceiptPending,
+  ReceiptLifecycleError,
+} from "./receipt-lifecycle.js";
+import {
+  computeIntegrityHashVersioned,
+  chainVersionOf,
+  CHAIN_PAYLOAD_V1,
+  CHAIN_PAYLOAD_V2,
+} from "../integrity-hash.js";
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+const DECL: CapabilityDeclarationSource = {
+  slug: "vat-validate",
+  inputSchema: { type: "object" },
+  outputSchema: { type: "object" },
+  transparencyTag: "algorithmic",
+  dataSource: "VIES",
+  capabilityType: "stable_api",
+  freshnessCategory: "live-fetch",
+  outputFieldReliability: { valid: "guaranteed" },
+  processesPersonalData: false,
+  personalDataCategories: [],
+  gdprArt22Classification: "data_lookup",
+};
+
+const ran = (order: number, slug: string, fill: string): SolutionStepIdentity => ({
+  step_order: order,
+  slug,
+  disposition: "ran",
+  manifest_digest: `sha256:${fill.repeat(64)}`,
+});
+
+describeMaybe("Phase 4 invariants cannot be bypassed", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  const txns = new Set<string>();
+  let userId = "";
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 4 });
+    db = drizzle(client);
+    userId = randomUUID();
+    await db.execute(sql`
+      INSERT INTO users (id, email, api_key_hash, key_prefix)
+      VALUES (${userId}::uuid, ${`inv-${userId}@test.local`}, ${randomUUID()}, 'sk_test_')
+    `);
+  });
+
+  afterAll(async () => {
+    for (const id of txns) await db.execute(sql`DELETE FROM transactions WHERE id = ${id}::uuid`);
+    await db.execute(sql`DELETE FROM users WHERE id = ${userId}::uuid`);
+    await client.end();
+  });
+
+  afterEach(async () => {
+    for (const id of txns) await db.execute(sql`DELETE FROM transactions WHERE id = ${id}::uuid`);
+    txns.clear();
+  });
+
+  async function txn(): Promise<string> {
+    const id = randomUUID();
+    txns.add(id);
+    await db.execute(sql`
+      INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
+                                data_jurisdiction, input, completed_at)
+      VALUES (${id}::uuid, ${userId}::uuid, 'completed', 5, 'algorithmic', 'EU',
+              '{}'::jsonb, now())
+    `);
+    return id;
+  }
+
+  async function completed(id: string): Promise<string> {
+    const built = buildExecutionReceipt(
+      {
+        transactionId: id, subjectKind: "capability", subjectSlug: "vat-validate",
+        deployCommit: "c".repeat(40), manifestDigest: `sha256:${"a".repeat(64)}`,
+        steps: null, rail: "v1_do", inputs: {}, status: "completed",
+        result: { ok: true }, error: null, method: "algorithmic",
+        sourceObservation: { kind: "computed" },
+      },
+      { NODE_ENV: "test" } as NodeJS.ProcessEnv,
+    );
+    if (built.outcome !== "complete") throw new Error("fixture must build");
+    await markReceiptPending(db, id);
+    await markReceiptComplete(db, id, built);
+    return built.digest;
+  }
+
+  // ── B1: chain-version authorship ─────────────────────────────────────────
+
+  it("the lifecycle never writes integrity_payload_version", async () => {
+    // The defect: all three lifecycle writers stamped v2, while the chain
+    // worker hashed under v1. The row declared one rule and was hashed under
+    // another — it verified only because nothing had implemented the
+    // documented rule yet.
+    const id = await txn();
+    await markReceiptPending(db, id);
+    let r = await db.execute(
+      sql`SELECT integrity_payload_version AS v FROM transactions WHERE id = ${id}::uuid`,
+    );
+    expect((r as unknown as Array<{ v: number | null }>)[0].v).toBeNull();
+
+    await completed(id);
+    r = await db.execute(
+      sql`SELECT integrity_payload_version AS v FROM transactions WHERE id = ${id}::uuid`,
+    );
+    expect((r as unknown as Array<{ v: number | null }>)[0].v).toBeNull();
+  });
+
+  it("a row hashed under v1 and declaring v2 is exactly what we now prevent", () => {
+    // The reproduction, kept as a test so the failure mode stays legible.
+    const rec = {
+      id: "x", userId: "u", status: "completed", input: {}, output: {}, error: null,
+      priceCents: 1, latencyMs: 1, provenance: null, auditTrail: null,
+      transparencyMarker: "algorithmic", dataJurisdiction: "EU",
+      createdAt: "2026-08-23T09:00:00.000Z", completedAt: "2026-08-23T09:00:01.000Z",
+      receiptDigest: `sha256:${"a".repeat(64)}`,
+    };
+    const hashedUnderV1 = computeIntegrityHashVersioned(rec, "prev", CHAIN_PAYLOAD_V1);
+    const verifiedAsV2 = computeIntegrityHashVersioned(rec, "prev", CHAIN_PAYLOAD_V2);
+    expect(verifiedAsV2).not.toBe(hashedUnderV1);
+  });
+
+  it("chainVersionOf fails closed on a version it does not know", () => {
+    expect(() => chainVersionOf(3)).toThrow(/unknown integrity_payload_version/);
+    expect(() => chainVersionOf(0)).toThrow();
+    expect(chainVersionOf(null)).toBe(CHAIN_PAYLOAD_V1);
+    expect(chainVersionOf(2)).toBe(CHAIN_PAYLOAD_V2);
+  });
+
+  // ── B3: legal transitions ────────────────────────────────────────────────
+
+  it("complete is absorbing — it cannot go back to pending or on to failed", async () => {
+    const id = await txn();
+    await completed(id);
+
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_status = 'pending', receipt_failure_reason = 'internal_error'
+         WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/terminal/i);
+
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_status = 'failed', receipt_failure_reason = 'internal_error'
+         WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/terminal/i);
+  });
+
+  it("failed is absorbing — a late success cannot resurrect it", async () => {
+    const id = await txn();
+    await markReceiptPending(db, id);
+    await markReceiptFailed(db, id, "unmapped_rail");
+
+    // Through the module: refused, because the guard requires 'pending'.
+    await expect(completed(id)).rejects.toThrow(ReceiptLifecycleError);
+
+    // And bypassing the module: refused by the database.
+    await expect(
+      db.execute(sql`
+        UPDATE transactions
+           SET receipt_status = 'complete', receipt_digest = ${`sha256:${"9".repeat(64)}`},
+               receipt_version = 'strale.execution.v1', receipt_canonicalization = 'RFC8785',
+               receipt_digest_alg = 'sha256'
+         WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/terminal/i);
+  });
+
+  it("a complete row's digest cannot be swapped", async () => {
+    const id = await txn();
+    await completed(id);
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_digest = ${`sha256:${"e".repeat(64)}`}
+         WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/terminal/i);
+  });
+
+  it("receipt metadata cannot be rewritten to something we never produce", async () => {
+    const id = await txn();
+    await markReceiptPending(db, id);
+    // Even on a pending row, garbage metadata is refused by CHECK.
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_version = 'fake.v9' WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/transactions_receipt_metadata_known/);
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_digest_alg = 'md5' WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/transactions_receipt_metadata_known/);
+  });
+
+  it("reason codes are a closed set", async () => {
+    const id = await txn();
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_status = 'failed', receipt_failure_reason = 'banana'
+         WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/transactions_receipt_reason_closed/);
+  });
+
+  it("post-epoch state cannot be cleared back to looking pre-epoch", async () => {
+    const id = await txn();
+    await markReceiptPending(db, id);
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_status = NULL, receipt_failure_reason = NULL
+         WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/pre-epoch/i);
+  });
+
+  it("a lifecycle write against a missing row is an error, not a silent no-op", async () => {
+    await expect(markReceiptPending(db, randomUUID())).rejects.toThrow(ReceiptLifecycleError);
+  });
+
+  it("pending is not a failure, so monitoring is not poisoned at birth", async () => {
+    const id = await txn();
+    await markReceiptPending(db, id);
+    const r = await db.execute(
+      sql`SELECT receipt_failure_reason AS reason FROM transactions WHERE id = ${id}::uuid`,
+    );
+    expect((r as unknown as Array<{ reason: string }>)[0].reason).toBe("not_yet_built");
+  });
+
+  // ── B5: content addressing ───────────────────────────────────────────────
+
+  it("a mis-addressed snapshot is refused on read, not returned", async () => {
+    // The attack: bypass the module and pair a wrong digest with real content.
+    const decl = normalizeCapabilityDeclaration(DECL);
+    const wrong = `sha256:${"1".repeat(64)}`;
+    expect(declarationDigest(decl)).not.toBe(wrong);
+
+    await db.execute(sql`
+      INSERT INTO execution_manifest_snapshots (digest, subject_kind, subject_slug, snapshot)
+      VALUES (${wrong}, 'capability', ${decl.slug as string}, ${JSON.stringify(decl)}::jsonb)
+      ON CONFLICT (digest) DO NOTHING
+    `);
+
+    await expect(readManifestSnapshot(db, wrong)).rejects.toThrow(/mis-addressed/);
+  });
+
+  it("subject columns cannot disagree with the hashed content", async () => {
+    const decl = normalizeCapabilityDeclaration(DECL);
+    await expect(
+      db.execute(sql`
+        INSERT INTO execution_manifest_snapshots (digest, subject_kind, subject_slug, snapshot)
+        VALUES (${`sha256:${"2".repeat(64)}`}, 'solution', 'a-different-slug',
+                ${JSON.stringify(decl)}::jsonb)
+      `),
+    ).rejects.toThrow(/subject_matches_content/);
+  });
+
+  it("a correctly addressed snapshot still round-trips", async () => {
+    const decl = normalizeCapabilityDeclaration(DECL);
+    const digest = await recordManifestSnapshot(db, decl);
+    expect(await readManifestSnapshot(db, digest)).toEqual(decl);
+  });
+
+  // ── B6: one reading per solution receipt ─────────────────────────────────
+
+  it("duplicate step_order is refused, so array position is never load-bearing", () => {
+    expect(() =>
+      normalizeSolutionDeclaration({
+        slug: "kyb",
+        steps: [ran(1, "x", "1"), { ...ran(1, "y", "2") }],
+      }),
+    ).toThrow(ManifestSnapshotError);
+  });
+
+  it("non-positive and non-integer step_order are refused", () => {
+    for (const bad of [-3, 0, 2.5]) {
+      expect(() =>
+        normalizeSolutionDeclaration({ slug: "kyb", steps: [{ ...ran(bad, "x", "1") }] }),
+      ).toThrow(/positive integer/);
+    }
+  });
+
+  it("a solution with no steps is refused", () => {
+    expect(() => normalizeSolutionDeclaration({ slug: "kyb", steps: [] })).toThrow(
+      /a solution is its steps/,
+    );
+  });
+
+  it("skipped and unresolved are DIFFERENT receipts", () => {
+    // The ambiguity: a null digest used to mean both, so the two produced an
+    // identical digest and a receipt had two readings.
+    const skipped = normalizeSolutionDeclaration({
+      slug: "kyb",
+      steps: [ran(1, "a", "1"), { step_order: 2, slug: "b", disposition: "skipped", manifest_digest: null }],
+    });
+    const unresolved = normalizeSolutionDeclaration({
+      slug: "kyb",
+      steps: [ran(1, "a", "1"), { step_order: 2, slug: "b", disposition: "unresolved", manifest_digest: null }],
+    });
+    expect(declarationDigest(unresolved)).not.toBe(declarationDigest(skipped));
+  });
+
+  it("a disposition and its digest must agree", () => {
+    expect(() =>
+      normalizeSolutionDeclaration({
+        slug: "kyb",
+        steps: [{ step_order: 1, slug: "a", disposition: "ran", manifest_digest: null }],
+      }),
+    ).toThrow(/ran but carries no manifest digest/);
+
+    expect(() =>
+      normalizeSolutionDeclaration({
+        slug: "kyb",
+        steps: [{ step_order: 1, slug: "a", disposition: "skipped", manifest_digest: `sha256:${"1".repeat(64)}` }],
+      }),
+    ).toThrow(/only a step that ran has one/);
+  });
+
+  it("the same steps in a different array order still agree, now that order is unique", () => {
+    const a = declarationDigest(
+      normalizeSolutionDeclaration({ slug: "kyb", steps: [ran(1, "a", "1"), ran(2, "b", "2")] }),
+    );
+    const b = declarationDigest(
+      normalizeSolutionDeclaration({ slug: "kyb", steps: [ran(2, "b", "2"), ran(1, "a", "1")] }),
+    );
+    expect(b).toBe(a);
+  });
+
+  // ── N3: permanence ───────────────────────────────────────────────────────
+
+  it("TRUNCATE cannot empty the snapshot table", async () => {
+    await recordManifestSnapshot(db, normalizeCapabilityDeclaration(DECL));
+    // Row-level DELETE triggers do not fire for TRUNCATE; a statement-level
+    // BEFORE TRUNCATE trigger is what closes it.
+    await expect(
+      db.execute(sql`TRUNCATE execution_manifest_snapshots`),
+    ).rejects.toThrow(/cannot be truncated/);
+
+    const rows = await db.execute(
+      sql`SELECT count(*)::int AS n FROM execution_manifest_snapshots`,
+    );
+    expect(Number((rows as unknown as Array<{ n: number }>)[0].n)).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
@@ -38,6 +38,7 @@ import {
   CHAIN_PAYLOAD_V1,
   CHAIN_PAYLOAD_V2,
 } from "../integrity-hash.js";
+import { runMigration0108_receiptStateInvariants } from "../startup-migrations.js";
 
 const DATABASE_URL_TEST = useTestDatabase();
 const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
@@ -72,6 +73,19 @@ describeMaybe("Phase 4 invariants cannot be bypassed", () => {
   beforeAll(async () => {
     client = postgres(DATABASE_URL_TEST!, { max: 4 });
     db = drizzle(client);
+
+    // RE-APPLY THE BLOCK THIS SUITE IS ABOUT.
+    //
+    // Without this, the triggers and constraints under test come from whatever
+    // ran against the database earlier, and the migration SOURCE is not
+    // load-bearing for the suite. Two mutation probes proved it: deleting the
+    // already-chained guard and removing a column from the trigger's comparison
+    // list both left the suite green, because the old trigger was still
+    // installed. The block is idempotent (CREATE OR REPLACE, DROP/ADD
+    // CONSTRAINT), so re-applying it here makes its text the thing being
+    // tested.
+    await runMigration0108_receiptStateInvariants(db as never);
+
     userId = randomUUID();
     await db.execute(sql`
       INSERT INTO users (id, email, api_key_hash, key_prefix)

--- a/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
@@ -338,18 +338,26 @@ describeMaybe("Phase 4 invariants cannot be bypassed", () => {
     ).rejects.toThrow(/terminal/i);
   });
 
-  it("the chain version cannot be flipped on a terminal row", async () => {
+  it("the chain version is WRITE-ONCE, not frozen-on-terminal", async () => {
+    // Semantics that matter: the worker sets this exactly once, in the same
+    // UPDATE as the hash — and it does so on a row whose receipt is ALREADY
+    // terminal, because the admission rule requires that. So "frozen on a
+    // terminal row" would block the only legitimate writer, which is precisely
+    // the defect this round fixed. Write-once is the correct rule.
     const id = await txn();
     await completed(id);
+
+    // First write, from NULL: allowed, even though the receipt is terminal.
     await db.execute(
-      sql`UPDATE transactions SET integrity_payload_version = NULL WHERE id = ${id}::uuid`,
-    ).catch(() => undefined);
-    // Setting it to 2 then clearing it must be refused, not merely detected.
+      sql`UPDATE transactions SET integrity_payload_version = 2 WHERE id = ${id}::uuid`,
+    );
+
+    // Any later change: refused, in both directions.
     await expect(
-      db.execute(sql`
-        UPDATE transactions SET integrity_payload_version = 2 WHERE id = ${id}::uuid
-      `),
-    ).rejects.toThrow(/terminal/i);
+      db.execute(
+        sql`UPDATE transactions SET integrity_payload_version = NULL WHERE id = ${id}::uuid`,
+      ),
+    ).rejects.toThrow(/cannot be rewritten/);
   });
 
   // ── R2-B3: the BUILDER enforces step rules, not only the snapshot ────────

--- a/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
@@ -263,6 +263,127 @@ describeMaybe("Phase 4 invariants cannot be bypassed", () => {
     expect((r as unknown as Array<{ reason: string }>)[0].reason).toBe("not_yet_built");
   });
 
+  // ── R2-B1: the dual of the admission rule ────────────────────────────────
+
+  it("a row already chained cannot acquire receipt state afterwards", async () => {
+    // Barring a row from the chain until its receipt settles is only half the
+    // property. A row chained under v1 — which is EVERY row today — could
+    // receive a complete receipt afterwards and keep its v1 hash, so the digest
+    // was never anchored. It verifies, under a rule that does not cover the
+    // receipt, and "a receipt digest cannot be swapped without invalidating the
+    // chain" is silently false for it.
+    const id = await txn();
+    await db.execute(sql`
+      UPDATE transactions
+         SET integrity_hash = ${"9".repeat(64)}, previous_hash = ${"8".repeat(64)},
+             compliance_hash_state = 'complete'
+       WHERE id = ${id}::uuid
+    `);
+
+    await expect(markReceiptPending(db, id)).rejects.toThrow(ReceiptLifecycleError);
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_status = 'pending', receipt_failure_reason = 'not_yet_built'
+         WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/already chained/);
+  });
+
+  it("an unchained row still accepts receipt state normally", async () => {
+    const id = await txn();
+    await markReceiptPending(db, id);
+    const r = await db.execute(
+      sql`SELECT receipt_status AS s FROM transactions WHERE id = ${id}::uuid`,
+    );
+    expect((r as unknown as Array<{ s: string }>)[0].s).toBe("pending");
+  });
+
+  // ── R2-B1 continued: every receipt-shaped column is compared ─────────────
+
+  it("receipt_manifest_digest cannot be swapped on a complete row", async () => {
+    // It is how a verifier finds the snapshot to recompute the implementation
+    // identity, and it is NOT inside the chain payload — so a swap was neither
+    // refused here nor detectable there.
+    const id = await txn();
+    await completed(id);
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_manifest_digest = ${`sha256:${"c".repeat(64)}`}
+         WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/terminal/i);
+  });
+
+  it("a failure reason cannot be stamped onto a complete row", async () => {
+    const id = await txn();
+    await completed(id);
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET receipt_failure_reason = 'unmapped_rail' WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/terminal/i);
+  });
+
+  it("the chain version cannot be flipped on a terminal row", async () => {
+    const id = await txn();
+    await completed(id);
+    await db.execute(
+      sql`UPDATE transactions SET integrity_payload_version = NULL WHERE id = ${id}::uuid`,
+    ).catch(() => undefined);
+    // Setting it to 2 then clearing it must be refused, not merely detected.
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET integrity_payload_version = 2 WHERE id = ${id}::uuid
+      `),
+    ).rejects.toThrow(/terminal/i);
+  });
+
+  // ── R2-B3: the BUILDER enforces step rules, not only the snapshot ────────
+
+  it("the receipt builder refuses malformed steps, not just the normalizer", () => {
+    const bad: Array<[string, SolutionStepIdentity[]]> = [
+      ["duplicate order", [ran(1, "a", "1"), { ...ran(1, "b", "2") }]],
+      ["zero order", [{ ...ran(0, "a", "1") }]],
+      ["negative order", [{ ...ran(-3, "a", "1") }]],
+      ["fractional order", [{ ...ran(2.5, "a", "1") }]],
+      ["empty", []],
+    ];
+    for (const [label, steps] of bad) {
+      const r = buildExecutionReceipt(
+        {
+          transactionId: "t", subjectKind: "solution", subjectSlug: "kyb",
+          deployCommit: "c".repeat(40), manifestDigest: `sha256:${"a".repeat(64)}`,
+          steps, rail: "v1_do", inputs: {}, status: "completed",
+          result: {}, error: null, method: "algorithmic",
+          sourceObservation: { kind: "computed" },
+        },
+        { NODE_ENV: "test" } as NodeJS.ProcessEnv,
+      );
+      expect(r.outcome, `${label} should refuse`).toBe("failed");
+      if (r.outcome === "failed") expect(r.reason).toBe("unresolvable_manifest");
+    }
+  });
+
+  it("skipped and unresolved produce DIFFERENT receipt digests", () => {
+    // The snapshot distinguished them; the receipt did not, and the receipt is
+    // the artifact the customer holds and the chain anchors.
+    function digestFor(disposition: "skipped" | "unresolved"): string {
+      const r = buildExecutionReceipt(
+        {
+          transactionId: "t", subjectKind: "solution", subjectSlug: "kyb",
+          deployCommit: "c".repeat(40), manifestDigest: `sha256:${"a".repeat(64)}`,
+          steps: [ran(1, "a", "1"), { step_order: 2, slug: "b", disposition, manifest_digest: null }],
+          rail: "v1_do", inputs: {}, status: "completed", result: {}, error: null,
+          method: "algorithmic", sourceObservation: { kind: "computed" },
+        },
+        { NODE_ENV: "test" } as NodeJS.ProcessEnv,
+      );
+      if (r.outcome !== "complete") throw new Error(`expected complete, got ${r.reason}`);
+      return r.digest;
+    }
+    expect(digestFor("unresolved")).not.toBe(digestFor("skipped"));
+  });
+
   // ── B5: content addressing ───────────────────────────────────────────────
 
   it("a mis-addressed snapshot is refused on read, not returned", async () => {
@@ -287,6 +408,19 @@ describeMaybe("Phase 4 invariants cannot be bypassed", () => {
         INSERT INTO execution_manifest_snapshots (digest, subject_kind, subject_slug, snapshot)
         VALUES (${`sha256:${"2".repeat(64)}`}, 'solution', 'a-different-slug',
                 ${JSON.stringify(decl)}::jsonb)
+      `),
+    ).rejects.toThrow(/subject_matches_content/);
+  });
+
+  it("a snapshot with no subject keys at all is refused", async () => {
+    // `col = snapshot->>'k'` is NULL when the key is absent, and a CHECK passes
+    // on NULL — so this was accepted under any slug until the key-presence
+    // tests were added.
+    await expect(
+      db.execute(sql`
+        INSERT INTO execution_manifest_snapshots (digest, subject_kind, subject_slug, snapshot)
+        VALUES (${`sha256:${"7".repeat(64)}`}, 'capability', 'anything-i-like',
+                '{"no_subject_keys":1}'::jsonb)
       `),
     ).rejects.toThrow(/subject_matches_content/);
   });

--- a/apps/api/src/lib/receipt/receipt-lifecycle.ts
+++ b/apps/api/src/lib/receipt/receipt-lifecycle.ts
@@ -11,19 +11,39 @@
  *   failed    construction was attempted and could not honestly complete;
  *             `receipt_failure_reason` says why
  *
+ * `complete` and `failed` are **absorbing**. Nothing leaves them. That is not a
+ * stylistic choice: the integrity chain anchors a row's receipt digest, so once
+ * a row is chained, changing its receipt state would rewrite an already-chained
+ * historical fact. Enforced by a database trigger (migration 0108), not here —
+ * a rule that only holds when one module is used is not a rule.
+ *
  * `legacy_unavailable` is **pre-epoch only** and is not a status at all — it is
- * what a NULL `receipt_status` means when read. Using it post-epoch would
- * disguise a present-day defect as a policy about history, which is the exact
- * confusion the lifecycle exists to prevent.
+ * what a NULL `receipt_status` means when read.
+ *
+ * ## Who owns `integrity_payload_version` — and it is NOT this module
+ *
+ * All three functions here used to write `integrity_payload_version = 2`. That
+ * was the worst defect in Phase 4's first cut.
+ *
+ * The column records **which rule produced the integrity hash**, so only the
+ * site that computes the hash may write it. Writing it here stamped v2 on a row
+ * the chain worker then hashed under v1 — a row declaring one rule and hashed
+ * under another. Nothing read the column yet, so rows still verified; the
+ * corruption was scheduled to materialise the instant anyone implemented the
+ * rule the design documents. Reproduced before removal: stored hash
+ * `d9a0d728eb…`, recomputed under the row's own declared rule `78c8ebaa7e…`,
+ * verifies false.
+ *
+ * `jobs/integrity-hash-retry.ts` now writes the version in the same UPDATE as
+ * the hash — the discipline that file already applies to `chain_seq`: a row
+ * cannot be hashed without recording which rule hashed it.
  *
  * ## The invariant that matters most
  *
  * **A successful business execution must never be recorded as receipt-complete
  * when receipt creation failed.** The transaction still commits — a customer's
  * call succeeded and they are billed for it — but the receipt state says
- * `failed` with a reason, visibly. The database enforces this too: the
- * `transactions_receipt_complete_is_complete` CHECK refuses a 'complete' row
- * without a digest, so the two cannot drift even if this module is bypassed.
+ * `failed` with a reason, visibly.
  */
 
 import { sql } from "drizzle-orm";
@@ -41,8 +61,23 @@ type Db = PostgresJsDatabase<Record<string, never>> | PostgresJsDatabase<any>;
 
 export type ReceiptStatus = "complete" | "pending" | "failed";
 
+/** Receipt states from which the integrity chain may hash a row. */
+export const TERMINAL_RECEIPT_STATUSES: ReadonlySet<string> = new Set(["complete", "failed"]);
+
 /**
- * Reasons that are worth another attempt, and reasons that are not.
+ * Why a row is `pending`.
+ *
+ * `not_yet_built` is the ordinary case and is NOT a failure. It exists because
+ * the `receipt_reason_required` CHECK demands a reason for `pending` as well as
+ * `failed`, and the first version defaulted to `internal_error` — so every
+ * healthy in-flight receipt landed in the monitoring counts as an internal
+ * error. A signal that fires for the normal case is not a signal.
+ */
+export const PENDING_NOT_YET_BUILT = "not_yet_built";
+export type PendingReason = ReceiptFailureReason | typeof PENDING_NOT_YET_BUILT;
+
+/**
+ * Reasons worth another attempt, and reasons that are not.
  *
  * The split is whether the thing that failed can plausibly be different next
  * time. A database hiccup can; a rail nobody mapped cannot, and retrying it
@@ -68,6 +103,30 @@ export function isRetryable(reason: ReceiptFailureReason): boolean {
   return RETRYABLE_REASONS.has(reason);
 }
 
+export class ReceiptLifecycleError extends Error {
+  constructor(detail: string) {
+    super(detail);
+    this.name = "ReceiptLifecycleError";
+  }
+}
+
+/**
+ * A lifecycle write that matched no row is a bug, not a no-op.
+ *
+ * All three writers were blind UPDATEs: writing against a transaction id that
+ * does not exist silently succeeded, so a caller with a stale or wrong id would
+ * believe it had recorded a receipt state that nothing carries.
+ */
+function assertTouchedOne(rows: unknown, transactionId: string, fn: string): void {
+  const n = (rows as unknown as Array<unknown>).length;
+  if (n !== 1) {
+    throw new ReceiptLifecycleError(
+      `${fn} matched ${n} rows for transaction ${transactionId}; expected exactly 1. ` +
+        "Either the id is wrong or the row is in a state this transition cannot leave.",
+    );
+  }
+}
+
 /**
  * Mark a row as awaiting its receipt.
  *
@@ -77,24 +136,33 @@ export function isRetryable(reason: ReceiptFailureReason): boolean {
 export async function markReceiptPending(
   db: Db,
   transactionId: string,
-  reason: ReceiptFailureReason = "internal_error",
+  reason: PendingReason = PENDING_NOT_YET_BUILT,
 ): Promise<void> {
-  await db.execute(sql`
+  const rows = await db.execute(sql`
     UPDATE transactions
        SET receipt_status = 'pending',
-           receipt_failure_reason = ${reason},
-           integrity_payload_version = 2
+           receipt_failure_reason = ${reason}
      WHERE id = ${transactionId}::uuid
+       AND receipt_status IS DISTINCT FROM 'complete'
+       AND receipt_status IS DISTINCT FROM 'failed'
+    RETURNING id
   `);
+  assertTouchedOne(rows, transactionId, "markReceiptPending");
 }
 
-/** Record a built receipt. The only path that may write 'complete'. */
+/**
+ * Record a built receipt. The only path that may write 'complete'.
+ *
+ * Guarded on the row still being `pending`: `failed` is absorbing, so a late
+ * success must not resurrect a row whose failure may already be anchored in the
+ * chain.
+ */
 export async function markReceiptComplete(
   db: Db,
   transactionId: string,
   receipt: Extract<ReceiptResult, { outcome: "complete" }>,
 ): Promise<void> {
-  await db.execute(sql`
+  const rows = await db.execute(sql`
     UPDATE transactions
        SET receipt_status = 'complete',
            receipt_failure_reason = NULL,
@@ -102,10 +170,12 @@ export async function markReceiptComplete(
            receipt_canonicalization = ${RECEIPT_CANONICALIZATION},
            receipt_digest_alg = ${RECEIPT_DIGEST_ALG},
            receipt_digest = ${receipt.digest},
-           receipt_manifest_digest = ${receipt.manifestDigest},
-           integrity_payload_version = 2
+           receipt_manifest_digest = ${receipt.manifestDigest}
      WHERE id = ${transactionId}::uuid
+       AND receipt_status = 'pending'
+    RETURNING id
   `);
+  assertTouchedOne(rows, transactionId, "markReceiptComplete");
 }
 
 /**
@@ -124,22 +194,25 @@ export async function markReceiptFailed(
     UPDATE transactions
        SET receipt_attempts = receipt_attempts + 1,
            receipt_failure_reason = ${reason},
-           integrity_payload_version = 2,
            receipt_status = CASE
              WHEN ${isRetryable(reason)} AND receipt_attempts + 1 < ${MAX_RECEIPT_ATTEMPTS}
                THEN 'pending'
              ELSE 'failed'
            END,
-           -- A failed build must never leave stale success metadata behind.
+           -- A failed build must never leave stale success metadata behind: a
+           -- digest on a failed row is a commitment to a receipt that was
+           -- withdrawn.
            receipt_digest = NULL,
            receipt_version = NULL,
            receipt_canonicalization = NULL,
            receipt_digest_alg = NULL
      WHERE id = ${transactionId}::uuid
+       AND receipt_status = 'pending'
     RETURNING receipt_status, receipt_attempts
   `);
+  assertTouchedOne(rows, transactionId, "markReceiptFailed");
   const row = (rows as unknown as Array<{ receipt_status: ReceiptStatus; receipt_attempts: number }>)[0];
-  return { status: row?.receipt_status ?? "failed", attempts: Number(row?.receipt_attempts ?? 0) };
+  return { status: row.receipt_status, attempts: Number(row.receipt_attempts) };
 }
 
 /** Rows a retry sweep should pick up. Bounded; oldest first. */
@@ -163,7 +236,8 @@ export async function selectPendingReceipts(
  *
  * A non-zero `failed` count is an alert, not a dashboard curiosity: it means
  * executions are happening that cannot be committed to. Grouped by reason so
- * the alert says which invariant broke.
+ * the alert says which invariant broke. `pending`/`not_yet_built` is the
+ * healthy in-flight population and is expected to be non-zero.
  */
 export async function receiptHealthCounts(
   db: Db,
@@ -182,12 +256,18 @@ export async function receiptHealthCounts(
 /**
  * How a row's receipt state reads to a verifier.
  *
- * The epoch is not a column and does not need to be: a NULL `receipt_status`
- * IS pre-epoch, because migration 0107 added the column with no backfill and
- * every write since sets it. There is no moment at which a post-epoch row has
- * a null status, so the two populations cannot be confused — and the
- * `transactions_chain_v2_has_receipt_state` CHECK makes that structural rather
- * than merely true today.
+ * ## What NULL means, honestly
+ *
+ * A NULL `receipt_status` means "no receipt state was recorded". Today that is
+ * the same thing as pre-epoch — but ONLY because no call site writes receipt
+ * state yet, and that is a property of the current wiring, not a database
+ * invariant. A row inserted right now through the ordinary path is
+ * byte-identical to one from April.
+ *
+ * The epoch becomes structurally enforceable when the rails are wired and every
+ * insert sets a status; until then this reports `legacy_unavailable` for
+ * anything with no state, which is accurate about what is known and does not
+ * claim to distinguish a genuine historical row from an unwired new one.
  */
 export function describeReceiptState(row: {
   receiptStatus: string | null;
@@ -201,8 +281,8 @@ export function describeReceiptState(row: {
     return {
       status: "legacy_unavailable",
       reason:
-        "this transaction predates the execution-receipt epoch; its implementation " +
-        "identity was never recorded and cannot be reconstructed",
+        "no execution receipt was recorded for this transaction; its implementation " +
+        "identity was never captured and cannot be reconstructed",
     };
   }
   if (row.receiptStatus === "complete" && row.receiptDigest) {

--- a/apps/api/src/lib/receipt/receipt-lifecycle.ts
+++ b/apps/api/src/lib/receipt/receipt-lifecycle.ts
@@ -145,6 +145,10 @@ export async function markReceiptPending(
      WHERE id = ${transactionId}::uuid
        AND receipt_status IS DISTINCT FROM 'complete'
        AND receipt_status IS DISTINCT FROM 'failed'
+       -- A chained row cannot acquire receipt state: its hash was computed
+       -- without one, so the digest would never be anchored. Mirrors the
+       -- database trigger; the trigger is the enforcement.
+       AND integrity_hash IS NULL
     RETURNING id
   `);
   assertTouchedOne(rows, transactionId, "markReceiptPending");

--- a/apps/api/src/lib/receipt/receipt-lifecycle.ts
+++ b/apps/api/src/lib/receipt/receipt-lifecycle.ts
@@ -1,0 +1,215 @@
+/**
+ * Receipt lifecycle persistence (Phase 4 §C).
+ *
+ * A post-epoch transaction may not simply have a null receipt with no
+ * explanation. Three states, and every one of them says something:
+ *
+ *   complete  a digest exists and can be recomputed
+ *   pending   the row committed, the receipt has not been built yet — the
+ *             expected transient state, because the money path must never wait
+ *             on receipt construction
+ *   failed    construction was attempted and could not honestly complete;
+ *             `receipt_failure_reason` says why
+ *
+ * `legacy_unavailable` is **pre-epoch only** and is not a status at all — it is
+ * what a NULL `receipt_status` means when read. Using it post-epoch would
+ * disguise a present-day defect as a policy about history, which is the exact
+ * confusion the lifecycle exists to prevent.
+ *
+ * ## The invariant that matters most
+ *
+ * **A successful business execution must never be recorded as receipt-complete
+ * when receipt creation failed.** The transaction still commits — a customer's
+ * call succeeded and they are billed for it — but the receipt state says
+ * `failed` with a reason, visibly. The database enforces this too: the
+ * `transactions_receipt_complete_is_complete` CHECK refuses a 'complete' row
+ * without a digest, so the two cannot drift even if this module is bypassed.
+ */
+
+import { sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+
+import {
+  RECEIPT_CANONICALIZATION,
+  RECEIPT_DIGEST_ALG,
+  RECEIPT_VERSION,
+  type ReceiptFailureReason,
+  type ReceiptResult,
+} from "./execution-receipt.js";
+
+type Db = PostgresJsDatabase<Record<string, never>> | PostgresJsDatabase<any>;
+
+export type ReceiptStatus = "complete" | "pending" | "failed";
+
+/**
+ * Reasons that are worth another attempt, and reasons that are not.
+ *
+ * The split is whether the thing that failed can plausibly be different next
+ * time. A database hiccup can; a rail nobody mapped cannot, and retrying it
+ * would bury the escalation an operator is supposed to act on.
+ */
+export const RETRYABLE_REASONS: ReadonlySet<ReceiptFailureReason> = new Set([
+  "snapshot_write_failed",
+  "internal_error",
+]);
+
+export const TERMINAL_REASONS: ReadonlySet<ReceiptFailureReason> = new Set([
+  "unmapped_rail",
+  "missing_deploy_identity",
+  "unresolvable_manifest",
+  "missing_subject",
+  "canonicalization_error",
+]);
+
+/** Attempts before a retryable reason becomes terminal. */
+export const MAX_RECEIPT_ATTEMPTS = 5;
+
+export function isRetryable(reason: ReceiptFailureReason): boolean {
+  return RETRYABLE_REASONS.has(reason);
+}
+
+/**
+ * Mark a row as awaiting its receipt.
+ *
+ * Written in the same transaction as the row itself, so a post-epoch row is
+ * never momentarily indistinguishable from a pre-epoch one.
+ */
+export async function markReceiptPending(
+  db: Db,
+  transactionId: string,
+  reason: ReceiptFailureReason = "internal_error",
+): Promise<void> {
+  await db.execute(sql`
+    UPDATE transactions
+       SET receipt_status = 'pending',
+           receipt_failure_reason = ${reason},
+           integrity_payload_version = 2
+     WHERE id = ${transactionId}::uuid
+  `);
+}
+
+/** Record a built receipt. The only path that may write 'complete'. */
+export async function markReceiptComplete(
+  db: Db,
+  transactionId: string,
+  receipt: Extract<ReceiptResult, { outcome: "complete" }>,
+): Promise<void> {
+  await db.execute(sql`
+    UPDATE transactions
+       SET receipt_status = 'complete',
+           receipt_failure_reason = NULL,
+           receipt_version = ${RECEIPT_VERSION},
+           receipt_canonicalization = ${RECEIPT_CANONICALIZATION},
+           receipt_digest_alg = ${RECEIPT_DIGEST_ALG},
+           receipt_digest = ${receipt.digest},
+           receipt_manifest_digest = ${receipt.manifestDigest},
+           integrity_payload_version = 2
+     WHERE id = ${transactionId}::uuid
+  `);
+}
+
+/**
+ * Record a refusal.
+ *
+ * A terminal reason goes straight to `failed`. A retryable one stays `pending`
+ * until the attempt budget is spent, then becomes `failed` carrying the last
+ * reason — so exhaustion is visible rather than looking like a stall.
+ */
+export async function markReceiptFailed(
+  db: Db,
+  transactionId: string,
+  reason: ReceiptFailureReason,
+): Promise<{ status: ReceiptStatus; attempts: number }> {
+  const rows = await db.execute(sql`
+    UPDATE transactions
+       SET receipt_attempts = receipt_attempts + 1,
+           receipt_failure_reason = ${reason},
+           integrity_payload_version = 2,
+           receipt_status = CASE
+             WHEN ${isRetryable(reason)} AND receipt_attempts + 1 < ${MAX_RECEIPT_ATTEMPTS}
+               THEN 'pending'
+             ELSE 'failed'
+           END,
+           -- A failed build must never leave stale success metadata behind.
+           receipt_digest = NULL,
+           receipt_version = NULL,
+           receipt_canonicalization = NULL,
+           receipt_digest_alg = NULL
+     WHERE id = ${transactionId}::uuid
+    RETURNING receipt_status, receipt_attempts
+  `);
+  const row = (rows as unknown as Array<{ receipt_status: ReceiptStatus; receipt_attempts: number }>)[0];
+  return { status: row?.receipt_status ?? "failed", attempts: Number(row?.receipt_attempts ?? 0) };
+}
+
+/** Rows a retry sweep should pick up. Bounded; oldest first. */
+export async function selectPendingReceipts(
+  db: Db,
+  limit = 50,
+): Promise<Array<{ id: string; attempts: number; reason: string | null }>> {
+  const rows = await db.execute(sql`
+    SELECT id::text AS id, receipt_attempts, receipt_failure_reason
+      FROM transactions
+     WHERE receipt_status = 'pending'
+     ORDER BY created_at ASC
+     LIMIT ${limit}
+  `);
+  return (rows as unknown as Array<{ id: string; receipt_attempts: number; receipt_failure_reason: string | null }>)
+    .map((r) => ({ id: r.id, attempts: Number(r.receipt_attempts), reason: r.receipt_failure_reason }));
+}
+
+/**
+ * What monitoring reads.
+ *
+ * A non-zero `failed` count is an alert, not a dashboard curiosity: it means
+ * executions are happening that cannot be committed to. Grouped by reason so
+ * the alert says which invariant broke.
+ */
+export async function receiptHealthCounts(
+  db: Db,
+): Promise<Array<{ status: string; reason: string | null; n: number }>> {
+  const rows = await db.execute(sql`
+    SELECT receipt_status AS status, receipt_failure_reason AS reason, count(*)::int AS n
+      FROM transactions
+     WHERE receipt_status IN ('pending', 'failed')
+     GROUP BY 1, 2
+     ORDER BY 3 DESC
+  `);
+  return (rows as unknown as Array<{ status: string; reason: string | null; n: number }>)
+    .map((r) => ({ status: r.status, reason: r.reason, n: Number(r.n) }));
+}
+
+/**
+ * How a row's receipt state reads to a verifier.
+ *
+ * The epoch is not a column and does not need to be: a NULL `receipt_status`
+ * IS pre-epoch, because migration 0107 added the column with no backfill and
+ * every write since sets it. There is no moment at which a post-epoch row has
+ * a null status, so the two populations cannot be confused — and the
+ * `transactions_chain_v2_has_receipt_state` CHECK makes that structural rather
+ * than merely true today.
+ */
+export function describeReceiptState(row: {
+  receiptStatus: string | null;
+  receiptFailureReason: string | null;
+  receiptDigest: string | null;
+}):
+  | { status: "legacy_unavailable"; reason: string }
+  | { status: "complete"; digest: string }
+  | { status: "pending" | "failed"; reason: string } {
+  if (row.receiptStatus === null) {
+    return {
+      status: "legacy_unavailable",
+      reason:
+        "this transaction predates the execution-receipt epoch; its implementation " +
+        "identity was never recorded and cannot be reconstructed",
+    };
+  }
+  if (row.receiptStatus === "complete" && row.receiptDigest) {
+    return { status: "complete", digest: row.receiptDigest };
+  }
+  return {
+    status: row.receiptStatus === "failed" ? "failed" : "pending",
+    reason: row.receiptFailureReason ?? "unknown",
+  };
+}

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1361,7 +1361,7 @@ describe("startup-migrations — block 0102 (account lifecycle tables)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 50 blocks in historical order", () => {
+  it("exports the expected 51 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1419,6 +1419,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0105_onboardingHookFailures",
       "runMigration0106_executionManifestSnapshots",
       "runMigration0107_executionReceiptColumns",
+      "runMigration0108_receiptStateInvariants",
     ]);
   });
 });
@@ -2278,7 +2279,7 @@ describe("startup-migrations — block identity is unique, not just the function
     const numbers = BLOCKS.map((fn) => Number(/runMigration(\d+)_/.exec(fn.name)?.[1] ?? "0"));
     const sorted = [...numbers].sort((a, b) => a - b);
     expect(numbers).toEqual(sorted);
-    expect(Math.max(...numbers)).toBe(107);
+    expect(Math.max(...numbers)).toBe(108);
   });
 });
 

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1361,7 +1361,7 @@ describe("startup-migrations — block 0102 (account lifecycle tables)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 48 blocks in historical order", () => {
+  it("exports the expected 50 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1417,6 +1417,8 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0103_redactedContentStaysRedacted",
       "runMigration0104_jobSchedule",
       "runMigration0105_onboardingHookFailures",
+      "runMigration0106_executionManifestSnapshots",
+      "runMigration0107_executionReceiptColumns",
     ]);
   });
 });
@@ -2276,7 +2278,7 @@ describe("startup-migrations — block identity is unique, not just the function
     const numbers = BLOCKS.map((fn) => Number(/runMigration(\d+)_/.exec(fn.name)?.[1] ?? "0"));
     const sorted = [...numbers].sort((a, b) => a - b);
     expect(numbers).toEqual(sorted);
-    expect(Math.max(...numbers)).toBe(105);
+    expect(Math.max(...numbers)).toBe(107);
   });
 });
 

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -3054,13 +3054,43 @@ export async function runMigration0108_receiptStateInvariants(
     CREATE OR REPLACE FUNCTION "transactions_receipt_state_transitions"()
     RETURNS trigger AS $$
     BEGIN
+      -- EVERY receipt-shaped column, not just the five that were obvious.
+      --
+      -- receipt_manifest_digest was missing, and it is how a verifier finds the
+      -- snapshot to recompute implementation.manifest_digest — and it is NOT
+      -- inside the chain payload, so swapping it was neither refused here nor
+      -- detectable there. receipt_failure_reason was missing, so a reason could
+      -- be stamped onto a complete row. integrity_payload_version was missing,
+      -- so it could be flipped 2 -> NULL, which verification then reports as
+      -- corruption rather than refusing outright. All reviewer-found, all via
+      -- this early return.
       IF OLD.receipt_status IS NOT DISTINCT FROM NEW.receipt_status
          AND OLD.receipt_digest IS NOT DISTINCT FROM NEW.receipt_digest
          AND OLD.receipt_version IS NOT DISTINCT FROM NEW.receipt_version
          AND OLD.receipt_canonicalization IS NOT DISTINCT FROM NEW.receipt_canonicalization
          AND OLD.receipt_digest_alg IS NOT DISTINCT FROM NEW.receipt_digest_alg
+         AND OLD.receipt_manifest_digest IS NOT DISTINCT FROM NEW.receipt_manifest_digest
+         AND OLD.receipt_failure_reason IS NOT DISTINCT FROM NEW.receipt_failure_reason
+         AND OLD.integrity_payload_version IS NOT DISTINCT FROM NEW.integrity_payload_version
       THEN
         RETURN NEW;  -- nothing receipt-shaped changed
+      END IF;
+
+      -- A CHAINED row cannot acquire receipt state afterwards.
+      --
+      -- The dual of the admission rule, and it was missing. Barring a row from
+      -- the chain until its receipt settles is only half the property: a row
+      -- chained under v1 — which is every row today — could receive a complete
+      -- receipt afterwards and keep its v1 hash, so the digest was never
+      -- anchored. The row verifies, under a rule that does not cover the
+      -- receipt, and "a receipt digest cannot be swapped without invalidating
+      -- the chain" is silently false for it. Reviewer-found.
+      IF OLD.integrity_hash IS NOT NULL
+         AND OLD.receipt_status IS NULL
+         AND NEW.receipt_status IS NOT NULL THEN
+        RAISE EXCEPTION
+          'transaction % is already chained under v1; introducing receipt state '
+          'now would leave its digest permanently unanchored.', OLD.id;
       END IF;
 
       -- complete and failed are absorbing.
@@ -3104,8 +3134,15 @@ export async function runMigration0108_receiptStateInvariants(
   await tx.execute(sql`
     ALTER TABLE execution_manifest_snapshots
       ADD CONSTRAINT execution_manifest_snapshots_subject_matches_content
+      -- The key-presence tests are load-bearing. A comparison against a
+      -- missing key yields NULL, and a CHECK passes on NULL, so without them a
+      -- snapshot carrying no subject keys at all was accepted under any slug.
+      -- jsonb_exists is the function spelling of the ? operator, used because a
+      -- bare ? in a driver template is asking for trouble.
       CHECK (
-        subject_kind = snapshot->>'subject_kind'
+        jsonb_exists(snapshot, 'subject_kind')
+        AND jsonb_exists(snapshot, 'slug')
+        AND subject_kind = snapshot->>'subject_kind'
         AND subject_slug = snapshot->>'slug'
       )
       NOT VALID

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -2966,18 +2966,200 @@ export async function runMigration0107_executionReceiptColumns(
   // full-table scan inside the boot path. New writes are checked from this
   // moment; the backfill scan is not this block's job and there is nothing to
   // find. Verified below rather than assumed.
+  // EXISTS with LIMIT 1, not count(*) over an OR.
+  //
+  // The first version counted `receipt_status IS NOT NULL OR
+  // integrity_payload_version IS NOT NULL`, which no index can serve — a full
+  // sequential scan of the largest table (~921k rows) on EVERY boot, inside the
+  // migration transaction. Reviewer-found. This answers the same question
+  // (is any row already carrying receipt state?) and stops at the first hit.
   const bad = await tx.execute(sql`
-    SELECT count(*)::int AS n FROM transactions
-     WHERE receipt_status IS NOT NULL OR integrity_payload_version IS NOT NULL
+    SELECT EXISTS (
+      SELECT 1 FROM transactions WHERE receipt_status IS NOT NULL LIMIT 1
+    ) AS any_state
   `);
-  const preexisting = Number((bad as unknown as Array<{ n: number }>)[0]?.n ?? 0);
+  const preexisting =
+    (bad as unknown as Array<{ any_state: boolean }>)[0]?.any_state === true ? 1 : 0;
 
   return {
     block: "0107_execution_receipt_columns",
     outcome:
       "receipt lifecycle columns + 6 CHECK constraints + pending/failed index; " +
-      `${preexisting} pre-existing rows carry receipt state (expected 0)`,
+      `pre-existing receipt state present: ${preexisting === 1} (expected false)`,
     rows_affected: preexisting,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+/**
+ * Phase 4 review round 1 — the invariants the design called structural but
+ * enforced only in application code.
+ *
+ * An adversarial review drove every one of these transitions through the
+ * database and they were all accepted. A rule that holds only when one module
+ * is used is not a rule, so each is now a trigger or a constraint:
+ *
+ *  - `complete` and `failed` are ABSORBING. Once a row is chained, its receipt
+ *    digest is anchored in the integrity hash — changing the state afterwards
+ *    would rewrite an already-chained historical fact.
+ *  - A `complete` row's receipt fields are frozen. The reviewer swapped a
+ *    digest on a complete row, and rewrote version/canonicalization/algorithm
+ *    to `fake.v9`/`NOPE`/`md5`; the existing CHECK only tested NOT NULL, so
+ *    garbage passed.
+ *  - Reason codes are a closed set. `'banana'` was accepted.
+ *  - A snapshot's `subject_kind`/`subject_slug` duplicate values inside
+ *    `snapshot` and could disagree with them.
+ *  - TRUNCATE does not fire row-level DELETE triggers, so the "permanent"
+ *    snapshot table could be emptied without error.
+ */
+export async function runMigration0108_receiptStateInvariants(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  // ── Closed reason-code set ────────────────────────────────────────────────
+  await tx.execute(sql`
+    ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_receipt_reason_closed
+  `);
+  await tx.execute(sql`
+    ALTER TABLE transactions ADD CONSTRAINT transactions_receipt_reason_closed
+      CHECK (
+        receipt_failure_reason IS NULL
+        OR receipt_failure_reason IN (
+          'not_yet_built', 'unmapped_rail', 'missing_deploy_identity',
+          'unresolvable_manifest', 'missing_subject', 'snapshot_write_failed',
+          'canonicalization_error', 'internal_error'
+        )
+      )
+      NOT VALID
+  `);
+
+  // A digest without its metadata cannot be recomputed; metadata that is not
+  // the metadata we produce is worse than none, because it looks recomputable.
+  await tx.execute(sql`
+    ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_receipt_metadata_known
+  `);
+  await tx.execute(sql`
+    ALTER TABLE transactions ADD CONSTRAINT transactions_receipt_metadata_known
+      CHECK (
+        (receipt_version IS NULL OR receipt_version = 'strale.execution.v1')
+        AND (receipt_canonicalization IS NULL OR receipt_canonicalization = 'RFC8785')
+        AND (receipt_digest_alg IS NULL OR receipt_digest_alg = 'sha256')
+      )
+      NOT VALID
+  `);
+
+  // ── Legal transitions, enforced ───────────────────────────────────────────
+  await tx.execute(sql`
+    CREATE OR REPLACE FUNCTION "transactions_receipt_state_transitions"()
+    RETURNS trigger AS $$
+    BEGIN
+      IF OLD.receipt_status IS NOT DISTINCT FROM NEW.receipt_status
+         AND OLD.receipt_digest IS NOT DISTINCT FROM NEW.receipt_digest
+         AND OLD.receipt_version IS NOT DISTINCT FROM NEW.receipt_version
+         AND OLD.receipt_canonicalization IS NOT DISTINCT FROM NEW.receipt_canonicalization
+         AND OLD.receipt_digest_alg IS NOT DISTINCT FROM NEW.receipt_digest_alg
+      THEN
+        RETURN NEW;  -- nothing receipt-shaped changed
+      END IF;
+
+      -- complete and failed are absorbing.
+      IF OLD.receipt_status IN ('complete', 'failed') THEN
+        RAISE EXCEPTION
+          'receipt state % is terminal: transaction % cannot move to %. Once a row '
+          'is chained its receipt digest is anchored in the integrity hash, so '
+          'changing it would rewrite an already-chained fact.',
+          OLD.receipt_status, OLD.id, COALESCE(NEW.receipt_status, 'NULL');
+      END IF;
+
+      -- Post-epoch state cannot be cleared back to looking pre-epoch.
+      IF OLD.receipt_status IS NOT NULL AND NEW.receipt_status IS NULL THEN
+        RAISE EXCEPTION
+          'transaction % cannot clear its receipt status: a post-epoch row must '
+          'not become indistinguishable from a pre-epoch one.', OLD.id;
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `);
+  await tx.execute(sql`
+    DROP TRIGGER IF EXISTS transactions_receipt_state_transitions_trg ON transactions
+  `);
+  await tx.execute(sql`
+    CREATE TRIGGER transactions_receipt_state_transitions_trg
+      BEFORE UPDATE ON transactions
+      FOR EACH ROW EXECUTE FUNCTION "transactions_receipt_state_transitions"()
+  `);
+
+  // ── Snapshot subject metadata must agree with the hashed content ──────────
+  //
+  // The digest-to-content relation itself cannot be a CHECK — Postgres has no
+  // RFC 8785 — so `readManifestSnapshot` recomputes before returning. What CAN
+  // be enforced here is that the denormalized columns match the bytes.
+  await tx.execute(sql`
+    ALTER TABLE execution_manifest_snapshots
+      DROP CONSTRAINT IF EXISTS execution_manifest_snapshots_subject_matches_content
+  `);
+  await tx.execute(sql`
+    ALTER TABLE execution_manifest_snapshots
+      ADD CONSTRAINT execution_manifest_snapshots_subject_matches_content
+      CHECK (
+        subject_kind = snapshot->>'subject_kind'
+        AND subject_slug = snapshot->>'slug'
+      )
+      NOT VALID
+  `);
+
+  // ── TRUNCATE does not fire row-level DELETE triggers ──────────────────────
+  await tx.execute(sql`
+    CREATE OR REPLACE FUNCTION "execution_manifest_snapshots_no_truncate"()
+    RETURNS trigger AS $$
+    BEGIN
+      RAISE EXCEPTION
+        'execution_manifest_snapshots cannot be truncated: it is the only record '
+        'of what a capability declared when a receipt was issued, and emptying it '
+        'makes every receipt permanently unverifiable.';
+    END;
+    $$ LANGUAGE plpgsql
+  `);
+  await tx.execute(sql`
+    DROP TRIGGER IF EXISTS execution_manifest_snapshots_no_truncate_trg
+      ON execution_manifest_snapshots
+  `);
+  await tx.execute(sql`
+    CREATE TRIGGER execution_manifest_snapshots_no_truncate_trg
+      BEFORE TRUNCATE ON execution_manifest_snapshots
+      FOR EACH STATEMENT EXECUTE FUNCTION "execution_manifest_snapshots_no_truncate"()
+  `);
+
+  // Verify every trigger this block depends on is present AND enabled.
+  const trg = await tx.execute(sql`
+    SELECT c.relname AS tbl, t.tgname, t.tgenabled
+      FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
+     WHERE NOT t.tgisinternal
+       AND t.tgname IN ('transactions_receipt_state_transitions_trg',
+                        'execution_manifest_snapshots_no_truncate_trg')
+  `);
+  const rows = trg as unknown as Array<{ tgname: string; tgenabled: string }>;
+  const enabled = rows.filter((r) => r.tgenabled === 'O').map((r) => r.tgname);
+  const missing = [
+    "transactions_receipt_state_transitions_trg",
+    "execution_manifest_snapshots_no_truncate_trg",
+  ].filter((n) => !enabled.includes(n));
+  if (missing.length > 0) {
+    throw new Error(
+      `receipt-state invariant triggers missing or disabled: ${missing.join(", ")} ` +
+        `(found ${JSON.stringify(rows)}). Refusing to report success: without them, ` +
+        "a completed receipt can be rewritten and the snapshot table can be emptied.",
+    );
+  }
+
+  return {
+    block: "0108_receipt_state_invariants",
+    outcome:
+      "transition trigger + TRUNCATE refusal + closed reason set + known receipt " +
+      "metadata + snapshot subject/content agreement, all present and verified",
     duration_ms: Date.now() - startedAt,
   };
 }
@@ -3037,6 +3219,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   // Phase 4: execution receipts.
   runMigration0106_executionManifestSnapshots,
   runMigration0107_executionReceiptColumns,
+  runMigration0108_receiptStateInvariants,
 ];
 
 /**

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -2746,6 +2746,242 @@ export async function runMigration0105_onboardingHookFailures(
   };
 }
 
+/**
+ * Phase 4 (execution receipts) — immutable manifest snapshots.
+ *
+ * The table is content-addressed: `digest` is a function of `snapshot`, so a
+ * snapshot cannot change without changing its own primary key. That makes
+ * mutation *pointless*, not impossible — these triggers make it impossible.
+ *
+ * Both refusals are deliberate and neither is defensive decoration:
+ *
+ *  - UPDATE would let the bytes behind a digest change while receipts keep
+ *    pointing at it, so every receipt referencing it would silently start
+ *    meaning something else.
+ *  - DELETE would make every receipt referencing it unverifiable, with no
+ *    error anywhere. Generic retention gets a loud error instead of a row
+ *    count. `db-retention.ts` is separately asserted never to list this table
+ *    (see execution-receipt.integration.test.ts) — belt and braces, because
+ *    the failure is silent and permanent.
+ */
+export async function runMigration0106_executionManifestSnapshots(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  await tx.execute(sql`
+    CREATE TABLE IF NOT EXISTS execution_manifest_snapshots (
+      digest        varchar(71) PRIMARY KEY,
+      subject_kind  varchar(16) NOT NULL,
+      subject_slug  text        NOT NULL,
+      snapshot      jsonb       NOT NULL,
+      first_seen_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT execution_manifest_snapshots_digest_shape
+        CHECK (digest ~ '^sha256:[0-9a-f]{64}$'),
+      CONSTRAINT execution_manifest_snapshots_subject_kind
+        CHECK (subject_kind IN ('capability', 'solution'))
+    )
+  `);
+
+  await tx.execute(sql`
+    CREATE OR REPLACE FUNCTION "execution_manifest_snapshots_are_immutable"()
+    RETURNS trigger AS $$
+    BEGIN
+      RAISE EXCEPTION
+        'execution_manifest_snapshots is insert-only: % on digest % refused. '
+        'Snapshots are the only record of what a capability declared when a '
+        'receipt was issued; changing or removing one makes every receipt that '
+        'references it silently wrong or unverifiable.',
+        TG_OP, COALESCE(OLD.digest, '(unknown)');
+    END;
+    $$ LANGUAGE plpgsql
+  `);
+
+  await tx.execute(sql`
+    DROP TRIGGER IF EXISTS execution_manifest_snapshots_no_update
+      ON execution_manifest_snapshots
+  `);
+  await tx.execute(sql`
+    CREATE TRIGGER execution_manifest_snapshots_no_update
+      BEFORE UPDATE ON execution_manifest_snapshots
+      FOR EACH ROW EXECUTE FUNCTION "execution_manifest_snapshots_are_immutable"()
+  `);
+
+  await tx.execute(sql`
+    DROP TRIGGER IF EXISTS execution_manifest_snapshots_no_delete
+      ON execution_manifest_snapshots
+  `);
+  await tx.execute(sql`
+    CREATE TRIGGER execution_manifest_snapshots_no_delete
+      BEFORE DELETE ON execution_manifest_snapshots
+      FOR EACH ROW EXECUTE FUNCTION "execution_manifest_snapshots_are_immutable"()
+  `);
+
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS execution_manifest_snapshots_subject_idx
+      ON execution_manifest_snapshots (subject_kind, subject_slug)
+  `);
+
+  // Verify the triggers exist and are ENABLED. A trigger that is present but
+  // disabled ('D') is the nameable failure here — the table would accept
+  // mutation while every reader assumed it could not.
+  const trg = await tx.execute(sql`
+    SELECT tgname, tgenabled FROM pg_trigger
+     WHERE tgrelid = 'execution_manifest_snapshots'::regclass
+       AND NOT tgisinternal
+     ORDER BY tgname
+  `);
+  const rows = trg as unknown as Array<{ tgname: string; tgenabled: string }>;
+  const enabled = rows.filter((r) => r.tgenabled === 'O').map((r) => r.tgname);
+  if (!enabled.includes("execution_manifest_snapshots_no_update") ||
+      !enabled.includes("execution_manifest_snapshots_no_delete")) {
+    throw new Error(
+      "execution_manifest_snapshots immutability triggers are missing or disabled " +
+        `(found: ${JSON.stringify(rows)}). Refusing to report success: without both, ` +
+        "a snapshot can be changed or pruned and every receipt referencing it becomes " +
+        "silently wrong or permanently unverifiable.",
+    );
+  }
+
+  return {
+    block: "0106_execution_manifest_snapshots",
+    outcome: "table + UPDATE/DELETE refusal triggers present and verified enabled",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+/**
+ * Phase 4 — receipt lifecycle columns and the chain-version marker.
+ *
+ * The CHECK constraints encode the state invariants the spec states in prose,
+ * because prose does not stop a write:
+ *
+ *  - a receipt digest is a FULL 256-bit value or absent; a truncated one is a
+ *    different claim wearing the same name;
+ *  - 'complete' requires the digest and its metadata, so a failed receipt
+ *    build can never be recorded as complete;
+ *  - 'pending' and 'failed' require a reason code from the closed set, so a
+ *    post-epoch row can never be quietly receipt-less;
+ *  - `integrity_payload_version` is 2 or NULL, and NULL means v1 by
+ *    definition — the verifier reads this to pick the algorithm.
+ *
+ * The epoch itself is NOT a column: it is `receipt_status IS NULL` meaning
+ * pre-epoch. See the receipt-epoch block below for why that is enough.
+ */
+export async function runMigration0107_executionReceiptColumns(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  await tx.execute(sql`
+    ALTER TABLE transactions
+      ADD COLUMN IF NOT EXISTS receipt_status varchar(16),
+      ADD COLUMN IF NOT EXISTS receipt_failure_reason varchar(40),
+      ADD COLUMN IF NOT EXISTS receipt_version varchar(32),
+      ADD COLUMN IF NOT EXISTS receipt_canonicalization varchar(16),
+      ADD COLUMN IF NOT EXISTS receipt_digest_alg varchar(16),
+      ADD COLUMN IF NOT EXISTS receipt_digest varchar(71),
+      ADD COLUMN IF NOT EXISTS receipt_manifest_digest varchar(71),
+      ADD COLUMN IF NOT EXISTS receipt_attempts integer NOT NULL DEFAULT 0,
+      ADD COLUMN IF NOT EXISTS integrity_payload_version integer
+  `);
+
+  await tx.execute(sql`
+    ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_receipt_status_valid
+  `);
+  await tx.execute(sql`
+    ALTER TABLE transactions ADD CONSTRAINT transactions_receipt_status_valid
+      CHECK (receipt_status IS NULL OR receipt_status IN ('complete', 'pending', 'failed'))
+      NOT VALID
+  `);
+
+  await tx.execute(sql`
+    ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_receipt_digest_shape
+  `);
+  await tx.execute(sql`
+    ALTER TABLE transactions ADD CONSTRAINT transactions_receipt_digest_shape
+      CHECK (receipt_digest IS NULL OR receipt_digest ~ '^sha256:[0-9a-f]{64}$')
+      NOT VALID
+  `);
+
+  // 'complete' is a claim that a digest exists and can be recomputed. Without
+  // the metadata a verifier cannot reproduce it, so the claim would be empty.
+  await tx.execute(sql`
+    ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_receipt_complete_is_complete
+  `);
+  await tx.execute(sql`
+    ALTER TABLE transactions ADD CONSTRAINT transactions_receipt_complete_is_complete
+      CHECK (
+        receipt_status IS DISTINCT FROM 'complete'
+        OR (receipt_digest IS NOT NULL
+            AND receipt_version IS NOT NULL
+            AND receipt_canonicalization IS NOT NULL
+            AND receipt_digest_alg IS NOT NULL)
+      )
+      NOT VALID
+  `);
+
+  // A non-complete post-epoch row must SAY why. Silence is the failure mode
+  // the whole lifecycle exists to remove.
+  await tx.execute(sql`
+    ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_receipt_reason_required
+  `);
+  await tx.execute(sql`
+    ALTER TABLE transactions ADD CONSTRAINT transactions_receipt_reason_required
+      CHECK (
+        receipt_status NOT IN ('pending', 'failed')
+        OR receipt_failure_reason IS NOT NULL
+      )
+      NOT VALID
+  `);
+
+  await tx.execute(sql`
+    ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_integrity_payload_version_valid
+  `);
+  await tx.execute(sql`
+    ALTER TABLE transactions ADD CONSTRAINT transactions_integrity_payload_version_valid
+      CHECK (integrity_payload_version IS NULL OR integrity_payload_version = 2)
+      NOT VALID
+  `);
+
+  // Chain v2 anchors the receipt digest, so a v2 row without one would anchor
+  // nothing while claiming to.
+  await tx.execute(sql`
+    ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_chain_v2_has_receipt_state
+  `);
+  await tx.execute(sql`
+    ALTER TABLE transactions ADD CONSTRAINT transactions_chain_v2_has_receipt_state
+      CHECK (integrity_payload_version IS DISTINCT FROM 2 OR receipt_status IS NOT NULL)
+      NOT VALID
+  `);
+
+  await tx.execute(sql`
+    CREATE INDEX IF NOT EXISTS transactions_receipt_status_idx
+      ON transactions (receipt_status)
+      WHERE receipt_status IN ('pending', 'failed')
+  `);
+
+  // NOT VALID everywhere above is deliberate: 921k existing rows all have NULL
+  // receipt columns and satisfy every constraint, but VALIDATE would take a
+  // full-table scan inside the boot path. New writes are checked from this
+  // moment; the backfill scan is not this block's job and there is nothing to
+  // find. Verified below rather than assumed.
+  const bad = await tx.execute(sql`
+    SELECT count(*)::int AS n FROM transactions
+     WHERE receipt_status IS NOT NULL OR integrity_payload_version IS NOT NULL
+  `);
+  const preexisting = Number((bad as unknown as Array<{ n: number }>)[0]?.n ?? 0);
+
+  return {
+    block: "0107_execution_receipt_columns",
+    outcome:
+      "receipt lifecycle columns + 6 CHECK constraints + pending/failed index; " +
+      `${preexisting} pre-existing rows carry receipt state (expected 0)`,
+    rows_affected: preexisting,
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResult>> = [
   runMigration0029_actualCostCents,
   runMigration0030_complianceColumns,
@@ -2798,6 +3034,9 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0103_redactedContentStaysRedacted,
   runMigration0104_jobSchedule,
   runMigration0105_onboardingHookFailures,
+  // Phase 4: execution receipts.
+  runMigration0106_executionManifestSnapshots,
+  runMigration0107_executionReceiptColumns,
 ];
 
 /**

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -3054,52 +3054,81 @@ export async function runMigration0108_receiptStateInvariants(
     CREATE OR REPLACE FUNCTION "transactions_receipt_state_transitions"()
     RETURNS trigger AS $$
     BEGIN
-      -- EVERY receipt-shaped column, not just the five that were obvious.
+      -- THREE SEPARATE QUESTIONS, ASKED SEPARATELY.
       --
-      -- receipt_manifest_digest was missing, and it is how a verifier finds the
-      -- snapshot to recompute implementation.manifest_digest — and it is NOT
-      -- inside the chain payload, so swapping it was neither refused here nor
-      -- detectable there. receipt_failure_reason was missing, so a reason could
-      -- be stamped onto a complete row. integrity_payload_version was missing,
-      -- so it could be flipped 2 -> NULL, which verification then reports as
-      -- corruption rather than refusing outright. All reviewer-found, all via
-      -- this early return.
-      IF OLD.receipt_status IS NOT DISTINCT FROM NEW.receipt_status
-         AND OLD.receipt_digest IS NOT DISTINCT FROM NEW.receipt_digest
-         AND OLD.receipt_version IS NOT DISTINCT FROM NEW.receipt_version
-         AND OLD.receipt_canonicalization IS NOT DISTINCT FROM NEW.receipt_canonicalization
-         AND OLD.receipt_digest_alg IS NOT DISTINCT FROM NEW.receipt_digest_alg
-         AND OLD.receipt_manifest_digest IS NOT DISTINCT FROM NEW.receipt_manifest_digest
-         AND OLD.receipt_failure_reason IS NOT DISTINCT FROM NEW.receipt_failure_reason
-         AND OLD.integrity_payload_version IS NOT DISTINCT FROM NEW.integrity_payload_version
+      -- The first version collapsed them into one early-return plus one
+      -- terminal check, and that combination BLOCKED THE ONE LEGITIMATE
+      -- WRITER. Adding integrity_payload_version to the compared columns
+      -- (so it could not be flipped) collided with the chain worker writing
+      -- exactly that column: the worker's UPDATE stopped taking the early
+      -- return, fell through to the terminal check, and was refused — because
+      -- that check tested OLD.receipt_status IN (...) rather than whether the
+      -- status was CHANGING. The worker is not moving a terminal row; it is
+      -- leaving it terminal while writing a different column.
+      --
+      -- The blast radius made it the worst defect of the review: the whole tick
+      -- runs in one transaction, so the RAISE aborted it, every later statement
+      -- failed, the per-row catch swallowed them, and the tick rolled back —
+      -- so ONE receipt-bearing row would have halted the tamper-evident chain
+      -- for every transaction in the system, permanently, retrying every 30s.
+      -- /v1/verify would answer "no integrity hash" and /v1/audit would answer
+      -- "still being computed" forever. Reviewer-found, and the entire repo
+      -- suite was green while it was true.
+
+      -- 1. Is the STATUS moving out of a terminal state?
+      IF OLD.receipt_status IS DISTINCT FROM NEW.receipt_status
+         AND OLD.receipt_status IN ('complete', 'failed') THEN
+        RAISE EXCEPTION
+          'receipt state % is terminal: transaction % cannot move to %. Once a row '
+          'is chained its receipt digest is anchored in the integrity hash, so '
+          'changing it would rewrite an already-chained fact.',
+          OLD.receipt_status, OLD.id, COALESCE(NEW.receipt_status, 'NULL');
+      END IF;
+
+      -- 2. Are a terminal row's receipt FIELDS being rewritten?
+      --
+      -- receipt_manifest_digest is in this list because it is how a verifier
+      -- finds the snapshot to recompute the implementation identity, and it is
+      -- NOT inside the chain payload — so a swap would be neither refused here
+      -- nor detectable there.
+      IF OLD.receipt_status IN ('complete', 'failed')
+         AND (OLD.receipt_digest           IS DISTINCT FROM NEW.receipt_digest
+           OR OLD.receipt_version          IS DISTINCT FROM NEW.receipt_version
+           OR OLD.receipt_canonicalization IS DISTINCT FROM NEW.receipt_canonicalization
+           OR OLD.receipt_digest_alg       IS DISTINCT FROM NEW.receipt_digest_alg
+           OR OLD.receipt_manifest_digest  IS DISTINCT FROM NEW.receipt_manifest_digest
+           OR OLD.receipt_failure_reason   IS DISTINCT FROM NEW.receipt_failure_reason)
       THEN
-        RETURN NEW;  -- nothing receipt-shaped changed
+        RAISE EXCEPTION
+          'transaction % has a terminal receipt; its receipt fields are frozen.', OLD.id;
+      END IF;
+
+      -- 3. Is the chain version being CHANGED after it was set?
+      --
+      -- Write-once, not frozen-on-terminal: the worker sets it exactly once, in
+      -- the same UPDATE as the hash. Setting it from NULL is that write; any
+      -- later change is a rewrite of which rule hashed the row.
+      IF OLD.integrity_payload_version IS NOT NULL
+         AND NEW.integrity_payload_version IS DISTINCT FROM OLD.integrity_payload_version
+      THEN
+        RAISE EXCEPTION
+          'transaction % already records integrity_payload_version %; the rule that '
+          'hashed a row cannot be rewritten.', OLD.id, OLD.integrity_payload_version;
       END IF;
 
       -- A CHAINED row cannot acquire receipt state afterwards.
       --
-      -- The dual of the admission rule, and it was missing. Barring a row from
-      -- the chain until its receipt settles is only half the property: a row
-      -- chained under v1 — which is every row today — could receive a complete
-      -- receipt afterwards and keep its v1 hash, so the digest was never
-      -- anchored. The row verifies, under a rule that does not cover the
-      -- receipt, and "a receipt digest cannot be swapped without invalidating
-      -- the chain" is silently false for it. Reviewer-found.
+      -- The dual of the admission rule. Barring a row from the chain until its
+      -- receipt settles is only half the property: a row chained under v1 —
+      -- which is every row today — could receive a complete receipt afterwards
+      -- and keep its v1 hash, so the digest was never anchored. The row
+      -- verifies, under a rule that does not cover the receipt.
       IF OLD.integrity_hash IS NOT NULL
          AND OLD.receipt_status IS NULL
          AND NEW.receipt_status IS NOT NULL THEN
         RAISE EXCEPTION
           'transaction % is already chained under v1; introducing receipt state '
           'now would leave its digest permanently unanchored.', OLD.id;
-      END IF;
-
-      -- complete and failed are absorbing.
-      IF OLD.receipt_status IN ('complete', 'failed') THEN
-        RAISE EXCEPTION
-          'receipt state % is terminal: transaction % cannot move to %. Once a row '
-          'is chained its receipt digest is anchored in the integrity hash, so '
-          'changing it would rewrite an already-chained fact.',
-          OLD.receipt_status, OLD.id, COALESCE(NEW.receipt_status, 'NULL');
       END IF;
 
       -- Post-epoch state cannot be cleared back to looking pre-epoch.

--- a/apps/api/src/routes/transactions.ts
+++ b/apps/api/src/routes/transactions.ts
@@ -5,7 +5,11 @@ import { transactions, capabilities, transactionQuality } from "../db/schema.js"
 import { authMiddleware, optionalAuthMiddleware } from "../lib/middleware.js";
 import { rateLimitByKey, rateLimitByIp } from "../lib/rate-limit.js";
 import { apiError } from "../lib/errors.js";
-import { computeIntegrityHash, GENESIS_HASH } from "../lib/integrity-hash.js";
+import {
+  computeIntegrityHashVersioned,
+  chainVersionOf,
+  GENESIS_HASH,
+} from "../lib/integrity-hash.js";
 import { walkChain } from "./verify.js";
 import { generateAuditToken } from "../lib/audit-token.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
@@ -248,7 +252,12 @@ transactionsRoute.get(
 
     // F-AUDIT-11: previousHash defaults to GENESIS_HASH, matching the worker
     // in jobs/integrity-hash-retry.ts and the public /v1/verify/:id endpoint.
-    const recomputed = computeIntegrityHash(txn, txn.previousHash ?? GENESIS_HASH);
+    // Same rule-selection as /v1/verify: the row says which payload hashed it.
+    const recomputed = computeIntegrityHashVersioned(
+      { ...txn, receiptDigest: txn.receiptDigest ?? null },
+      txn.previousHash ?? GENESIS_HASH,
+      chainVersionOf(txn.integrityPayloadVersion),
+    );
     const storedHash = txn.integrityHash;
     const hashValid = recomputed === storedHash;
 

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -7,7 +7,11 @@ import { Hono } from "hono";
 import { eq } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { transactions, capabilities } from "../db/schema.js";
-import { computeIntegrityHash, GENESIS_HASH } from "../lib/integrity-hash.js";
+import {
+  computeIntegrityHashVersioned,
+  chainVersionOf,
+  GENESIS_HASH,
+} from "../lib/integrity-hash.js";
 import { rateLimitByIp } from "../lib/rate-limit.js";
 import { apiError } from "../lib/errors.js";
 import type { AppEnv } from "../types.js";
@@ -76,7 +80,13 @@ verifyRoute.get("/:transactionId", async (c) => {
   }
 
   // Recompute hash for this transaction
-  const recomputed = computeIntegrityHash(
+  // SELECT THE RULE FROM THE ROW, not from what this file assumes.
+  //
+  // This called the v1-only entry point unconditionally. Once the chain worker
+  // began writing genuine v2 hashes, that would have reported hash_valid:false
+  // on a perfectly intact receipt — a public endpoint calling real records
+  // tampered. Reviewer-found, after the fix that armed it.
+  const recomputed = computeIntegrityHashVersioned(
     {
       id: txn.id,
       userId: txn.userId,
@@ -92,8 +102,10 @@ verifyRoute.get("/:transactionId", async (c) => {
       dataJurisdiction: txn.dataJurisdiction,
       createdAt: txn.createdAt,
       completedAt: txn.completedAt,
+      receiptDigest: txn.receiptDigest ?? null,
     },
     txn.previousHash ?? GENESIS_HASH,
+    chainVersionOf(txn.integrityPayloadVersion),
   );
 
   const hashValid = recomputed === txn.integrityHash;
@@ -306,7 +318,7 @@ export async function walkChain(
     }
 
     // Same field mapping as storeIntegrityHash() in do.ts
-    const recomputed = computeIntegrityHash(
+    const recomputed = computeIntegrityHashVersioned(
       {
         id: prev.id,
         userId: prev.userId,
@@ -322,8 +334,10 @@ export async function walkChain(
         dataJurisdiction: prev.dataJurisdiction,
         createdAt: prev.createdAt,
         completedAt: prev.completedAt,
+        receiptDigest: prev.receiptDigest ?? null,
       },
       prev.previousHash ?? GENESIS_HASH,
+      chainVersionOf(prev.integrityPayloadVersion),
     );
 
     if (recomputed === prev.integrityHash) {


### PR DESCRIPTION
## Execution receipt, Phase 4 — receipt authority, immutable snapshots, chain v2

Implements the accepted `PHASE-2-SPEC.md`. **No rail is wired.** Persistence, the two authorities and chain-v2 correctness are established and proven first, per §I.

> **Review history — four rounds, ending PASS.**
>
> | round | head | verdict |
> |---|---|---|
> | 1 | `885ca00` | **FAIL** — 25 attacks, **all 25 succeeded**; 6 blocking |
> | 2 | `6534d1b` | **FAIL** — 4 blocking, incl. the repo suite red at that head |
> | 3 | `7ee63a5` | **FAIL** — 1 blocking, introduced *by* a round-2 fix |
> | 4 | `1d8cb81` | **PASS** |
>
> Six claims this PR body previously made were **false**. They are listed below rather than edited away, because the corrections are the most useful part of the record.
>
> **The round-3 finding is the one to read.** Adding `integrity_payload_version` to the transition trigger's frozen-column list collided with the chain worker writing exactly that column: the worker's UPDATE fell through to a terminal check that tested `OLD.receipt_status IN (...)` rather than whether the status was *changing*. The whole tick runs in one transaction, so the RAISE aborted it, the per-row catch swallowed the cascade, and the tick rolled back — **one receipt-bearing row would have halted the tamper-evident chain for every transaction in the system, permanently**, with `/v1/verify` answering "no integrity hash" and `/v1/audit` answering "still being computed" forever. The full repo suite was green while that was true. Both halves were tested; their junction was not.

---

### Schema and migrations

**`0106`** — the content-addressed snapshot table, with `BEFORE UPDATE` and `BEFORE DELETE` triggers. The block refuses to report success unless both exist and are **enabled**.

**`0107`** — nine columns on `transactions` and six CHECK constraints (status enum, digest shape, complete-implies-metadata, reason-required, chain-version validity, v2-implies-receipt-state).

**`0108`** (new, from review round 1) — the invariants the design called structural and enforced nowhere:

| enforcement | refuses |
|---|---|
| transition trigger | `complete → pending`, `complete → failed`, `failed → complete`, digest swap on complete, clearing post-epoch state back to NULL |
| `receipt_reason_closed` | any reason outside the closed set (`'banana'` was accepted before) |
| `receipt_metadata_known` | `receipt_version`/`canonicalization`/`digest_alg` set to anything we never produce (`fake.v9`, `NOPE`, `md5` were accepted) |
| `subject_matches_content` | a snapshot whose `subject_kind`/`subject_slug` disagree with the hashed bytes |
| `BEFORE TRUNCATE` trigger | emptying the snapshot table — row-level DELETE triggers do **not** fire for TRUNCATE |

### The six blocking findings

**B1 — chain-version authorship was inverted.** All three lifecycle writers stamped `integrity_payload_version = 2`, while the chain worker hashed with the **v1** entry point. A post-epoch row declared one rule and was hashed under another. It verified only because *nothing reads the column yet* — the corruption was scheduled to appear the instant anyone implemented the rule this document describes. Reproduced: stored `d9a0d728eb…`, recomputed under the row's own declared rule `78c8ebaa7e…`, **verifies false**.

The column now belongs to the hashing site and is written in the same UPDATE as the hash — the discipline that file already applies to `chain_seq`.

**B2 — a `pending` receipt could be chained.** Chain v2 anchors the receipt digest, so hashing a row whose receipt was unbuilt would anchor `null` and let the real digest arrive afterwards; completing it would then rewrite an already-chained fact. Guaranteed rather than theoretical, because retries are owned by that same worker.

The worker now admits only rows whose receipt state is **terminal or absent**. A `failed` receipt is admitted with a null digest deliberately: the chain then commits to *"at chain time this row had no recomputable receipt"* — permanently true, because `failed` never recovers. Excluding failures would leave a real, billed transaction outside the tamper-evident record, which is worse.

**B3 — no transition was enforced.** Every illegal one was accepted. Now a database trigger, not a convention.

**B4 — the epoch is NOT structurally enforceable yet, and this PR claimed it was.** A transaction inserted now, through the ordinary path, is byte-identical to a legacy row. The `chain_v2_has_receipt_state` CHECK constrains only rows that *declare* v2 — vacuous for rows declaring nothing, which is all of them. **The gap is real and remains**; it closes when the rails are wired and every insert sets a status. The claim is corrected, not the gap papered over.

**B5 — content addressing was asserted, not enforced.** A direct INSERT could pair digest A with snapshot B and the reader returned it. `readManifestSnapshot` now **recomputes before trusting** and refuses a mis-addressed row; the writer verifies on conflict; a CHECK ties the subject columns to the hashed content. The digest↔content relation cannot be a CHECK — Postgres has no RFC 8785 — so the one reader a verifier depends on is where it belongs.

**B6 — solution identity had two readings.** A null digest meant both "skipped" and "unresolved"; duplicate `step_order` made caller array position silently load-bearing; `-3`, `0`, `2.5` and an empty step list were all accepted. Steps now carry an explicit `disposition` (`ran`/`skipped`/`unresolved`), and ordering must be strictly increasing positive integers.

### Claims previously made here that were false

| claim | reality |
|---|---|
| "The verifier picks the rule from the row's own `integrity_payload_version`" | Nothing read the column. Fixed in B1; still nothing *verifies* by it, because no verifier is wired — see below. |
| "Production asserts deploy identity at boot, so `missing_deploy_identity` is unreachable" | **`assertDeployIdentity` has zero callers.** Nothing in `index.ts`. It must land with the first rail. |
| "every write since sets it, so there is no moment at which a post-epoch row has a null status" | No rail is wired, so no write sets it. B4. |
| "`chain_v2_has_receipt_state` makes that structural" | Vacuous for rows that declare nothing. B4. |
| "recorded as `failed`, never `complete` — enforced by CHECK … cannot drift even if the module is bypassed" | The CHECK only tested NOT NULL; a bypassing writer set `complete` with garbage metadata. True now, via 0108. |
| "a skipped step is explicit, not omitted" | Explicit, but indistinguishable from *unresolved*. True now, via B6. |

### Proof

**280 integration tests across 24 files**, including 77 for receipts — each new one an attack that used to work. Unit lane 2837 passing, zero assertion failures.

`receipt-chain-junction.integration.test.ts` drives the **real worker** over real rows and closes the gap that hid R3-B1: complete → chained v2 → recomputed and verified under its own rule; failed → chained v2 with a null digest; pending → not chained *and does not block its neighbours*; one receipt row does not stop the batch; a pending row chains once it settles; a row chains exactly once; and a receipt-blocked row is **counted** rather than silently excluded.

Round 4 re-verified all of it independently through `runIntegrityHashRetryOnce()` and the live routes — 16 probes, zero `integrity-hash-retry-row-failed` lines, against 33 in a single tick at the previous head.

Fail-before through the repo guard (`mutation-test.mjs`): lifecycle re-stamps the version → **caught**; reader stops recomputing → **caught**; duplicate `step_order` allowed → **caught**; empty step list allowed → **caught**; `chainVersionOf` falls back silently → **caught**.

### Also fixed from the non-blocking set

`chainVersionOf` fails closed on an unknown version. Pending is `not_yet_built` rather than `internal_error`, so healthy in-flight receipts stop landing in the alert counts. Lifecycle writes assert they touched a row. `0107`'s boot check is `EXISTS … LIMIT 1` rather than a `count(*)` over an `OR` that no index could serve — a full scan of 921k rows on **every** boot.

### What actually reaches production on deploy

Two — now three — migration blocks: a table, four triggers, nine columns, ten constraints, two indexes. All inert; all satisfied by the existing 921k rows. **No behaviour changes**, because nothing calls the receipt modules: verified by import graph, nothing in `routes/` or the executors references them.

The deploy-identity boot refusal is **not** wired, so it cannot take production down. That was luck rather than design in the first cut, since this document claimed it was active.

### Acceptance criteria for the rail PR

Not residual risks — things to be **checked**, because residual risks get read once:

1. **The deploy-identity boot gate must be wired.** `assertDeployIdentity` has zero callers today. Before wiring, verify with the platform that `RAILWAY_GIT_COMMIT_SHA` is set on *every* deploy path, including image redeploys and rollbacks — a deploy not originating from a git commit would refuse to boot. Do not weaken the refusal to accommodate one.
2. **`describeReceiptState` needs a `redacted` arm.** After retention clears content, a row keeps `receipt_status='complete'` and its digest while the content the digest commits to is gone — permanently unrecomputable, still reported as complete. `walkChain` already has this classification; the receipt lifecycle does not.
3. **The retry sweeper.** The backlog counter shipped here so a stuck row is visible, but nothing yet settles one.

### Residual risks

1. **The epoch is not structurally enforced** (B4) and will not be until rail wiring. Disclosed, not claimed away.
2. **Nothing calls this yet**, so every proof is against constructed inputs.
3. **The deploy-identity gate must land with the first rail.** When it does, a deploy not originating from a git commit would refuse to boot — verify with the platform that `RAILWAY_GIT_COMMIT_SHA` is set on every deploy path *before* wiring it. Do not weaken the refusal to accommodate an unusual path.
4. **`CapabilityDeclarationSource` is hand-maintained** with no parity guard, so a future execution-relevant column could silently never enter the digest. The repo has the right pattern in `capability-field-authority.test.ts`; adding it is owed.
5. **Three excluded fields are read on the execution path** — `data_update_cycle_days` and `dataset_last_updated` feed the `require_fresh` gate, and `name` is the fallback for a null `data_source`. None is worth blocking, but the boundary is a judgement call, not a derivation.
6. **No FK** from `transactions.receipt_manifest_digest` to the snapshot table.
7. **`NOT VALID` constraints** are enforced for new writes only.
8. **Snapshot growth is unbounded and permanent** by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
