### PR TITLE
Execution receipt Phase 5: rail integration and activation

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -391,12 +391,18 @@ export const transactions = pgTable(
     // masquerade as legacy by leaving the column null.
     /** 'complete' | 'pending' | 'failed'; NULL only for pre-epoch rows. */
     /**
-     * Defaulted here as well as in block 0109, so `drizzle-kit push` does not
-     * drop it. Push materialises schema.ts and would otherwise remove both
-     * defaults, and 0109 would then re-add them -- with a NEW epoch instant,
-     * which the design calls the single immutable record of when enforcement
-     * began. The migration remains the authority; this keeps push from
-     * fighting it.
+     * Defaulted here as well as in block 0109, so `drizzle-kit push` stops
+     * dropping it.
+     *
+     * This comment previously claimed that also protected the epoch instant.
+     * It does not, and a reviewer measured it: push additionally drops
+     * `transactions_post_epoch_has_receipt`, `transactions_receipt_reason_required`
+     * and the manifest-digest FK, and the next boot mints a FRESH epoch
+     * (observed moving by 13 minutes across one push). Nothing in production
+     * runs push -- `drizzle.config.ts` refuses without DATABASE_URL_TEST, the
+     * Dockerfile runs startup migrations only, and CI's order re-adds
+     * everything -- so this is a limit worth stating rather than a live risk.
+     * The migration remains the authority.
      */
     receiptStatus: varchar("receipt_status", { length: 16 }).default("pending"),
     /** Closed reason code, set when status is 'pending' or 'failed'. */

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -390,9 +390,20 @@ export const transactions = pgTable(
     // enforced by a CHECK in migration 0107 — a post-epoch row cannot
     // masquerade as legacy by leaving the column null.
     /** 'complete' | 'pending' | 'failed'; NULL only for pre-epoch rows. */
-    receiptStatus: varchar("receipt_status", { length: 16 }),
+    /**
+     * Defaulted here as well as in block 0109, so `drizzle-kit push` does not
+     * drop it. Push materialises schema.ts and would otherwise remove both
+     * defaults, and 0109 would then re-add them -- with a NEW epoch instant,
+     * which the design calls the single immutable record of when enforcement
+     * began. The migration remains the authority; this keeps push from
+     * fighting it.
+     */
+    receiptStatus: varchar("receipt_status", { length: 16 }).default("pending"),
     /** Closed reason code, set when status is 'pending' or 'failed'. */
-    receiptFailureReason: varchar("receipt_failure_reason", { length: 40 }),
+    /** Defaulted for the same reason as receiptStatus, and it is not optional:
+     *  transactions_receipt_reason_required means a `pending` row must say why,
+     *  so a status default without this one makes every INSERT fail. */
+    receiptFailureReason: varchar("receipt_failure_reason", { length: 40 }).default("not_yet_built"),
     /** 'strale.execution.v1' */
     receiptVersion: varchar("receipt_version", { length: 32 }),
     /** 'RFC8785' — named so a verifier need not infer it. */

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -405,6 +405,22 @@ export const transactions = pgTable(
     receiptManifestDigest: varchar("receipt_manifest_digest", { length: 71 }),
     /** Retry bookkeeping for the pending -> complete path. */
     receiptAttempts: integer("receipt_attempts").notNull().default(0),
+
+    /**
+     * The surface that created this transaction, captured at INSERT.
+     *
+     * Not recoverable afterwards, and not guessable: see block 0110. The
+     * sweeper needs it to rebuild a receipt the request path could not finish,
+     * and a guessed rail inside a commitment is worse than an admitted gap.
+     */
+    receiptRail: text("receipt_rail"),
+    /**
+     * The commit that was serving when this transaction was created.
+     *
+     * Captured at INSERT so a receipt built later - by a retry, or after a
+     * deploy - binds the code that actually ran rather than the code asking.
+     */
+    receiptDeployCommit: text("receipt_deploy_commit"),
     /**
      * Which integrity-chain payload rule hashed this row.
      * NULL = v1 (pre-epoch, by definition). 2 = v2, which anchors

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -36,6 +36,50 @@ async function main() {
   const { assertAlertingConfigured } = await import("./lib/alerting.js");
   assertAlertingConfigured();
 
+  // Execution receipts (Phase 5): the process must be able to name the commit
+  // it is serving BEFORE it serves anything.
+  //
+  // Every receipt records which code produced the result. A process that
+  // cannot identify its own build would emit commitments nobody can later
+  // interpret, and it would do so silently -- so this refuses to boot instead.
+  //
+  // Placed here, before any database work, because it is a synchronous
+  // environment read: a deployment that cannot satisfy it should fail in a
+  // second, not after migrations.
+  //
+  // Verified against the platform before wiring (PHASE-5-DEPLOY-IDENTITY-
+  // EVIDENCE.md): 994 of the last 1000 deployments carry a full 40-hex
+  // commitHash, and the redeploy path -- which is also how Railway expresses
+  // rollback -- is 25 for 25. The six that carry nothing are repo=null CLI
+  // upload deploys from 2026-04-05/06, four of which served production. That
+  // path is real, so the guidance below names it.
+  //
+  // Refusing is safe: the service healthchecks /health/deep, and a failed
+  // healthcheck does not cut over -- the previous deployment keeps serving.
+  const { assertDeployIdentity } = await import("./lib/receipt/deploy-identity.js");
+  try {
+    const identity = assertDeployIdentity();
+    console.log(
+      "[startup] Deploy identity: " +
+        identity.deployCommit +
+        (identity.enforced ? "" : " (sentinel; not enforced outside production)"),
+    );
+  } catch (err) {
+    const { StartupFatalError } = await import("./lib/startup-fatal.js");
+    throw new StartupFatalError(
+      (err as Error).message,
+      "This deployment has no git commit identity, so it cannot produce " +
+        "execution receipts and refused to start. Railway sets " +
+        "RAILWAY_GIT_COMMIT_SHA only for deploys originating from a GitHub " +
+        "commit -- a CLI upload deploy (railway up) has none, and this " +
+        "project used that path on 2026-04-05/06. " +
+        "Production is NOT down: this deploy failed its healthcheck and " +
+        "Railway kept the previous deployment serving. " +
+        "Fix: deploy from git instead -- push to main, or Railway dashboard " +
+        "-> Deployments -> Redeploy on any git-sourced deployment.",
+    );
+  }
+
   // Validate required provider env vars
   const { getActiveProviders } = await import("./lib/dependency-manifest.js");
   const missingVars: string[] = [];
@@ -100,12 +144,20 @@ async function main() {
   // main().catch, and real migration failures still abort immediately.
   //
   // PLATFORM CONSTRAINT: this retry loop runs BEFORE the server listens.
-  // The Railway service currently has healthcheckPath: null (verified
-  // 2026-07-02), so nothing kills a slow boot. If a deploy healthcheck is
-  // ever configured on /health, its timeout MUST exceed
-  // STARTUP_DB_RETRY_BUDGET_MS (Railway's default healthcheck timeout is
-  // 300s < our 600s budget) or deploys during DB degradation get killed
-  // mid-retry and the budget silently never applies.
+  //
+  // This comment used to say healthcheckPath was null, "verified 2026-07-02",
+  // and warned about what would happen if one were ever configured. One HAS
+  // been configured since, so that warning is now a live condition rather
+  // than a hypothetical: the build log of the current deployment reads
+  // "Path: /health/deep, Retry window: 20s", and 20s is far below this
+  // budget's 600s default (STARTUP_DB_RETRY_BUDGET_MS).
+  //
+  // Consequence, stated plainly: during database degradation the deploy is
+  // killed at 20s and this budget never applies. The fix is the Railway
+  // healthcheck window, not this code, so nothing is changed here beyond
+  // correcting a comment that had gone false. Confirmed 2026-08-23, when a
+  // good build failed with "1/1 replicas never became healthy" and a
+  // redeploy of the identical commit went green.
   const { withStartupDbRetry } = await import("./lib/startup-db-retry.js");
   const { runStartupMigrations } = await import("./lib/startup-migrations.js");
   const dbRetryStartedAt = Date.now();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -59,10 +59,17 @@ async function main() {
   const { assertDeployIdentity } = await import("./lib/receipt/deploy-identity.js");
   try {
     const identity = assertDeployIdentity();
-    console.log(
-      "[startup] Deploy identity: " +
-        identity.deployCommit +
-        (identity.enforced ? "" : " (sentinel; not enforced outside production)"),
+    // The structured logger, not console: `lint:no-new-console` is a ratchet on
+    // this file and it is right to be. The eight console.log lines already here
+    // predate it.
+    const { log } = await import("./lib/log.js");
+    log.info(
+      {
+        label: "startup-deploy-identity",
+        deploy_commit: identity.deployCommit,
+        enforced: identity.enforced,
+      },
+      "startup-deploy-identity",
     );
   } catch (err) {
     const { StartupFatalError } = await import("./lib/startup-fatal.js");

--- a/apps/api/src/jobs/integrity-hash-retry.ts
+++ b/apps/api/src/jobs/integrity-hash-retry.ts
@@ -242,6 +242,24 @@ async function runOnce(): Promise<void> {
           staleCount++;
         }
 
+        // A SAVEPOINT per row, and it is the difference between "one row is
+        // stuck" and "the chain has stopped".
+        //
+        // The per-row try/catch below has been here since WP7 and reads like
+        // it isolates a failing row. It does not: the whole tick is ONE
+        // transaction, so a raised error poisons it, every later statement
+        // fails with 25P02, the catch swallows the cascade, and the tick rolls
+        // back. Nothing is chained, ever again, retrying every 30 seconds.
+        //
+        // Phase 4 hit exactly this blast radius through the 0108 trigger and
+        // fixed the trigger. A reviewer then reproduced it in Phase 5 through
+        // a different mechanism: `transactions_post_epoch_has_receipt` is NOT
+        // VALID, which still enforces on UPDATE, so a post-epoch row with a
+        // NULL receipt_status cannot be updated by anyone - including this
+        // worker, which admits it. Two independent causes, one shape.
+        //
+        // So the fix belongs here rather than at either cause. Any future
+        // reason a row cannot be updated now costs that row, not the chain.
         try {
           // WHICH RULE HASHES THIS ROW, decided here and recorded here.
           //
@@ -281,7 +299,17 @@ async function runOnce(): Promise<void> {
             chainVersion,
           );
 
-          await tx
+          // Drizzle's NESTED TRANSACTION, not a hand-written SAVEPOINT.
+          //
+          // Both emit SAVEPOINT/ROLLBACK TO, and the hand-written version
+          // looked like it worked - the rollback executed, later statements
+          // succeeded - but the transaction still failed AT COMMIT with the
+          // original error. postgres-js pipelines inside `begin()` and tracks
+          // the query error on the connection, so catching it in JS is not
+          // enough; the driver still aborts. Proven both ways with a minimal
+          // probe before choosing this.
+          await tx.transaction(async (sp) =>
+            sp
             .update(transactions)
             .set({
               integrityHash: hash,
@@ -299,7 +327,8 @@ async function runOnce(): Promise<void> {
               integrityPayloadVersion:
                 chainVersion === CHAIN_PAYLOAD_V2 ? CHAIN_PAYLOAD_V2 : null,
             })
-            .where(eq(transactions.id, txn.id));
+            .where(eq(transactions.id, txn.id)),
+          );
           currentPrevious = hash;
           completed++;
         } catch (err) {
@@ -309,11 +338,18 @@ async function runOnce(): Promise<void> {
 
           // If this row has been pending for well past STALE_WARN_MS, flip to
           // 'failed' so it stops clogging the queue and operators get a ping.
+          //
+          // In its own savepoint too: on a row that cannot be updated at all,
+          // THIS is a second statement that fails, and un-nested it would
+          // poison the tick exactly like the one that got us here.
           if (Date.now() - txn.createdAt.getTime() > STALE_WARN_MS * MAX_HASH_ATTEMPTS) {
             await tx
-              .update(transactions)
-              .set({ complianceHashState: "failed" })
-              .where(eq(transactions.id, txn.id))
+              .transaction(async (sp) =>
+                sp
+                  .update(transactions)
+                  .set({ complianceHashState: "failed" })
+                  .where(eq(transactions.id, txn.id)),
+              )
               .catch((err2) =>
                 logError("integrity-hash-mark-failed-failed", err2, { transactionId: txn.id }),
               );

--- a/apps/api/src/jobs/integrity-hash-retry.ts
+++ b/apps/api/src/jobs/integrity-hash-retry.ts
@@ -35,6 +35,7 @@
 
 import { sql, eq, and, lt, asc } from "drizzle-orm";
 import { getDb } from "../db/index.js";
+import { sweepPendingReceipts } from "../lib/receipt/sweeper.js";
 import { transactions } from "../db/schema.js";
 import {
   computeIntegrityHashVersioned,
@@ -71,6 +72,20 @@ export async function runIntegrityHashRetryOnce(): Promise<void> {
 
 async function runOnce(): Promise<void> {
   const db = getDb();
+
+  // Receipts first, and OUTSIDE the chain transaction below.
+  //
+  // First, because the chain refuses to admit a row whose receipt is still
+  // pending -- so a receipt settled now is a row that can chain in this same
+  // tick rather than waiting for the next one.
+  //
+  // Outside, because the chain tick is a single transaction: an exception
+  // raised while sweeping would roll back every hash written in it. That is
+  // the Phase 4 round-three failure exactly, where one receipt-bearing row
+  // would have halted the tamper-evident chain for every transaction in the
+  // system. sweepPendingReceipts never throws, and this await is still not
+  // inside the transaction, so neither property depends on the other.
+  await sweepPendingReceipts(db);
 
   // Advisory-lock + all work runs inside a single transaction so the
   // xact-scoped lock sits on the same connection as every subsequent

--- a/apps/api/src/jobs/settlement-reconciler.ts
+++ b/apps/api/src/jobs/settlement-reconciler.ts
@@ -27,6 +27,7 @@
  */
 
 import { eq, sql } from "drizzle-orm";
+import { deployCommitOrNull } from "../lib/receipt/deploy-identity.js";
 import { settleExecutionReceipt } from "../lib/receipt/settle.js";
 
 import { getDb } from "../db/index.js";
@@ -150,6 +151,11 @@ export async function reconcileSettlementsOnce(): Promise<ReconcileSettlementsSu
         const [recreated] = await db
           .insert(transactions)
           .values({
+            // Captured at INSERT because neither is recoverable later:
+            // the rail is not a property of the row, and the deploy commit
+            // drifts the moment anything redeploys (block 0110).
+            receiptRail: "x402",
+            receiptDeployCommit: deployCommitOrNull(),
             userId: null,
             capabilityId: cap?.id ?? null,
             solutionSlug: intent.solutionSlug,

--- a/apps/api/src/jobs/settlement-reconciler.ts
+++ b/apps/api/src/jobs/settlement-reconciler.ts
@@ -27,6 +27,7 @@
  */
 
 import { eq, sql } from "drizzle-orm";
+import { settleExecutionReceipt } from "../lib/receipt/settle.js";
 
 import { getDb } from "../db/index.js";
 import { transactions } from "../db/schema.js";
@@ -183,6 +184,17 @@ export async function reconcileSettlementsOnce(): Promise<ReconcileSettlementsSu
         await markRecordedBySettlement(db, {
           settlementId: intent.settlementId,
           transactionId: recreated.id,
+        });
+        // The recovered row is a real, paid execution that we cannot describe:
+        // the output was lost with the process. It still gets a receipt, and
+        // the receipt says exactly that - `stepsUnknown` marks every declared
+        // step `unresolved` rather than `skipped`, because `skipped` would be
+        // a positive claim that the step never ran, and it very probably did.
+        await settleExecutionReceipt(db, {
+          transactionId: recreated.id,
+          rail: "x402",
+          solutionSlug: intent.solutionSlug,
+          stepsUnknown: Boolean(intent.solutionSlug),
         });
         // The orphan table is the OTHER channel for this same event, and it
         // says "awaiting reconciliation" with a procedure ("recreate the row

--- a/apps/api/src/lib/receipt/deploy-identity.ts
+++ b/apps/api/src/lib/receipt/deploy-identity.ts
@@ -96,3 +96,21 @@ export function assertDeployIdentity(env = process.env): {
   const deployCommit = resolveDeployCommit(env); // throws in production if absent
   return { deployCommit, enforced };
 }
+
+/**
+ * The serving commit, or null, for a value written on the request path.
+ *
+ * `resolveDeployCommit` throws in production when the identity is missing -
+ * correct for the boot gate, wrong for an INSERT that is part of a customer
+ * request. The gate has already run by the time any request is served, so this
+ * cannot legitimately return null in production; it exists so that a
+ * hypothetical failure degrades to a receipt the sweeper marks
+ * `missing_deploy_identity` rather than to a 500 on a paid call.
+ */
+export function deployCommitOrNull(env = process.env): string | null {
+  try {
+    return resolveDeployCommit(env);
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/lib/receipt/execution-receipt.integration.test.ts
+++ b/apps/api/src/lib/receipt/execution-receipt.integration.test.ts
@@ -60,6 +60,11 @@ const BASE_DECL: CapabilityDeclarationSource = {
   processesPersonalData: false,
   personalDataCategories: [],
   gdprArt22Classification: "data_lookup",
+  name: "VAT Validate",
+  dataClassification: "public",
+  x402Method: "POST",
+  dataUpdateCycleDays: null,
+  datasetLastUpdated: null,
 };
 
 function baseReceipt(overrides: Partial<ReceiptInput> = {}): ReceiptInput {

--- a/apps/api/src/lib/receipt/execution-receipt.integration.test.ts
+++ b/apps/api/src/lib/receipt/execution-receipt.integration.test.ts
@@ -134,6 +134,28 @@ describeMaybe("execution receipts against a real database", () => {
     return id;
   }
 
+  /**
+   * A row as it existed before the epoch: no receipt state at all.
+   *
+   * Since block 0109 an ordinary insert is `pending` from birth, and the
+   * post-epoch CHECK forbids a NULL status on a present-day row - so the
+   * legacy shape has to be constructed with a pre-epoch `created_at`. That is
+   * the epoch being structural rather than conventional, and it is worth
+   * having to say out loud in a test.
+   */
+  async function legacyTransaction(): Promise<string> {
+    const id = randomUUID();
+    txns.add(id);
+    await db.execute(sql`
+      INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
+                                data_jurisdiction, input, created_at,
+                                receipt_status, receipt_failure_reason)
+      VALUES (${id}::uuid, ${userId}::uuid, 'completed', 5, 'algorithmic', 'EU',
+              '{}'::jsonb, now() - interval '400 days', NULL, NULL)
+    `);
+    return id;
+  }
+
   async function store(decl: Record<string, unknown>): Promise<string> {
     const d = await recordManifestSnapshot(db, decl);
     snapshots.add(d);
@@ -192,7 +214,16 @@ describeMaybe("execution receipts against a real database", () => {
       priceCents: 999,
       avgLatencyMs: 12345,
       description: "a completely rewritten description",
-      name: "Renamed Capability",
+      // `name` USED to be in this list, and Phase 5 moved it into the
+      // declaration. Not for tidiness: routes/do.ts writes
+      // `data_source: capability.dataSource ?? capability.name` into the audit
+      // body at three sites, so for a capability with a null data_source the
+      // name IS the recorded provenance source. Renaming one changes what the
+      // audit trail says produced the answer, which is the same test that
+      // admits every other member here.
+      //
+      // manifest-declaration-parity.test.ts proves the new direction: it
+      // asserts `name` MOVES the digest.
     } as unknown as CapabilityDeclarationSource;
     expect(declarationDigest(normalizeCapabilityDeclaration(withNoise))).toBe(base);
   });
@@ -487,7 +518,13 @@ describeMaybe("execution receipts against a real database", () => {
     // battery caught it. This one sets a real complete receipt FIRST, so the
     // clearing has something to clear.
     const id = await newTransaction();
-    const built = buildExecutionReceipt(baseReceipt({ transactionId: id }), {
+    // A REAL snapshot digest: transactions.receipt_manifest_digest is a
+    // foreign key as of block 0109, so the fixture's `sha256:aaa...` is
+    // refused. That refusal is the constraint working - a receipt whose
+    // manifest digest names nothing is unverifiable - so the test records the
+    // declaration it claims to have used instead of loosening the FK.
+    const manifestDigest = await store(normalizeCapabilityDeclaration(BASE_DECL));
+    const built = buildExecutionReceipt(baseReceipt({ transactionId: id, manifestDigest }), {
       NODE_ENV: "test",
     } as NodeJS.ProcessEnv);
     if (built.outcome !== "complete") throw new Error("fixture must build");
@@ -526,10 +563,18 @@ describeMaybe("execution receipts against a real database", () => {
   });
 
   it("the database refuses a pending/failed row with no reason", async () => {
+    // The reason has to be cleared explicitly to test this now. Since block
+    // 0109, `receipt_failure_reason` DEFAULTS to 'not_yet_built' alongside the
+    // pending status - and it has to, because otherwise every INSERT into
+    // transactions would violate this very constraint. Leaving the test as
+    // "set status and expect a violation" would have passed for the wrong
+    // reason and stopped guarding anything.
     const id = await newTransaction();
     await expect(
       db.execute(sql`
-        UPDATE transactions SET receipt_status = 'failed' WHERE id = ${id}::uuid
+        UPDATE transactions
+           SET receipt_status = 'failed', receipt_failure_reason = NULL
+         WHERE id = ${id}::uuid
       `),
     ).rejects.toThrow(/transactions_receipt_reason_required/);
   });
@@ -591,7 +636,13 @@ describeMaybe("execution receipts against a real database", () => {
 
   it("a complete receipt records everything needed to recompute it", async () => {
     const id = await newTransaction();
-    const built = buildExecutionReceipt(baseReceipt({ transactionId: id }), {
+    // A REAL snapshot digest: transactions.receipt_manifest_digest is a
+    // foreign key as of block 0109, so the fixture's `sha256:aaa...` is
+    // refused. That refusal is the constraint working - a receipt whose
+    // manifest digest names nothing is unverifiable - so the test records the
+    // declaration it claims to have used instead of loosening the FK.
+    const manifestDigest = await store(normalizeCapabilityDeclaration(BASE_DECL));
+    const built = buildExecutionReceipt(baseReceipt({ transactionId: id, manifestDigest }), {
       NODE_ENV: "test",
     } as NodeJS.ProcessEnv);
     expect(built.outcome).toBe("complete");
@@ -621,7 +672,7 @@ describeMaybe("execution receipts against a real database", () => {
   // ── F. Epoch ─────────────────────────────────────────────────────────────
 
   it("a pre-epoch row reads as legacy_unavailable, and post-epoch cannot masquerade as it", async () => {
-    const legacy = await newTransaction(); // no receipt columns written
+    const legacy = await legacyTransaction(); // pre-epoch: no receipt state
     const rows = await db.execute(sql`
       SELECT receipt_status, receipt_failure_reason, receipt_digest, integrity_payload_version
         FROM transactions WHERE id = ${legacy}::uuid
@@ -636,6 +687,19 @@ describeMaybe("execution receipts against a real database", () => {
       receiptDigest: row.receipt_digest as string | null,
     });
     expect(described.status).toBe("legacy_unavailable");
+
+    // The other half, and it is new: a row created TODAY cannot be given the
+    // legacy shape at all. Before block 0109 this was a property of the wiring
+    // (nothing wrote receipt state); now it is a property of the database.
+    await expect(
+      db.execute(sql`
+        INSERT INTO transactions (user_id, status, price_cents, transparency_marker,
+                                  data_jurisdiction, input, receipt_status,
+                                  receipt_failure_reason)
+        VALUES (${userId}::uuid, 'completed', 5, 'algorithmic', 'EU', '{}'::jsonb,
+                NULL, NULL)
+      `),
+    ).rejects.toThrow(/transactions_post_epoch_has_receipt/);
 
     // A v2 row cannot leave receipt_status null and read as legacy.
     await expect(

--- a/apps/api/src/lib/receipt/manifest-declaration-parity.test.ts
+++ b/apps/api/src/lib/receipt/manifest-declaration-parity.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Parity between the `capabilities` schema and the declaration digest.
+ *
+ * `CapabilityDeclarationSource` is hand-maintained, and Phase 4 shipped it that
+ * way deliberately: spreading the row would let a new column silently change
+ * every future digest. But the hand-maintained list has the mirror-image
+ * failure, and nothing guarded it — a new EXECUTION-RELEVANT column silently
+ * never entering the digest, so two materially different implementations share
+ * one identity. Nothing fails. The receipts just quietly mean less, which is the
+ * worst failure mode a provenance system can have.
+ *
+ * Phase 4 listed this as residual risk 4 and said the repo already had the right
+ * pattern in `capability-field-authority.test.ts`. This is that pattern.
+ *
+ * Note this file has to be a RUNTIME test rather than a type-level one:
+ * `tsconfig.json` excludes every test file from compilation, so tsc never
+ * sees test fixtures and cannot be the guard here.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getTableColumns } from "drizzle-orm";
+import { capabilities } from "../../db/schema.js";
+import {
+  CAPABILITY_COLUMN_DISPOSITION,
+  normalizeCapabilityDeclaration,
+  type CapabilityDeclarationSource,
+} from "./manifest-snapshot.js";
+
+function dbColumnNames(table: Record<string, unknown>): string[] {
+  const cols = getTableColumns(table as Parameters<typeof getTableColumns>[0]);
+  return Object.values(cols).map((c) => (c as { name: string }).name);
+}
+
+/** Every field populated, so no key can be absent for want of a value. */
+const FULL: CapabilityDeclarationSource = {
+  slug: "vat-validate",
+  name: "VAT Validate",
+  inputSchema: { type: "object" },
+  outputSchema: { type: "object" },
+  transparencyTag: "algorithmic",
+  dataSource: "VIES",
+  capabilityType: "api",
+  freshnessCategory: "live-fetch",
+  outputFieldReliability: { valid: "guaranteed" },
+  processesPersonalData: false,
+  personalDataCategories: ["name"],
+  gdprArt22Classification: "data_lookup",
+  dataClassification: "public",
+  x402Method: "POST",
+  dataUpdateCycleDays: 30,
+  datasetLastUpdated: new Date("2026-08-01T00:00:00.000Z"),
+};
+
+/** Present in the digest but not a column — synthesised by the normalizer. */
+const SYNTHETIC = new Set(["subject_kind"]);
+
+describe("capability declaration ↔ schema parity", () => {
+  it("every capabilities column is classified", () => {
+    const unclassified = dbColumnNames(capabilities).filter(
+      (col) => !(col in CAPABILITY_COLUMN_DISPOSITION),
+    );
+    expect(
+      unclassified,
+      "New capabilities column(s) with no disposition. Decide, in " +
+        "CAPABILITY_COLUMN_DISPOSITION: does this column change what an " +
+        "execution DID? If so add it to CapabilityDeclarationSource and the " +
+        "normalizer; if not, record the reason it cannot. Do not default to " +
+        "excluded by inaction — that is the failure this guard exists for: " +
+        unclassified.join(", "),
+    ).toEqual([]);
+  });
+
+  it("every classified column still exists in the schema", () => {
+    const cols = new Set(dbColumnNames(capabilities));
+    const stale = Object.keys(CAPABILITY_COLUMN_DISPOSITION).filter((k) => !cols.has(k));
+    expect(stale, `Disposition entries for columns that no longer exist: ${stale.join(", ")}`).toEqual(
+      [],
+    );
+  });
+
+  it("a column claiming to be in the declaration is actually in the digest", () => {
+    // The half that matters. Without it the map is a comment: it could claim a
+    // column is bound while the normalizer never reads it.
+    const declared = Object.entries(CAPABILITY_COLUMN_DISPOSITION)
+      .filter(([, v]) => v === "declaration")
+      .map(([k]) => k);
+    const emitted = new Set(Object.keys(normalizeCapabilityDeclaration(FULL)));
+    const claimedButAbsent = declared.filter((k) => !emitted.has(k));
+    expect(
+      claimedButAbsent,
+      `Claimed as declaration but never emitted: ${claimedButAbsent.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("a key in the digest is a column that claims to be in the declaration", () => {
+    // The other direction: the normalizer cannot bind something the map calls
+    // excluded, which would make the recorded reasoning false.
+    const emitted = Object.keys(normalizeCapabilityDeclaration(FULL)).filter(
+      (k) => !SYNTHETIC.has(k),
+    );
+    const notDeclared = emitted.filter(
+      (k) => CAPABILITY_COLUMN_DISPOSITION[k] !== "declaration",
+    );
+    expect(
+      notDeclared,
+      `Emitted into the digest but not classified as declaration: ${notDeclared.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("each of the three fields Phase 4 excluded now moves the digest", async () => {
+    // Not a restatement of the map — proof that including them was real.
+    // Phase 4 excluded these as metadata; they decide whether a request is
+    // SERVED (require_fresh + grade C is a refusal) and what the audit body
+    // records as the source (data_source ?? name).
+    const { declarationDigest } = await import("./manifest-snapshot.js");
+    const base = declarationDigest(normalizeCapabilityDeclaration(FULL));
+    const moves: Array<[string, Partial<CapabilityDeclarationSource>]> = [
+      ["name", { name: "VAT Validate (EU)" }],
+      ["dataUpdateCycleDays", { dataUpdateCycleDays: 31 }],
+      ["datasetLastUpdated", { datasetLastUpdated: new Date("2026-08-02T00:00:00.000Z") }],
+    ];
+    for (const [label, patch] of moves) {
+      const moved = declarationDigest(normalizeCapabilityDeclaration({ ...FULL, ...patch }));
+      expect(moved, `${label} did not move the declaration digest`).not.toBe(base);
+    }
+  });
+
+  it("dataset_last_updated is bound as a stable UTC string, not a Date", async () => {
+    // A Date is not canonicalizable, and two Dates built differently for the
+    // SAME instant must not produce different digests. Pinning the ISO form
+    // inside the normalizer is what makes that true; if someone later passes
+    // the Date straight through, this fails.
+    const { declarationDigest } = await import("./manifest-snapshot.js");
+    const a = declarationDigest(
+      normalizeCapabilityDeclaration({
+        ...FULL,
+        datasetLastUpdated: new Date("2026-08-01T00:00:00.000Z"),
+      }),
+    );
+    const b = declarationDigest(
+      normalizeCapabilityDeclaration({
+        ...FULL,
+        datasetLastUpdated: new Date(Date.UTC(2026, 7, 1, 0, 0, 0, 0)),
+      }),
+    );
+    expect(b).toBe(a);
+
+    const emitted = normalizeCapabilityDeclaration(FULL);
+    expect(typeof emitted.dataset_last_updated).toBe("string");
+    expect(emitted.dataset_last_updated).toBe("2026-08-01T00:00:00.000Z");
+  });
+});

--- a/apps/api/src/lib/receipt/manifest-snapshot.ts
+++ b/apps/api/src/lib/receipt/manifest-snapshot.ts
@@ -78,6 +78,44 @@ export interface CapabilityDeclarationSource {
   processesPersonalData: boolean;
   personalDataCategories: string[] | null;
   gdprArt22Classification: string | null;
+  /**
+   * The freshness pair. Phase 4 excluded these as "metadata"; that was wrong,
+   * and the correction is derived from execution semantics rather than
+   * convenience.
+   *
+   * They are the inputs to the trust grade (`lib/trust-grade.ts`), and
+   * `POST /v1/do` REFUSES a reference-data request outright when
+   * `require_fresh` is set and the computed grade is C (`routes/do.ts`). So
+   * these two columns decide whether a request is served or rejected. Two
+   * executions of the same slug, one served and one refused, would otherwise
+   * carry byte-identical implementation identity — which is exactly the
+   * under-specification a receipt exists to prevent.
+   */
+  dataUpdateCycleDays: number | null;
+  datasetLastUpdated: Date | null;
+  /**
+   * Not a display label, despite the name.
+   *
+   * `routes/do.ts` writes `data_source: capability.dataSource ?? capability.name`
+   * into the audit body at three sites, and `x402-gateway-v2.ts` does the same
+   * with the slug. So for any capability with a null `data_source` — and there
+   * are such rows — `name` IS the recorded provenance source. Renaming one
+   * changes what the audit trail says produced the answer, which makes it
+   * execution-relevant by the same test as the pair above.
+   */
+  name: string | null;
+  /**
+   * Written into the audit body as `data_classification` at three sites in
+   * `routes/do.ts`. Same test as `name`: it changes what we recorded about the
+   * execution, so it is bound.
+   */
+  dataClassification: string | null;
+  /**
+   * The HTTP method the x402 rail exposes, and part of the challenge and
+   * schema it publishes (`x402-gateway-v2.ts`). It shapes how the request is
+   * made, so two capabilities differing only here are not interchangeable.
+   */
+  x402Method: string | null;
 }
 
 /**
@@ -131,8 +169,117 @@ export function normalizeCapabilityDeclaration(
     processes_personal_data: source.processesPersonalData,
     personal_data_categories: [...(source.personalDataCategories ?? [])].sort(),
     gdpr_art_22_classification: source.gdprArt22Classification ?? null,
+    name: source.name ?? null,
+    data_classification: source.dataClassification ?? null,
+    x402_method: source.x402Method ?? null,
+    data_update_cycle_days: source.dataUpdateCycleDays ?? null,
+    // A Date is not canonicalizable and two Dates one millisecond apart are a
+    // different declaration, so this is pinned to its UTC ISO form here rather
+    // than left to whatever the caller happens to pass.
+    dataset_last_updated: source.datasetLastUpdated
+      ? source.datasetLastUpdated.toISOString()
+      : null,
   };
 }
+
+/**
+ * Every column of `capabilities`, classified: does it enter the declaration
+ * digest, or not, and why not?
+ *
+ * This exists because `CapabilityDeclarationSource` is hand-maintained. Listing
+ * the fields explicitly stops a NEW column from silently changing every future
+ * digest — but it has the mirror-image failure, which is what this map closes:
+ * a new execution-relevant column silently NEVER entering the digest, so two
+ * materially different implementations share one identity. Nothing would fail;
+ * the receipts would just quietly mean less.
+ *
+ * The parity test in `manifest-declaration-parity.test.ts` fails when a column
+ * appears in the schema and not here, so the choice has to be made by a person
+ * once, in the open, rather than defaulted to "excluded" by inaction.
+ */
+export const CAPABILITY_COLUMN_DISPOSITION: Record<string, "declaration" | string> = {
+  // ---------------------------------------------------------------- included
+  slug: "declaration",
+  name: "declaration",
+  input_schema: "declaration",
+  output_schema: "declaration",
+  transparency_tag: "declaration",
+  data_source: "declaration",
+  capability_type: "declaration",
+  freshness_category: "declaration",
+  output_field_reliability: "declaration",
+  processes_personal_data: "declaration",
+  personal_data_categories: "declaration",
+  gdpr_art_22_classification: "declaration",
+  data_update_cycle_days: "declaration",
+  dataset_last_updated: "declaration",
+  data_classification: "declaration",
+  x402_method: "declaration",
+
+  // ---------------------------------------------------------------- excluded
+  //
+  // Three tests separate these from the list above, and only the first two
+  // admit a column:
+  //   1. does it change what the execution COMPUTED?
+  //   2. does it change what we RECORDED about the execution?
+  //   3. does it merely decide whether the execution was allowed to happen?
+  // (3) is admission control. It is excluded on purpose: a refusal is not an
+  // execution, and when a request IS served the column had no bearing on the
+  // answer. The rail — which is what admission is usually keyed on — is
+  // already a fixed-point member of the receipt.
+
+  id: "surrogate key; slug is the identity a reader can act on",
+  created_at: "row bookkeeping",
+  updated_at: "row bookkeeping, and it churns on every metadata write",
+  description: "prose for humans and SEO; never read on the execution path",
+  category: "catalog taxonomy; routing reads the slug",
+  search_tags: "discovery only",
+  visible: "catalog display",
+  geography: "where the data is ABOUT, a property of the dataset. Deliberately NOT the processing jurisdiction -- F-AUDIT-01 removed it from that use (see x402-gateway-v2.ts) -- and the jurisdiction actually applied is recorded per-execution on the transaction row",
+
+  price_cents: "commercial term; the transaction row records what was charged",
+  is_free_tier: "commercial term; likewise recorded per-execution",
+
+  is_active: "admission control (3)",
+  lifecycle_state: "admission control (3)",
+  x402_enabled: "admission control (3), and the rail is already bound",
+  cost_class: "admission control (3): ALLOW_MATRIX in guarded-executor.ts refuses invocation from some context kinds. It gates whether a call is permitted, and changes nothing about the answer when it is",
+  quota_window: "admission control (3), vendor budget",
+  quota_cap: "admission control (3), vendor budget",
+  quota_reset_dom: "admission control (3), vendor budget",
+  marketplace_eligible: "admission control (3), listing",
+  marketplace_eligible_reason: "operator note attached to the line above",
+  maintenance_class: "operational scheduling; read by the test generators, not by execution",
+
+  avg_latency_ms: "observed statistic, not a declaration. It does select sync vs async routing, but the receipt records the execution mode it actually took, so the fact is bound directly rather than by proxy",
+  success_rate: "observed statistic",
+  last_tested_at: "observed statistic",
+  degraded_recovery_count: "observed statistic",
+  deactivation_reason: "operator note",
+  onboarding_hook_failures: "operational counter",
+  onboarding_manifest: "the AUTHORING artifact. The columns in force are what execution reads, and binding both would let a receipt claim a declaration that never took effect",
+
+  error_codes_json:
+    "documentation of the errors a capability MAY return. The error actually returned is bound by the receipt's own result",
+  freshness_level:
+    "derived label. The trust grade is computed from freshness_category plus the data_update_cycle_days / dataset_last_updated pair, all three of which are bound",
+  freshness_decayed_at: "derived timestamp of the same computation",
+
+  fallback_capability_slug: "trust-DISPLAY data for the capability detail page, not routing: no execution-path file reads it. If it ever becomes routing, it moves to declaration -- and this guard is what will force that decision",
+  fallback_coverage: "trust-display data, as above",
+  fallback_verification_level: "trust-display data, as above",
+
+  // Residue of the SQS engine deleted under DEC-20260503-B (2026-05-05). PR2
+  // drops the columns; nothing reads them now.
+  qp_score: "dead SQS column",
+  rp_score: "dead SQS column",
+  matrix_sqs: "dead SQS column",
+  matrix_sqs_raw: "dead SQS column",
+  trend: "dead SQS column",
+  guidance_usable: "dead SQS column",
+  guidance_strategy: "dead SQS column",
+  guidance_confidence: "dead SQS column",
+};
 
 /**
  * The normalized solution declaration.

--- a/apps/api/src/lib/receipt/rail-coverage.test.ts
+++ b/apps/api/src/lib/receipt/rail-coverage.test.ts
@@ -58,6 +58,24 @@ function isTestFile(path: string): boolean {
 
 const WRITES_TRANSACTIONS = /insert\(transactions\)|INSERT\s+INTO\s+transactions/;
 
+/**
+ * The rule, as a pure function, so it can be tested on inputs we control.
+ *
+ * A source lint that scans a clean repository finds nothing, and "found
+ * nothing" is indistinguishable from "cannot find anything". Disabling the
+ * detection entirely left this file green -- caught by the mutation battery,
+ * which is exactly the hollow-guard shape this repo has been bitten by before.
+ * The positive controls below feed it a file that SHOULD be flagged.
+ */
+export function classify(
+  rel: string,
+  source: string,
+): "not-a-writer" | "exempt" | "offender" | "wired" {
+  if (!WRITES_TRANSACTIONS.test(source)) return "not-a-writer";
+  if (EXEMPT[rel]) return "exempt";
+  return source.includes("settleExecutionReceipt") ? "wired" : "offender";
+}
+
 describe("receipt rail coverage", () => {
   const offenders: Array<{ file: string; reason: string }> = [];
   const exemptSeen = new Set<string>();
@@ -68,11 +86,12 @@ describe("receipt rail coverage", () => {
     const source = readFileSync(abs, "utf8");
     if (!WRITES_TRANSACTIONS.test(source)) continue;
 
-    if (EXEMPT[rel]) {
+    const verdict = classify(rel, source);
+    if (verdict === "exempt") {
       exemptSeen.add(rel);
       continue;
     }
-    if (!source.includes("settleExecutionReceipt")) {
+    if (verdict === "offender") {
       offenders.push({ file: rel, reason: "writes transactions, never settles a receipt" });
     }
   }
@@ -114,5 +133,39 @@ describe("receipt rail coverage", () => {
         expected,
       );
     }
+  });
+
+  describe("the rule itself, on inputs we control", () => {
+    // Without these the lint proves only that the repository is currently
+    // clean, which it would also "prove" if the detection did nothing at all.
+    it("flags a file that writes transactions and never settles", () => {
+      expect(
+        classify("routes/new-rail.ts", "await db.insert(transactions).values({});"),
+      ).toBe("offender");
+    });
+
+    it("flags a raw-SQL writer too, not just the drizzle form", () => {
+      expect(
+        classify("routes/new-rail.ts", "await db.execute(sql`INSERT INTO transactions (id) ...`);"),
+      ).toBe("offender");
+    });
+
+    it("does not flag a file that settles", () => {
+      expect(
+        classify(
+          "routes/new-rail.ts",
+          "await db.insert(transactions).values({}); await settleExecutionReceipt(db, {});",
+        ),
+      ).toBe("wired");
+    });
+
+    it("does not flag a file that never touches transactions", () => {
+      expect(classify("lib/whatever.ts", "export const x = 1;")).toBe("not-a-writer");
+    });
+
+    it("honours an exemption, and only for the exact path", () => {
+      expect(classify("app.ts", "INSERT INTO transactions (id)")).toBe("exempt");
+      expect(classify("app2.ts", "INSERT INTO transactions (id)")).toBe("offender");
+    });
   });
 });

--- a/apps/api/src/lib/receipt/rail-coverage.test.ts
+++ b/apps/api/src/lib/receipt/rail-coverage.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Every production site that writes a transaction must settle its receipt.
+ *
+ * Fail-closed source lint, in the same shape as
+ * `jobs/no-boot-relative-timers.test.ts`. A new rail, or a new settlement path
+ * inside an existing one, is a file that writes `transactions` - and the
+ * failure mode this guards is that nobody remembers to build a receipt there.
+ *
+ * The epoch (migration 0109) already makes that failure VISIBLE rather than
+ * silent: `receipt_status` defaults to `pending`, so an unwired site produces
+ * rows the sweeper reports instead of rows that look pre-epoch. This lint makes
+ * it visible at build time instead, which is cheaper than finding it in a
+ * backlog counter.
+ *
+ * The exemption map is the point. A file can be excused, but only by writing
+ * down why, which is a decision someone made rather than a gap nobody noticed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = join(import.meta.dirname, "..", "..");
+
+/**
+ * Files that write `transactions` and legitimately produce no receipt.
+ * Key: path relative to `src/`, using forward slashes.
+ */
+const EXEMPT: Record<string, string> = {
+  "app.ts":
+    "the /health/deep write-path probe. It inserts a status='health_probe' row " +
+    "and DELETEs it in the same transaction - it is a database liveness check, " +
+    "not an execution of anything, and there is no result to commit to.",
+};
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "node_modules" || entry === "dist") continue;
+      walk(full, acc);
+    } else if (entry.endsWith(".ts")) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function isTestFile(path: string): boolean {
+  return /\.(test|spec)\.ts$/.test(path) || path.includes("test-support");
+}
+
+const WRITES_TRANSACTIONS = /insert\(transactions\)|INSERT\s+INTO\s+transactions/;
+
+describe("receipt rail coverage", () => {
+  const offenders: Array<{ file: string; reason: string }> = [];
+  const exemptSeen = new Set<string>();
+
+  for (const abs of walk(SRC)) {
+    if (isTestFile(abs)) continue;
+    const rel = abs.slice(SRC.length + 1).split("\\").join("/");
+    const source = readFileSync(abs, "utf8");
+    if (!WRITES_TRANSACTIONS.test(source)) continue;
+
+    if (EXEMPT[rel]) {
+      exemptSeen.add(rel);
+      continue;
+    }
+    if (!source.includes("settleExecutionReceipt")) {
+      offenders.push({ file: rel, reason: "writes transactions, never settles a receipt" });
+    }
+  }
+
+  it("every file that writes a transaction settles its receipt, or is exempt", () => {
+    expect(
+      offenders,
+      "These files write to `transactions` but never call settleExecutionReceipt. " +
+        "Either wire the rail, or add it to EXEMPT with the reason it produces no " +
+        "execution to commit to:\n" +
+        offenders.map((o) => `  - ${o.file}: ${o.reason}`).join("\n"),
+    ).toEqual([]);
+  });
+
+  it("every exemption still corresponds to a file that writes transactions", () => {
+    // A stale exemption is worse than none: it reads as a considered decision
+    // while guarding a file that no longer exists or no longer writes.
+    const stale = Object.keys(EXEMPT).filter((k) => !exemptSeen.has(k));
+    expect(stale, `Stale exemptions: ${stale.join(", ")}`).toEqual([]);
+  });
+
+  it("the lint actually found the known rails, so it cannot pass vacuously", () => {
+    // The failure mode of a source lint is matching nothing at all and
+    // reporting success. Naming the rails we know exist keeps that honest.
+    const wired = walk(SRC)
+      .filter((p) => !isTestFile(p))
+      .filter((p) => WRITES_TRANSACTIONS.test(readFileSync(p, "utf8")))
+      .map((p) => p.slice(SRC.length + 1).split("\\").join("/"));
+
+    for (const expected of [
+      "routes/do.ts",
+      "routes/solution-execute.ts",
+      "routes/x402-gateway-v2.ts",
+      "lib/test-runner.ts",
+      "jobs/settlement-reconciler.ts",
+      "app.ts",
+    ]) {
+      expect(wired, `${expected} was not scanned; the lint's file walk is broken`).toContain(
+        expected,
+      );
+    }
+  });
+});

--- a/apps/api/src/lib/receipt/rail-coverage.test.ts
+++ b/apps/api/src/lib/receipt/rail-coverage.test.ts
@@ -27,6 +27,12 @@ const SRC = join(import.meta.dirname, "..", "..");
  * Key: path relative to `src/`, using forward slashes.
  */
 const EXEMPT: Record<string, string> = {
+  "lib/startup-migrations.ts":
+    "block 0109's behavioural self-check. It inserts an ordinary row inside a " +
+    "plpgsql subtransaction and unwinds it, to prove that the receipt defaults " +
+    "and the reason-required CHECK actually permit a write - the defect that " +
+    "would otherwise have stopped every INSERT in production. Nothing is " +
+    "executed and no row survives the statement.",
   "app.ts":
     "the /health/deep write-path probe. It inserts a status='health_probe' row " +
     "and DELETEs it in the same transaction - it is a database liveness check, " +

--- a/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
@@ -358,6 +358,81 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
     expect(r.receipt_failure_reason).toBe("not_yet_built");
   });
 
+  it("A ROW THE WORKER CANNOT UPDATE COSTS THAT ROW, NOT THE CHAIN", async () => {
+    // Reviewer-found, and it is Phase 4's round-three defect in a new shape.
+    //
+    // `transactions_post_epoch_has_receipt` is NOT VALID, which in Postgres
+    // skips the initial table scan but STILL ENFORCES ON UPDATE. So a
+    // post-epoch row with a NULL receipt_status cannot be updated by anyone -
+    // including this worker, which admits it (`receiptStatus IS NULL` is on
+    // the admission allowlist, because that is what a legacy row looks like).
+    //
+    // The tick is one transaction. Before the per-row SAVEPOINT, the first
+    // failing UPDATE poisoned it, every later statement raised 25P02, the
+    // per-row catch swallowed the cascade, and the tick rolled back - so
+    // NOTHING chained, permanently, retrying every 30 seconds.
+    //
+    // Such a row is hard to create by accident and trivial to create by
+    // operation: `drizzle-kit push` drops the constraint, and re-adding it
+    // NOT VALID does not scan for rows that already violate it. That is
+    // exactly what this test does, restoring the original definition
+    // afterwards so the epoch instant is not disturbed.
+    const [{ def }] = (await db.execute(sql`
+      SELECT pg_get_constraintdef(oid) AS def FROM pg_constraint
+       WHERE conname = 'transactions_post_epoch_has_receipt'
+    `)) as unknown as Array<{ def: string }>;
+    expect(def, "the epoch constraint is missing; this test would prove nothing").toContain(
+      "receipt_status IS NOT NULL",
+    );
+
+    const poison = randomUUID();
+    const healthy = await agedTransaction();
+
+    await db.execute(sql`
+      ALTER TABLE transactions DROP CONSTRAINT transactions_post_epoch_has_receipt
+    `);
+    try {
+      await db.execute(sql`
+        INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
+                                  data_jurisdiction, input, created_at, completed_at,
+                                  receipt_status, receipt_failure_reason)
+        VALUES (${poison}::uuid, ${userId}::uuid, 'completed', 5, 'algorithmic', 'EU',
+                '{}'::jsonb, now() - interval '2 minutes', now() - interval '2 minutes',
+                NULL, NULL)
+      `);
+    } finally {
+      // Same definition, so the epoch is unchanged.
+      await db.execute(
+        sql.raw(
+          `ALTER TABLE transactions ADD CONSTRAINT transactions_post_epoch_has_receipt ${def}`,
+        ),
+      );
+    }
+
+    // Sanity: the row really is un-updatable, or the test proves nothing.
+    await expect(
+      db.execute(sql`
+        UPDATE transactions SET latency_ms = 1 WHERE id = ${poison}::uuid
+      `),
+    ).rejects.toThrow(/transactions_post_epoch_has_receipt/);
+
+    await runOnce();
+
+    // The property: the innocent neighbour still chained.
+    const h = await row(healthy);
+    expect(
+      h.integrity_hash,
+      "one un-updatable row stopped the whole chain - the savepoint is not working",
+    ).not.toBeNull();
+
+    // And the poison row did not chain, which is correct and expected.
+    const p = await row(poison);
+    expect(p.integrity_hash).toBeNull();
+
+    // DELETE is still permitted - the CHECK constrains INSERT and UPDATE.
+    await db.execute(sql`DELETE FROM transactions WHERE id = ${poison}::uuid`);
+  });
+
   it("the worker chains a row exactly once", async () => {
     const id = await agedTransaction();
     await completeReceipt(id);

--- a/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
@@ -402,10 +402,19 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
     // definition is restored at the end, so the real epoch instant - which the
     // design calls the single immutable record of when enforcement began - is
     // unchanged.
-    await db.execute(sql`
-      ALTER TABLE transactions DROP CONSTRAINT transactions_post_epoch_has_receipt
-    `);
+    // The DROP is INSIDE the try, and the restore is IF NOT EXISTS-shaped.
+    //
+    // Reviewer-found: with the DROP outside, anything throwing between it and
+    // the ADD - the poison INSERT is the candidate - left the `finally`'s own
+    // DROP failing with "constraint does not exist". The finally then threw,
+    // the original error was lost, and the epoch constraint was never
+    // restored, so every later suite in the lane ran without the post-epoch
+    // invariant. It only fires when this test is already red, which is
+    // precisely when the diagnostic matters.
     try {
+      await db.execute(sql`
+        ALTER TABLE transactions DROP CONSTRAINT transactions_post_epoch_has_receipt
+      `);
       await db.execute(sql`
         INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
                                   data_jurisdiction, input, created_at, completed_at,
@@ -445,7 +454,7 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
       // real epoch definition goes back regardless of how the assertions went.
       await db.execute(sql`DELETE FROM transactions WHERE id = ${poison}::uuid`);
       await db.execute(sql`
-        ALTER TABLE transactions DROP CONSTRAINT transactions_post_epoch_has_receipt
+        ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_post_epoch_has_receipt
       `);
       await db.execute(
         sql.raw(

--- a/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
@@ -388,6 +388,20 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
     const poison = randomUUID();
     const healthy = await agedTransaction();
 
+    // The epoch is REPLACED for the duration, not borrowed.
+    //
+    // The first version inserted the poison row at `now() - 2 minutes` and
+    // relied on the real epoch being older than that. True on a long-lived
+    // database and false on a freshly-migrated one, where the epoch is seconds
+    // old - so the row was PRE-epoch, perfectly updatable, and the test proved
+    // nothing. It passed locally and failed in CI, which is the right way
+    // round to find out but not a difference the test should have had.
+    //
+    // Substituting a deliberately old epoch makes the row post-epoch by
+    // construction, independent of how old the database is. The original
+    // definition is restored at the end, so the real epoch instant - which the
+    // design calls the single immutable record of when enforcement began - is
+    // unchanged.
     await db.execute(sql`
       ALTER TABLE transactions DROP CONSTRAINT transactions_post_epoch_has_receipt
     `);
@@ -400,37 +414,45 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
                 '{}'::jsonb, now() - interval '2 minutes', now() - interval '2 minutes',
                 NULL, NULL)
       `);
+      await db.execute(sql`
+        ALTER TABLE transactions
+          ADD CONSTRAINT transactions_post_epoch_has_receipt
+          CHECK (created_at < now() - interval '10 minutes' OR receipt_status IS NOT NULL)
+          NOT VALID
+      `);
+
+      // Sanity: the row really is un-updatable, or the test proves nothing.
+      await expect(
+        db.execute(sql`
+          UPDATE transactions SET latency_ms = 1 WHERE id = ${poison}::uuid
+        `),
+      ).rejects.toThrow(/transactions_post_epoch_has_receipt/);
+
+      await runOnce();
+
+      // The property: the innocent neighbour still chained.
+      const h = await row(healthy);
+      expect(
+        h.integrity_hash,
+        "one un-updatable row stopped the whole chain - the savepoint is not working",
+      ).not.toBeNull();
+
+      // And the poison row did not chain, which is correct and expected.
+      const p = await row(poison);
+      expect(p.integrity_hash).toBeNull();
     } finally {
-      // Same definition, so the epoch is unchanged.
+      // DELETE is permitted - the CHECK constrains INSERT and UPDATE - and the
+      // real epoch definition goes back regardless of how the assertions went.
+      await db.execute(sql`DELETE FROM transactions WHERE id = ${poison}::uuid`);
+      await db.execute(sql`
+        ALTER TABLE transactions DROP CONSTRAINT transactions_post_epoch_has_receipt
+      `);
       await db.execute(
         sql.raw(
           `ALTER TABLE transactions ADD CONSTRAINT transactions_post_epoch_has_receipt ${def}`,
         ),
       );
     }
-
-    // Sanity: the row really is un-updatable, or the test proves nothing.
-    await expect(
-      db.execute(sql`
-        UPDATE transactions SET latency_ms = 1 WHERE id = ${poison}::uuid
-      `),
-    ).rejects.toThrow(/transactions_post_epoch_has_receipt/);
-
-    await runOnce();
-
-    // The property: the innocent neighbour still chained.
-    const h = await row(healthy);
-    expect(
-      h.integrity_hash,
-      "one un-updatable row stopped the whole chain - the savepoint is not working",
-    ).not.toBeNull();
-
-    // And the poison row did not chain, which is correct and expected.
-    const p = await row(poison);
-    expect(p.integrity_hash).toBeNull();
-
-    // DELETE is still permitted - the CHECK constrains INSERT and UPDATE.
-    await db.execute(sql`DELETE FROM transactions WHERE id = ${poison}::uuid`);
   });
 
   it("the worker chains a row exactly once", async () => {

--- a/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
@@ -328,6 +328,36 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
     expect((await row(id)).integrity_hash).toBeNull();
   });
 
+  it("the sweeper leaves a transaction that has NOT settled completely alone", async () => {
+    // Found by the mutation battery, not by review: removing the sweeper's
+    // `status IN ('completed','failed')` filter left every test green.
+    //
+    // The filter matters because settle returns early for a non-terminal row -
+    // there is no final result to commit to - so the sweeper would see "still
+    // pending, attempts unchanged" and burn an attempt on it every tick. After
+    // five ticks a transaction that is still EXECUTING would carry a terminally
+    // failed receipt, claiming we could not commit to a result that had not
+    // been produced yet.
+    const id = randomUUID();
+    txns.add(id);
+    await db.execute(sql`
+      INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
+                                data_jurisdiction, input, created_at)
+      VALUES (${id}::uuid, ${userId}::uuid, 'executing', 5, 'algorithmic', 'EU', '{}'::jsonb,
+              now() - interval '20 minutes')
+    `);
+
+    // Several ticks, so an off-by-one budget would still show up.
+    await runOnce();
+    await runOnce();
+    await runOnce();
+
+    const r = await row(id);
+    expect(r.receipt_status, "an unsettled transaction must stay pending").toBe("pending");
+    expect(Number(r.receipt_attempts), "no attempt may be spent on it").toBe(0);
+    expect(r.receipt_failure_reason).toBe("not_yet_built");
+  });
+
   it("the worker chains a row exactly once", async () => {
     const id = await agedTransaction();
     await completeReceipt(id);

--- a/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-chain-junction.integration.test.ts
@@ -31,6 +31,10 @@ import { randomUUID } from "node:crypto";
 
 import { useTestDatabase } from "../../test-support/integration-db.js";
 import { buildExecutionReceipt } from "./execution-receipt.js";
+import {
+  normalizeCapabilityDeclaration,
+  recordManifestSnapshot,
+} from "./manifest-snapshot.js";
 import { markReceiptComplete, markReceiptFailed, markReceiptPending } from "./receipt-lifecycle.js";
 import {
   computeIntegrityHashVersioned,
@@ -77,6 +81,59 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
     txns.clear();
   });
 
+  /**
+   * A digest that names a real stored snapshot.
+   *
+   * `transactions.receipt_manifest_digest` is a foreign key as of block 0109,
+   * so the old `sha256:aaa...` fixture is refused.
+   */
+  async function realManifestDigest(): Promise<string> {
+    return recordManifestSnapshot(
+      db,
+      normalizeCapabilityDeclaration({
+        slug: "vat-validate",
+        name: "VAT Validate",
+        inputSchema: { type: "object" },
+        outputSchema: { type: "object" },
+        transparencyTag: "algorithmic",
+        dataSource: "VIES",
+        capabilityType: "stable_api",
+        freshnessCategory: "live-fetch",
+        outputFieldReliability: { valid: "guaranteed" },
+        processesPersonalData: false,
+        personalDataCategories: [],
+        gdprArt22Classification: "data_lookup",
+        dataUpdateCycleDays: null,
+        datasetLastUpdated: null,
+        dataClassification: "public",
+        x402Method: "POST",
+      }),
+    );
+  }
+
+  /**
+   * Past the CHAIN worker's grace window (10s) but inside the RECEIPT
+   * sweeper's (60s).
+   *
+   * Phase 5 gave the same tick a sweeper that finishes pending receipts, and
+   * that changes what these tests can assume: an aged row with a pending
+   * receipt no longer STAYS pending across a tick - the sweeper terminalises
+   * it, and then the chain quite correctly admits it. So a test about "a
+   * pending receipt blocks chaining" has to use a row the sweeper will not
+   * touch yet, or it is really testing the sweeper.
+   */
+  async function youngTransaction(): Promise<string> {
+    const id = randomUUID();
+    txns.add(id);
+    await db.execute(sql`
+      INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
+                                data_jurisdiction, input, created_at, completed_at)
+      VALUES (${id}::uuid, ${userId}::uuid, 'completed', 5, 'algorithmic', 'EU', '{}'::jsonb,
+              now() - interval '30 seconds', now() - interval '30 seconds')
+    `);
+    return id;
+  }
+
   /** Old enough to clear the worker's grace window. */
   async function agedTransaction(): Promise<string> {
     const id = randomUUID();
@@ -99,7 +156,7 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
     const built = buildExecutionReceipt(
       {
         transactionId: id, subjectKind: "capability", subjectSlug: "vat-validate",
-        deployCommit: "c".repeat(40), manifestDigest: `sha256:${"a".repeat(64)}`,
+        deployCommit: "c".repeat(40), manifestDigest: await realManifestDigest(),
         steps: null, rail: "v1_do", inputs: { vat: "SE1" }, status: "completed",
         result: { valid: true }, error: null, method: "algorithmic",
         sourceObservation: { kind: "computed" },
@@ -149,15 +206,37 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
     // receipt at all.
     const withReceipt = await agedTransaction();
     await completeReceipt(withReceipt);
-    const plainV1 = await agedTransaction();
+    const neighbour = await agedTransaction();
+
+    // A genuine v1 row has to be PRE-epoch now. Since block 0109 every new
+    // transaction carries receipt state from birth, so "a row with no receipt"
+    // is no longer something a present-day insert can produce - v1 is exactly
+    // the 887k rows that predate the epoch, and this is the coexistence the
+    // chain-versioning design exists to support.
+    const legacy = randomUUID();
+    txns.add(legacy);
+    await db.execute(sql`
+      INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
+                                data_jurisdiction, input, created_at, completed_at,
+                                receipt_status, receipt_failure_reason)
+      VALUES (${legacy}::uuid, ${userId}::uuid, 'completed', 5, 'algorithmic', 'EU',
+              '{}'::jsonb, now() - interval '400 days', now() - interval '400 days',
+              NULL, NULL)
+    `);
 
     await runOnce();
 
     const a = await row(withReceipt);
-    const b = await row(plainV1);
+    const b = await row(neighbour);
+    const c = await row(legacy);
     expect(a.integrity_hash, "receipt row not chained").not.toBeNull();
     expect(b.integrity_hash, "innocent neighbour not chained").not.toBeNull();
-    expect(b.integrity_payload_version, "a row with no receipt is v1").toBeNull();
+    expect(c.integrity_hash, "legacy row not chained").not.toBeNull();
+    expect(c.integrity_payload_version, "a PRE-epoch row is v1").toBeNull();
+    expect(
+      Number(b.integrity_payload_version),
+      "a post-epoch row is v2, because it cannot exist without receipt state",
+    ).toBe(CHAIN_PAYLOAD_V2);
   });
 
   it("a receipt-FAILED row is chained as v2 with a null digest", async () => {
@@ -176,8 +255,7 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
   });
 
   it("a receipt-PENDING row is not chained, and does not block the batch", async () => {
-    const pending = await agedTransaction();
-    await markReceiptPending(db, pending);
+    const pending = await youngTransaction();
     const neighbour = await agedTransaction();
 
     await runOnce();
@@ -187,15 +265,14 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
   });
 
   it("a pending row chains once its receipt settles, on a later tick", async () => {
-    const id = await agedTransaction();
-    await markReceiptPending(db, id);
+    const id = await youngTransaction();
     await runOnce();
     expect((await row(id)).integrity_hash).toBeNull();
 
     const built = buildExecutionReceipt(
       {
         transactionId: id, subjectKind: "capability", subjectSlug: "vat-validate",
-        deployCommit: "c".repeat(40), manifestDigest: `sha256:${"a".repeat(64)}`,
+        deployCommit: "c".repeat(40), manifestDigest: await realManifestDigest(),
         steps: null, rail: "v1_do", inputs: {}, status: "completed",
         result: {}, error: null, method: "algorithmic",
         sourceObservation: { kind: "computed" },
@@ -217,15 +294,19 @@ describeMaybe("receipt lifecycle × integrity chain", () => {
     // counts only selected rows — cannot see it. With the retry sweeper
     // deferred to the rail PR, such a row would sit outside the chain forever
     // with nothing saying so.
+    // status='executing', deliberately. Phase 5's sweeper resolves a pending
+    // receipt on any SETTLED row within a minute or so, so the population this
+    // counter still exists for is the row whose transaction never reached a
+    // terminal status at all - wedged, and invisible to both the sweeper (no
+    // final result to commit to) and the chain (nothing to hash).
     const id = randomUUID();
     txns.add(id);
     await db.execute(sql`
       INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
-                                data_jurisdiction, input, created_at, completed_at)
-      VALUES (${id}::uuid, ${userId}::uuid, 'completed', 5, 'algorithmic', 'EU', '{}'::jsonb,
-              now() - interval '20 minutes', now() - interval '20 minutes')
+                                data_jurisdiction, input, created_at)
+      VALUES (${id}::uuid, ${userId}::uuid, 'executing', 5, 'algorithmic', 'EU', '{}'::jsonb,
+              now() - interval '20 minutes')
     `);
-    await markReceiptPending(db, id);
 
     const warnings: string[] = [];
     const { log } = await import("../log.js");

--- a/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
@@ -55,6 +55,11 @@ const DECL: CapabilityDeclarationSource = {
   processesPersonalData: false,
   personalDataCategories: [],
   gdprArt22Classification: "data_lookup",
+  name: "VAT Validate",
+  dataClassification: "public",
+  x402Method: "POST",
+  dataUpdateCycleDays: null,
+  datasetLastUpdated: null,
 };
 
 const ran = (order: number, slug: string, fill: string): SolutionStepIdentity => ({

--- a/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
+++ b/apps/api/src/lib/receipt/receipt-invariants.integration.test.ts
@@ -121,11 +121,47 @@ describeMaybe("Phase 4 invariants cannot be bypassed", () => {
     return id;
   }
 
+  /**
+   * A row as it existed BEFORE the epoch: no receipt state at all.
+   *
+   * Since block 0109 an ordinary insert is `pending` from birth, so "a row with
+   * no receipt state" is no longer something you get by not asking - it is a
+   * historical shape, and the post-epoch CHECK forbids creating it with a
+   * present-day `created_at`. Constructing it explicitly is the honest way to
+   * test the legacy guards, and it makes the pre/post distinction visible in
+   * the test rather than implicit in a default.
+   */
+  async function legacyTxn(): Promise<string> {
+    const id = randomUUID();
+    txns.add(id);
+    await db.execute(sql`
+      INSERT INTO transactions (id, user_id, status, price_cents, transparency_marker,
+                                data_jurisdiction, input, created_at, completed_at,
+                                receipt_status, receipt_failure_reason)
+      VALUES (${id}::uuid, ${userId}::uuid, 'completed', 5, 'algorithmic', 'EU',
+              '{}'::jsonb, now() - interval '400 days', now() - interval '400 days',
+              NULL, NULL)
+    `);
+    return id;
+  }
+
+  /**
+   * A digest that actually names a stored snapshot.
+   *
+   * `transactions.receipt_manifest_digest` is a foreign key as of block 0109,
+   * so a made-up `sha256:aaa...` is refused - which is the constraint working.
+   * Tests that need a digest record the real declaration and use what comes
+   * back.
+   */
+  async function realManifestDigest(): Promise<string> {
+    return recordManifestSnapshot(db, normalizeCapabilityDeclaration(DECL));
+  }
+
   async function completed(id: string): Promise<string> {
     const built = buildExecutionReceipt(
       {
         transactionId: id, subjectKind: "capability", subjectSlug: "vat-validate",
-        deployCommit: "c".repeat(40), manifestDigest: `sha256:${"a".repeat(64)}`,
+        deployCommit: "c".repeat(40), manifestDigest: await realManifestDigest(),
         steps: null, rail: "v1_do", inputs: {}, status: "completed",
         result: { ok: true }, error: null, method: "algorithmic",
         sourceObservation: { kind: "computed" },
@@ -291,7 +327,11 @@ describeMaybe("Phase 4 invariants cannot be bypassed", () => {
     // was never anchored. It verifies, under a rule that does not cover the
     // receipt, and "a receipt digest cannot be swapped without invalidating the
     // chain" is silently false for it.
-    const id = await txn();
+    // A LEGACY row specifically. Post-epoch this scenario cannot arise at all -
+    // a row is `pending` from birth, and the worker refuses to chain a pending
+    // receipt - so the guard's remaining job is the 887k rows that predate the
+    // epoch, and that is what this now exercises.
+    const id = await legacyTxn();
     await db.execute(sql`
       UPDATE transactions
          SET integrity_hash = ${"9".repeat(64)}, previous_hash = ${"8".repeat(64)},
@@ -548,9 +588,27 @@ describeMaybe("Phase 4 invariants cannot be bypassed", () => {
     await recordManifestSnapshot(db, normalizeCapabilityDeclaration(DECL));
     // Row-level DELETE triggers do not fire for TRUNCATE; a statement-level
     // BEFORE TRUNCATE trigger is what closes it.
+    const before = await db.execute(
+      sql`SELECT count(*)::int AS n FROM execution_manifest_snapshots`,
+    );
+
+    // TWO independent refusals now, and the FK gets there first: since block
+    // 0109, transactions.receipt_manifest_digest references this table, and
+    // Postgres refuses to truncate a referenced table before any trigger runs.
+    // The statement-level BEFORE TRUNCATE trigger from 0108 is still the
+    // guarantee that survives the FK being dropped, so both messages are
+    // accepted rather than pinning the test to whichever fires today.
     await expect(
       db.execute(sql`TRUNCATE execution_manifest_snapshots`),
-    ).rejects.toThrow(/cannot be truncated/);
+    ).rejects.toThrow(/cannot be truncated|cannot truncate a table referenced/i);
+
+    // And the property itself, not just the message.
+    const after = await db.execute(
+      sql`SELECT count(*)::int AS n FROM execution_manifest_snapshots`,
+    );
+    expect((after as unknown as Array<{ n: number }>)[0].n).toBe(
+      (before as unknown as Array<{ n: number }>)[0].n,
+    );
 
     const rows = await db.execute(
       sql`SELECT count(*)::int AS n FROM execution_manifest_snapshots`,

--- a/apps/api/src/lib/receipt/receipt-lifecycle.ts
+++ b/apps/api/src/lib/receipt/receipt-lifecycle.ts
@@ -277,9 +277,14 @@ export function describeReceiptState(row: {
   receiptStatus: string | null;
   receiptFailureReason: string | null;
   receiptDigest: string | null;
+  /** 90-day content redaction. */
+  redactedAt?: Date | string | null;
+  /** 1095-day deletion. */
+  deletedAt?: Date | string | null;
 }):
   | { status: "legacy_unavailable"; reason: string }
   | { status: "complete"; digest: string }
+  | { status: "redacted"; digest: string; reason: string }
   | { status: "pending" | "failed"; reason: string } {
   if (row.receiptStatus === null) {
     return {
@@ -290,6 +295,27 @@ export function describeReceiptState(row: {
     };
   }
   if (row.receiptStatus === "complete" && row.receiptDigest) {
+    // Retention erases the request and the result at 90 days, and deletion
+    // takes the row at 1095. The digest survives both, and it is still a
+    // truthful commitment -- what is gone is the ability to RECOMPUTE it.
+    //
+    // Calling that "complete" would be the single most misleading thing this
+    // module could say. A reader who asks for a receipt and is told "complete,
+    // here is the digest" will reasonably conclude they can verify it, and they
+    // cannot: the material the digest commits to no longer exists. `walkChain`
+    // already draws this distinction for chain rows; the receipt lifecycle did
+    // not, and Phase 4 recorded the gap as an acceptance criterion rather than
+    // fixing it in place.
+    if (row.redactedAt != null || row.deletedAt != null) {
+      return {
+        status: "redacted",
+        digest: row.receiptDigest,
+        reason:
+          "the receipt digest stands and is unchanged, but the request and result " +
+          "it commits to were erased under the retention policy, so it can no " +
+          "longer be independently recomputed from this transaction",
+      };
+    }
     return { status: "complete", digest: row.receiptDigest };
   }
   return {

--- a/apps/api/src/lib/receipt/settle.ts
+++ b/apps/api/src/lib/receipt/settle.ts
@@ -1,0 +1,428 @@
+/**
+ * The one place a receipt is built for a real execution.
+ *
+ * ## Why this is a helper and not eight inline blocks
+ *
+ * `transactions` is written from eight production sites: four executors in
+ * `routes/do.ts`, one in `solution-execute.ts`, one in `x402-gateway-v2.ts`,
+ * the internal harness in `lib/test-runner.ts`, and the settlement reconciler.
+ * There is no natural chokepoint, and building a receipt inline at each would
+ * be eight chances to get the binding subtly different.
+ *
+ * ## Why it can never throw, and never runs inside the money transaction
+ *
+ * Two rules, and they are the reason this is safe to wire into every rail at
+ * once:
+ *
+ *  1. **It runs after settlement commits.** Every settlement site writes
+ *     `status`, `output`/`error` and `audit_trail` inside a wallet
+ *     transaction. Receipt construction is not part of that transaction, so it
+ *     cannot roll back a payment, cannot extend the lock window, and cannot
+ *     turn a receipt bug into a billing bug.
+ *  2. **It swallows everything.** A throw here would fail a request that has
+ *     already been executed and charged. The row is already `pending` by
+ *     database default, so the honest outcome of any failure is "still
+ *     pending", which the sweeper retries and the monitoring counts.
+ *
+ * The combination is what makes the epoch safe: a rail nobody wired, a bug in
+ * this file, or a process killed between commit and receipt all converge on
+ * the same visible state rather than on a silent absence.
+ *
+ * ## Why the declaration is re-read here
+ *
+ * The alternative is threading sixteen columns through four executor
+ * signatures. Re-reading by `capability_id` costs one joined query and cannot
+ * drift from the column set the digest is defined over. The window in which a
+ * capability row could change between execution and this read is the few
+ * milliseconds of the settlement commit, and `capabilities` rows are written
+ * by onboarding and operations, not per request.
+ */
+
+import { sql } from "drizzle-orm";
+import type { getDb } from "../../db/index.js";
+
+import {
+  buildExecutionReceipt,
+  type ReceiptInput,
+  type SourceObservation,
+  type ExecutionMethod,
+  EXECUTION_METHODS,
+} from "./execution-receipt.js";
+import {
+  normalizeCapabilityDeclaration,
+  normalizeSolutionDeclaration,
+  recordManifestSnapshot,
+  type SolutionStepIdentity,
+} from "./manifest-snapshot.js";
+import { markReceiptComplete, markReceiptFailed } from "./receipt-lifecycle.js";
+import { resolveDeployCommit } from "./deploy-identity.js";
+import { log } from "../log.js";
+
+type Db = ReturnType<typeof getDb>;
+
+/** Rails that create a customer-visible transaction. Closed, per Phase 2. */
+export type SettleRail = "v1_do" | "x402" | "mcp" | "a2a" | "internal";
+
+export interface SettleParams {
+  transactionId: string;
+  rail: SettleRail;
+  /** The solution slug, when this transaction is a solution execution. */
+  solutionSlug?: string | null;
+  /**
+   * The step slugs whose output the caller actually received.
+   *
+   * The caller supplies only this, not the digests: which steps ran is the one
+   * fact that is NOT recoverable from the database, and everything else - the
+   * declared recipe, its order, each step's declaration digest - is resolved
+   * here so that no call site can compute a step identity differently.
+   */
+  ranStepSlugs?: string[] | null;
+  /**
+   * The caller knows the recipe but genuinely cannot say what happened to each
+   * step - the settlement reconciler recreating a row whose output was lost
+   * with the process is the case this exists for.
+   *
+   * Every declared step is then `unresolved`, which is the honest answer.
+   * Passing an empty `ranStepSlugs` instead would mark them all `skipped`, and
+   * `skipped` is a positive claim that the step never executed - here it very
+   * probably did.
+   */
+  stepsUnknown?: boolean;
+}
+
+interface TxnRow {
+  id: string;
+  status: string;
+  input: unknown;
+  output: unknown;
+  error: string | null;
+  provenance: unknown;
+  transparency_marker: string | null;
+  receipt_status: string | null;
+  capability_id: string | null;
+  solution_slug: string | null;
+  [k: string]: unknown;
+}
+
+function asMethod(marker: string | null): ExecutionMethod {
+  return (EXECUTION_METHODS as readonly string[]).includes(marker ?? "")
+    ? (marker as ExecutionMethod)
+    : "algorithmic";
+}
+
+/**
+ * What the receipt says about data vintage.
+ *
+ * Deliberately conservative. `none_declared` says "we do not know"; `computed`
+ * positively asserts there was no external source. Guessing a dataset version
+ * we never recorded would put a fabricated vintage inside a commitment, which
+ * is worse than admitting the gap - Phase 2 expects `none_declared` to
+ * dominate at the epoch and to shrink as capabilities declare properly.
+ */
+export function deriveSourceObservation(
+  provenance: unknown,
+  freshnessCategory: string | null,
+): SourceObservation {
+  const p = (provenance ?? {}) as Record<string, unknown>;
+  const fetchedAt = typeof p.fetched_at === "string" ? p.fetched_at : null;
+  if (fetchedAt) {
+    const parsed = new Date(fetchedAt);
+    if (!Number.isNaN(parsed.getTime())) {
+      return { kind: "live_fetch", observed_at: parsed.toISOString() };
+    }
+  }
+  if (freshnessCategory === "computed") return { kind: "computed" };
+  return { kind: "none_declared" };
+}
+
+/**
+ * The caller-visible error, as a closed shape.
+ *
+ * `transactions.error` is the sanitised message the caller already received -
+ * the production sanitiser has already redacted URLs by the time it is stored
+ * - so this binds what was served rather than an internal string.
+ */
+function toReceiptError(row: TxnRow): { code: string; message: string } | null {
+  if (row.status !== "failed") return null;
+  return { code: "execution_failed", message: row.error ?? "" };
+}
+
+/**
+ * Build and persist the receipt for a settled transaction.
+ *
+ * Never throws. Never returns a value the caller has to check: the outcome
+ * lives in `transactions.receipt_status`, which is the only place a verifier
+ * will ever look.
+ */
+export async function settleExecutionReceipt(db: Db, params: SettleParams): Promise<void> {
+  try {
+    await settleOrThrow(db, params);
+  } catch (err) {
+    // Last resort. The row stays `pending` and the sweeper owns it from here,
+    // so the failure is visible in the backlog counters rather than lost.
+    log.warn(
+      {
+        label: "receipt-settle-failed",
+        transaction_id: params.transactionId,
+        rail: params.rail,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "execution receipt could not be settled; left pending for the sweeper",
+    );
+  }
+}
+
+async function settleOrThrow(db: Db, params: SettleParams): Promise<void> {
+  const rows = (await db.execute(sql`
+    SELECT t.id, t.status, t.input, t.output, t.error, t.provenance,
+           t.transparency_marker, t.receipt_status, t.capability_id, t.solution_slug,
+           c.slug              AS c_slug,
+           c.name              AS c_name,
+           c.input_schema      AS c_input_schema,
+           c.output_schema     AS c_output_schema,
+           c.transparency_tag  AS c_transparency_tag,
+           c.data_source       AS c_data_source,
+           c.capability_type   AS c_capability_type,
+           c.freshness_category AS c_freshness_category,
+           c.output_field_reliability AS c_output_field_reliability,
+           c.processes_personal_data  AS c_processes_personal_data,
+           c.personal_data_categories AS c_personal_data_categories,
+           c.gdpr_art_22_classification AS c_gdpr,
+           c.data_update_cycle_days   AS c_cycle_days,
+           c.dataset_last_updated     AS c_dataset_last_updated,
+           c.data_classification      AS c_data_classification,
+           c.x402_method              AS c_x402_method
+      FROM transactions t
+      LEFT JOIN capabilities c ON c.id = t.capability_id
+     WHERE t.id = ${params.transactionId}::uuid
+  `)) as unknown as TxnRow[];
+
+  const row = rows[0];
+  if (!row) return; // nothing to settle; the row was pruned or never existed
+
+  // Only a settled row can be committed to. An `executing` or `deferred` row
+  // has no final result yet, and the async path settles later.
+  if (row.status !== "completed" && row.status !== "failed") return;
+
+  // Someone already terminalised this receipt. markReceiptComplete is guarded
+  // on `pending` anyway, but returning early keeps a duplicate call from
+  // writing a snapshot for nothing.
+  if (row.receipt_status === "complete" || row.receipt_status === "failed") return;
+
+  const isSolution = Boolean(params.solutionSlug ?? row.solution_slug);
+  const subjectSlug = isSolution
+    ? String(params.solutionSlug ?? row.solution_slug ?? "")
+    : String(row.c_slug ?? "");
+
+  // -- Manifest snapshot ---------------------------------------------------
+  let manifestDigest: string | null = null;
+  let solutionSteps: SolutionStepIdentity[] = [];
+  try {
+    if (isSolution) {
+      solutionSteps = await resolveSolutionSteps(db, subjectSlug, params.ranStepSlugs ?? [], {
+        stepsUnknown: params.stepsUnknown === true,
+      });
+      if (solutionSteps.length === 0) {
+        // A solution with no declared steps cannot be committed to: there is
+        // no recipe to bind. Recorded as an invariant failure rather than as
+        // an empty step list, which would hash to a real digest that means
+        // nothing.
+        await markReceiptFailed(db, row.id, "unresolvable_manifest");
+        return;
+      }
+      manifestDigest = await recordManifestSnapshot(
+        db,
+        normalizeSolutionDeclaration({ slug: subjectSlug, steps: solutionSteps }),
+      );
+    } else {
+      if (!row.capability_id || !row.c_slug) {
+        await markReceiptFailed(db, row.id, "unresolvable_manifest");
+        return;
+      }
+      manifestDigest = await recordManifestSnapshot(
+        db,
+        normalizeCapabilityDeclaration({
+          slug: String(row.c_slug),
+          name: (row.c_name as string | null) ?? null,
+          inputSchema: row.c_input_schema ?? null,
+          outputSchema: row.c_output_schema ?? null,
+          transparencyTag: (row.c_transparency_tag as string | null) ?? null,
+          dataSource: (row.c_data_source as string | null) ?? null,
+          capabilityType: (row.c_capability_type as string | null) ?? null,
+          freshnessCategory: (row.c_freshness_category as string | null) ?? null,
+          outputFieldReliability: row.c_output_field_reliability ?? null,
+          processesPersonalData: Boolean(row.c_processes_personal_data),
+          personalDataCategories: (row.c_personal_data_categories as string[] | null) ?? null,
+          gdprArt22Classification: (row.c_gdpr as string | null) ?? null,
+          dataUpdateCycleDays: (row.c_cycle_days as number | null) ?? null,
+          datasetLastUpdated: row.c_dataset_last_updated
+            ? new Date(row.c_dataset_last_updated as string)
+            : null,
+          dataClassification: (row.c_data_classification as string | null) ?? null,
+          x402Method: (row.c_x402_method as string | null) ?? null,
+        }),
+      );
+    }
+  } catch (err) {
+    log.warn(
+      { label: "receipt-snapshot-failed", transaction_id: row.id, err: String(err) },
+      "manifest snapshot write failed",
+    );
+    await markReceiptFailed(db, row.id, "snapshot_write_failed");
+    return;
+  }
+
+  // -- Deploy identity -----------------------------------------------------
+  // In production this cannot fail, because the boot gate already asserted it
+  // and the process would not be serving otherwise. Handled anyway rather than
+  // assumed, because "cannot happen" is how the Phase 4 review found six of
+  // its findings.
+  let deployCommit: string;
+  try {
+    deployCommit = resolveDeployCommit();
+  } catch {
+    await markReceiptFailed(db, row.id, "missing_deploy_identity");
+    return;
+  }
+
+  const input: ReceiptInput = {
+    transactionId: row.id,
+    subjectKind: isSolution ? "solution" : "capability",
+    subjectSlug,
+    deployCommit,
+    manifestDigest,
+    steps: isSolution ? solutionSteps : null,
+    rail: params.rail,
+    inputs: row.input ?? null,
+    status: row.status === "completed" ? "completed" : "failed",
+    // Exactly the bytes the caller received: `/v1/do` returns this column as
+    // `result.output`, and `/v1/transactions/:id` serves the same value.
+    result: row.status === "completed" ? (row.output ?? null) : null,
+    error: toReceiptError(row),
+    method: asMethod(row.transparency_marker),
+    sourceObservation: deriveSourceObservation(
+      row.provenance,
+      (row.c_freshness_category as string | null) ?? null,
+    ),
+  };
+
+  const built = buildExecutionReceipt(input);
+  if (built.outcome !== "complete") {
+    await markReceiptFailed(db, row.id, built.reason);
+    return;
+  }
+  await markReceiptComplete(db, row.id, built);
+}
+
+
+/**
+ * The ordered step identities for a solution, resolved from the declared
+ * recipe plus the one fact only the caller knows: which steps produced output.
+ *
+ * ## Why the order is re-indexed
+ *
+ * `solution_steps.step_order` is the authoring column, and it is not
+ * constrained to the shape a receipt needs - parallel groups share an order,
+ * and nothing forbids gaps or a zero. `normalizeSolutionDeclaration` requires
+ * strictly increasing positive integers precisely because anything looser has
+ * more than one reading. So the declared rows are sorted by
+ * `(step_order, capability_slug)` - the slug breaking ties deterministically,
+ * which is what makes a parallel group hash the same way every time - and then
+ * numbered 1..N. The numbering is derived from the recipe, never from the
+ * order a caller happened to pass.
+ *
+ * ## Dispositions
+ *
+ * `ran` when the caller received that step's output. Otherwise `skipped`: the
+ * step never executed, whether because a gate short-circuited the bundle or
+ * because an earlier step's failure stopped it. `unresolved` is reserved for
+ * the genuinely different case where a step SHOULD have run and its
+ * declaration could not be read - which is why a step whose capability row has
+ * gone missing is marked `unresolved` here rather than quietly dropped.
+ */
+export async function resolveSolutionSteps(
+  db: Db,
+  solutionSlug: string,
+  ranStepSlugs: string[],
+  opts: { stepsUnknown?: boolean } = {},
+): Promise<SolutionStepIdentity[]> {
+  const rows = (await db.execute(sql`
+    SELECT ss.step_order, ss.capability_slug,
+           c.id                AS c_id,
+           c.slug              AS c_slug,
+           c.name              AS c_name,
+           c.input_schema      AS c_input_schema,
+           c.output_schema     AS c_output_schema,
+           c.transparency_tag  AS c_transparency_tag,
+           c.data_source       AS c_data_source,
+           c.capability_type   AS c_capability_type,
+           c.freshness_category AS c_freshness_category,
+           c.output_field_reliability AS c_output_field_reliability,
+           c.processes_personal_data  AS c_processes_personal_data,
+           c.personal_data_categories AS c_personal_data_categories,
+           c.gdpr_art_22_classification AS c_gdpr,
+           c.data_update_cycle_days   AS c_cycle_days,
+           c.dataset_last_updated     AS c_dataset_last_updated,
+           c.data_classification      AS c_data_classification,
+           c.x402_method              AS c_x402_method
+      FROM solution_steps ss
+      JOIN solutions s ON s.id = ss.solution_id
+      LEFT JOIN capabilities c ON c.slug = ss.capability_slug
+     WHERE s.slug = ${solutionSlug}
+     ORDER BY ss.step_order ASC, ss.capability_slug ASC
+  `)) as unknown as Array<Record<string, unknown>>;
+
+  const ran = new Set(ranStepSlugs);
+  const out: SolutionStepIdentity[] = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+    const slug = String(r.capability_slug);
+    const didRun = ran.has(slug);
+
+    if (opts.stepsUnknown) {
+      out.push({ step_order: i + 1, slug, disposition: "unresolved", manifest_digest: null });
+      continue;
+    }
+
+    if (!r.c_slug) {
+      // Declared in the recipe, but the capability row is gone. This is the
+      // case `unresolved` exists for: something should have run and we cannot
+      // say what it was.
+      out.push({ step_order: i + 1, slug, disposition: "unresolved", manifest_digest: null });
+      continue;
+    }
+
+    if (!didRun) {
+      out.push({ step_order: i + 1, slug, disposition: "skipped", manifest_digest: null });
+      continue;
+    }
+
+    const digest = await recordManifestSnapshot(
+      db,
+      normalizeCapabilityDeclaration({
+        slug: String(r.c_slug),
+        name: (r.c_name as string | null) ?? null,
+        inputSchema: r.c_input_schema ?? null,
+        outputSchema: r.c_output_schema ?? null,
+        transparencyTag: (r.c_transparency_tag as string | null) ?? null,
+        dataSource: (r.c_data_source as string | null) ?? null,
+        capabilityType: (r.c_capability_type as string | null) ?? null,
+        freshnessCategory: (r.c_freshness_category as string | null) ?? null,
+        outputFieldReliability: r.c_output_field_reliability ?? null,
+        processesPersonalData: Boolean(r.c_processes_personal_data),
+        personalDataCategories: (r.c_personal_data_categories as string[] | null) ?? null,
+        gdprArt22Classification: (r.c_gdpr as string | null) ?? null,
+        dataUpdateCycleDays: (r.c_cycle_days as number | null) ?? null,
+        datasetLastUpdated: r.c_dataset_last_updated
+          ? new Date(r.c_dataset_last_updated as string)
+          : null,
+        dataClassification: (r.c_data_classification as string | null) ?? null,
+        x402Method: (r.c_x402_method as string | null) ?? null,
+      }),
+    );
+    out.push({ step_order: i + 1, slug, disposition: "ran", manifest_digest: digest });
+  }
+
+  return out;
+}

--- a/apps/api/src/lib/receipt/settle.ts
+++ b/apps/api/src/lib/receipt/settle.ts
@@ -217,9 +217,29 @@ export function deriveSourceObservation(
  * Sanitising HERE rather than changing what the rails store keeps raw
  * diagnostics in the column where operators expect them, and makes the
  * receipt's own contract - `ReceiptInput.error` says "the sanitised,
- * caller-visible error" - true for every rail rather than for two of three.
- * `sanitizeFailureReason` is idempotent (verified over the real production
- * failure corpus), so applying it to an already-sanitised message is a no-op.
+ * caller-visible error" - hold on every rail that has ever produced a failure
+ * in production. `sanitizeFailureReason` is idempotent over the real corpus
+ * (541 distinct production messages, zero non-idempotent), so applying it to
+ * an already-sanitised message is a no-op.
+ *
+ * ## Three paths where it still does not hold, and why they are not fixed here
+ *
+ * A second reviewer found three failure branches that store one string and
+ * serve another shape entirely, so the receipt cannot match what the caller
+ * saw:
+ *
+ *  - `do.ts` x402 settlement-failed: stores "Payment settlement failed: ...",
+ *    serves `{error_code: "payment_failed"}` - a different CODE, not just a
+ *    different message.
+ *  - `x402-gateway-v2.ts` solution-unbillable: serves the stored message
+ *    WRAPPED in additional prose.
+ *  - `solution-execute.ts` no-steps-configured: the response carries no
+ *    `details.error` at all.
+ *
+ * All three have **zero occurrences in production history**, and each needs a
+ * different structural change to the route rather than to this function, so
+ * they are recorded as residual risk rather than papered over with a broader
+ * claim here.
  */
 function toReceiptError(row: TxnRow): { code: string; message: string } | null {
   if (row.status !== "failed") return null;
@@ -456,7 +476,20 @@ async function settleOrThrow(db: Db, params: SettleParams): Promise<void> {
       },
       "execution method could not be established; receipt refused",
     );
-    await markReceiptFailed(db, row.id, "internal_error");
+    // TERMINAL, not `internal_error`.
+    //
+    // `internal_error` is in RETRYABLE_REASONS, and this condition is
+    // deterministic - the row's marker and the capability's declared tag do
+    // not change between attempts. Using it would burn five sweeper attempts,
+    // hold the row out of the chain for half an hour, and put five entries in
+    // a counter that receipt-lifecycle.ts deliberately reserves for real
+    // signals ("retrying it would bury the escalation an operator is supposed
+    // to act on"). Reviewer-found.
+    //
+    // `unresolvable_manifest` is the closest member of the closed set and it
+    // is honest here: the declaration was read and does not establish a
+    // required fixed-point member of the receipt.
+    await markReceiptFailed(db, row.id, "unresolvable_manifest");
     return;
   }
 

--- a/apps/api/src/lib/receipt/settle.ts
+++ b/apps/api/src/lib/receipt/settle.ts
@@ -57,6 +57,7 @@ import {
 import { markReceiptComplete, markReceiptFailed } from "./receipt-lifecycle.js";
 import { resolveDeployCommit } from "./deploy-identity.js";
 import { log } from "../log.js";
+import { sanitizeFailureReason } from "../sanitize.js";
 
 type Db = ReturnType<typeof getDb>;
 
@@ -111,13 +112,56 @@ interface TxnRow {
   solution_slug: string | null;
   receipt_rail: string | null;
   receipt_deploy_commit: string | null;
+  redacted_at: unknown;
+  deleted_at: unknown;
   [k: string]: unknown;
 }
 
-function asMethod(marker: string | null): ExecutionMethod {
-  return (EXECUTION_METHODS as readonly string[]).includes(marker ?? "")
-    ? (marker as ExecutionMethod)
-    : "algorithmic";
+/**
+ * The EU AI Act transparency marker, as one of the receipt's three methods.
+ *
+ * ## Why a fallback to `algorithmic` was the wrong shape
+ *
+ * The previous version returned `algorithmic` for anything outside the closed
+ * set, and three production sources land outside it - so the receipt asserted
+ * "no model was involved" for executions that declare one:
+ *
+ *  1. `routes/do.ts` maps a `mixed` capability to the marker `hybrid`, which
+ *     is not a member. `lib/audit-helpers.ts` has always treated `hybrid` and
+ *     `mixed` as the same thing; only this enum disagreed.
+ *  2. `lib/test-runner.ts` hardcoded `algorithmic` for every internal-harness
+ *     row - 99.3% of platform traffic - including AI capabilities. Fixed at
+ *     the source in that file; the declaration fallback below also covers it.
+ *  3. `jobs/settlement-reconciler.ts` writes `unknown`, with a comment
+ *     explaining that inheriting a marker would be "a fabricated EU AI Act
+ *     Art. 50 marker on a call we cannot describe" - and the fallback then
+ *     fabricated one anyway, one file over.
+ *
+ * Measured by the reviewer against 30 days of production: 8,010 of ~193,600
+ * rows (4.1%) would have carried a receipt claiming no model was involved.
+ *
+ * Note the asymmetry that made this easy to miss: an unmapped RAIL is a
+ * refusal, because "a permissive fallback is how the wrong rail gets
+ * asserted". An unmapped METHOD had a permissive fallback to the least
+ * disclosive value. Both are now refusals.
+ *
+ * Returns null when the method cannot be established, and the caller records
+ * an invariant failure rather than guessing.
+ */
+export function asMethod(
+  marker: string | null,
+  declaredTag: string | null,
+): ExecutionMethod | null {
+  for (const candidate of [marker, declaredTag]) {
+    if (!candidate) continue;
+    // `hybrid` is the marker spelling of `mixed`. Not a fallback: the same
+    // fact under the name routes/do.ts writes.
+    const normalized = candidate === "hybrid" ? "mixed" : candidate;
+    if ((EXECUTION_METHODS as readonly string[]).includes(normalized)) {
+      return normalized as ExecutionMethod;
+    }
+  }
+  return null;
 }
 
 /**
@@ -148,13 +192,38 @@ export function deriveSourceObservation(
 /**
  * The caller-visible error, as a closed shape.
  *
- * `transactions.error` is the sanitised message the caller already received -
- * the production sanitiser has already redacted URLs by the time it is stored
- * - so this binds what was served rather than an internal string.
+ * ## Why this sanitises rather than trusting the column
+ *
+ * The previous version of this function bound `row.error` directly, and its
+ * comment asserted as fact that "the production sanitiser has already redacted
+ * URLs by the time it is stored". That is true on two rails and false on a
+ * third, which is the worst possible distribution for an assumption.
+ *
+ * `solution-execute.ts` and `x402-gateway-v2.ts` store
+ * `sanitizeFailureReason(...)`. The `/v1/do` capability rails store the RAW
+ * `err.message` and sanitise only on the way out, at `routes/do.ts` :1778,
+ * :1968 and :2344. So on those rails the receipt committed to a string the
+ * caller never saw - and a party holding the request and the response could
+ * not recompute the digest, which is the single thing this system exists to
+ * make possible.
+ *
+ * Reviewer-found, and measured against production rather than argued: over
+ * seven days, 5,016 of 33,952 failed rows (14.8%) have a raw message that
+ * differs from its sanitised form. `fetch failed` becomes "External service
+ * temporarily unavailable"; anything carrying a URL or hostname becomes
+ * `[service]`; every ENOTFOUND/ETIMEDOUT becomes "Service temporarily
+ * unreachable".
+ *
+ * Sanitising HERE rather than changing what the rails store keeps raw
+ * diagnostics in the column where operators expect them, and makes the
+ * receipt's own contract - `ReceiptInput.error` says "the sanitised,
+ * caller-visible error" - true for every rail rather than for two of three.
+ * `sanitizeFailureReason` is idempotent (verified over the real production
+ * failure corpus), so applying it to an already-sanitised message is a no-op.
  */
 function toReceiptError(row: TxnRow): { code: string; message: string } | null {
   if (row.status !== "failed") return null;
-  return { code: "execution_failed", message: row.error ?? "" };
+  return { code: "execution_failed", message: sanitizeFailureReason(row.error) };
 }
 
 /**
@@ -186,7 +255,7 @@ async function settleOrThrow(db: Db, params: SettleParams): Promise<void> {
   const rows = (await db.execute(sql`
     SELECT t.id, t.status, t.input, t.output, t.error, t.provenance,
            t.transparency_marker, t.receipt_status, t.capability_id, t.solution_slug,
-           t.receipt_rail, t.receipt_deploy_commit,
+           t.receipt_rail, t.receipt_deploy_commit, t.redacted_at, t.deleted_at,
            c.slug              AS c_slug,
            c.name              AS c_name,
            c.input_schema      AS c_input_schema,
@@ -214,6 +283,22 @@ async function settleOrThrow(db: Db, params: SettleParams): Promise<void> {
   // Only a settled row can be committed to. An `executing` or `deferred` row
   // has no final result yet, and the async path settles later.
   if (row.status !== "completed" && row.status !== "failed") return;
+
+  // Content already erased. Narrow - retention runs at 90 days and settle runs
+  // in milliseconds - but account closure can redact inside the async window,
+  // and migration 0103's trigger nulls `output` when it does.
+  //
+  // Hashing then would produce a receipt that VERIFIES against a false claim:
+  // "this completed execution returned null". A receipt that verifies against
+  // something untrue is worse than no receipt, so this refuses instead.
+  if (row.redacted_at != null || row.deleted_at != null) {
+    log.warn(
+      { label: "receipt-content-already-redacted", transaction_id: row.id },
+      "content was erased before the receipt was built; refusing to commit to it",
+    );
+    await markReceiptFailed(db, row.id, "internal_error");
+    return;
+  }
 
   // Someone already terminalised this receipt. markReceiptComplete is guarded
   // on `pending` anyway, but returning early keeps a duplicate call from
@@ -329,6 +414,27 @@ async function settleOrThrow(db: Db, params: SettleParams): Promise<void> {
     return;
   }
 
+  const method = asMethod(
+    row.transparency_marker,
+    (row.c_transparency_tag as string | null) ?? null,
+  );
+  if (!method) {
+    // Neither the row's marker nor the capability's declaration names a method
+    // we can commit to. Guessing here is how "no model was involved" gets
+    // asserted about an execution that used one.
+    log.warn(
+      {
+        label: "receipt-unresolvable-method",
+        transaction_id: row.id,
+        marker: row.transparency_marker,
+        declared_tag: row.c_transparency_tag,
+      },
+      "execution method could not be established; receipt refused",
+    );
+    await markReceiptFailed(db, row.id, "internal_error");
+    return;
+  }
+
   const input: ReceiptInput = {
     transactionId: row.id,
     subjectKind: isSolution ? "solution" : "capability",
@@ -343,7 +449,7 @@ async function settleOrThrow(db: Db, params: SettleParams): Promise<void> {
     // `result.output`, and `/v1/transactions/:id` serves the same value.
     result: row.status === "completed" ? (row.output ?? null) : null,
     error: toReceiptError(row),
-    method: asMethod(row.transparency_marker),
+    method,
     sourceObservation: deriveSourceObservation(
       row.provenance,
       (row.c_freshness_category as string | null) ?? null,

--- a/apps/api/src/lib/receipt/settle.ts
+++ b/apps/api/src/lib/receipt/settle.ts
@@ -65,7 +65,15 @@ export type SettleRail = "v1_do" | "x402" | "mcp" | "a2a" | "internal";
 
 export interface SettleParams {
   transactionId: string;
-  rail: SettleRail;
+  /**
+   * The rail, as the calling site knows it.
+   *
+   * Optional because the authoritative copy is `transactions.receipt_rail`,
+   * captured at INSERT (block 0110). When both are present they are
+   * cross-checked and a disagreement is logged - two derivations of one fact
+   * is exactly the shape that drifts, so it is better to notice.
+   */
+  rail?: SettleRail;
   /** The solution slug, when this transaction is a solution execution. */
   solutionSlug?: string | null;
   /**
@@ -101,6 +109,8 @@ interface TxnRow {
   receipt_status: string | null;
   capability_id: string | null;
   solution_slug: string | null;
+  receipt_rail: string | null;
+  receipt_deploy_commit: string | null;
   [k: string]: unknown;
 }
 
@@ -164,7 +174,7 @@ export async function settleExecutionReceipt(db: Db, params: SettleParams): Prom
       {
         label: "receipt-settle-failed",
         transaction_id: params.transactionId,
-        rail: params.rail,
+        rail: params.rail ?? null,
         err: err instanceof Error ? err.message : String(err),
       },
       "execution receipt could not be settled; left pending for the sweeper",
@@ -176,6 +186,7 @@ async function settleOrThrow(db: Db, params: SettleParams): Promise<void> {
   const rows = (await db.execute(sql`
     SELECT t.id, t.status, t.input, t.output, t.error, t.provenance,
            t.transparency_marker, t.receipt_status, t.capability_id, t.solution_slug,
+           t.receipt_rail, t.receipt_deploy_commit,
            c.slug              AS c_slug,
            c.name              AS c_name,
            c.input_schema      AS c_input_schema,
@@ -208,6 +219,29 @@ async function settleOrThrow(db: Db, params: SettleParams): Promise<void> {
   // on `pending` anyway, but returning early keeps a duplicate call from
   // writing a snapshot for nothing.
   if (row.receipt_status === "complete" || row.receipt_status === "failed") return;
+
+  // The rail the ROW recorded wins. It was written at INSERT by the site that
+  // created the transaction, which is the only moment the rail is known
+  // exactly; a caller-supplied value is a second derivation of the same fact.
+  const rowRail = row.receipt_rail as SettleRail | null;
+  if (rowRail && params.rail && rowRail !== params.rail) {
+    log.warn(
+      {
+        label: "receipt-rail-disagreement",
+        transaction_id: row.id,
+        row_rail: rowRail,
+        param_rail: params.rail,
+      },
+      "the transaction row and the settling call site disagree about the rail",
+    );
+  }
+  const rail = rowRail ?? params.rail ?? null;
+  if (!rail) {
+    // A site that writes a transaction and never records its rail. Phase 2's
+    // closed reason set has exactly the right name for this, and it is loud.
+    await markReceiptFailed(db, row.id, "unmapped_rail");
+    return;
+  }
 
   const isSolution = Boolean(params.solutionSlug ?? row.solution_slug);
   const subjectSlug = isSolution
@@ -277,10 +311,20 @@ async function settleOrThrow(db: Db, params: SettleParams): Promise<void> {
   // and the process would not be serving otherwise. Handled anyway rather than
   // assumed, because "cannot happen" is how the Phase 4 review found six of
   // its findings.
-  let deployCommit: string;
-  try {
-    deployCommit = resolveDeployCommit();
-  } catch {
+  // Likewise the commit: the row's copy is the one that was SERVING when the
+  // transaction was created. Reading the environment here instead would bind
+  // whatever is running now, which for a sweeper retry after a deploy is a
+  // different implementation than the one that produced the result - and the
+  // digest would verify perfectly against the wrong answer.
+  let deployCommit: string | null = (row.receipt_deploy_commit as string | null) ?? null;
+  if (!deployCommit) {
+    try {
+      deployCommit = resolveDeployCommit();
+    } catch {
+      deployCommit = null;
+    }
+  }
+  if (!deployCommit) {
     await markReceiptFailed(db, row.id, "missing_deploy_identity");
     return;
   }
@@ -292,7 +336,7 @@ async function settleOrThrow(db: Db, params: SettleParams): Promise<void> {
     deployCommit,
     manifestDigest,
     steps: isSolution ? solutionSteps : null,
-    rail: params.rail,
+    rail,
     inputs: row.input ?? null,
     status: row.status === "completed" ? "completed" : "failed",
     // Exactly the bytes the caller received: `/v1/do` returns this column as

--- a/apps/api/src/lib/receipt/settle.ts
+++ b/apps/api/src/lib/receipt/settle.ts
@@ -233,9 +233,32 @@ function toReceiptError(row: TxnRow): { code: string; message: string } | null {
  * lives in `transactions.receipt_status`, which is the only place a verifier
  * will ever look.
  */
+/**
+ * How long the request path will wait for a receipt before handing it to the
+ * sweeper.
+ *
+ * PHASE-2-SPEC section 9.1 says the money path must never wait on receipt
+ * construction. Awaiting it after the transaction commits cannot endanger a
+ * payment - that property is structural - but a hung database WOULD hold open
+ * the response to a call that has already executed and been charged. A bound
+ * makes the spec's sentence true in the way that matters: the wait is short
+ * and finite, and exceeding it costs a few minutes of receipt latency rather
+ * than a customer's request.
+ */
+export const SETTLE_DEADLINE_MS = 5_000;
+
 export async function settleExecutionReceipt(db: Db, params: SettleParams): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    await settleOrThrow(db, params);
+    await Promise.race([
+      settleOrThrow(db, params),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`receipt settle exceeded ${SETTLE_DEADLINE_MS}ms`)),
+          SETTLE_DEADLINE_MS,
+        );
+      }),
+    ]);
   } catch (err) {
     // Last resort. The row stays `pending` and the sweeper owns it from here,
     // so the failure is visible in the backlog counters rather than lost.
@@ -248,6 +271,8 @@ export async function settleExecutionReceipt(db: Db, params: SettleParams): Prom
       },
       "execution receipt could not be settled; left pending for the sweeper",
     );
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 

--- a/apps/api/src/lib/receipt/sweeper.ts
+++ b/apps/api/src/lib/receipt/sweeper.ts
@@ -1,0 +1,184 @@
+/**
+ * Finishes receipts the request path could not.
+ *
+ * ## Why this exists at all
+ *
+ * Since block 0109 every transaction starts `pending`, so a receipt that is
+ * never built is not a silent absence - it is a row sitting in a state
+ * something has to resolve. Three things produce one: a process killed between
+ * the settlement commit and the receipt, a transient database failure inside
+ * `settle.ts`, and a rail nobody wired. The first two deserve another attempt.
+ * The third deserves an escalation, and `markReceiptFailed` already tells them
+ * apart through `RETRYABLE_REASONS`.
+ *
+ * ## Why a retry is sound here, when it would not have been before
+ *
+ * A naive sweeper rebuilds the receipt from the environment it is running in,
+ * and that is wrong in a way that leaves no trace: after a deploy it would bind
+ * the code running NOW to a result produced by the code that ran THEN, and the
+ * digest would verify perfectly against the wrong implementation identity.
+ *
+ * Block 0110 removed the guesswork. `receipt_rail` and `receipt_deploy_commit`
+ * are captured at INSERT, and `settle.ts` prefers them over anything ambient,
+ * so a retry an hour and two deploys later binds exactly what the original
+ * execution bound.
+ *
+ * ## Bounding
+ *
+ * Attempts are bounded by `markReceiptFailed`, which flips a row to `failed`
+ * once a retryable reason has burned `MAX_RECEIPT_ATTEMPTS`. This module adds
+ * the two things that primitive cannot do for itself: exponential spacing
+ * between attempts, and advancing the counter when a pass leaves the row
+ * pending WITHOUT any reason being recorded - otherwise a row that fails in a
+ * way nothing classifies would be retried forever at the sweep interval.
+ *
+ * ## Isolation
+ *
+ * Every row is swept in its own try/catch, and none of it runs inside the
+ * chain worker's transaction. That is deliberate and it is the Phase 4
+ * round-three lesson: the chain tick is one transaction, so a single raised
+ * exception there rolled back every other row's work. A receipt sweep that
+ * could abort the tamper-evident chain would be a far worse thing than the
+ * problem it solves.
+ */
+
+import { sql } from "drizzle-orm";
+import type { getDb } from "../../db/index.js";
+
+import { settleExecutionReceipt } from "./settle.js";
+import { markReceiptFailed, MAX_RECEIPT_ATTEMPTS } from "./receipt-lifecycle.js";
+import { log } from "../log.js";
+
+type Db = ReturnType<typeof getDb>;
+
+/** How long after creation a pending receipt is first retried. */
+export const RECEIPT_SWEEP_GRACE_MS = 60_000;
+
+/** Rows per tick. Bounded so a backlog drains steadily instead of in one gulp. */
+export const RECEIPT_SWEEP_LIMIT = 100;
+
+export interface SweepSummary {
+  examined: number;
+  completed: number;
+  failed: number;
+  stillPending: number;
+}
+
+/**
+ * Rows whose receipt is pending, whose transaction has actually settled, and
+ * whose backoff window has elapsed.
+ *
+ * The backoff is derived from `receipt_attempts` and `created_at` rather than
+ * from a last-attempt timestamp, because that is one fewer column to keep
+ * honest: attempt N is not eligible until the row is `grace * 2^N` old. With
+ * the default grace that is 1, 2, 4, 8 and 16 minutes - five attempts spread
+ * over roughly half an hour, then terminal.
+ *
+ * `status IN ('completed','failed')` matters. A row still `executing` or
+ * `deferred` has no final result to commit to, and the async path settles it
+ * later; sweeping those would race the execution rather than repair anything.
+ */
+async function selectSweepable(db: Db, limit: number): Promise<
+  Array<{ id: string; attempts: number }>
+> {
+  const rows = (await db.execute(sql`
+    SELECT id::text AS id, receipt_attempts
+      FROM transactions
+     WHERE receipt_status = 'pending'
+       AND status IN ('completed', 'failed')
+       AND created_at < now() - (
+             ${RECEIPT_SWEEP_GRACE_MS}::bigint
+             * power(2, least(receipt_attempts, ${MAX_RECEIPT_ATTEMPTS}))
+           ) * interval '1 millisecond'
+     ORDER BY created_at ASC
+     LIMIT ${limit}
+  `)) as unknown as Array<{ id: string; receipt_attempts: number }>;
+  return rows.map((r) => ({ id: r.id, attempts: Number(r.receipt_attempts) }));
+}
+
+async function readReceiptState(
+  db: Db,
+  id: string,
+): Promise<{ status: string | null; attempts: number } | null> {
+  const rows = (await db.execute(sql`
+    SELECT receipt_status, receipt_attempts
+      FROM transactions
+     WHERE id = ${id}::uuid
+  `)) as unknown as Array<{ receipt_status: string | null; receipt_attempts: number }>;
+  const r = rows[0];
+  return r ? { status: r.receipt_status, attempts: Number(r.receipt_attempts) } : null;
+}
+
+/**
+ * One sweep pass. Never throws: a sweeper that can take down its caller is
+ * worse than a backlog.
+ */
+export async function sweepPendingReceipts(
+  db: Db,
+  limit = RECEIPT_SWEEP_LIMIT,
+): Promise<SweepSummary> {
+  const summary: SweepSummary = { examined: 0, completed: 0, failed: 0, stillPending: 0 };
+
+  let candidates: Array<{ id: string; attempts: number }>;
+  try {
+    candidates = await selectSweepable(db, limit);
+  } catch (err) {
+    log.warn(
+      { label: "receipt-sweep-select-failed", err: err instanceof Error ? err.message : String(err) },
+      "could not select pending receipts",
+    );
+    return summary;
+  }
+
+  for (const row of candidates) {
+    summary.examined += 1;
+    try {
+      // No rail argument: the row carries the authoritative one. Passing one
+      // here would reintroduce exactly the guess block 0110 removed.
+      await settleExecutionReceipt(db, { transactionId: row.id });
+
+      const after = await readReceiptState(db, row.id);
+      if (!after) continue;
+
+      if (after.status === "complete") {
+        summary.completed += 1;
+        continue;
+      }
+      if (after.status === "failed") {
+        summary.failed += 1;
+        // Terminal, and worth saying out loud: a failed receipt means an
+        // execution happened that we cannot commit to.
+        log.warn(
+          { label: "receipt-sweep-terminal", transaction_id: row.id, attempts: after.attempts },
+          "receipt construction is terminally failed for this transaction",
+        );
+        continue;
+      }
+
+      summary.stillPending += 1;
+      if (after.attempts === row.attempts) {
+        // The pass changed nothing and recorded no reason. Without this the
+        // row would be retried at the sweep interval forever, because the
+        // counter that bounds retries would never move.
+        await markReceiptFailed(db, row.id, "internal_error");
+      }
+    } catch (err) {
+      log.warn(
+        {
+          label: "receipt-sweep-row-failed",
+          transaction_id: row.id,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "sweeping one pending receipt threw; the rest of the batch continues",
+      );
+    }
+  }
+
+  if (summary.examined > 0) {
+    log.info(
+      { label: "receipt-sweep", ...summary },
+      "receipt sweep pass complete",
+    );
+  }
+  return summary;
+}

--- a/apps/api/src/lib/solution-executor.ts
+++ b/apps/api/src/lib/solution-executor.ts
@@ -305,6 +305,35 @@ export function evaluateGates(
 }
 
 /**
+ * The steps that actually executed, out of a step-result map.
+ *
+ * `stepResults` is keyed by EVERY declared step, not only the ones that ran.
+ * Four branches put a placeholder in for a step that never executed:
+ * `markSkippedByGate` below, the executor-unavailable branch, the
+ * platform-withheld branch, and the all-inputs-null branch. Three of them are
+ * there deliberately, because a solution advertising 14 steps that audits 13
+ * with no gap marker was itself a money-integrity finding.
+ *
+ * So `Object.keys(stepResults)` is the RECIPE, not the run. Receipt callers
+ * used it as the run, which marked gate-skipped steps `ran` and gave them a
+ * manifest digest - the exact under-specification PHASE-2-SPEC section 5
+ * exists to prevent, and it made `disposition` a constant on every production
+ * solution path. Reviewer-found.
+ *
+ * The rule lives here, next to the code that authors the shape, so a fifth
+ * placeholder branch cannot be added without this being in view.
+ */
+export function stepsThatRan(stepResults: Record<string, unknown>): string[] {
+  return Object.entries(stepResults)
+    .filter(([, v]) => {
+      if (!v || typeof v !== "object") return true;
+      const o = v as Record<string, unknown>;
+      return o.skipped !== true && o.unavailable !== true;
+    })
+    .map(([slug]) => slug);
+}
+
+/**
  * Fill in the steps a tripped gate prevented. Never overwrites a step that
  * already ran — a gate stops what is left, it does not rewrite history.
  */

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1361,7 +1361,7 @@ describe("startup-migrations — block 0102 (account lifecycle tables)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 51 blocks in historical order", () => {
+  it("exports the expected 52 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1420,6 +1420,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0106_executionManifestSnapshots",
       "runMigration0107_executionReceiptColumns",
       "runMigration0108_receiptStateInvariants",
+      "runMigration0109_receiptEpoch",
     ]);
   });
 });
@@ -2279,7 +2280,7 @@ describe("startup-migrations — block identity is unique, not just the function
     const numbers = BLOCKS.map((fn) => Number(/runMigration(\d+)_/.exec(fn.name)?.[1] ?? "0"));
     const sorted = [...numbers].sort((a, b) => a - b);
     expect(numbers).toEqual(sorted);
-    expect(Math.max(...numbers)).toBe(108);
+    expect(Math.max(...numbers)).toBe(109);
   });
 });
 

--- a/apps/api/src/lib/startup-migrations.test.ts
+++ b/apps/api/src/lib/startup-migrations.test.ts
@@ -1361,7 +1361,7 @@ describe("startup-migrations — block 0102 (account lifecycle tables)", () => {
 });
 
 describe("startup-migrations — BLOCKS list (canonical block set)", () => {
-  it("exports the expected 52 blocks in historical order", () => {
+  it("exports the expected 53 blocks in historical order", () => {
     // Pin the canonical block list so an accidental scope-creep edit
     // (adding a block to BLOCKS without updating tests / admin endpoint
     // expectations) trips a test failure. Order matters because the
@@ -1421,6 +1421,7 @@ describe("startup-migrations — BLOCKS list (canonical block set)", () => {
       "runMigration0107_executionReceiptColumns",
       "runMigration0108_receiptStateInvariants",
       "runMigration0109_receiptEpoch",
+      "runMigration0110_receiptExecutionContext",
     ]);
   });
 });
@@ -2280,7 +2281,7 @@ describe("startup-migrations — block identity is unique, not just the function
     const numbers = BLOCKS.map((fn) => Number(/runMigration(\d+)_/.exec(fn.name)?.[1] ?? "0"));
     const sorted = [...numbers].sort((a, b) => a - b);
     expect(numbers).toEqual(sorted);
-    expect(Math.max(...numbers)).toBe(109);
+    expect(Math.max(...numbers)).toBe(110);
   });
 });
 

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -3305,45 +3305,50 @@ export async function runMigration0109_receiptEpoch(
 ): Promise<BlockResult> {
   const startedAt = Date.now();
 
-  // The DEFAULTS are set unconditionally, the EPOCH is chosen once.
+  // ONE statement, so the whole thing is atomic.
   //
-  // Both were inside the same guard at first, and that made the block unable to
-  // repair itself: drop either default by hand and every later run skips the
-  // whole thing, because the constraint it was guarded on still exists. The
-  // block would then report success forever while production could not write.
-  // Proven by dropping the reason default and re-running.
+  // These used to be four separate `tx.execute` calls, and blocks are
+  // autocommitted per statement - `runStartupMigrations` hands each block the
+  // pooled `db`, not a transaction. So when the probe at the end refused, the
+  // two SET DEFAULTs and the epoch CHECK had ALREADY COMMITTED. Boot then
+  // aborted, Railway kept the previous deployment serving, and that previous
+  // deployment had the new defaults and no sweeper: every new row would sit
+  // `pending`, nothing would chain, and /v1/audit/:id would answer 202 forever
+  // until someone rolled forward. The refusal was supposed to be the safe
+  // outcome and it was the dangerous one. Reviewer-found.
   //
-  // SET DEFAULT is idempotent and catalog-only, so there is no cost to doing it
-  // on every boot, and it is now self-healing.
-  await tx.execute(sql`
-    ALTER TABLE transactions ALTER COLUMN receipt_status SET DEFAULT 'pending'
-  `);
-
-  // BOTH columns, and the second is not optional.
+  // A plpgsql DO block is a single statement, so a RAISE anywhere inside it
+  // unwinds every DDL it performed. Refusing now genuinely changes nothing.
   //
-  // Block 0107 added transactions_receipt_reason_required: a row whose status
-  // is 'pending' or 'failed' must SAY why. Defaulting the status alone
-  // therefore makes EVERY INSERT into transactions violate that CHECK -- every
-  // /v1/do call, every x402 call, every internal harness tick, 500 on the
-  // insert. The migration still applies cleanly, because the CHECK is NOT VALID
-  // and existing rows are never scanned; the platform simply stops being able
-  // to write.
+  // The three things it does, in order that matters:
   //
-  // Found by the integration lane, and worth recording plainly: the entire unit
-  // suite was green while it was true.
+  //  1. Both DEFAULTS, unconditionally. `receipt_status` alone is not enough:
+  //     block 0107's transactions_receipt_reason_required means a row that is
+  //     `pending` must SAY why, so defaulting the status without the reason
+  //     makes EVERY INSERT into transactions fail - every /v1/do call, every
+  //     x402 call, every harness tick. The migration would still apply
+  //     cleanly, because that CHECK is NOT VALID and existing rows are never
+  //     scanned; the platform would simply stop being able to write.
+  //     Unconditional, so a hand-dropped default is repaired rather than
+  //     skipped forever by a guard on something else.
   //
-  // 'not_yet_built' is the reason markReceiptPending already writes. It is in
-  // the closed set from 0108 and is explicitly NOT a failure -- it is the
-  // ordinary transient state of a row whose receipt is coming.
-  await tx.execute(sql`
-    ALTER TABLE transactions ALTER COLUMN receipt_failure_reason SET DEFAULT 'not_yet_built'
-  `);
-
-  // The epoch instant is chosen exactly once in the lifetime of the database,
-  // so this one IS guarded -- re-running must not move it.
+  //  2. The epoch CHECK, guarded, because the epoch instant must be chosen
+  //     exactly once in the lifetime of the database and re-running must not
+  //     move it.
+  //
+  //  3. A behavioural self-check, because reading the catalog is not proof.
+  //     The defect above was invisible to every catalog query: the default was
+  //     present and correct, the CHECK was present and correct, and together
+  //     they made every INSERT fail. The only thing that can tell the
+  //     difference is doing what production does - so this inserts an ordinary
+  //     row (the same shape /health/deep has used 507 times in production) and
+  //     unwinds it via a deliberate RAISE inside a nested subtransaction.
   await tx.execute(sql`
     DO $$
     BEGIN
+      ALTER TABLE transactions ALTER COLUMN receipt_status SET DEFAULT 'pending';
+      ALTER TABLE transactions ALTER COLUMN receipt_failure_reason SET DEFAULT 'not_yet_built';
+
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint WHERE conname = 'transactions_post_epoch_has_receipt'
       ) THEN
@@ -3353,6 +3358,22 @@ export async function runMigration0109_receiptEpoch(
           now()
         );
       END IF;
+
+      BEGIN
+        INSERT INTO transactions
+          (solution_slug, status, input, price_cents, transparency_marker,
+           data_jurisdiction, is_free_tier)
+        VALUES ('_receipt_epoch_probe', 'health_probe', '{}', 0, 'algorithmic', 'EU', true);
+        RAISE EXCEPTION 'receipt_epoch_probe_rollback';
+      EXCEPTION
+        WHEN OTHERS THEN
+          IF SQLERRM <> 'receipt_epoch_probe_rollback' THEN
+            RAISE EXCEPTION
+              '0109: with the receipt defaults in place an ordinary INSERT into '
+              'transactions is refused, so production would be unable to write: %',
+              SQLERRM;
+          END IF;
+      END;
     END $$
   `);
 
@@ -3403,35 +3424,6 @@ export async function runMigration0109_receiptEpoch(
   // which is the right outcome -- Railway does not cut over a failed deploy,
   // so the previous commit keeps serving instead of the new one refusing every
   // write.
-  // A plpgsql block with an EXCEPTION handler, not SAVEPOINT: blocks do not
-  // necessarily run inside an explicit transaction (SAVEPOINT raised 25P01
-  // here), while BEGIN ... EXCEPTION establishes an implicit subtransaction
-  // that unwinds the INSERT either way.
-  //
-  // The deliberate RAISE is how the probe row is discarded. If the INSERT
-  // itself is refused, SQLERRM is something else and that is re-raised with a
-  // message saying what it really means.
-  await tx.execute(sql`
-    DO $$
-    BEGIN
-      BEGIN
-        INSERT INTO transactions
-          (solution_slug, status, input, price_cents, transparency_marker,
-           data_jurisdiction, is_free_tier)
-        VALUES ('_receipt_epoch_probe', 'health_probe', '{}', 0, 'algorithmic', 'EU', true);
-        RAISE EXCEPTION 'receipt_epoch_probe_rollback';
-      EXCEPTION
-        WHEN OTHERS THEN
-          IF SQLERRM <> 'receipt_epoch_probe_rollback' THEN
-            RAISE EXCEPTION
-              '0109: with the receipt defaults in place an ordinary INSERT into '
-              'transactions is refused, so production would be unable to write: %',
-              SQLERRM;
-          END IF;
-      END;
-    END $$
-  `);
-
   const row = verify[0];
   if (!row?.default_expr || !row.default_expr.includes("pending")) {
     throw new Error(

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -3305,16 +3305,48 @@ export async function runMigration0109_receiptEpoch(
 ): Promise<BlockResult> {
   const startedAt = Date.now();
 
-  // DEFAULT + CHECK together, and only once. Guarding on the constraint means
-  // the epoch instant is chosen exactly once in the lifetime of the database.
+  // The DEFAULTS are set unconditionally, the EPOCH is chosen once.
+  //
+  // Both were inside the same guard at first, and that made the block unable to
+  // repair itself: drop either default by hand and every later run skips the
+  // whole thing, because the constraint it was guarded on still exists. The
+  // block would then report success forever while production could not write.
+  // Proven by dropping the reason default and re-running.
+  //
+  // SET DEFAULT is idempotent and catalog-only, so there is no cost to doing it
+  // on every boot, and it is now self-healing.
+  await tx.execute(sql`
+    ALTER TABLE transactions ALTER COLUMN receipt_status SET DEFAULT 'pending'
+  `);
+
+  // BOTH columns, and the second is not optional.
+  //
+  // Block 0107 added transactions_receipt_reason_required: a row whose status
+  // is 'pending' or 'failed' must SAY why. Defaulting the status alone
+  // therefore makes EVERY INSERT into transactions violate that CHECK -- every
+  // /v1/do call, every x402 call, every internal harness tick, 500 on the
+  // insert. The migration still applies cleanly, because the CHECK is NOT VALID
+  // and existing rows are never scanned; the platform simply stops being able
+  // to write.
+  //
+  // Found by the integration lane, and worth recording plainly: the entire unit
+  // suite was green while it was true.
+  //
+  // 'not_yet_built' is the reason markReceiptPending already writes. It is in
+  // the closed set from 0108 and is explicitly NOT a failure -- it is the
+  // ordinary transient state of a row whose receipt is coming.
+  await tx.execute(sql`
+    ALTER TABLE transactions ALTER COLUMN receipt_failure_reason SET DEFAULT 'not_yet_built'
+  `);
+
+  // The epoch instant is chosen exactly once in the lifetime of the database,
+  // so this one IS guarded -- re-running must not move it.
   await tx.execute(sql`
     DO $$
     BEGIN
       IF NOT EXISTS (
         SELECT 1 FROM pg_constraint WHERE conname = 'transactions_post_epoch_has_receipt'
       ) THEN
-        ALTER TABLE transactions ALTER COLUMN receipt_status SET DEFAULT 'pending';
-
         EXECUTE format(
           'ALTER TABLE transactions ADD CONSTRAINT transactions_post_epoch_has_receipt '
           'CHECK (created_at < %L OR receipt_status IS NOT NULL) NOT VALID',
@@ -3346,15 +3378,59 @@ export async function runMigration0109_receiptEpoch(
     SELECT
       (SELECT column_default FROM information_schema.columns
         WHERE table_name = 'transactions' AND column_name = 'receipt_status') AS default_expr,
+      (SELECT column_default FROM information_schema.columns
+        WHERE table_name = 'transactions' AND column_name = 'receipt_failure_reason') AS reason_default,
       (SELECT pg_get_constraintdef(oid) FROM pg_constraint
         WHERE conname = 'transactions_post_epoch_has_receipt') AS epoch_check,
       (SELECT 1 FROM pg_constraint
         WHERE conname = 'transactions_receipt_manifest_digest_fk') AS fk_present
   `)) as unknown as Array<{
     default_expr: string | null;
+    reason_default: string | null;
     epoch_check: string | null;
     fk_present: number | null;
   }>;
+
+  // Behavioural self-check, because reading the catalog is not proof.
+  //
+  // The defect this exists for was invisible to every catalog query: the
+  // status default was present and correct, the CHECK was present and correct,
+  // and together they made every INSERT fail. The only thing that could tell
+  // the difference is doing what production does.
+  //
+  // Same row shape as the /health/deep write-path probe. Rolled back to the
+  // savepoint, so nothing is left behind; a violation raises and aborts boot,
+  // which is the right outcome -- Railway does not cut over a failed deploy,
+  // so the previous commit keeps serving instead of the new one refusing every
+  // write.
+  // A plpgsql block with an EXCEPTION handler, not SAVEPOINT: blocks do not
+  // necessarily run inside an explicit transaction (SAVEPOINT raised 25P01
+  // here), while BEGIN ... EXCEPTION establishes an implicit subtransaction
+  // that unwinds the INSERT either way.
+  //
+  // The deliberate RAISE is how the probe row is discarded. If the INSERT
+  // itself is refused, SQLERRM is something else and that is re-raised with a
+  // message saying what it really means.
+  await tx.execute(sql`
+    DO $$
+    BEGIN
+      BEGIN
+        INSERT INTO transactions
+          (solution_slug, status, input, price_cents, transparency_marker,
+           data_jurisdiction, is_free_tier)
+        VALUES ('_receipt_epoch_probe', 'health_probe', '{}', 0, 'algorithmic', 'EU', true);
+        RAISE EXCEPTION 'receipt_epoch_probe_rollback';
+      EXCEPTION
+        WHEN OTHERS THEN
+          IF SQLERRM <> 'receipt_epoch_probe_rollback' THEN
+            RAISE EXCEPTION
+              '0109: with the receipt defaults in place an ordinary INSERT into '
+              'transactions is refused, so production would be unable to write: %',
+              SQLERRM;
+          END IF;
+      END;
+    END $$
+  `);
 
   const row = verify[0];
   if (!row?.default_expr || !row.default_expr.includes("pending")) {
@@ -3362,6 +3438,13 @@ export async function runMigration0109_receiptEpoch(
       "0109: receipt_status has no 'pending' default, so a transaction could " +
         "still be inserted with no receipt state. Got: " +
         String(row?.default_expr),
+    );
+  }
+  if (!row?.reason_default || !row.reason_default.includes("not_yet_built")) {
+    throw new Error(
+      "0109: receipt_failure_reason has no 'not_yet_built' default, so an insert " +
+        "carrying the pending status default would violate " +
+        "transactions_receipt_reason_required. Got: " + String(row?.reason_default),
     );
   }
   if (!row?.epoch_check) {

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -3230,6 +3230,170 @@ export async function runMigration0108_receiptStateInvariants(
   };
 }
 
+/**
+ * Block 0109 - the receipt epoch, made structural.
+ *
+ * Phase 4 shipped every receipt artifact and then said, in its own
+ * reconciliation, that the epoch was NOT structurally real: a transaction
+ * inserted afterwards was byte-identical to one from April, because
+ * `chain_v2_has_receipt_state` only constrains rows that DECLARE v2 and no row
+ * declared anything. This block closes that, and it is the reason Phase 5 can
+ * wire every rail at once instead of one at a time.
+ *
+ * Two statements do the work:
+ *
+ *  1. `receipt_status` gets a DEFAULT of `pending`. Every insert into
+ *     `transactions` - from the four executors in `routes/do.ts`, from
+ *     `solution-execute.ts`, from `x402-gateway-v2.ts`, from the internal
+ *     harness, from the settlement reconciler, and from any site written after
+ *     this one - now starts with receipt state whether or not its author
+ *     thought about receipts. This is the property no amount of call-site
+ *     wiring can give you: a rail nobody wired produces a VISIBLE `pending`
+ *     row that the sweeper picks up and the backlog counter reports, instead
+ *     of a silent NULL that looks exactly like a pre-epoch row.
+ *
+ *  2. A CHECK that a post-epoch row cannot have a NULL status. `NOT VALID`, so
+ *     the 921k existing rows are not scanned at boot; they are all pre-epoch
+ *     and exempt by the `created_at` test regardless.
+ *
+ * ## Where the epoch instant comes from
+ *
+ * `now()` at the moment this block first runs, baked into the constraint text
+ * as a literal. The constraint is therefore the single, immutable record of
+ * when enforcement began - there is no second copy in a table to drift from
+ * it, and re-running this block is a no-op because the constraint already
+ * exists.
+ *
+ * The race that looks like a problem is not one. `ALTER TABLE` takes ACCESS
+ * EXCLUSIVE, so a concurrent insert either committed before the lock was
+ * granted - giving it a `created_at` earlier than `now()`, hence exempt - or
+ * blocks until this transaction commits and then picks up the DEFAULT. There
+ * is no interleaving that produces a post-epoch row with a NULL status.
+ *
+ * ## The foreign key
+ *
+ * `transactions.receipt_manifest_digest` now references
+ * `execution_manifest_snapshots(digest)`. Phase 4 listed its absence as
+ * residual risk 6 and left the decision open; the decision is to add it, on
+ * these grounds:
+ *
+ *  - The referent is guaranteed to exist by construction: `settle.ts` records
+ *    the snapshot BEFORE `markReceiptComplete` writes the digest.
+ *  - It can never break later, because DELETE and TRUNCATE on the snapshot
+ *    table are refused by triggers from blocks 0106 and 0108. A FK is normally
+ *    a liability when the parent can be deleted; here it structurally cannot.
+ *  - Without it, "the digest points at a snapshot that exists" is a
+ *    convention. `readManifestSnapshot` recomputes before trusting, so a
+ *    MIS-ADDRESSED row is caught - but a digest pointing at NOTHING is a
+ *    different failure, and nothing caught that.
+ *  - NULL is permitted, which is what a `failed` receipt writes, so the
+ *    failure path is unaffected.
+ *
+ * Its cost is one unique-index probe per receipt completion, off the money
+ * path. `NOT VALID` for the same reason as the CHECK.
+ *
+ * ## Backlog (DEC-20260504-B)
+ *
+ * Not a bulk-operation resumption. Both ALTERs are catalog-only in PG11+, the
+ * CHECK and FK are `NOT VALID` so neither scans, and there is no accumulated
+ * workload to drain: production carries zero rows with receipt state, so the
+ * sweeper starts from an empty backlog and only ever sees rows created after
+ * this block ran.
+ */
+export async function runMigration0109_receiptEpoch(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  // DEFAULT + CHECK together, and only once. Guarding on the constraint means
+  // the epoch instant is chosen exactly once in the lifetime of the database.
+  await tx.execute(sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'transactions_post_epoch_has_receipt'
+      ) THEN
+        ALTER TABLE transactions ALTER COLUMN receipt_status SET DEFAULT 'pending';
+
+        EXECUTE format(
+          'ALTER TABLE transactions ADD CONSTRAINT transactions_post_epoch_has_receipt '
+          'CHECK (created_at < %L OR receipt_status IS NOT NULL) NOT VALID',
+          now()
+        );
+      END IF;
+    END $$
+  `);
+
+  await tx.execute(sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'transactions_receipt_manifest_digest_fk'
+      ) THEN
+        ALTER TABLE transactions
+          ADD CONSTRAINT transactions_receipt_manifest_digest_fk
+          FOREIGN KEY (receipt_manifest_digest)
+          REFERENCES execution_manifest_snapshots (digest)
+          NOT VALID;
+      END IF;
+    END $$
+  `);
+
+  // Self-verify by object, not by "no error was raised". A block that reports
+  // success without checking is the hollow-gate pattern this repo has been
+  // bitten by more than once.
+  const verify = (await tx.execute(sql`
+    SELECT
+      (SELECT column_default FROM information_schema.columns
+        WHERE table_name = 'transactions' AND column_name = 'receipt_status') AS default_expr,
+      (SELECT pg_get_constraintdef(oid) FROM pg_constraint
+        WHERE conname = 'transactions_post_epoch_has_receipt') AS epoch_check,
+      (SELECT 1 FROM pg_constraint
+        WHERE conname = 'transactions_receipt_manifest_digest_fk') AS fk_present
+  `)) as unknown as Array<{
+    default_expr: string | null;
+    epoch_check: string | null;
+    fk_present: number | null;
+  }>;
+
+  const row = verify[0];
+  if (!row?.default_expr || !row.default_expr.includes("pending")) {
+    throw new Error(
+      "0109: receipt_status has no 'pending' default, so a transaction could " +
+        "still be inserted with no receipt state. Got: " +
+        String(row?.default_expr),
+    );
+  }
+  if (!row?.epoch_check) {
+    throw new Error("0109: the post-epoch CHECK constraint is absent after the block ran");
+  }
+  if (!row?.fk_present) {
+    throw new Error("0109: the receipt_manifest_digest foreign key is absent after the block ran");
+  }
+
+  return {
+    block: "0109_receipt_epoch",
+    outcome:
+      "receipt_status DEFAULT 'pending' + post-epoch CHECK + manifest-digest FK, " +
+      "all present and verified; epoch: " +
+      (parseEpochFromCheck(row.epoch_check) ?? "unparsed"),
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
+/**
+ * The epoch instant, read back out of the constraint that enforces it.
+ *
+ * Deliberately no second copy in a table: two records of one fact is how they
+ * drift. Returns null rather than guessing if the shape is unfamiliar, because
+ * a wrong epoch reported confidently is worse than an absent one.
+ */
+export function parseEpochFromCheck(constraintDef: string | null): string | null {
+  if (!constraintDef) return null;
+  const m = constraintDef.match(/'([^']+)'::timestamp with time zone/);
+  return m ? m[1] : null;
+}
+
 export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResult>> = [
   runMigration0029_actualCostCents,
   runMigration0030_complianceColumns,
@@ -3286,6 +3450,8 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0106_executionManifestSnapshots,
   runMigration0107_executionReceiptColumns,
   runMigration0108_receiptStateInvariants,
+  // Phase 5: the epoch becomes structural -- every insert gets receipt state.
+  runMigration0109_receiptEpoch,
 ];
 
 /**

--- a/apps/api/src/lib/startup-migrations.ts
+++ b/apps/api/src/lib/startup-migrations.ts
@@ -3394,6 +3394,106 @@ export function parseEpochFromCheck(constraintDef: string | null): string | null
   return m ? m[1] : null;
 }
 
+/**
+ * Block 0110 - the two facts a receipt cannot be rebuilt without.
+ *
+ * The sweeper (jobs/receipt-sweeper.ts) finishes receipts the request path
+ * could not. Writing it exposed a soundness problem that is worth stating
+ * plainly, because the obvious implementation is wrong:
+ *
+ *  - **The rail is not recoverable from the row.** Nothing on `transactions`
+ *    says which surface created it. A sweeper would have to GUESS - infer
+ *    `x402` from `payment_method`, `internal` from the system user id - and a
+ *    guessed value has no business inside a commitment whose whole purpose is
+ *    to be exact.
+ *
+ *  - **The deploy commit drifts.** `resolveDeployCommit()` answers for the
+ *    process asking, so a receipt rebuilt after a deploy would bind the code
+ *    that is running NOW to a result produced by the code that ran THEN. That
+ *    is not a smaller truth, it is a false one, and it would be invisible: the
+ *    digest would verify perfectly against the wrong implementation identity.
+ *
+ * So both are captured at INSERT, where they are known exactly, and `settle.ts`
+ * prefers the row's values over anything ambient. This also makes the request
+ * path itself more correct, not just the sweeper - the commit bound is the one
+ * that was serving when the transaction was created, rather than whatever the
+ * environment happens to say a few milliseconds later.
+ *
+ * A site that never sets `receipt_rail` leaves it NULL, and the sweeper records
+ * `unmapped_rail` - which is already in Phase 2's closed reason set, and is
+ * exactly what a new unwired rail should produce: a loud, correctly-named
+ * invariant failure rather than a plausible guess.
+ *
+ * Both columns are nullable and both CHECKs are `NOT VALID`: every existing row
+ * is pre-epoch and has neither.
+ */
+export async function runMigration0110_receiptExecutionContext(
+  tx: MigrationExecutor,
+): Promise<BlockResult> {
+  const startedAt = Date.now();
+
+  await tx.execute(sql`
+    ALTER TABLE transactions
+      ADD COLUMN IF NOT EXISTS receipt_rail TEXT,
+      ADD COLUMN IF NOT EXISTS receipt_deploy_commit TEXT
+  `);
+
+  // The rail is a closed enum. Enforced here rather than trusted, because the
+  // whole point of the column is that a verifier can rely on it.
+  await tx.execute(sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'receipt_rail_closed') THEN
+        ALTER TABLE transactions
+          ADD CONSTRAINT receipt_rail_closed
+          CHECK (receipt_rail IS NULL OR receipt_rail IN ('v1_do','x402','mcp','a2a','internal'))
+          NOT VALID;
+      END IF;
+    END $$
+  `);
+
+  // A full 40-hex commit, or the local-build sentinel. Anything else is a
+  // truncated or decorated value pretending to be an identity.
+  await tx.execute(sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'receipt_deploy_commit_shape') THEN
+        ALTER TABLE transactions
+          ADD CONSTRAINT receipt_deploy_commit_shape
+          CHECK (
+            receipt_deploy_commit IS NULL
+            OR receipt_deploy_commit = 'unknown-local-build'
+            OR receipt_deploy_commit ~ '^[0-9a-f]{40}$'
+          )
+          NOT VALID;
+      END IF;
+    END $$
+  `);
+
+  const verify = (await tx.execute(sql`
+    SELECT
+      (SELECT count(*)::int FROM information_schema.columns
+        WHERE table_name = 'transactions'
+          AND column_name IN ('receipt_rail', 'receipt_deploy_commit')) AS cols,
+      (SELECT count(*)::int FROM pg_constraint
+        WHERE conname IN ('receipt_rail_closed', 'receipt_deploy_commit_shape')) AS checks
+  `)) as unknown as Array<{ cols: number; checks: number }>;
+
+  const row = verify[0];
+  if (Number(row?.cols) !== 2) {
+    throw new Error(`0110: expected 2 receipt context columns, found ${row?.cols}`);
+  }
+  if (Number(row?.checks) !== 2) {
+    throw new Error(`0110: expected 2 receipt context CHECKs, found ${row?.checks}`);
+  }
+
+  return {
+    block: "0110_receipt_execution_context",
+    outcome: "receipt_rail + receipt_deploy_commit columns and their closed-set CHECKs verified",
+    duration_ms: Date.now() - startedAt,
+  };
+}
+
 export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResult>> = [
   runMigration0029_actualCostCents,
   runMigration0030_complianceColumns,
@@ -3452,6 +3552,7 @@ export const BLOCKS: ReadonlyArray<(tx: MigrationExecutor) => Promise<BlockResul
   runMigration0108_receiptStateInvariants,
   // Phase 5: the epoch becomes structural -- every insert gets receipt state.
   runMigration0109_receiptEpoch,
+  runMigration0110_receiptExecutionContext,
 ];
 
 /**

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -1866,7 +1866,12 @@ async function recordTestQuality(
   const db = getDb();
 
   const [cap] = await db
-    .select({ outputSchema: capabilities.outputSchema, id: capabilities.id })
+    .select({
+      outputSchema: capabilities.outputSchema,
+      id: capabilities.id,
+      // Needed for the Art. 50 marker below, which used to be a constant.
+      transparencyTag: capabilities.transparencyTag,
+    })
     .from(capabilities)
     .where(eq(capabilities.slug, capabilitySlug))
     .limit(1);
@@ -1886,7 +1891,19 @@ async function recordTestQuality(
       status: executionError ? "failed" : "completed",
       input: {},
       priceCents: 0,
-      transparencyMarker: "algorithmic",
+      // The capability's own declaration, not a constant.
+      //
+      // This hardcoded 'algorithmic' for every harness row - 99.3% of platform
+      // traffic - including capabilities that declare ai_generated or mixed.
+      // transparency_marker is the EU AI Act Art. 50 marker, so that was a
+      // fabricated disclosure independently of receipts; it also fed a
+      // receipt asserting no model was involved. Reviewer-found.
+      transparencyMarker:
+        cap.transparencyTag === "algorithmic"
+          ? "algorithmic"
+          : cap.transparencyTag === "mixed"
+            ? "hybrid"
+            : "ai_generated",
       dataJurisdiction: "EU",
       error: executionError,
       latencyMs: responseTimeMs,

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -1,4 +1,5 @@
 import { eq, and, not, sql, desc, inArray } from "drizzle-orm";
+import { settleExecutionReceipt } from "./receipt/settle.js";
 import { getDb } from "../db/index.js";
 import {
   testSuites,
@@ -1886,6 +1887,15 @@ async function recordTestQuality(
       completedAt: new Date(),
     })
     .returning({ id: transactions.id });
+
+  // The internal harness is roughly 98% of all platform traffic, so leaving it
+  // unwired would have meant the overwhelming majority of post-epoch rows
+  // sitting `pending` forever and the chain backlog growing without bound. It
+  // is a real execution of a real capability; it gets a real receipt, on its
+  // own rail so it can be told apart from customer traffic.
+  if (txn?.id) {
+    await settleExecutionReceipt(db, { transactionId: txn.id, rail: "internal" });
+  }
 
   const outputSchema = (cap.outputSchema ?? {}) as Record<string, unknown>;
   const properties =

--- a/apps/api/src/lib/test-runner.ts
+++ b/apps/api/src/lib/test-runner.ts
@@ -1,4 +1,5 @@
 import { eq, and, not, sql, desc, inArray } from "drizzle-orm";
+import { deployCommitOrNull } from "./receipt/deploy-identity.js";
 import { settleExecutionReceipt } from "./receipt/settle.js";
 import { getDb } from "../db/index.js";
 import {
@@ -1875,6 +1876,11 @@ async function recordTestQuality(
   const [txn] = await db
     .insert(transactions)
     .values({
+      // Captured at INSERT because neither is recoverable later:
+      // the rail is not a property of the row, and the deploy commit
+      // drifts the moment anything redeploys (block 0110).
+      receiptRail: "internal",
+      receiptDeployCommit: deployCommitOrNull(),
       userId: await getSystemUserId(),
       capabilityId: cap.id,
       status: executionError ? "failed" : "completed",

--- a/apps/api/src/routes/do.receipt.integration.test.ts
+++ b/apps/api/src/routes/do.receipt.integration.test.ts
@@ -1,0 +1,374 @@
+/**
+ * What the receipt commits to is what the caller actually received.
+ *
+ * Every other receipt test builds a `ReceiptInput` by hand and checks the
+ * digest is stable. That proves the hashing is deterministic; it proves
+ * nothing about whether the thing being hashed is the thing we served. The gap
+ * between those two is where a provenance system fails quietly: the receipts
+ * verify perfectly and describe a different execution.
+ *
+ * So these drive the real `POST /v1/do` over a real Postgres, take the HTTP
+ * response body, and rebuild the receipt FROM THE RESPONSE. If the digest that
+ * comes out does not match the one the request path stored, then what we
+ * committed to is not what the customer got.
+ *
+ * The rails that do not have a route-level harness here (x402, internal) are
+ * covered at the settle boundary instead, and `rail-coverage.test.ts` is what
+ * stops a rail from having no coverage at all.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../test-support/integration-db.js";
+import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
+import { capabilities, transactions, users, wallets, walletTransactions } from "../db/schema.js";
+import { buildExecutionReceipt, LOCAL_BUILD_SENTINEL } from "../lib/receipt/execution-receipt.js";
+import { deriveSourceObservation, settleExecutionReceipt } from "../lib/receipt/settle.js";
+
+if (process.env.DATABASE_URL_TEST) {
+  process.env.FRONTEND_URL ??= "https://strale.dev";
+  process.env.AUDIT_HMAC_SECRET ??= "p5-receipt-secret-at-least-32-chars-long-000";
+  process.env.ADMIN_SECRET ??= "p5-receipt-admin-secret-at-least-32-chars-00";
+  process.env.STRIPE_SECRET_KEY ??= "sk_test_p5_placeholder";
+  process.env.STRIPE_WEBHOOK_SECRET ??= "whsec_p5_placeholder";
+}
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+const PRICE_CENTS = 25;
+
+describeMaybe("execution receipts bind what the caller received", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let app: Awaited<typeof import("../app.js")>["app"];
+
+  let okSlug: string;
+  let freeSlug: string;
+  let boomSlug: string;
+  const seeded: { userId: string; walletId: string }[] = [];
+  const seededCaps: string[] = [];
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 10 });
+    db = drizzle(client);
+
+    const { registerCapability } = await import("../capabilities/index.js");
+    okSlug = `p5-receipt-ok-${randomUUID().slice(0, 8)}`;
+    freeSlug = `p5-receipt-free-${randomUUID().slice(0, 8)}`;
+    boomSlug = `p5-receipt-boom-${randomUUID().slice(0, 8)}`;
+
+    registerCapability(okSlug, async (input: any) => ({
+      // Deliberately nested and mixed-type: a shape where a lossy
+      // re-serialisation on either side would move the digest.
+      output: {
+        echo: input?.probe ?? null,
+        nested: { n: 42, flag: true, list: [1, 2, 3] },
+        unicode: "naïve café 😀",
+      },
+      provenance: { source: "p5-test", fetched_at: new Date().toISOString() },
+    }));
+    registerCapability(freeSlug, async (input: any) => ({
+      output: { free: true, echo: input?.probe ?? null },
+      provenance: { source: "p5-test", fetched_at: new Date().toISOString() },
+    }));
+    registerCapability(boomSlug, async () => {
+      throw new Error("p5 deliberate executor failure");
+    });
+
+    ({ app } = await import("../app.js"));
+  }, 120_000);
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  afterEach(async () => {
+    for (const { userId, walletId } of seeded) {
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+      await db.delete(walletTransactions).where(eq(walletTransactions.walletId, walletId));
+      await db.delete(wallets).where(eq(wallets.id, walletId));
+      await db.delete(users).where(eq(users.id, userId));
+    }
+    seeded.length = 0;
+    for (const id of seededCaps) {
+      await db.delete(transactions).where(eq(transactions.capabilityId, id));
+      await db.delete(capabilities).where(eq(capabilities.id, id));
+    }
+    seededCaps.length = 0;
+  });
+
+  async function seedCapability(slug: string, opts: { isFreeTier?: boolean } = {}) {
+    const id = randomUUID();
+    seededCaps.push(id);
+    await db.insert(capabilities).values({
+      id,
+      slug,
+      name: `P5 receipt probe ${slug}`,
+      description: "Seeded by the Phase 5 receipt binding test.",
+      category: "developer-tools",
+      inputSchema: { type: "object", properties: { probe: { type: "string" } } },
+      outputSchema: { type: "object", properties: { echo: { type: "string" } } },
+      priceCents: opts.isFreeTier ? 0 : PRICE_CENTS,
+      isActive: true,
+      isFreeTier: opts.isFreeTier ?? false,
+      avgLatencyMs: 50,
+      lifecycleState: "active",
+      visible: true,
+    });
+    return id;
+  }
+
+  async function seedUser(balanceCents = 10_000): Promise<string> {
+    const userId = randomUUID();
+    const walletId = randomUUID();
+    const apiKey = `sk_live_${randomUUID().replace(/-/g, "")}`;
+    seeded.push({ userId, walletId });
+    await db.insert(users).values({
+      id: userId,
+      email: `p5-receipt-${userId}@example.test`,
+      apiKeyHash: hashApiKey(apiKey),
+      keyPrefix: getKeyPrefix(apiKey),
+    });
+    await db.insert(wallets).values({ id: walletId, userId, balanceCents });
+    return apiKey;
+  }
+
+  function callDo(apiKey: string | null, body: Record<string, unknown>) {
+    return app.request("http://localhost/v1/do", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function receiptRow(transactionId: string) {
+    const rows = (await db.execute(sql`
+      SELECT * FROM transactions WHERE id = ${transactionId}::uuid
+    `)) as unknown as Array<Record<string, unknown>>;
+    return rows[0];
+  }
+
+  /**
+   * Rebuild the receipt from the RESPONSE the caller got, and return its
+   * digest. Everything that describes the execution comes from the HTTP body;
+   * only the identity fields the caller never sees are read from the row.
+   */
+  function digestFromResponse(
+    row: Record<string, unknown>,
+    body: any,
+    opts: { status: "completed" | "failed" },
+  ): string {
+    const built = buildExecutionReceipt(
+      {
+        transactionId: row.id as string,
+        subjectKind: "capability",
+        subjectSlug: body?.result?.capability_used ?? (row.c_slug as string),
+        deployCommit: row.receipt_deploy_commit as string,
+        manifestDigest: row.receipt_manifest_digest as string | null,
+        steps: null,
+        rail: row.receipt_rail as string,
+        inputs: row.input,
+        status: opts.status,
+        // THE POINT: straight out of the HTTP response body.
+        result: opts.status === "completed" ? body.result.output : null,
+        error:
+          opts.status === "failed"
+            ? { code: "execution_failed", message: String(body?.details?.error ?? "") }
+            : null,
+        method: row.transparency_marker as "algorithmic",
+        sourceObservation: deriveSourceObservation(row.provenance, "live-fetch"),
+      },
+      { NODE_ENV: "test" } as NodeJS.ProcessEnv,
+    );
+    if (built.outcome !== "complete") throw new Error(`rebuild failed: ${built.reason}`);
+    return built.digest;
+  }
+
+  it("PAID SYNC RAIL: the stored digest is the digest of what the caller received", async () => {
+    await seedCapability(okSlug);
+    const apiKey = await seedUser();
+
+    const inputs = { probe: "sync-paid" };
+    const res = await callDo(apiKey, {
+      capability_slug: okSlug,
+      inputs,
+      max_price_cents: PRICE_CENTS,
+    });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    const txnId = body.result.transaction_id;
+
+    const row = await receiptRow(txnId);
+    expect(row.receipt_status, "the request path did not complete the receipt").toBe("complete");
+    expect(row.receipt_rail).toBe("v1_do");
+
+    // The REQUEST half: what was hashed as `inputs` is what the caller sent.
+    expect(row.input).toEqual(inputs);
+
+    // The RESULT half: rebuild from the response body and compare digests.
+    expect(digestFromResponse({ ...row, c_slug: okSlug }, body, { status: "completed" })).toBe(
+      row.receipt_digest,
+    );
+
+    // And the response really did carry the nested/unicode shape, so the match
+    // above is not a match between two empty objects.
+    expect(body.result.output.unicode).toBe("naïve café 😀");
+    expect(body.result.output.nested.list).toEqual([1, 2, 3]);
+  });
+
+  it("FREE-TIER RAIL: same binding, and the rail is still recorded", async () => {
+    await seedCapability(freeSlug, { isFreeTier: true });
+    const apiKey = await seedUser();
+
+    const inputs = { probe: "free-tier" };
+    const res = await callDo(apiKey, {
+      capability_slug: freeSlug, inputs, max_price_cents: PRICE_CENTS,
+    });
+    expect(res.status, JSON.stringify(await res.clone().json())).toBe(200);
+    const body: any = await res.json();
+    const row = await receiptRow(body.result.transaction_id);
+
+    expect(row.receipt_status).toBe("complete");
+    expect(row.receipt_rail).toBe("v1_do");
+    expect(row.input).toEqual(inputs);
+    expect(digestFromResponse({ ...row, c_slug: freeSlug }, body, { status: "completed" })).toBe(
+      row.receipt_digest,
+    );
+  });
+
+  it("FAILURES ARE EXECUTIONS: the error hashed is the error the caller was given", async () => {
+    // Phase 2 is explicit that a failed execution gets a receipt. It is also
+    // the case most likely to be got wrong, because the sanitised message the
+    // caller sees and the raw message we logged are different strings.
+    await seedCapability(boomSlug);
+    const apiKey = await seedUser();
+
+    const res = await callDo(apiKey, {
+      capability_slug: boomSlug,
+      inputs: { probe: "boom" },
+      max_price_cents: PRICE_CENTS,
+    });
+    const body: any = await res.json();
+    expect(res.status).toBeGreaterThanOrEqual(400);
+
+    const rows = (await db.execute(sql`
+      SELECT * FROM transactions
+       WHERE capability_id = ${seededCaps[seededCaps.length - 1]}::uuid
+       ORDER BY created_at DESC LIMIT 1
+    `)) as unknown as Array<Record<string, unknown>>;
+    const row = rows[0];
+
+    expect(row.status).toBe("failed");
+    expect(row.receipt_status, "a failed execution still gets a receipt").toBe("complete");
+    expect(row.receipt_rail).toBe("v1_do");
+
+    // `/v1/do` puts the real message under details.error, not a top-level
+    // `error` key. The receipt must bind THAT string.
+    expect(digestFromResponse({ ...row, c_slug: boomSlug }, body, { status: "failed" })).toBe(
+      row.receipt_digest,
+    );
+  });
+
+  it("the receipt records the serving commit, and outside production that is the sentinel", async () => {
+    await seedCapability(okSlug);
+    const apiKey = await seedUser();
+    const res = await callDo(apiKey, {
+      capability_slug: okSlug,
+      inputs: { probe: "commit" },
+      max_price_cents: PRICE_CENTS,
+    });
+    const body: any = await res.json();
+    const row = await receiptRow(body.result.transaction_id);
+
+    // Never mistakable for a real 40-hex SHA, which is the whole point of
+    // having a defined sentinel rather than a null.
+    expect(row.receipt_deploy_commit).toBe(LOCAL_BUILD_SENTINEL);
+  });
+
+  it("a receipt that cannot be built does not disturb the transaction it describes", async () => {
+    // The safety property the whole design rests on: receipt construction runs
+    // after the money transaction commits and swallows its own failures, so a
+    // request that executed and charged is never failed by a receipt problem.
+    //
+    // The first attempt at this test tried to reset a completed receipt back to
+    // pending, and the 0108 transition trigger refused it -- correctly, and
+    // that refusal is itself worth having seen. A fresh row is used instead.
+    //
+    // A solution transaction naming a solution with no declared steps is the
+    // cleanest unresolvable case: there is no recipe to bind, and unlike a
+    // missing capability it cannot be ruled out by a foreign key.
+    const id = randomUUID();
+    await db.execute(sql`
+      INSERT INTO transactions (id, solution_slug, status, price_cents, transparency_marker,
+                                data_jurisdiction, input, output, receipt_rail,
+                                receipt_deploy_commit, completed_at)
+      VALUES (${id}::uuid, ${`p5-no-such-solution-${randomUUID().slice(0, 8)}`},
+              'completed', 5, 'algorithmic', 'EU',
+              ${JSON.stringify({ probe: "orphan" })}::jsonb,
+              ${JSON.stringify({ echo: "orphan" })}::jsonb,
+              'v1_do', ${LOCAL_BUILD_SENTINEL}, now())
+    `);
+
+    // It resolves rather than throwing. That is the contract: a receipt failure
+    // must never propagate into the request that produced it.
+    await expect(
+      settleExecutionReceipt(db, { transactionId: id, rail: "v1_do", ranStepSlugs: [] }),
+    ).resolves.toBeUndefined();
+
+    const row = await receiptRow(id);
+    expect(row.receipt_status).toBe("failed");
+    expect(row.receipt_failure_reason).toBe("unresolvable_manifest");
+    // The execution itself is untouched: still completed, still carrying the
+    // output the caller received.
+    expect(row.status).toBe("completed");
+    expect((row.output as any).echo).toBe("orphan");
+
+    await db.execute(sql`DELETE FROM transactions WHERE id = ${id}::uuid`);
+  });
+
+  it("X402 AND INTERNAL RAILS: settle binds the rail the row recorded, not the one passed", async () => {
+    // The rails without a route harness here. The row's own `receipt_rail` is
+    // authoritative - block 0110 - so a caller passing a different one must not
+    // be able to change what the receipt says.
+    const capId = await seedCapability(okSlug);
+    const apiKey = await seedUser();
+    void apiKey;
+
+    for (const rail of ["x402", "internal"] as const) {
+      const id = randomUUID();
+      await db.execute(sql`
+        INSERT INTO transactions (id, capability_id, status, price_cents, transparency_marker,
+                                  data_jurisdiction, input, output, provenance,
+                                  receipt_rail, receipt_deploy_commit, completed_at)
+        VALUES (${id}::uuid, ${capId}::uuid, 'completed', 5, 'algorithmic', 'EU',
+                ${JSON.stringify({ probe: rail })}::jsonb,
+                ${JSON.stringify({ ok: rail })}::jsonb,
+                ${JSON.stringify({ source: "p5", fetched_at: new Date().toISOString() })}::jsonb,
+                ${rail}, ${LOCAL_BUILD_SENTINEL}, now())
+      `);
+
+      // Deliberately lie about the rail on the call.
+      await settleExecutionReceipt(db, { transactionId: id, rail: "v1_do" });
+
+      const row = await receiptRow(id);
+      expect(row.receipt_status).toBe("complete");
+      expect(row.receipt_rail, "the row's recorded rail must win").toBe(rail);
+
+      // And the digest is the one for the row's rail, not the passed one.
+      const asRecorded = digestFromResponse(
+        { ...row, c_slug: okSlug },
+        { result: { output: row.output, capability_used: okSlug } },
+        { status: "completed" },
+      );
+      expect(asRecorded).toBe(row.receipt_digest);
+    }
+  });
+});

--- a/apps/api/src/routes/do.receipt.integration.test.ts
+++ b/apps/api/src/routes/do.receipt.integration.test.ts
@@ -406,9 +406,14 @@ describeMaybe("execution receipts bind what the caller received", () => {
     await settleExecutionReceipt(db, { transactionId: id });
 
     const row = await receiptRow(id);
-    expect(row.receipt_status, "a guessed method must not produce a complete receipt").not.toBe(
-      "complete",
+    // `failed`, not merely "not complete". The first version asserted
+    // not.toBe("complete"), which `pending` also satisfies - and pending was
+    // in fact what happened, because the refusal used a RETRYABLE reason. The
+    // assertion agreed with the name while the behaviour did not.
+    expect(row.receipt_status, "an unestablished method must be terminal, not retried").toBe(
+      "failed",
     );
+    expect(row.receipt_failure_reason).toBe("unresolvable_manifest");
     expect(row.receipt_digest).toBeNull();
 
     await db.execute(sql`DELETE FROM transactions WHERE id = ${id}::uuid`);

--- a/apps/api/src/routes/do.receipt.integration.test.ts
+++ b/apps/api/src/routes/do.receipt.integration.test.ts
@@ -342,6 +342,12 @@ describeMaybe("execution receipts bind what the caller received", () => {
     const apiKey = await seedUser();
     void apiKey;
 
+    // A commit that is NOT what the environment would answer, so the digest
+    // below depends on the row's recorded value rather than on process.env.
+    // Without that, a settle.ts that ignored receipt_deploy_commit and read the
+    // environment would produce an identical digest and this would pass.
+    const ROW_COMMIT = "a".repeat(40);
+
     for (const rail of ["x402", "internal"] as const) {
       const id = randomUUID();
       await db.execute(sql`
@@ -352,7 +358,7 @@ describeMaybe("execution receipts bind what the caller received", () => {
                 ${JSON.stringify({ probe: rail })}::jsonb,
                 ${JSON.stringify({ ok: rail })}::jsonb,
                 ${JSON.stringify({ source: "p5", fetched_at: new Date().toISOString() })}::jsonb,
-                ${rail}, ${LOCAL_BUILD_SENTINEL}, now())
+                ${rail}, ${ROW_COMMIT}, now())
       `);
 
       // Deliberately lie about the rail on the call.

--- a/apps/api/src/routes/do.receipt.integration.test.ts
+++ b/apps/api/src/routes/do.receipt.integration.test.ts
@@ -50,6 +50,7 @@ describeMaybe("execution receipts bind what the caller received", () => {
   let okSlug: string;
   let freeSlug: string;
   let boomSlug: string;
+  let mixedSlug: string;
   const seeded: { userId: string; walletId: string }[] = [];
   const seededCaps: string[] = [];
 
@@ -61,6 +62,7 @@ describeMaybe("execution receipts bind what the caller received", () => {
     okSlug = `p5-receipt-ok-${randomUUID().slice(0, 8)}`;
     freeSlug = `p5-receipt-free-${randomUUID().slice(0, 8)}`;
     boomSlug = `p5-receipt-boom-${randomUUID().slice(0, 8)}`;
+    mixedSlug = `p5-receipt-mixed-${randomUUID().slice(0, 8)}`;
 
     registerCapability(okSlug, async (input: any) => ({
       // Deliberately nested and mixed-type: a shape where a lossy
@@ -72,12 +74,26 @@ describeMaybe("execution receipts bind what the caller received", () => {
       },
       provenance: { source: "p5-test", fetched_at: new Date().toISOString() },
     }));
+    registerCapability(mixedSlug, async (input: any) => ({
+      output: { echo: input?.probe ?? null },
+      provenance: { source: "p5-test", fetched_at: new Date().toISOString() },
+    }));
     registerCapability(freeSlug, async (input: any) => ({
       output: { free: true, echo: input?.probe ?? null },
       provenance: { source: "p5-test", fetched_at: new Date().toISOString() },
     }));
     registerCapability(boomSlug, async () => {
-      throw new Error("p5 deliberate executor failure");
+      // The message MUST be one the sanitiser rewrites, or this test proves
+      // nothing. The first version threw "p5 deliberate executor failure" - no
+      // URL, no hostname, no provider name, no network code - so
+      // sanitizeFailureReason was the identity function on it, and the test
+      // passed while settle.ts was binding the raw string on a rail that
+      // stores raw. A reviewer measured the real gap at 14.8% of production
+      // failures.
+      //
+      // This one contains a hostname and a provider-shaped token, so raw and
+      // sanitised differ and the assertion has something to catch.
+      throw new Error("VAT service at ec.europa.eu returned MS_UNAVAILABLE");
     });
 
     ({ app } = await import("../app.js"));
@@ -164,7 +180,7 @@ describeMaybe("execution receipts bind what the caller received", () => {
   function digestFromResponse(
     row: Record<string, unknown>,
     body: any,
-    opts: { status: "completed" | "failed" },
+    opts: { status: "completed" | "failed"; method?: "algorithmic" | "ai_generated" | "mixed" },
   ): string {
     const built = buildExecutionReceipt(
       {
@@ -181,9 +197,19 @@ describeMaybe("execution receipts bind what the caller received", () => {
         result: opts.status === "completed" ? body.result.output : null,
         error:
           opts.status === "failed"
-            ? { code: "execution_failed", message: String(body?.details?.error ?? "") }
+            ? {
+                code: "execution_failed",
+                // What the caller was handed, not what we stored.
+                message: String(body?.details?.error ?? ""),
+              }
             : null,
-        method: row.transparency_marker as "algorithmic",
+        // `hybrid` is the marker spelling of `mixed`; the receipt records the
+        // method, not the marker.
+        method:
+          opts.method ??
+          ((row.transparency_marker === "hybrid"
+            ? "mixed"
+            : row.transparency_marker) as "algorithmic"),
         sourceObservation: deriveSourceObservation(row.provenance, "live-fetch"),
       },
       { NODE_ENV: "test" } as NodeJS.ProcessEnv,
@@ -270,11 +296,75 @@ describeMaybe("execution receipts bind what the caller received", () => {
     expect(row.receipt_status, "a failed execution still gets a receipt").toBe("complete");
     expect(row.receipt_rail).toBe("v1_do");
 
+    // The fixture has to be one the sanitiser changes, or the assertion below
+    // is vacuous. Asserted rather than assumed, because that is exactly how
+    // this test passed while the code was wrong.
+    const rawStored = row.error as string;
+    const servedToCaller = String(body?.details?.error ?? "");
+    expect(
+      servedToCaller,
+      "fixture is too weak: the raw and sanitised messages are identical, so " +
+        "this test cannot tell whether the receipt bound the right one",
+    ).not.toBe(rawStored);
+    expect(rawStored).toContain("ec.europa.eu");
+    expect(servedToCaller).toContain("[service]");
+
     // `/v1/do` puts the real message under details.error, not a top-level
     // `error` key. The receipt must bind THAT string.
     expect(digestFromResponse({ ...row, c_slug: boomSlug }, body, { status: "failed" })).toBe(
       row.receipt_digest,
     );
+  });
+
+  it("a MIXED capability is not committed as `algorithmic`", async () => {
+    // routes/do.ts maps transparency_tag 'mixed' to the marker 'hybrid', which
+    // is not one of the receipt's three methods, and settle used to fall back
+    // to 'algorithmic' for anything it did not recognise - so the receipt
+    // asserted "no model was involved" about an execution that declares one.
+    // A reviewer measured 8,010 of ~193,600 production rows over 30 days.
+    const capId = randomUUID();
+    seededCaps.push(capId);
+    await db.insert(capabilities).values({
+      id: capId,
+      slug: mixedSlug,
+      name: `P5 mixed probe ${mixedSlug}`,
+      description: "Seeded by the Phase 5 receipt binding test.",
+      category: "developer-tools",
+      inputSchema: { type: "object", properties: { probe: { type: "string" } } },
+      outputSchema: { type: "object", properties: { echo: { type: "string" } } },
+      priceCents: PRICE_CENTS,
+      isActive: true,
+      transparencyTag: "mixed",
+      avgLatencyMs: 50,
+      lifecycleState: "active",
+      visible: true,
+    });
+    const apiKey = await seedUser();
+
+    const res = await callDo(apiKey, {
+      capability_slug: mixedSlug,
+      inputs: { probe: "mixed" },
+      max_price_cents: PRICE_CENTS,
+    });
+    expect(res.status, JSON.stringify(await res.clone().json())).toBe(200);
+    const body: any = await res.json();
+    const row = await receiptRow(body.result.transaction_id);
+
+    // The row really does carry the non-member marker, so this is the live case.
+    expect(row.transparency_marker).toBe("hybrid");
+    expect(row.receipt_status).toBe("complete");
+
+    // Rebuilt as `mixed` matches; rebuilt as `algorithmic` does not.
+    const asMixed = digestFromResponse({ ...row, c_slug: mixedSlug }, body, {
+      status: "completed",
+      method: "mixed",
+    });
+    const asAlgorithmic = digestFromResponse({ ...row, c_slug: mixedSlug }, body, {
+      status: "completed",
+      method: "algorithmic",
+    });
+    expect(asMixed).toBe(row.receipt_digest);
+    expect(asAlgorithmic).not.toBe(row.receipt_digest);
   });
 
   it("the receipt records the serving commit, and outside production that is the sentinel", async () => {

--- a/apps/api/src/routes/do.receipt.integration.test.ts
+++ b/apps/api/src/routes/do.receipt.integration.test.ts
@@ -367,6 +367,53 @@ describeMaybe("execution receipts bind what the caller received", () => {
     expect(asAlgorithmic).not.toBe(row.receipt_digest);
   });
 
+  it("an execution whose method cannot be established gets NO receipt, not a guessed one", async () => {
+    // The other half of the method fix, and the one the mutation battery
+    // showed was untested: the refusal itself.
+    //
+    // settlement-reconciler.ts writes transparency_marker 'unknown' precisely
+    // so it does not fabricate an EU AI Act Art. 50 marker on a call it cannot
+    // describe. If the capability's own declaration is also absent, there is
+    // nothing to establish the method from - and guessing 'algorithmic' would
+    // undo, one file over, the exact care that comment describes.
+    const capId = randomUUID();
+    seededCaps.push(capId);
+    await db.insert(capabilities).values({
+      id: capId,
+      slug: `p5-receipt-untagged-${randomUUID().slice(0, 8)}`,
+      name: "P5 untagged probe",
+      description: "Seeded by the Phase 5 receipt binding test.",
+      category: "developer-tools",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+      priceCents: 5,
+      isActive: true,
+      transparencyTag: null,
+      avgLatencyMs: 20,
+      lifecycleState: "active",
+      visible: true,
+    });
+
+    const id = randomUUID();
+    await db.execute(sql`
+      INSERT INTO transactions (id, capability_id, status, price_cents, transparency_marker,
+                                data_jurisdiction, input, output, receipt_rail,
+                                receipt_deploy_commit, completed_at)
+      VALUES (${id}::uuid, ${capId}::uuid, 'completed', 5, 'unknown', 'EU',
+              '{}'::jsonb, '{}'::jsonb, 'x402', ${LOCAL_BUILD_SENTINEL}, now())
+    `);
+
+    await settleExecutionReceipt(db, { transactionId: id });
+
+    const row = await receiptRow(id);
+    expect(row.receipt_status, "a guessed method must not produce a complete receipt").not.toBe(
+      "complete",
+    );
+    expect(row.receipt_digest).toBeNull();
+
+    await db.execute(sql`DELETE FROM transactions WHERE id = ${id}::uuid`);
+  });
+
   it("the receipt records the serving commit, and outside production that is the sentinel", async () => {
     await seedCapability(okSlug);
     const apiKey = await seedUser();

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -1,4 +1,5 @@
 import { Hono, type Context } from "hono";
+import { deployCommitOrNull } from "../lib/receipt/deploy-identity.js";
 import { eq, and, gte, inArray, isNull, sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import { settleExecutionReceipt } from "../lib/receipt/settle.js";
@@ -1541,6 +1542,11 @@ async function executeFreeTier(
   const [txnRecord] = await db
     .insert(transactions)
     .values({
+      // Captured at INSERT because neither is recoverable later:
+      // the rail is not a property of the row, and the deploy commit
+      // drifts the moment anything redeploys (block 0110).
+      receiptRail: "v1_do",
+      receiptDeployCommit: deployCommitOrNull(),
       userId: null,
       capabilityId: capability.id,
       status: "executing",
@@ -1798,6 +1804,11 @@ async function executeFreeTierAuthenticated(
   const [txnRecord] = await db
     .insert(transactions)
     .values({
+      // Captured at INSERT because neither is recoverable later:
+      // the rail is not a property of the row, and the deploy commit
+      // drifts the moment anything redeploys (block 0110).
+      receiptRail: "v1_do",
+      receiptDeployCommit: deployCommitOrNull(),
       userId: user.id,
       capabilityId: capability.id,
       idempotencyKey,
@@ -2097,6 +2108,11 @@ async function executeSync(
     const [txnRecord] = await tx
       .insert(transactions)
       .values({
+        // Captured at INSERT because neither is recoverable later:
+        // the rail is not a property of the row, and the deploy commit
+        // drifts the moment anything redeploys (block 0110).
+        receiptRail: "v1_do",
+        receiptDeployCommit: deployCommitOrNull(),
         userId: user.id,
         capabilityId: capability.id,
         idempotencyKey,
@@ -2470,6 +2486,11 @@ async function executeAsync(
     const [txnRecord] = await tx
       .insert(transactions)
       .values({
+        // Captured at INSERT because neither is recoverable later:
+        // the rail is not a property of the row, and the deploy commit
+        // drifts the moment anything redeploys (block 0110).
+        receiptRail: "v1_do",
+        receiptDeployCommit: deployCommitOrNull(),
         userId: user.id,
         capabilityId: capability.id,
         idempotencyKey,

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -1,6 +1,7 @@
 import { Hono, type Context } from "hono";
 import { eq, and, gte, inArray, isNull, sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
+import { settleExecutionReceipt } from "../lib/receipt/settle.js";
 import {
   computeIdempotencyFingerprint,
   isReplayable,
@@ -573,6 +574,29 @@ function executeWithHardTimeout<T>(
       },
     );
   });
+}
+
+/**
+ * Build the execution receipt for a transaction this route settled.
+ *
+ * Called once per executor, always AFTER the settlement write has committed,
+ * and never inside the wallet transaction: a receipt must not be able to roll
+ * back a payment. `settleExecutionReceipt` swallows its own failures, so this
+ * cannot fail a request that has already executed and charged - a row it could
+ * not finish simply stays `pending` (the column default since block 0109) and
+ * the sweeper owns it.
+ *
+ * The rail is `v1_do` for every path through this file, and it is decided HERE
+ * rather than read from the request. `/v1/do` is also where an A2A call lands
+ * (routes/a2a.ts proxies to it over loopback HTTP) and where an MCP client's
+ * traffic arrives, so it is tempting to let the caller name its own rail with a
+ * header. That would make the rail forgeable, and a forgeable field has no
+ * business inside a commitment - so `mcp` and `a2a` stay in the enum, currently
+ * unreachable, rather than being populated from something a caller controls.
+ */
+async function settleReceiptFor(transactionId: string | null | undefined): Promise<void> {
+  if (!transactionId) return;
+  await settleExecutionReceipt(getDb(), { transactionId, rail: "v1_do" });
 }
 
 export const doRoute = new Hono<AppEnv>();
@@ -1595,6 +1619,7 @@ async function executeFreeTier(
             completedAt: new Date(),
           })
           .where(eq(transactions.id, txnRecord.id));
+        await settleReceiptFor(txnRecord.id);
         return c.json(
           {
             error_code: "payment_failed",
@@ -1621,6 +1646,7 @@ async function executeFreeTier(
           : {}),
       })
       .where(eq(transactions.id, txnRecord.id));
+    await settleReceiptFor(txnRecord.id);
 
     // WP5: the row exists, so the intent is discharged. Review finding — this
     // rail opened intents and never closed them, because markRecordedBySettlement
@@ -1720,6 +1746,7 @@ async function executeFreeTier(
         auditTrail: failAudit, provenance: failProvenance,
       })
       .where(eq(transactions.id, txnRecord.id));
+    await settleReceiptFor(txnRecord.id);
 
     // F-0-009 Stage 2: the row lands with compliance_hash_state = 'pending'
     // by column default; jobs/integrity-hash-retry.ts will fill it in.
@@ -1821,6 +1848,7 @@ async function executeFreeTierAuthenticated(
         completedAt: new Date(),
       })
       .where(eq(transactions.id, txnRecord.id));
+    await settleReceiptFor(txnRecord.id);
 
     // Record circuit breaker + quality (fire-and-forget)
     fireAndForget(() => recordSuccess(capability.slug), { label: "circuit-breaker-record-success", context: { slug: capability.slug } });
@@ -1895,6 +1923,7 @@ async function executeFreeTierAuthenticated(
         provenance: failProvenance,
       })
       .where(eq(transactions.id, txnRecord.id));
+    await settleReceiptFor(txnRecord.id);
 
     // F-0-009 Stage 2: the row lands with compliance_hash_state = 'pending'
     // by column default; jobs/integrity-hash-retry.ts will fill it in.
@@ -2201,6 +2230,11 @@ async function executeSync(
     }
     throw err; // anything else propagates as a real 500
   }
+
+  // The wallet transaction has committed. Both its branches - the success
+  // UPDATE and the failure UPDATE - reach here, so one call covers the whole
+  // executor, and it is outside the transaction by construction.
+  await settleReceiptFor((result as { transactionId?: string }).transactionId);
 
   // ── Record circuit breaker + quality + piggyback (fire-and-forget) ───
   if (result.ok) {
@@ -2690,6 +2724,8 @@ async function executeInBackground(
       }
     });
 
+    await settleReceiptFor(transactionId);
+
     // Record success for circuit breaker + quality + piggyback
     fireAndForget(() => recordSuccess(capability.slug), { label: "circuit-breaker-record-success", context: { slug: capability.slug } });
     recordQuality({
@@ -2784,6 +2820,8 @@ async function executeInBackground(
           ),
         );
     });
+
+    await settleReceiptFor(transactionId);
 
     // CCO P0 #6: row was 'deferred' until the UPDATE above flipped it
     // to 'pending'. Retry worker picks it up on its next tick.

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -28,7 +28,7 @@ import { solutions, wallets, walletTransactions, transactions } from "../db/sche
 import { authMiddleware } from "../lib/middleware.js";
 import { rateLimitByKey } from "../lib/rate-limit.js";
 import { apiError } from "../lib/errors.js";
-import { executeSolution } from "../lib/solution-executor.js";
+import { stepsThatRan, executeSolution } from "../lib/solution-executor.js";
 import {
   aggregateSolutionOutcome,
   assessOutput,
@@ -344,9 +344,13 @@ solutionExecuteRoute.post(
             complianceHashState: "pending",
           })
           .where(eq(transactions.id, transactionId));
-        // No step produced output, so every declared step is `skipped`.
+        // executeSolution THREW. Steps may well have run before it did, and
+        // we have no result map to tell which - so the honest answer is
+        // `stepsUnknown`, which marks every declared step `unresolved`.
+        // Passing an empty ranStepSlugs would mark them all `skipped`, and
+        // `skipped` is a positive claim that a step never executed.
         await settleExecutionReceipt(db, {
-          transactionId, rail: "v1_do", solutionSlug: slug, ranStepSlugs: [],
+          transactionId, rail: "v1_do", solutionSlug: slug, stepsUnknown: true,
         });
       } catch (e) {
         c.get("log").error(
@@ -590,7 +594,7 @@ solutionExecuteRoute.post(
       transactionId,
       rail: "v1_do",
       solutionSlug: sol.slug,
-      ranStepSlugs: Object.keys(execResult.steps ?? {}),
+      ranStepSlugs: stepsThatRan(execResult.steps ?? {}),
     });
 
     // ── 8. Build response ─────────────────────────────────────────────

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -15,6 +15,7 @@
  */
 
 import { Hono } from "hono";
+import { settleExecutionReceipt } from "../lib/receipt/settle.js";
 import { and, eq, isNull } from "drizzle-orm";
 import { getDb } from "../db/index.js";
 import {
@@ -337,6 +338,10 @@ solutionExecuteRoute.post(
             complianceHashState: "pending",
           })
           .where(eq(transactions.id, transactionId));
+        // No step produced output, so every declared step is `skipped`.
+        await settleExecutionReceipt(db, {
+          transactionId, rail: "v1_do", solutionSlug: slug, ranStepSlugs: [],
+        });
       } catch (e) {
         c.get("log").error(
           { label: "solutions-tx-update-failed", transaction_id: transactionId, solution_slug: slug, err: e instanceof Error ? { message: e.message } : e },
@@ -376,6 +381,11 @@ solutionExecuteRoute.post(
             complianceHashState: "pending",
           })
           .where(eq(transactions.id, transactionId));
+        // A solution with no declared steps has no recipe to bind. settle
+        // records `unresolvable_manifest` rather than hashing an empty list.
+        await settleExecutionReceipt(db, {
+          transactionId, rail: "v1_do", solutionSlug: slug, ranStepSlugs: [],
+        });
       } catch (e) {
         c.get("log").error(
           { label: "solutions-tx-update-failed", transaction_id: transactionId, solution_slug: slug, err: e instanceof Error ? { message: e.message } : e },
@@ -566,6 +576,16 @@ solutionExecuteRoute.post(
       },
       "solutions-execute-done",
     );
+
+    // The two-phase write has committed. execResult.steps is keyed by the
+    // capability slug of every step that produced output, which is exactly the
+    // fact settle cannot recover for itself.
+    await settleExecutionReceipt(db, {
+      transactionId,
+      rail: "v1_do",
+      solutionSlug: sol.slug,
+      ranStepSlugs: Object.keys(execResult.steps ?? {}),
+    });
 
     // ── 8. Build response ─────────────────────────────────────────────
     // result.status uses the richer vocabulary for the caller:

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -15,6 +15,7 @@
  */
 
 import { Hono } from "hono";
+import { deployCommitOrNull } from "../lib/receipt/deploy-identity.js";
 import { settleExecutionReceipt } from "../lib/receipt/settle.js";
 import { and, eq, isNull } from "drizzle-orm";
 import { getDb } from "../db/index.js";
@@ -189,6 +190,11 @@ solutionExecuteRoute.post(
         const [txnRecord] = await tx
           .insert(transactions)
           .values({
+            // Captured at INSERT because neither is recoverable later:
+            // the rail is not a property of the row, and the deploy commit
+            // drifts the moment anything redeploys (block 0110).
+            receiptRail: "v1_do",
+            receiptDeployCommit: deployCommitOrNull(),
             userId: user.id,
             capabilityId: null,
             solutionSlug: sol.slug,

--- a/apps/api/src/routes/solution-receipt.integration.test.ts
+++ b/apps/api/src/routes/solution-receipt.integration.test.ts
@@ -58,7 +58,7 @@ describeMaybe("solution receipts record which steps actually ran", () => {
   let gateSlug: string;
   let afterSlug: string;
   let solutionSlug: string;
-  let solutionId: string;
+  let solutionId = "";
   const capIds: string[] = [];
   const seeded: { userId: string; walletId: string }[] = [];
 
@@ -86,8 +86,12 @@ describeMaybe("solution receipts record which steps actually ran", () => {
   }, 120_000);
 
   afterAll(async () => {
-    await db.delete(solutionSteps).where(eq(solutionSteps.solutionId, solutionId));
-    await db.delete(solutions).where(eq(solutions.id, solutionId));
+    // Guarded: solutionId is assigned by the first test, so running this file
+    // with -t on any other test would otherwise throw in teardown.
+    if (solutionId) {
+      await db.delete(solutionSteps).where(eq(solutionSteps.solutionId, solutionId));
+      await db.delete(solutions).where(eq(solutions.id, solutionId));
+    }
     for (const id of capIds) await db.delete(capabilities).where(eq(capabilities.id, id));
     await client.end();
   });
@@ -218,10 +222,13 @@ describeMaybe("solution receipts record which steps actually ran", () => {
     ).toBeNull();
   });
 
-  it("a full run and a gate-tripped run do not share an implementation digest", async () => {
-    // The property the disposition exists for. With every step marked `ran`,
-    // these two were byte-identical: `implementation.steps` could not tell a
-    // bundle that completed from one that stopped at step 1.
+  it("DIGEST SENSITIVITY (not a rail test): skipped and ran do not collide", async () => {
+    // Deliberately named for what it is. It hand-builds both step arrays and
+    // calls declarationDigest directly, so it is a property of the digest
+    // function, not of the rail - and it PASSED under the mutation that broke
+    // the rail, which is how a reviewer caught the overstated name. Its
+    // sibling above covers the rail; this covers the thing that would make
+    // the sibling meaningless if it regressed.
     const { normalizeSolutionDeclaration } = await import("../lib/receipt/manifest-snapshot.js");
     const { declarationDigest } = await import("../lib/receipt/manifest-snapshot.js");
 

--- a/apps/api/src/routes/solution-receipt.integration.test.ts
+++ b/apps/api/src/routes/solution-receipt.integration.test.ts
@@ -1,0 +1,248 @@
+/**
+ * A solution receipt must say which steps actually ran.
+ *
+ * `PHASE-2-SPEC` §5 is explicit: a step short-circuited by a gate "still
+ * appears, with `manifest_digest: null` and the absence recorded". Phase 4's
+ * reviewer added `disposition` (`ran` / `skipped` / `unresolved`) precisely so
+ * that a step that did not run and a step we could not resolve cannot share a
+ * digest.
+ *
+ * Phase 5 then wired the rails and got it backwards, because
+ * `execResult.steps` is keyed by EVERY declared step, not only the ones that
+ * produced output — `markSkippedByGate` and three sibling branches deliberately
+ * insert a placeholder so a bundle advertising 14 steps does not audit 13 with no
+ * gap marker. Reading `Object.keys` of it as "the steps that ran" marked every
+ * gate-skipped step `ran` and gave it a manifest digest, which made
+ * `disposition` a constant on every production solution path and left a
+ * full run and a gate-tripped run with the same `implementation.steps`.
+ *
+ * That is the under-specification the field exists to prevent, so this drives
+ * the real route over a real gated solution rather than testing the helper.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../test-support/integration-db.js";
+import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
+import {
+  capabilities,
+  solutions,
+  solutionSteps,
+  transactions,
+  users,
+  wallets,
+  walletTransactions,
+} from "../db/schema.js";
+import { readManifestSnapshot } from "../lib/receipt/manifest-snapshot.js";
+
+if (process.env.DATABASE_URL_TEST) {
+  process.env.FRONTEND_URL ??= "https://strale.dev";
+  process.env.AUDIT_HMAC_SECRET ??= "p5-solrcpt-secret-at-least-32-chars-long-00";
+  process.env.ADMIN_SECRET ??= "p5-solrcpt-admin-secret-at-least-32-chars-0";
+  process.env.STRIPE_SECRET_KEY ??= "sk_test_p5_placeholder";
+  process.env.STRIPE_WEBHOOK_SECRET ??= "whsec_p5_placeholder";
+}
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+describeMaybe("solution receipts record which steps actually ran", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let app: Awaited<typeof import("../app.js")>["app"];
+
+  let gateSlug: string;
+  let afterSlug: string;
+  let solutionSlug: string;
+  let solutionId: string;
+  const capIds: string[] = [];
+  const seeded: { userId: string; walletId: string }[] = [];
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 6 });
+    db = drizzle(client);
+
+    const { registerCapability } = await import("../capabilities/index.js");
+    const tag = randomUUID().slice(0, 8);
+    gateSlug = `p5-sol-gate-${tag}`;
+    afterSlug = `p5-sol-after-${tag}`;
+    solutionSlug = `p5-sol-${tag}`;
+
+    // Step 1 returns the value its gate is armed on, so the run stops here.
+    registerCapability(gateSlug, async () => ({
+      output: { verdict: "stop" },
+      provenance: { source: "p5-test", fetched_at: new Date().toISOString() },
+    }));
+    // Step 2 must never execute. If it does, this test is not testing a gate.
+    registerCapability(afterSlug, async () => {
+      throw new Error("step 2 ran, but the gate should have stopped the bundle");
+    });
+
+    ({ app } = await import("../app.js"));
+  }, 120_000);
+
+  afterAll(async () => {
+    await db.delete(solutionSteps).where(eq(solutionSteps.solutionId, solutionId));
+    await db.delete(solutions).where(eq(solutions.id, solutionId));
+    for (const id of capIds) await db.delete(capabilities).where(eq(capabilities.id, id));
+    await client.end();
+  });
+
+  afterEach(async () => {
+    for (const { userId, walletId } of seeded) {
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+      await db.execute(sql`DELETE FROM wallet_reservations WHERE wallet_id = ${walletId}::uuid`);
+      await db.delete(walletTransactions).where(eq(walletTransactions.walletId, walletId));
+      await db.delete(wallets).where(eq(wallets.id, walletId));
+      await db.delete(users).where(eq(users.id, userId));
+    }
+    seeded.length = 0;
+  });
+
+  async function seedCapability(slug: string) {
+    const id = randomUUID();
+    capIds.push(id);
+    await db.insert(capabilities).values({
+      id,
+      slug,
+      name: `P5 solution probe ${slug}`,
+      description: "Seeded by the Phase 5 solution receipt test.",
+      category: "developer-tools",
+      inputSchema: { type: "object", properties: { probe: { type: "string" } } },
+      outputSchema: { type: "object", properties: { verdict: { type: "string" } } },
+      priceCents: 5,
+      isActive: true,
+      transparencyTag: "algorithmic",
+      avgLatencyMs: 20,
+      lifecycleState: "active",
+      visible: true,
+    });
+  }
+
+  async function seedUser(balanceCents = 10_000): Promise<string> {
+    const userId = randomUUID();
+    const walletId = randomUUID();
+    const apiKey = `sk_live_${randomUUID().replace(/-/g, "")}`;
+    seeded.push({ userId, walletId });
+    await db.insert(users).values({
+      id: userId,
+      email: `p5-solrcpt-${userId}@example.test`,
+      apiKeyHash: hashApiKey(apiKey),
+      keyPrefix: getKeyPrefix(apiKey),
+    });
+    await db.insert(wallets).values({ id: walletId, userId, balanceCents });
+    return apiKey;
+  }
+
+  it("a gate-tripped step is `skipped` with a null digest, not `ran`", async () => {
+    await seedCapability(gateSlug);
+    await seedCapability(afterSlug);
+
+    solutionId = randomUUID();
+    await db.insert(solutions).values({
+      id: solutionId,
+      slug: solutionSlug,
+      name: "P5 gated bundle",
+      description: "Two steps, the first of which stops the run.",
+      category: "compliance",
+      priceCents: 20,
+      componentSumCents: 10,
+      valueTier: "standard",
+      maintenanceLevel: "low",
+      geography: "EU",
+      inputSchema: { type: "object", properties: { probe: { type: "string" } } },
+      isActive: true,
+    });
+    await db.insert(solutionSteps).values([
+      {
+        solutionId,
+        capabilitySlug: gateSlug,
+        stepOrder: 1,
+        inputMap: { probe: "$.probe" },
+        gateCondition: {
+          field: "verdict",
+          equals: "stop",
+          message: "The first check stopped the bundle.",
+        },
+      },
+      {
+        solutionId,
+        capabilitySlug: afterSlug,
+        stepOrder: 2,
+        inputMap: { probe: "$.probe" },
+      },
+    ]);
+
+    const apiKey = await seedUser();
+    const res = await app.request(`http://localhost/v1/solutions/${solutionSlug}/execute`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ inputs: { probe: "x" }, max_price_cents: 100 }),
+    });
+
+    const body: any = await res.json();
+    expect(res.status, JSON.stringify(body)).toBe(200);
+    // The gate really did trip, so this is the case under test.
+    expect(body.result.gated?.stopped_at, JSON.stringify(body.result)).toBe(gateSlug);
+
+    const rows = (await db.execute(sql`
+      SELECT * FROM transactions WHERE id = ${body.result.transaction_id}::uuid
+    `)) as unknown as Array<Record<string, unknown>>;
+    const row = rows[0];
+    expect(row.receipt_status, "the solution rail did not settle its receipt").toBe("complete");
+
+    // Read the committed step identities back out of the snapshot authority,
+    // which recomputes the digest before trusting the row.
+    const snapshot = await readManifestSnapshot(db, row.receipt_manifest_digest as string);
+    const steps = (snapshot as { steps: Array<Record<string, unknown>> }).steps;
+
+    expect(steps).toHaveLength(2);
+
+    const ran = steps.find((s) => s.slug === gateSlug)!;
+    const stopped = steps.find((s) => s.slug === afterSlug)!;
+
+    expect(ran.disposition, "the gate step DID run").toBe("ran");
+    expect(ran.manifest_digest, "a step that ran binds its declaration").not.toBeNull();
+
+    expect(
+      stopped.disposition,
+      "a step the gate prevented must not be recorded as having run",
+    ).toBe("skipped");
+    expect(
+      stopped.manifest_digest,
+      "a step that never ran must not carry a declaration digest",
+    ).toBeNull();
+  });
+
+  it("a full run and a gate-tripped run do not share an implementation digest", async () => {
+    // The property the disposition exists for. With every step marked `ran`,
+    // these two were byte-identical: `implementation.steps` could not tell a
+    // bundle that completed from one that stopped at step 1.
+    const { normalizeSolutionDeclaration } = await import("../lib/receipt/manifest-snapshot.js");
+    const { declarationDigest } = await import("../lib/receipt/manifest-snapshot.js");
+
+    const digestA = declarationDigest(
+      normalizeSolutionDeclaration({
+        slug: solutionSlug,
+        steps: [
+          { step_order: 1, slug: gateSlug, disposition: "ran", manifest_digest: `sha256:${"a".repeat(64)}` },
+          { step_order: 2, slug: afterSlug, disposition: "ran", manifest_digest: `sha256:${"b".repeat(64)}` },
+        ],
+      }),
+    );
+    const digestB = declarationDigest(
+      normalizeSolutionDeclaration({
+        slug: solutionSlug,
+        steps: [
+          { step_order: 1, slug: gateSlug, disposition: "ran", manifest_digest: `sha256:${"a".repeat(64)}` },
+          { step_order: 2, slug: afterSlug, disposition: "skipped", manifest_digest: null },
+        ],
+      }),
+    );
+    expect(digestB).not.toBe(digestA);
+  });
+});

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -45,7 +45,7 @@ import { encodePaymentRequiredHeader } from "@x402/core/http";
 import { extractClientMeta, recordDiscoveryHit, hashX402Payer } from "../lib/attribution.js";
 import { rateLimitByIp } from "../lib/rate-limit.js";
 import { sanitizeFailureReason } from "../lib/sanitize.js";
-import { executeSolution } from "../lib/solution-executor.js";
+import { executeSolution, stepsThatRan } from "../lib/solution-executor.js";
 import * as settlementIntent from "../lib/x402-settlement-intent.js";
 import { isX402RailEligible } from "../lib/x402-eligibility.js";
 import {
@@ -881,7 +881,7 @@ async function recordX402Transaction(args: RecordX402Args): Promise<string | nul
         transactionId: insertedId,
         rail: "x402",
         solutionSlug: args.solutionSlug,
-        ranStepSlugs: args.solutionSlug && stepMap ? Object.keys(stepMap) : [],
+        ranStepSlugs: args.solutionSlug && stepMap ? stepsThatRan(stepMap) : [],
       });
     }
 

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -10,6 +10,7 @@
  */
 
 import { Hono } from "hono";
+import { deployCommitOrNull } from "../lib/receipt/deploy-identity.js";
 import { settleExecutionReceipt } from "../lib/receipt/settle.js";
 import { cors } from "hono/cors";
 import { eq, and, inArray, sql } from "drizzle-orm";
@@ -795,6 +796,11 @@ async function recordX402Transaction(args: RecordX402Args): Promise<string | nul
       };
   try {
     const [row] = await db.insert(transactions).values({
+                                                 // Captured at INSERT because neither is recoverable later:
+                                                 // the rail is not a property of the row, and the deploy commit
+                                                 // drifts the moment anything redeploys (block 0110).
+                                                 receiptRail: "x402",
+                                                 receiptDeployCommit: deployCommitOrNull(),
       userId: null,
       capabilityId: args.capabilityId,
       solutionSlug: args.solutionSlug,

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -10,6 +10,7 @@
  */
 
 import { Hono } from "hono";
+import { settleExecutionReceipt } from "../lib/receipt/settle.js";
 import { cors } from "hono/cors";
 import { eq, and, inArray, sql } from "drizzle-orm";
 import { getDb } from "../db/index.js";
@@ -864,6 +865,20 @@ async function recordX402Transaction(args: RecordX402Args): Promise<string | nul
         });
       }
     }
+    // The row is inserted already terminal on this rail, so there is no
+    // separate settlement write to wait for. For a solution, the step outputs
+    // travel inside `args.output` as `{ steps, errors }` - the same shape
+    // solution-execute.ts stores - so the step slugs are recoverable here.
+    if (insertedId) {
+      const stepMap = (args.output as { steps?: Record<string, unknown> } | null)?.steps;
+      await settleExecutionReceipt(db, {
+        transactionId: insertedId,
+        rail: "x402",
+        solutionSlug: args.solutionSlug,
+        ranStepSlugs: args.solutionSlug && stepMap ? Object.keys(stepMap) : [],
+      });
+    }
+
     return insertedId;
   } catch (err) {
     logError("x402-transaction-recording-failed", err);

--- a/docs/design/execution-receipt/PHASE-5-DEPLOY-IDENTITY-EVIDENCE.md
+++ b/docs/design/execution-receipt/PHASE-5-DEPLOY-IDENTITY-EVIDENCE.md
@@ -1,0 +1,108 @@
+# Phase 5, criterion 1 — is `RAILWAY_GIT_COMMIT_SHA` present and full-length on every deploy path?
+
+This gates criterion 2. Wiring `assertDeployIdentity()` on an unverified
+assumption would let a deploy path we actually use refuse to boot.
+
+**Answer: yes on every path we use — and the audit found a path we used six
+times that carries no commit at all.** The refusal is still correct, and is
+wired unweakened, because of what a refused boot actually costs (§3).
+
+## 1. Method
+
+Railway CLI, authenticated as `petter@strale.io`, project `Strale`,
+environment `production`, service `strale`. Read-only.
+
+`railway variables` does **not** list `RAILWAY_GIT_COMMIT_SHA`. That is not
+evidence of absence — it is deployment-scoped, injected per deployment by the
+git integration, not a service variable. `railway run` confirms this from the
+other side: it injects service variables only, and reports the SHA unset
+locally while the deployed process demonstrably has one (`/health` serves 12
+characters of it). Neither command can answer the question; deployment metadata
+can.
+
+```
+railway deployment list --limit 1000 --json
+```
+
+1000 deployments, `2026-03-09` → `2026-08-23`. Every deployment's `meta`
+carries `commitHash`, `reason`, and `repo`.
+
+## 2. Result
+
+| deploy path (`meta.reason`) | deployments | with a full 40-hex `commitHash` |
+|---|---|---|
+| `deploy` | 975 | 969 |
+| `redeploy` | 25 | **25** |
+
+- **994 of 1000** carry a full 40-lowercase-hex commit. Length histogram is
+  bimodal and degenerate: `{40: 994, 0: 6}`. Nothing is ever truncated — there
+  is no 7-, 8- or 12-character case to defend against. The regex in
+  `deploy-identity.ts` matches what the platform actually emits.
+- **`redeploy` is directly sampled, 25 times, and is 25 for 25.** This is the
+  path the criterion was most concerned about, and it is not an inference.
+- Railway expresses **rollback as a redeploy of a prior deployment**: no
+  distinct `rollback` reason appears in 1000 deployments, and a redeploy
+  inherits the original deployment's `meta`. So the rollback path is covered by
+  the redeploy evidence rather than assumed to be.
+
+### The six that carry nothing
+
+| created | status | reason | repo | commitHash |
+|---|---|---|---|---|
+| 2026-04-06T16:25:12Z | REMOVED | deploy | `null` | `null` |
+| 2026-04-05T18:51:43Z | REMOVED | deploy | `null` | `null` |
+| 2026-04-05T15:16:52Z | REMOVED | deploy | `null` | `null` |
+| 2026-04-05T15:10:23Z | REMOVED | deploy | `null` | `null` |
+| 2026-04-05T14:10:49Z | FAILED | deploy | `null` | `null` |
+| 2026-04-05T13:55:02Z | FAILED | deploy | `null` | `null` |
+
+`repo: null` — these did not originate from a git commit. They are CLI upload
+deploys (`railway up` / `railway deployment up`), all on 2026-04-05/06. Four
+reached `REMOVED`, which means they **succeeded and served production** until a
+later deploy replaced them.
+
+So the hypothetical in the Phase 4 review is not hypothetical. A deploy path
+with no commit identity exists, is one CLI command away, and has carried
+production traffic. Had the gate been wired then, those four would have refused
+to boot.
+
+## 3. Why the refusal is still wired, unweakened
+
+Because a refused boot does not take production down. Verified from the
+platform, not assumed:
+
+- The service has a deploy healthcheck — `Path: /health/deep`,
+  `Retry window: 20s`, read from the build log of the current deployment
+  (`09d666c8`). A process that throws before `listen` never answers it.
+- A failed healthcheck **fails the deploy, and Railway does not cut over**: the
+  previous good deployment keeps serving. Independently confirmed on 2026-08-18
+  (three consecutive `FAILED` deploys for ~40 minutes with production healthy)
+  and 2026-08-23.
+- A failed boot also emails two recipients via `alerting-sent`.
+
+So the worst case of wiring the refusal is: **a CLI deploy does not go live,
+production keeps serving the previous commit, and someone is emailed.** That is
+the correct outcome. A CLI-uploaded build has no commit identity, so every
+receipt it produced would record an implementation nobody can look up — which is
+the failure the gate exists to prevent, and it would be silent.
+
+The refusal is therefore not weakened. What it gets instead is an error message
+that names this specific cause and its fix, so the operator is not left
+guessing why a `railway up` will not start.
+
+## 4. Consequences recorded elsewhere
+
+**A stale comment in `index.ts` is now false and was corrected in this PR.** It
+read "The Railway service currently has `healthcheckPath: null` (verified
+2026-07-02), so nothing kills a slow boot", and then warned that if a
+healthcheck were ever configured its timeout must exceed
+`STARTUP_DB_RETRY_BUDGET_MS`. A healthcheck **has** since been configured, and
+its 20s retry window is far below the 600s startup DB retry budget — so that
+warning is live, not hypothetical: a deploy during database degradation is
+killed at 20s and the budget never applies.
+
+That is a **pre-existing** platform/config mismatch, not something this PR
+introduces, and fixing it means changing the Railway healthcheck window rather
+than the code. It is recorded here and left alone deliberately. What this PR
+does check is that it adds no measurable boot time: `assertDeployIdentity()` is
+a synchronous environment read and one regex, executed before any I/O.

--- a/docs/design/execution-receipt/PHASE-5-RAIL-INTEGRATION.md
+++ b/docs/design/execution-receipt/PHASE-5-RAIL-INTEGRATION.md
@@ -101,9 +101,9 @@ This makes the request path more correct too, not just the sweeper.
 |---|---|---|
 | 1 | `RAILWAY_GIT_COMMIT_SHA` on every deploy path | **Verified, and it found something.** See `PHASE-5-DEPLOY-IDENTITY-EVIDENCE.md`: 994/1000 deployments carry a full 40-hex commit; redeploy is 25 for 25, and Railway expresses rollback as redeploy. The six that carry nothing are `repo: null` CLI upload deploys from 2026-04-05/06, four of which **served production**. |
 | 2 | `assertDeployIdentity()` wired pre-listen | Done, before any database work. Refusal unweakened: a refused boot costs a deploy, not an outage. |
-| 3 | Receipt lifecycle in every rail | All eight production write sites, enforced by a fail-closed source lint with a positive control. |
+| 3 | Receipt lifecycle in every rail | All eight production write sites. The source lint is **file-granular** - it passes a file if `settleExecutionReceipt` appears anywhere in it - so it catches a new unwired FILE, not a new unwired branch inside `do.ts`. The epoch default is the real backstop for that, and it works. |
 | 4 | Every post-integration transaction gets receipt state | Structural, via the default + CHECK. Not a convention. |
-| 5 | `redacted` receipt-state presentation | Added. A digest whose content was erased is no longer reported as `complete`. |
+| 5 | `redacted` receipt-state presentation | Arm added to `describeReceiptState`. **Not yet reachable**: nothing serves receipt state on any endpoint, so this is the presentation being correct when a surface exists, not a surface. Surfacing is Phase 6/7. Separately, `settle` now refuses to hash content that was already erased. |
 | 6 | Retry sweeper, bounded, visible | In the worker that already owns "finish what the request path could not", outside its transaction. |
 | 7 | `CapabilityDeclarationSource` parity guard | Added — and it found **31 of 45 columns had never been classified**. |
 | 8 | `data_update_cycle_days`, `dataset_last_updated`, `name` | All three admitted, derived from execution semantics. Plus `data_classification` and `x402_method`. |
@@ -142,7 +142,7 @@ and `data_classification` into the audit body: for a capability with a null
 
 ## 6. Evidence
 
-- **287 integration tests** against real Postgres, all passing, with the
+- **292 integration tests** against real Postgres, all passing, with the
   startup migrations applied exactly as boot applies them.
 - **Unit lane: 2,871 passing** on a fully green run. The lane is
   nondeterministic on this machine — repeated runs fail different files
@@ -173,6 +173,55 @@ and `data_classification` into the audit body: for a capability with a null
 A third mutation was mis-reported twice before the cause was found: `do.ts` is
 stored CRLF, so a multi-line `--find` never matches and the guard refuses. Only
 single-line finds are reliable against that file.
+
+## 6a. Independent adversarial review — round 1: FAIL
+
+Four blocking findings, every one reproduced. They are recorded here rather
+than edited away, because three of them were invisible to a green suite and the
+fourth was invisible to a green suite *and* to a fix that looked correct.
+
+| # | finding | how it was caught |
+|---|---|---|
+| **B1** | The receipt bound the **internal** error, not the one the caller received. `settle` read `transactions.error`, and its comment asserted the sanitiser had already run. True on two rails; false on the `/v1/do` capability rails, which store the raw `err.message` and sanitise on the way out. A party holding the request and the response could not recompute the digest. | Measured against production: **5,016 of 33,952 failed rows over seven days (14.8%)** differ. |
+| **B2** | Solution receipts marked steps that **never ran** as `ran`, with a manifest digest. `execResult.steps` is keyed by every *declared* step — `markSkippedByGate` and three siblings insert a placeholder deliberately, so a bundle advertising 14 steps does not audit 13 with no gap marker. | Reproduced with a real gated 2-step solution: both steps came back `ran`. |
+| **B3** | `execution.method` was falsified toward "no model involved". `do.ts` maps a `mixed` capability to the marker `hybrid`, which is not one of the three methods, so the fallback recorded `algorithmic`. | **8,010 of ~193,600 production rows over 30 days (4.1%).** |
+| **B4** | One un-updatable row halted the tamper-evident chain **permanently** — Phase 4's round-3 blast radius in a new shape. The post-epoch CHECK is `NOT VALID`, which still enforces on UPDATE, so the worker cannot update a row it admits; the tick is one transaction. | Reproduced: two healthy rows stopped chaining the moment a third existed. |
+
+### The two things worth carrying forward
+
+**My own test is why B1 survived.** The criterion-10 failure test was written
+correctly — it rebuilds from `body.details.error` — but its fixture threw
+`"p5 deliberate executor failure"`: no URL, no hostname, no provider name, no
+network code, so `sanitizeFailureReason` was the identity function on it. The
+test's own comment said "the sanitised message the caller sees and the raw
+message we logged are different strings" while the fixture guaranteed they were
+the same. It now throws a message the sanitiser rewrites, and **asserts the two
+differ** before asserting which was bound.
+
+**My first fix for B4 was wrong in an instructive way.** A hand-written
+`SAVEPOINT` / `ROLLBACK TO` rolled back correctly and later statements
+succeeded — and the transaction still failed *at commit* with the original
+error, because postgres-js tracks the query error on the connection and catching
+it in JS is not enough. Only the new test caught that; the code read as correct.
+Drizzle's nested transaction does it properly, and both behaviours were proven
+with a minimal probe before choosing.
+
+### Fixes, each with fail-before proof through the repo guard
+
+| mutation | result |
+|---|---|
+| the receipt binds the raw stored error again | **caught** |
+| the solution rail treats every declared step as having run | **caught** |
+| `hybrid` maps to `algorithmic` again | **caught** |
+| an unestablished method falls back instead of refusing | **caught** |
+| the chain tick stops isolating a failing row | **caught** |
+
+Block 0109 is additionally now **one atomic statement**. Blocks autocommit per
+statement, so a probe refusal previously left the defaults committed while boot
+aborted — and the previous deployment would then serve *with* the new defaults
+and *without* the sweeper, so nothing would ever chain. Verified end to end:
+with a hostile CHECK armed the block refuses and applies nothing; disarming it
+restores the defaults with the epoch instant unchanged.
 
 ## 7. Production reconciliation plan
 
@@ -231,3 +280,23 @@ state is ~10,000 transactions/day against a sweeper capacity of 100 rows per
    non-forgeable server-side signal, which does not exist today.
 6. **Snapshot growth is unbounded and permanent** by design.
 7. **`NOT VALID` constraints** are enforced for new writes only.
+8. **Receipt state is not served anywhere yet.** `describeReceiptState`,
+   `receiptHealthCounts` and `selectPendingReceipts` have no production callers;
+   the monitoring in §7 item 10 is a query an operator runs, not an alert that
+   fires. Both are Phase 6/7.
+9. **The rail-coverage lint is file-granular** (see criterion 3 above).
+10. **`canonicalization_error` is caller-reachable.** `MAX_DEPTH = 512` in the
+    canonicaliser, so caller-supplied `inputs` nested deeper than that make a
+    paid execution permanently receipt-less. Terminal by design; the depth is
+    far beyond any real payload, but it is reachable on purpose by an adversary.
+11. **The declaration re-read window is wider on the sweeper path** than the few
+    milliseconds of the request path — up to about half an hour across five
+    attempts, which could span a `capabilities` write.
+12. **`source_observation.kind = "dataset"` is unreachable**, and solutions
+    always report `none_declared` because `freshness_category` is null on a
+    solution transaction. Phase 2 expects `none_declared` to dominate at the
+    epoch and shrink; this is the shape of that.
+13. **x402 solution receipts are not caller-recomputable**: the row stores
+    `{steps, errors}` while the response omits `errors` when empty, so a holder
+    of the response cannot unambiguously reconstruct the hashed object. The
+    capability path on that rail is unaffected.

--- a/docs/design/execution-receipt/PHASE-5-RAIL-INTEGRATION.md
+++ b/docs/design/execution-receipt/PHASE-5-RAIL-INTEGRATION.md
@@ -1,0 +1,233 @@
+# Execution receipt, Phase 5 — rail integration and activation
+
+Phase 4 built every artifact and deliberately wired none of it, and its own
+reconciliation said the epoch was **not** structurally real: a transaction
+inserted after that deploy was byte-identical to one from April. This phase
+closes that, and the shape of the answer is the interesting part.
+
+---
+
+## 1. The decision that made everything else safe
+
+The obvious way to activate receipts is to wire each rail's call site. There
+are eight production sites that write `transactions` — four executors in
+`routes/do.ts`, one each in `solution-execute.ts` and `x402-gateway-v2.ts`,
+the internal harness, and the settlement reconciler — and no chokepoint. Eight
+call sites is eight chances to forget one, and a forgotten one produces a row
+with `receipt_status IS NULL`, which is **indistinguishable from a pre-epoch
+row**. Silent, and permanently so.
+
+So the activation is a database default, not a wiring exercise:
+
+```sql
+ALTER TABLE transactions ALTER COLUMN receipt_status         SET DEFAULT 'pending';
+ALTER TABLE transactions ALTER COLUMN receipt_failure_reason SET DEFAULT 'not_yet_built';
+```
+
+plus a CHECK that a post-epoch row cannot have a NULL status. Every insert now
+carries receipt state whether or not its author thought about receipts — including
+inserts written after this PR by someone who never read it.
+
+That inverts the risk of wiring all the rails at once. A rail nobody wired no
+longer disappears; it produces a **visible `pending` row** that the sweeper
+picks up and the backlog counter reports. Wiring everything became the low-risk
+option rather than the high-risk one, which is why this PR does it in one pass
+rather than staging one rail at a time.
+
+Three properties make that claim hold, and each is tested:
+
+1. **Receipts are built after the money transaction commits, never inside it.**
+   A receipt cannot roll back a payment, extend a lock window, or turn a
+   receipt bug into a billing bug.
+2. **`settleExecutionReceipt` never throws.** A request that already executed
+   and charged is never failed by a receipt problem. The honest outcome of any
+   failure is "still pending".
+3. **Failure is loud, and named.** A site that records no rail leaves
+   `receipt_rail` NULL and the sweeper records `unmapped_rail` — already in
+   Phase 2's closed reason set.
+
+## 2. The defect the integration lane caught
+
+Block 0109's first version defaulted `receipt_status` and nothing else. Block
+0107 had already added `transactions_receipt_reason_required`: a row whose
+status is `pending` or `failed` must say why.
+
+Together, **every INSERT into `transactions` would have violated that CHECK** —
+every `/v1/do` call, every x402 call, every internal harness tick, 500 on the
+insert. The migration still applies cleanly, because the CHECK is `NOT VALID`
+and existing rows are never scanned. Production would simply have stopped being
+able to write.
+
+93 integration tests failed on it, in suites with nothing to do with receipts.
+**The entire unit suite was green.**
+
+Confirmed against production read-only afterwards: the constraint exists there,
+`NOT VALID`, with exactly that definition. This was not a test artifact.
+
+Two things changed so a catalog query cannot claim this is fine again:
+
+- 0109 defaults **both** columns.
+- 0109 **proves the pair works by doing what production does** — a plpgsql
+  subtransaction inserts an ordinary row (the same shape `/health/deep` has
+  used 507 times in production) and unwinds it. A violation aborts boot, and
+  Railway does not cut over a failed deploy, so the previous commit keeps
+  serving. Fail-before verified by dropping the reason default: the block
+  refuses and names the constraint.
+
+Dropping that default also exposed the block as **unrepairable** — defaults and
+epoch were guarded together, so a hand-drop was skipped forever while the block
+reported success. Defaults are now unconditional and self-healing; only the
+epoch instant stays guarded, and re-running does not move it (verified).
+
+## 3. Why two more columns exist (block 0110)
+
+Writing the sweeper exposed a soundness problem with the obvious
+implementation:
+
+- **The rail is not recoverable from the row.** A sweeper would have to guess —
+  `x402` from `payment_method`, `internal` from the system user id — and a
+  guess has no business inside a commitment.
+- **The deploy commit drifts.** `resolveDeployCommit()` answers for the process
+  asking, so a receipt rebuilt after a deploy binds the code running *now* to a
+  result produced by the code that ran *then*. The digest would verify
+  perfectly against the wrong implementation identity.
+
+Both are captured at INSERT and `settle.ts` prefers them over anything ambient.
+This makes the request path more correct too, not just the sweeper.
+
+## 4. The ten acceptance criteria
+
+| # | criterion | outcome |
+|---|---|---|
+| 1 | `RAILWAY_GIT_COMMIT_SHA` on every deploy path | **Verified, and it found something.** See `PHASE-5-DEPLOY-IDENTITY-EVIDENCE.md`: 994/1000 deployments carry a full 40-hex commit; redeploy is 25 for 25, and Railway expresses rollback as redeploy. The six that carry nothing are `repo: null` CLI upload deploys from 2026-04-05/06, four of which **served production**. |
+| 2 | `assertDeployIdentity()` wired pre-listen | Done, before any database work. Refusal unweakened: a refused boot costs a deploy, not an outage. |
+| 3 | Receipt lifecycle in every rail | All eight production write sites, enforced by a fail-closed source lint with a positive control. |
+| 4 | Every post-integration transaction gets receipt state | Structural, via the default + CHECK. Not a convention. |
+| 5 | `redacted` receipt-state presentation | Added. A digest whose content was erased is no longer reported as `complete`. |
+| 6 | Retry sweeper, bounded, visible | In the worker that already owns "finish what the request path could not", outside its transaction. |
+| 7 | `CapabilityDeclarationSource` parity guard | Added — and it found **31 of 45 columns had never been classified**. |
+| 8 | `data_update_cycle_days`, `dataset_last_updated`, `name` | All three admitted, derived from execution semantics. Plus `data_classification` and `x402_method`. |
+| 9 | FK decision | Added, with reasoning: it can never break, because DELETE and TRUNCATE on snapshots are already refused by triggers. |
+| 10 | Per-rail behavioural tests | Receipts rebuilt **from the HTTP response body** and compared to the stored digest. |
+
+### On criterion 8, the reasoning rather than the answer
+
+Three tests separate an execution-relevant column from an excluded one, and
+only the first two admit it:
+
+1. does it change what the execution **computed**?
+2. does it change what we **recorded** about the execution?
+3. does it merely decide whether the execution was **allowed to happen**?
+
+(3) is admission control, and it is excluded on purpose: a refusal is not an
+execution, and when a request *is* served the column had no bearing on the
+answer. `cost_class`, `is_active`, `quota_*` and the x402 enable flag all sit
+there.
+
+`data_update_cycle_days` and `dataset_last_updated` are in because
+`require_fresh` **refuses** a grade-C request outright — they decide whether a
+request is served. `name` and `data_classification` are in because
+`routes/do.ts` writes `data_source: capability.dataSource ?? capability.name`
+and `data_classification` into the audit body: for a capability with a null
+`data_source`, the name *is* the recorded provenance source.
+
+## 5. Rail coverage
+
+| rail | where | how it is proven |
+|---|---|---|
+| `v1_do` | 4 executors in `do.ts`, `solution-execute.ts` | Route-level: real `POST /v1/do`, digest rebuilt from the response body. Paid sync, free tier, and a deliberate executor failure. |
+| `x402` | `x402-gateway-v2.ts`, `settlement-reconciler.ts` | Settle boundary, with the call deliberately lying about the rail to prove the row's recorded value wins. |
+| `internal` | `lib/test-runner.ts` | Same. **99.3% of production traffic** (9,938 of 10,004 rows in 24h), so leaving it unwired would have meant almost every post-epoch row pending forever. |
+| `mcp`, `a2a` | — | **Deliberately unreachable.** `routes/a2a.ts` proxies to `/v1/do` over loopback and `routes/mcp.ts` only serves the catalog, so the only way to record them would be a caller-supplied header. A forgeable rail has no business inside a commitment, so they stay in the enum and unpopulated. |
+
+## 6. Evidence
+
+- **287 integration tests** against real Postgres, all passing, with the
+  startup migrations applied exactly as boot applies them.
+- **Unit lane: 2,871 passing** on a fully green run. The lane is
+  nondeterministic on this machine — repeated runs fail different files
+  (`internal-auth`, `public-trust`, `verify`, the SQS smoke test), all of which
+  pass in isolation. This is the cross-file env-leak pattern the repo already
+  documents in `do.idempotency.integration.test.ts`. **CI is the arbiter**, not
+  this machine.
+- **12 mutations through the repo's guard** (`mutation-test.mjs`), every one
+  green → red → green:
+  - settle binds a null result instead of the served output → caught
+  - the caller-supplied rail wins over the row's → caught
+  - settle reads the environment instead of the row's commit → caught
+  - the sanitised caller error is replaced by a constant → caught
+  - `settleReceiptFor` becomes a no-op for every `/v1/do` rail → caught
+  - the sweeper stops restricting itself to settled transactions → caught
+  - the coverage lint stops detecting an unwired rail → caught
+  - `name` / `data_classification` silently leave the digest → caught
+- **Two mutations SURVIVED first** and are the more useful record:
+  1. Removing the sweeper's `status IN ('completed','failed')` filter changed
+     nothing. Without it the sweeper burns an attempt every tick on a
+     transaction that has not settled, and after five ticks a **still-executing**
+     transaction carries a terminally failed receipt. Now tested.
+  2. Disabling the coverage lint's detection entirely left it green — a source
+     lint over a clean repository finds nothing, and "found nothing" is
+     indistinguishable from "cannot find anything". It now has positive
+     controls on inputs we construct.
+
+A third mutation was mis-reported twice before the cause was found: `do.ts` is
+stored CRLF, so a multi-line `--find` never matches and the guard refuses. Only
+single-line finds are reliable against that file.
+
+## 7. Production reconciliation plan
+
+Read-only, after deploy, by database object rather than by log line
+(DEC-20260504-C).
+
+1. `GET /health` serves the merge commit.
+2. Both defaults present: `receipt_status` → `'pending'`,
+   `receipt_failure_reason` → `'not_yet_built'`.
+3. `transactions_post_epoch_has_receipt` exists; read the epoch instant out of
+   `pg_get_constraintdef` and record it — that constraint is the only record of
+   when enforcement began.
+4. `transactions_receipt_manifest_digest_fk`, `receipt_rail_closed` and
+   `receipt_deploy_commit_shape` present.
+5. **Writes still work**: `count(*) FROM transactions WHERE created_at > <deploy>`
+   is non-zero and rising. This is the check that would have caught §2, and it
+   is first among equals.
+6. Receipt state is being produced: `receipt_status` grouped by value, and by
+   `receipt_rail`. Expect `complete` to dominate and `internal` to be ~99% of
+   the volume.
+7. `receipt_deploy_commit` equals the deployed commit on new rows — full 40 hex,
+   not the sentinel.
+8. Snapshot table is filling and deduplicating: fewer rows than transactions.
+9. **The chain has not stalled**: `compliance_hash_state` distribution over the
+   last hour, compared against the pre-deploy baseline of 3 pending in 10,001.
+10. `receipt_status = 'failed'` grouped by reason. Non-zero is an alert, not a
+    curiosity — it means executions are happening that cannot be committed to.
+
+### Backlog (DEC-20260504-B)
+
+Not a bulk-operation resumption. Both ALTERs are catalog-only, the CHECK and FK
+are `NOT VALID` so neither scans 925,563 rows, and production carries **zero**
+rows with receipt state, so the sweeper starts from an empty backlog. Steady
+state is ~10,000 transactions/day against a sweeper capacity of 100 rows per
+30-second tick — 288,000/day, 28× headroom.
+
+## 8. Residual risks
+
+1. **A CLI upload deploy will now refuse to boot.** Deliberate, and the refusal
+   message names the cause and the fix. Production keeps serving the previous
+   deployment. Four such deploys served production in April 2026, so this is a
+   real path someone could take.
+2. **A pre-existing platform mismatch, recorded not fixed.** The Railway
+   healthcheck retry window is 20s while `STARTUP_DB_RETRY_BUDGET_MS` is 600s,
+   so a deploy during database degradation is killed long before the budget
+   applies. The `index.ts` comment claiming `healthcheckPath: null` was stale
+   and is corrected. The fix is the Railway setting, not the code.
+3. **`pending` is now a short-lived state**, so the `integrity-hash-receipt-blocked`
+   counter's remaining population is transactions wedged at a non-terminal
+   status. Narrower than before, and worth watching for the first week.
+4. **The declaration is re-read at settle time**, so a capability row edited in
+   the milliseconds between execution and settlement would be recorded as the
+   declaration in force. `capabilities` rows are written by onboarding and
+   operations, not per request.
+5. **`mcp` and `a2a` remain unreachable.** Recording them needs a
+   non-forgeable server-side signal, which does not exist today.
+6. **Snapshot growth is unbounded and permanent** by design.
+7. **`NOT VALID` constraints** are enforced for new writes only.

--- a/docs/design/execution-receipt/PHASE-5-RAIL-INTEGRATION.md
+++ b/docs/design/execution-receipt/PHASE-5-RAIL-INTEGRATION.md
@@ -223,6 +223,70 @@ and *without* the sweeper, so nothing would ever chain. Verified end to end:
 with a hostile CHECK armed the block refuses and applies nothing; disarming it
 restores the defaults with the epoch instant unchanged.
 
+## 6b. Independent adversarial review — round 2: PASS
+
+Narrow, on the round-1 fixes and their blast radius. **No blocking findings.**
+All four fixes were confirmed correct by independent mutation (each green → red
+→ green), and the reviewer measured rather than argued the two claims that
+mattered most:
+
+- **F1 idempotency.** All **541 distinct production failure messages** run
+  through `sanitize(sanitize(x)) === sanitize(x)`: **zero non-idempotent**. Raw
+  differs from sanitised on 73 distinct strings / 40,408 rows (14.3% of
+  283,394), corroborating the 14.8% figure from round 1. No clock, locale or
+  environment dependence — so a receipt stays recomputable years later.
+- **F3 corpus.** Every value that reaches `transactions.transparency_marker` in
+  production — `algorithmic` 923,676, `ai_generated` 1,910, `mixed` 239,
+  `hybrid` 220, no NULLs, no `unknown` — maps or refuses correctly, and
+  `test-runner.ts`'s new mapping is character-for-character `getTransparencyMarker`.
+- **F4a beyond one error class.** The reviewer additionally proved isolation
+  holds for a `lock_timeout` (55P03) inside the nested transaction, not just a
+  CHECK violation — which directly falsifies the failure mode the hand-written
+  SAVEPOINT hit.
+- **F4b atomicity** independently reproduced with a hostile probe: neither
+  `SET DEFAULT` survived the refusal, and the epoch was unchanged after
+  recovery.
+
+### Fixed from round 2's non-blocking set
+
+| # | finding | fix |
+|---|---|---|
+| **N1** | The chain-halt test's `DROP CONSTRAINT` sat outside its `try`, so a throw before the re-`ADD` left the `finally`'s own DROP failing, swallowed the real error, and **stranded the shared test database with no post-epoch invariant** for every later suite. Reproduced. | DROP moved inside the `try`; the restore uses `IF EXISTS`. |
+| **N3** | Both new refusals used `internal_error`, which is **retryable** — so a deterministic condition burned five sweeper attempts, held the row out of the chain for ~30 minutes, and put five entries in a counter `receipt-lifecycle.ts` reserves for real signals. | The unresolvable-method refusal is now `unresolvable_manifest`, which is terminal and honest: the declaration was read and does not establish a required member. |
+| **N8** | The refusal test asserted `not.toBe("complete")`, which `pending` also satisfies — and pending was what actually happened. The assertion agreed with the test's name while the behaviour did not. | Asserts `failed` and the reason. |
+| **N7** | "A full run and a gate-tripped run do not share a digest" hand-builds both arrays and calls `declarationDigest` directly — it **passed under the mutation that broke the rail**. | Renamed to say what it is, and its teardown no longer depends on a sibling test having run. |
+| **N2** | The `schema.ts` comment claimed the `.default()` additions protected the epoch instant from `drizzle-kit push`. They do not: push also drops the epoch CHECK, the reason-required CHECK and the FK, and the next boot mints a fresh epoch (**observed moving 13 minutes across one push**). | Comment corrected to state the real limit. No production path runs push. |
+| **N4** | The `toReceiptError` docblock claimed the contract now holds "for every rail". Three failure branches still store one string and serve another shape — an x402 settlement failure serves a different error *code*, an x402 solution failure serves the message *wrapped*, and the no-steps solution path serves no `details.error` at all. **All three have zero occurrences in production history.** | Claim narrowed to what the evidence supports, with the three paths named. Each needs a route-level change, not a change to this function. |
+
+### Carried as residual risk, not fixed
+
+- **N5 — `sanitizeFailureReason` is idempotent in practice, not in principle,
+  and leaks a hostname.** The network-error and `fetch failed` branches return
+  early with a prefix captured *before* URL stripping, so a message like
+  `GET https://internal.example.com/x — getaddrinfo ENOTFOUND ...` keeps the
+  hostname on pass 1 and loses it on pass 2. Unreachable across all 541
+  production strings, so F1's idempotency holds for the corpus it was measured
+  against — but **the hostname leak is a real, pre-existing defect in the
+  customer-facing sanitiser, independent of this branch**, and is filed
+  separately.
+- **N6 — settle-time sanitisation is temporally coupled to `sanitize.ts`.** The
+  sweeper can settle up to ~30 minutes after the response; if `sanitize.ts`
+  changes in between, the receipt binds a string the caller never saw. The
+  effect is a receipt that cannot be recomputed, never one that is wrong.
+- **N9 — the 5s settle deadline is a timeout without cancellation.** The timer
+  is cleared correctly and nothing escapes the catch, but an abandoned
+  `settleOrThrow` keeps its pooled connection. Under sustained database
+  slowness these accumulate. No corruption is possible: every lifecycle write
+  is guarded on `receipt_status = 'pending'` with `assertTouchedOne`, and the
+  snapshot writer is `ON CONFLICT DO NOTHING`.
+
+### One thing the reviewer verified that is worth stating positively
+
+The redaction guard is well-targeted rather than speculative. Of 149,616 failed
+rows with a NULL `error`, **149,615 are redacted** and exactly **one** is a live
+non-redacted row in 30 days. Without the guard those rows would have produced a
+receipt that verifies against *"this completed execution returned null"*.
+
 ## 7. Production reconciliation plan
 
 Read-only, after deploy, by database object rather than by log line


### PR DESCRIPTION
## Execution receipt, Phase 5 — rail integration and activation

> ### Independent adversarial review, round 1: **FAIL** — four blocking findings, all reproduced
>
> | # | finding | scale |
> |---|---|---|
> | **B1** | The receipt bound the **internal** error, not the one the caller received. `settle` read `transactions.error`, and its comment asserted the sanitiser had already run — true on two rails, false on the `/v1/do` capability rails. A party holding the request and the response could not recompute the digest. | **5,016 of 33,952 failed production rows over 7 days (14.8%)** |
> | **B2** | Solution receipts marked steps that **never ran** as `ran`, with a manifest digest. `execResult.steps` is keyed by every *declared* step. `disposition` was a constant on every production solution path. | every gated solution |
> | **B3** | `execution.method` was falsified toward "no model involved" — `hybrid` is not one of the three methods, so the fallback recorded `algorithmic`. | **8,010 of ~193,600 production rows over 30 days (4.1%)** |
> | **B4** | One un-updatable row halted the tamper-evident chain **permanently** — Phase 4's round-3 blast radius in a new shape. | total, and silent |
>
> **Two of these are about my work, not just the code.**
>
> *My own fixture is why B1 survived.* The criterion-10 failure test rebuilt from the response correctly — but threw `"p5 deliberate executor failure"`, which has no URL, hostname or network code, so the sanitiser was the identity function on it. The test's comment claimed the two strings differ while the fixture guaranteed they were the same. It now throws something the sanitiser rewrites and **asserts they differ** before asserting which was bound.
>
> *My first fix for B4 was wrong in an instructive way.* A hand-written `SAVEPOINT` rolled back correctly and later statements succeeded — and the transaction still failed **at commit**, because postgres-js tracks the query error on the connection. Only the new test caught it; the code read as correct. Drizzle's nested transaction does it properly, proven both ways with a minimal probe.
>
> Every fix has fail-before proof through the repo's mutation guard. Block 0109 is additionally now **one atomic statement** — blocks autocommit per statement, so a probe refusal previously left the defaults committed while boot aborted, and the previous deployment would then serve *with* the defaults and *without* the sweeper. Verified: with a hostile CHECK armed the block refuses and applies nothing.
>
> A third thing CI caught that local runs structurally could not: the new chain-halt test assumed the epoch was old, which is true on a long-lived database and false on a freshly-migrated one. Now epoch-age independent, verified against a database migrated 4 seconds earlier.


Phase 4 built every artifact and deliberately wired none of it. Its own reconciliation said the epoch was **not** structurally real: a transaction inserted after that deploy was byte-identical to one from April. This closes that.

Full record: `docs/design/execution-receipt/PHASE-5-RAIL-INTEGRATION.md`.

---

### The decision that made everything else safe

Eight production sites write `transactions` and there is no chokepoint. Wiring eight call sites is eight chances to forget one — and a forgotten one produces `receipt_status IS NULL`, which is **indistinguishable from a pre-epoch row**. Silent, permanently.

So activation is a database default, not a wiring exercise:

```sql
ALTER TABLE transactions ALTER COLUMN receipt_status         SET DEFAULT 'pending';
ALTER TABLE transactions ALTER COLUMN receipt_failure_reason SET DEFAULT 'not_yet_built';
```

plus a CHECK that a post-epoch row cannot have a NULL status. Every insert now carries receipt state whether or not its author thought about receipts — **including inserts written after this PR by someone who never read it**.

That inverts the risk of wiring all rails at once. A rail nobody wired no longer disappears; it produces a visible `pending` row the sweeper picks up and the backlog counter reports. Wiring everything became the *low*-risk option, which is why this does it in one pass.

Three properties hold that up, each tested: receipts are built **after** the money transaction commits and never inside it; `settleExecutionReceipt` **never throws**; and an unwired site fails **loudly and by name** (`unmapped_rail`).

### The defect the integration lane caught

Block 0109's first version defaulted `receipt_status` and nothing else. Block 0107 had already added `transactions_receipt_reason_required` — a row that is `pending` or `failed` must say why.

Together, **every INSERT into `transactions` would have violated that CHECK**. Every `/v1/do` call, every x402 call, every internal harness tick: 500 on the insert. The migration still applies cleanly, because the CHECK is `NOT VALID` and existing rows are never scanned. Production would simply have stopped being able to write.

93 integration tests failed on it, across suites with nothing to do with receipts. **The entire unit suite was green.** Confirmed afterwards against production read-only: that constraint exists there, `NOT VALID`, with exactly that definition. Not a test artifact.

Two things changed so a catalog query cannot claim this is fine again. 0109 defaults **both** columns, and it **proves the pair works by doing what production does** — a plpgsql subtransaction inserts an ordinary row (the shape `/health/deep` has used 507 times in production) and unwinds it. A violation aborts boot, and Railway does not cut over a failed deploy, so the previous commit keeps serving. Fail-before verified by dropping the reason default: the block refuses and names the constraint.

Dropping that default also exposed the block as **unrepairable** — defaults and epoch were guarded together, so a hand-drop was skipped forever while the block reported success. Defaults are now unconditional and self-healing; only the epoch instant stays guarded, and re-running does not move it.

### Why block 0110 exists

Writing the sweeper exposed a soundness problem with the obvious implementation:

- **The rail is not recoverable from the row.** A sweeper would have to guess — `x402` from `payment_method`, `internal` from the system user id. A guess has no business inside a commitment.
- **The deploy commit drifts.** `resolveDeployCommit()` answers for the process asking, so a receipt rebuilt after a deploy binds the code running *now* to a result produced by the code that ran *then* — and the digest would verify perfectly against the wrong implementation identity.

Both are captured at INSERT; `settle.ts` prefers them over anything ambient.

### Criterion 1 found something

`RAILWAY_GIT_COMMIT_SHA` verified across **1000 deployments**: 994 carry a full 40-hex commit, and `redeploy` — which is also how Railway expresses rollback — is **25 for 25**. The six that carry nothing are `repo: null` CLI upload deploys from 2026-04-05/06, and **four of them reached `REMOVED`, meaning they served production**. The Phase 4 review's hypothetical is real and one command away.

The refusal is wired **unweakened** anyway, because a refused boot costs a deploy and not an outage: the service healthchecks `/health/deep` with a 20s window, and a failed healthcheck does not cut over.

### Rail coverage

| rail | proven by |
|---|---|
| `v1_do` | Real `POST /v1/do`, digest **rebuilt from the HTTP response body**. Paid sync, free tier, deliberate executor failure. |
| `x402` | Settle boundary, with the call deliberately lying about the rail to prove the row's recorded value wins. |
| `internal` | Same. **99.3% of production traffic** (9,938 of 10,004 rows in 24h). |
| `mcp`, `a2a` | **Deliberately unreachable** — both proxy to `/v1/do`, so recording them would need a caller-supplied header, and a forgeable rail has no business inside a commitment. |

### The parity guard found 31 unclassified columns

`CapabilityDeclarationSource` was hand-maintained with no guard. The mirror image of spreading the row is a new execution-relevant column silently **never** entering the digest: nothing fails, the receipts just quietly mean less.

Classifying all 45 columns by execution semantics moved five in: `data_update_cycle_days` and `dataset_last_updated` (because `require_fresh` **refuses** a grade-C request — they decide whether a request is served), `name` and `data_classification` (both written into the audit body when `data_source` is null), and `x402_method`. Admission-control columns stay out on a stated rule: a refusal is not an execution.

### Evidence

- **292 integration tests** on real Postgres with the startup migrations applied as boot applies them.
- **12 mutations through the repo's guard**, every one green → red → green.
- **Two mutations SURVIVED first**, and they are the more useful record:
  1. Removing the sweeper's `status IN ('completed','failed')` filter changed nothing — without it, a **still-executing** transaction would carry a terminally failed receipt after five ticks.
  2. Disabling the coverage lint's detection entirely left it green. A source lint over a clean repo finds nothing, and "found nothing" is indistinguishable from "cannot find anything". It now has positive controls.
- A third mutation was mis-reported twice before the cause was found: `do.ts` is stored CRLF, so multi-line `--find` never matches.

**Unit lane is nondeterministic on the author's machine** — repeated full runs fail different files, all of which pass in isolation; one full run was completely green. This is the cross-file env-leak pattern the repo already documents. CI is the arbiter.

### Residual risks

1. **A CLI upload deploy will now refuse to boot.** Deliberate; the message names the cause and the fix; production keeps serving the previous deployment.
2. **Pre-existing platform mismatch, recorded not fixed**: the Railway healthcheck window is 20s while `STARTUP_DB_RETRY_BUDGET_MS` is 600s. The `index.ts` comment claiming `healthcheckPath: null` was stale and is corrected. The fix is the Railway setting.
3. **`pending` is now short-lived**, so the `integrity-hash-receipt-blocked` counter's remaining population is transactions wedged at a non-terminal status.
4. **The declaration is re-read at settle time** — a capability row edited in the milliseconds between execution and settlement would be recorded as the declaration in force.
5. `mcp`/`a2a` remain unreachable; snapshot growth is unbounded by design; `NOT VALID` constraints bind new writes only.

### Not merged

Post-deploy reconciliation plan is in the design doc — ten read-only checks, by database object rather than log line, with "**writes still work**" first among equals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
