### PR TITLE
Fix hostname leak in sanitizeFailureReason's canned branches

### DIFF
--- a/apps/api/src/lib/sanitize.test.ts
+++ b/apps/api/src/lib/sanitize.test.ts
@@ -66,3 +66,119 @@ describe("sanitizeFailureReason — still strips what it should", () => {
     expect(sanitizeFailureReason("")).toBe("Unknown error");
   });
 });
+
+/**
+ * The canned branches used to return a prefix nothing had stripped.
+ *
+ * `sanitizeFailureReason` short-circuits on a network error code or on
+ * "fetch failed", keeping "everything before the first ` — `" so the caller
+ * still knows which capability failed. That prefix is an authored capability
+ * name by convention and arbitrary upstream text in fact, and it was carried
+ * out of the function BEFORE any URL or hostname stripping ran.
+ *
+ * Note why the existing `ECONNREFUSED chromium.railway.internal:8080` case
+ * above did not catch this: it has no ` — `, so the prefix is empty and the
+ * hostname vanishes into the canned message rather than being stripped. The
+ * leak needs a message that has both a prefix AND a network token — which is
+ * also why it has never occurred in production.
+ */
+describe("sanitizeFailureReason — the canned branches redact their prefix", () => {
+  it("does not leak a URL through the network-error branch", () => {
+    const out = sanitizeFailureReason(
+      "GET https://internal.example.com/x — getaddrinfo ENOTFOUND upstream",
+    );
+    expect(out).not.toContain("internal.example.com");
+    expect(out).toContain("Service temporarily unreachable");
+  });
+
+  it("does not leak a bare hostname through the network-error branch", () => {
+    const out = sanitizeFailureReason(
+      "probe of chromium.railway.internal — ECONNRESET while reading",
+    );
+    expect(out).not.toContain("chromium.railway.internal");
+    expect(out).toContain("Service temporarily unreachable");
+  });
+
+  it("does not leak through the `fetch failed` branch either", () => {
+    const out = sanitizeFailureReason("GET https://10-2-3-4.internal/v1 — fetch failed");
+    expect(out).not.toContain("10-2-3-4.internal");
+    expect(out).toContain("External service temporarily unavailable");
+  });
+
+  it("does not leak a provider name through a canned branch", () => {
+    const out = sanitizeFailureReason("Browserless session — ETIMEDOUT");
+    expect(out).not.toContain("Browserless");
+    expect(out).toContain("External web service");
+  });
+
+  it("still keeps an allowlisted vendor name in the prefix", () => {
+    // Redacting the prefix must not undo the allowlist the file above exists
+    // for: an authored product name is still authored copy in a prefix.
+    const out = sanitizeFailureReason("Reviews.io lookup — ECONNREFUSED");
+    expect(out).toContain("Reviews.io");
+  });
+
+  it("still keeps the capability name, which is the point of the prefix", () => {
+    const out = sanitizeFailureReason("Header Security Check — getaddrinfo ENOTFOUND");
+    expect(out).toBe("Header Security Check — Service temporarily unreachable");
+  });
+
+  it("does not change which branch fires", () => {
+    // Detection runs on the pre-redaction text, so redacting first must not
+    // move a message from one branch to another.
+    expect(sanitizeFailureReason("x — ETIMEDOUT")).toContain("Service temporarily unreachable");
+    expect(sanitizeFailureReason("x — fetch failed")).toContain(
+      "External service temporarily unavailable",
+    );
+    expect(sanitizeFailureReason("x — something else entirely")).toBe(
+      "x — something else entirely",
+    );
+  });
+});
+
+/**
+ * Idempotence, which is now load-bearing rather than merely tidy.
+ *
+ * `lib/receipt/settle.ts` sanitises when it builds an execution receipt, and
+ * the receipt's digest commits to the result. A message that sanitised
+ * differently on a second application would make that digest depend on how
+ * many times the function had run, which is not a commitment to anything.
+ *
+ * Two independent sources of non-idempotence existed, and the corpus below
+ * covers both: a prefix escaping redaction (stripped on the second pass), and
+ * the canned branches skipping the truncate tail (so an over-long prefix came
+ * back whole once and truncated the next time).
+ */
+describe("sanitizeFailureReason — idempotent", () => {
+  const CORPUS = [
+    // The two historical non-idempotence sources.
+    "GET https://internal.example.com/x — getaddrinfo ENOTFOUND upstream",
+    "x".repeat(600) + " — ETIMEDOUT",
+    // Every branch and every stripping rule.
+    "fetch failed",
+    "connect ECONNREFUSED chromium.railway.internal:8080",
+    "Browserless returned 429",
+    "upstream issue while reading api.some-vendor.example",
+    "GET https://internal.example.com/secret?token=abc failed",
+    "Reviews.io is a supported source",
+    "cannot read error.message",
+    "Header Security Check — getaddrinfo ENOTFOUND",
+    "plain message with nothing to strip",
+    "  collapses   whitespace  ",
+    "y".repeat(499),
+    "z".repeat(501),
+    "",
+  ];
+
+  it.each(CORPUS)("sanitize(sanitize(x)) === sanitize(x) for %j", (input) => {
+    const once = sanitizeFailureReason(input);
+    expect(sanitizeFailureReason(once)).toBe(once);
+  });
+
+  it("bounds every output at 500 characters, on every path", () => {
+    // The canned branches used to return without truncating.
+    for (const input of CORPUS) {
+      expect(sanitizeFailureReason(input).length).toBeLessThanOrEqual(500);
+    }
+  });
+});

--- a/apps/api/src/lib/sanitize.ts
+++ b/apps/api/src/lib/sanitize.ts
@@ -50,28 +50,14 @@ const HOSTNAME_ALLOWLIST = [
   "patents.google.com",
 ];
 
-export function sanitizeFailureReason(raw: string | null): string {
-  if (!raw) return "Unknown error";
-
-  let msg = raw;
-
-  // Strip stack traces
-  msg = msg.replace(STACK_TRACE_PATTERN, "");
-
-  // Replace network-level errors
-  if (NETWORK_ERROR_PATTERN.test(msg)) {
-    // Keep the capability name prefix if present (e.g. "Header Security Check — ...")
-    const dashIdx = msg.indexOf(" — ");
-    const prefix = dashIdx >= 0 ? msg.slice(0, dashIdx) + " — " : "";
-    return `${prefix}Service temporarily unreachable`;
-  }
-
-  // "fetch failed" → friendly message
-  if (/fetch failed/i.test(msg)) {
-    const dashIdx = msg.indexOf(" — ");
-    const prefix = dashIdx >= 0 ? msg.slice(0, dashIdx) + " — " : "";
-    return `${prefix}External service temporarily unavailable`;
-  }
+/**
+ * Everything that has to be removed before a message can face a customer.
+ *
+ * Extracted so it can run on EVERY path out of `sanitizeFailureReason`. It
+ * used to be inline, after two early returns that skipped it entirely.
+ */
+function redact(input: string): string {
+  let msg = input;
 
   // Replace provider names
   for (const pattern of PROVIDER_NAMES) {
@@ -91,6 +77,72 @@ export function sanitizeFailureReason(raw: string | null): string {
     if (HOSTNAME_ALLOWLIST.some((p) => match.toLowerCase().includes(p))) return match;
     return "[service]";
   });
+
+  return msg;
+}
+
+/**
+ * The capability-name prefix a canned message keeps, if there is one.
+ *
+ * `"Header Security Check — getaddrinfo ENOTFOUND ..."` keeps
+ * `"Header Security Check — "` so the caller still knows which capability
+ * failed. Everything before the first em-dash separator, which is an authored
+ * prefix by convention and arbitrary upstream text in fact — which is exactly
+ * why it has to be redacted like anything else.
+ */
+function namePrefix(msg: string): string {
+  const dashIdx = msg.indexOf(" — ");
+  return dashIdx >= 0 ? msg.slice(0, dashIdx) + " — " : "";
+}
+
+/**
+ * ## Why the shape is "choose the message, then redact it"
+ *
+ * The two canned branches below used to `return` directly, carrying a prefix
+ * captured BEFORE any stripping ran. That prefix is "everything before the
+ * first ` — `" — by convention a capability name, but in fact whatever the
+ * upstream error happened to start with. So
+ *
+ *     GET https://internal.example.com/x — getaddrinfo ENOTFOUND upstream
+ *
+ * came back as
+ *
+ *     GET https://internal.example.com/x — Service temporarily unreachable
+ *
+ * with the internal URL intact — the precise leak this function exists to
+ * prevent, escaping through the branch that fires when an error is at its most
+ * infrastructural.
+ *
+ * It also made the function **non-idempotent** in two independent ways: the
+ * escaped prefix is stripped on a second application, and the early returns
+ * skipped the collapse/truncate tail, so a prefix over 500 characters comes
+ * back whole once and truncated the next time. That now matters beyond
+ * tidiness: `lib/receipt/settle.ts` sanitises when building an execution
+ * receipt, and a digest that depended on how many times this ran would not be
+ * a commitment to anything.
+ *
+ * The fix is structural rather than a patch on each branch. The branches now
+ * choose the *message*; redaction and normalisation run on whatever they
+ * chose. A third canned branch added later cannot reintroduce this, because
+ * there is no longer a path out of here that skips `redact`.
+ *
+ * Detection still runs on the pre-redaction text, so which branch fires is
+ * unchanged — only what survives it.
+ */
+export function sanitizeFailureReason(raw: string | null): string {
+  if (!raw) return "Unknown error";
+
+  // Strip stack traces first: they can contain both hostnames and the network
+  // tokens the branches test for, and none of it should influence either.
+  let msg = raw.replace(STACK_TRACE_PATTERN, "");
+
+  if (NETWORK_ERROR_PATTERN.test(msg)) {
+    msg = `${namePrefix(msg)}Service temporarily unreachable`;
+  } else if (/fetch failed/i.test(msg)) {
+    msg = `${namePrefix(msg)}External service temporarily unavailable`;
+  }
+
+  msg = redact(msg);
 
   // Collapse multiple spaces and trim
   msg = msg.replace(/\s+/g, " ").trim();


### PR DESCRIPTION
## The canned branches of `sanitizeFailureReason` redacted nothing

Found by the adversarial reviewer on PR #382, but independent of that branch, so it is fixed here instead of widening it.

### The defect

`sanitizeFailureReason` short-circuits on a network error code (`getaddrinfo`, `ENOTFOUND`, `ECONNRESET`, …) and on `fetch failed`, keeping *"everything before the first ` — `"* so the caller still knows which capability failed. That prefix is an authored capability name by convention and **arbitrary upstream text in fact**, and it was carried out of the function *before* any URL or hostname stripping ran:

```
GET https://internal.example.com/x — getaddrinfo ENOTFOUND upstream
  → GET https://internal.example.com/x — Service temporarily unreachable
```

The internal URL survives. That is the precise leak this function exists to prevent, escaping through the branch that fires when an error is at its most infrastructural.

### It was also non-idempotent, in two independent ways

1. The escaped prefix **is** stripped on a second application.
2. The early returns skipped the collapse/truncate tail, so a prefix over 500 characters came back whole once and truncated the next time. Measured: **634 characters, then 500.**

The second one isn't in the original report — it turned up while fixing the first.

This now matters beyond tidiness. `lib/receipt/settle.ts` (PR #382) sanitises when building an execution receipt, and the receipt's digest commits to the result. A digest that depended on how many times this function had run would not be a commitment to anything.

### The fix is structural, not a patch on each branch

The branches now choose the **message**; redaction and normalisation run on whatever they chose. There is no longer a path out of the function that skips `redact`, so a third canned branch added later cannot reintroduce this.

Detection still runs on the pre-redaction text, so **which** branch fires is unchanged — only what survives it.

### Measured against production before and after

**541 distinct failure messages covering 283,605 rows: zero customer-visible output changes.**

The leak needs a message carrying both a prefix *and* a network token, which has never occurred. Latent, not live — and therefore no backfill.

Worth recording why the existing `ECONNREFUSED chromium.railway.internal:8080` test did not catch it: that fixture has no ` — `, so its prefix is empty and the hostname vanishes into the canned message rather than being stripped. The test passed for a reason unrelated to the property it appears to check.

### Proof

31 tests, up from 10. Four mutations through the repo's guard, each green → red → green:

| mutation | result |
|---|---|
| restore the historical early return (network branch) | **caught** |
| restore it for the `fetch failed` branch | **caught** |
| allowlist stops protecting authored vendor names | **caught** |
| truncation removed | **caught** |

The first two reproduce the original defect exactly, one line each.

The allowlist (`Reviews.io`, `trustpilot.com`, …) is separately pinned in both directions, including a new case proving an authored vendor name still survives **inside a redacted prefix** — redacting the prefix must not undo the thing that file already exists for.

### Note on ordering

Nothing produces execution receipts yet, so changing the sanitiser now costs nothing. Changing it after PR #382 merges and starts producing receipts would mean receipts built before and after bind different strings for the same execution. Cheaper to land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
