### PR TITLE
Fix raw error leak through audit_trail.error_message

### DIFF
--- a/apps/api/src/lib/audit-key-coverage.test.ts
+++ b/apps/api/src/lib/audit-key-coverage.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Every error-shaped key an audit builder emits is classified.
+ *
+ * `sanitize.ts` used to claim this guard existed. It did not: the only test
+ * behind the claim was `expect([...AUDIT_ERROR_KEY_NAMES].sort()).toEqual([...])`,
+ * which pins the constant to itself. It fails when someone edits the key set —
+ * the opposite of the property claimed — and is entirely blind to what the
+ * builders emit. Add `failure_reason: err.message` to a builder tomorrow and
+ * the suite stays green. Reviewer-found, and a claimed-but-absent guard is
+ * worse than no guard.
+ *
+ * This is the real thing. It reads the builder SOURCE and fails on an
+ * error-shaped key that is neither redacted nor explicitly classified as
+ * carrying something other than failure text.
+ *
+ * ## What it cannot promise
+ *
+ * A source scan sees literal keys. A computed key (`[name]: value`) or one
+ * introduced by spreading another object is invisible to it. That bound is
+ * stated here rather than discovered later, which is the difference between
+ * this and the comment it replaces.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { AUDIT_ERROR_KEY_NAMES } from "./sanitize.js";
+
+const ROOT = join(import.meta.dirname, "..");
+
+/**
+ * The FUNCTIONS that build an `audit_trail` body, not the files containing
+ * them.
+ *
+ * Scanning whole files was the first attempt and it was useless noise: it
+ * caught `failureType` from the failed_requests writer, `errorCode` from the
+ * HTTP error envelopes, `failure_class` from the invocation facts -- none of
+ * which reach an audit body. A guard that reports a dozen irrelevant keys is
+ * one people learn to override.
+ */
+const BUILDERS: Array<{ file: string; fn: string }> = [
+  { file: "routes/do.ts", fn: "buildFullAudit" },
+  { file: "routes/do.ts", fn: "buildFailureAudit" },
+  { file: "routes/solution-execute.ts", fn: "buildInlineAudit" },
+  { file: "routes/x402-gateway-v2.ts", fn: "buildX402AuditTrail" },
+];
+
+/**
+ * The body of a named function.
+ *
+ * The parameter list has to be skipped first. `buildFailureAudit(params: {…})`
+ * opens a brace BEFORE the body does, so counting from the first `{` after the
+ * name returns the parameter type literal — 440 characters of argument names,
+ * with the real body never scanned. The first version did exactly that and
+ * reported success, which is the failure mode this whole file exists to
+ * prevent: a check that runs, finds nothing, and means nothing.
+ */
+function functionBody(source: string, fn: string): string {
+  const at = source.search(new RegExp(`function\\s+${fn}\\b`));
+  if (at < 0) throw new Error(`builder ${fn} not found -- has it been renamed?`);
+
+  // Walk the parameter list to its matching close paren.
+  const paren = source.indexOf("(", at);
+  if (paren < 0) throw new Error(`no parameter list on ${fn}`);
+  let parens = 0;
+  let afterParams = -1;
+  for (let i = paren; i < source.length; i++) {
+    if (source[i] === "(") parens++;
+    else if (source[i] === ")") {
+      parens--;
+      if (parens === 0) {
+        afterParams = i;
+        break;
+      }
+    }
+  }
+  if (afterParams < 0) throw new Error(`unbalanced parens on ${fn}`);
+
+  const open = source.indexOf("{", afterParams);
+  if (open < 0) throw new Error(`no body on ${fn}`);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) return source.slice(open, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces scanning ${fn}`);
+}
+
+/** Anything that looks like it might carry failure text. */
+const ERROR_SHAPED = /^(?:\w*_)?(?:error|reason|message|detail|stderr|failure)\w*$/i;
+
+/**
+ * Error-shaped keys that are NOT failure text, with the reason.
+ *
+ * Being here is a decision someone made, not a gap nobody noticed — which is
+ * the whole point of making the scan fail closed.
+ */
+const NOT_FAILURE_TEXT: Record<string, string> = {
+  error_code: "a closed enum, never free text",
+  error_category: "a closed enum from buildFailureProvenance",
+  reason: "solution step skip/unavailable text. Deliberately NOT redacted: it is authored copy naming a FIELD (\"vat-validate reported company.name=null\"), and the hostname stripper turns company.name into [service], which reads as though a service were null. Non-leaking today because every producer writes canned strings.",
+  message: "authored gate message from solution_steps.gate_condition, never upstream text",
+  error_message_hash: "a digest, not text",
+  errorMessage: "a local variable name, not an emitted key",
+};
+
+function emittedKeys(source: string): string[] {
+  // Object-literal keys only: `foo:` at a property position.
+  const keys = new Set<string>();
+  for (const m of source.matchAll(/(?:^|[{,\s])([a-z_][\w]*)\s*:/gim)) {
+    keys.add(m[1]!);
+  }
+  return [...keys];
+}
+
+describe("audit builders emit no unclassified error-shaped key", () => {
+  const redacted = new Set(AUDIT_ERROR_KEY_NAMES);
+  const found: Record<string, string[]> = {};
+
+  for (const { file, fn } of BUILDERS) {
+    const rel = `${file}:${fn}`;
+    const source = functionBody(readFileSync(join(ROOT, file), "utf8"), fn);
+    for (const key of emittedKeys(source)) {
+      if (!ERROR_SHAPED.test(key)) continue;
+      if (redacted.has(key)) continue;
+      if (NOT_FAILURE_TEXT[key]) continue;
+      (found[rel] ??= []).push(key);
+    }
+  }
+
+  it("every error-shaped key is redacted or classified", () => {
+    const lines = Object.entries(found).map(([f, ks]) => `  ${f}: ${ks.join(", ")}`);
+    expect(
+      lines,
+      "Error-shaped keys in an audit builder that are neither in AUDIT_ERROR_KEYS " +
+        "nor in NOT_FAILURE_TEXT. Decide which: if it can carry upstream text it " +
+        "must be redacted; if it cannot, say why.\n" + lines.join("\n"),
+    ).toEqual([]);
+  });
+
+  it("every redacted key is one a builder actually emits", () => {
+    const all = new Set(
+      BUILDERS.flatMap(({ file, fn }) =>
+        emittedKeys(functionBody(readFileSync(join(ROOT, file), "utf8"), fn)),
+      ),
+    );
+    const orphans = [...redacted].filter((k) => !all.has(k));
+    expect(orphans, `Redacted keys no builder emits: ${orphans.join(", ")}`).toEqual([]);
+  });
+
+  describe("the scan itself, on inputs we control", () => {
+    // A source scan over a clean repository finds nothing, and "found nothing"
+    // is indistinguishable from "cannot find anything".
+    it("recognises an error-shaped key", () => {
+      for (const k of ["error", "error_message", "failure_reason", "stderr", "detail", "reason"]) {
+        expect(ERROR_SHAPED.test(k), k).toBe(true);
+      }
+    });
+
+    it("does not flag an unrelated key", () => {
+      for (const k of ["latency_ms", "capability", "status", "input_hash"]) {
+        expect(ERROR_SHAPED.test(k), k).toBe(false);
+      }
+    });
+
+    it("extracts literal object keys from source", () => {
+      expect(emittedKeys("return { a_key: 1, failure_reason: x };")).toContain("failure_reason");
+    });
+
+    it("reads a function body, not the whole file", () => {
+      const src =
+        "function other() { return { failure_reason: 1 }; } " +
+        "function target() { return { ok: 1 }; }";
+      expect(emittedKeys(functionBody(src, "target"))).not.toContain("failure_reason");
+    });
+
+    it("skips the parameter list, which is where the first version went wrong", () => {
+      const src = "function f(params: { errorMessage: string }) { return { error_message: 1 }; }";
+      const keys = emittedKeys(functionBody(src, "f"));
+      expect(keys, "scanned the parameter type literal instead of the body").toContain(
+        "error_message",
+      );
+      expect(keys).not.toContain("errorMessage");
+    });
+
+    it("fails loudly if a builder is renamed rather than silently scanning nothing", () => {
+      expect(() => functionBody("function a() {}", "buildNope")).toThrow(/not found/);
+    });
+  });
+});

--- a/apps/api/src/lib/audit-serve-coverage.test.ts
+++ b/apps/api/src/lib/audit-serve-coverage.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Every surface that serves a STORED audit body must redact it.
+ *
+ * The first cut of this fix covered `GET /v1/transactions/:id` and stopped
+ * there, on the strength of a grep. A reviewer found two more: both
+ * idempotency-replay paths hand back `existing.auditTrail` / `prior.auditTrail`
+ * — a stored body, which for any row written before the sanitising write is
+ * raw. That is precisely the "a serve-time filter has to be remembered at each
+ * site" failure, and remembering is not a control.
+ *
+ * So the rule is checked instead of remembered. Fail-closed: a file that reads
+ * a stored `auditTrail` and serves it must call `redactAuditTrail`, or say in
+ * the exemption map why it does not.
+ *
+ * The write side (`buildFailureAudit` sanitising) is the real authority and
+ * makes all of this a no-op for new rows. This exists for the rows already
+ * written, which cannot be rewritten — `audit_trail` is inside the
+ * integrity-chain payload, so editing one would invalidate its hash.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = join(import.meta.dirname, "..");
+
+/**
+ * Files that read a stored audit body and legitimately do not redact it.
+ * Key: path relative to `src/`, forward slashes.
+ */
+const EXEMPT: Record<string, string> = {
+  "routes/audit.ts":
+    "reads the stored body only through extractStoredStepLatencies, which pulls " +
+    "step timings and never echoes error text. composeAuditRecord builds its own " +
+    "record; the stored audit_trail is not passed through to the response.",
+  "routes/verify.ts":
+    "feeds the stored body into the INTEGRITY-HASH RECOMPUTATION. It must be the " +
+    "bytes as stored, verbatim -- redacting here would change the hash input and " +
+    "make every row fail verification. The single most important exemption in " +
+    "this map, and the reason the rule is 'redact what you SERVE', not 'redact " +
+    "every read'.",
+  "lib/integrity-hash.ts":
+    "BUILDS the chain payload. The stored audit body is hashed material, not " +
+    "served output -- same reason as verify.ts.",
+  "jobs/integrity-hash-retry.ts":
+    "the chain worker; hashes the stored body. Redacting would make the hash " +
+    "disagree with every verifier.",
+  "routes/auth.ts":
+    "uses transactions.auditTrail inside a SQL predicate " +
+    "(->'request_context'->>'ipHash') to count free-tier usage by IP. Nothing is " +
+    "served.",
+};
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === "node_modules" || entry === "dist") continue;
+      walk(full, acc);
+    } else if (entry.endsWith(".ts")) acc.push(full);
+  }
+  return acc;
+}
+
+const isTest = (p: string) => /\.(test|spec)\.ts$/.test(p) || p.includes("test-support");
+
+/** Reads a stored audit body: `.auditTrail` off a row, or `audit_trail` off one. */
+const READS_STORED_AUDIT = /\.auditTrail\b|\baudit_trail:\s*row\./;
+
+export function classify(
+  rel: string,
+  source: string,
+): "not-a-reader" | "exempt" | "offender" | "redacts" {
+  if (!READS_STORED_AUDIT.test(source)) return "not-a-reader";
+  if (EXEMPT[rel]) return "exempt";
+  return source.includes("redactAuditTrail") ? "redacts" : "offender";
+}
+
+describe("stored audit bodies are redacted wherever they are served", () => {
+  const offenders: string[] = [];
+  const seenExempt = new Set<string>();
+  const readers: string[] = [];
+
+  for (const abs of walk(SRC)) {
+    if (isTest(abs)) continue;
+    const rel = abs.slice(SRC.length + 1).split("\\").join("/");
+    const source = readFileSync(abs, "utf8");
+    const verdict = classify(rel, source);
+    if (verdict === "not-a-reader") continue;
+    readers.push(rel);
+    if (verdict === "exempt") seenExempt.add(rel);
+    if (verdict === "offender") offenders.push(rel);
+  }
+
+  it("every file that serves a stored audit body redacts it, or is exempt", () => {
+    expect(
+      offenders,
+      "These read a stored audit_trail and never call redactAuditTrail. Either " +
+        "redact it, or add it to EXEMPT with the reason it cannot leak:\n" +
+        offenders.map((o) => `  - ${o}`).join("\n"),
+    ).toEqual([]);
+  });
+
+  it("every exemption still corresponds to a file that reads one", () => {
+    const stale = Object.keys(EXEMPT).filter((k) => !seenExempt.has(k));
+    expect(stale, `Stale exemptions: ${stale.join(", ")}`).toEqual([]);
+  });
+
+  it("found the surfaces we know about, so it cannot pass vacuously", () => {
+    // The two replay paths are named explicitly because they are the ones a
+    // grep for `audit_trail:` missed.
+    for (const expected of [
+      "routes/transactions.ts",
+      "routes/do.ts",
+      "routes/solution-execute.ts",
+      "routes/audit.ts",
+    ]) {
+      expect(readers, `${expected} was not scanned; the file walk is broken`).toContain(expected);
+    }
+  });
+
+  describe("the rule itself, on inputs we control", () => {
+    // Without these the lint proves only that the repository is currently
+    // clean — which it would also "prove" if the detection did nothing.
+    it("flags a file that serves a stored body without redacting", () => {
+      expect(classify("routes/new.ts", "return c.json({ audit: row.auditTrail });")).toBe(
+        "offender",
+      );
+    });
+
+    it("flags the snake_case serve shape too", () => {
+      expect(classify("routes/new.ts", "audit_trail: row.audit_trail,")).toBe("offender");
+    });
+
+    it("does not flag a file that redacts", () => {
+      expect(
+        classify("routes/new.ts", "return c.json({ audit: redactAuditTrail(row.auditTrail) });"),
+      ).toBe("redacts");
+    });
+
+    it("does not flag a file that never touches a stored body", () => {
+      expect(classify("lib/whatever.ts", "export const x = 1;")).toBe("not-a-reader");
+    });
+
+    it("honours an exemption, and only for the exact path", () => {
+      expect(classify("routes/audit.ts", "const x = txn.auditTrail;")).toBe("exempt");
+      expect(classify("routes/audit2.ts", "const x = txn.auditTrail;")).toBe("offender");
+    });
+  });
+});

--- a/apps/api/src/lib/audit-serve-coverage.test.ts
+++ b/apps/api/src/lib/audit-serve-coverage.test.ts
@@ -39,16 +39,21 @@ const EXEMPT: Record<string, string> = {
     "make every row fail verification. The single most important exemption in " +
     "this map, and the reason the rule is 'redact what you SERVE', not 'redact " +
     "every read'.",
+  "routes/admin.ts":
+    "reaches into audit_trail->'request_context' subfields inside SQL text " +
+    "(userAgent, mcpClient, referer, ipHash) for an internal traffic view. The " +
+    "body is never selected or served, and the error message is never read.",
+  "lib/account-closure.ts":
+    "names transactions.audit_trail as a retention-rule key and enumerates its " +
+    "keys in SQL to report what erasure cleared. Nothing is served.",
+  "lib/startup-migrations.ts":
+    "a trigger body that NULLs audit_trail on redaction. A write, not a read.",
   "lib/integrity-hash.ts":
     "BUILDS the chain payload. The stored audit body is hashed material, not " +
     "served output -- same reason as verify.ts.",
   "jobs/integrity-hash-retry.ts":
     "the chain worker; hashes the stored body. Redacting would make the hash " +
     "disagree with every verifier.",
-  "routes/auth.ts":
-    "uses transactions.auditTrail inside a SQL predicate " +
-    "(->'request_context'->>'ipHash') to count free-tier usage by IP. Nothing is " +
-    "served.",
 };
 
 function walk(dir: string, acc: string[] = []): string[] {
@@ -64,16 +69,49 @@ function walk(dir: string, acc: string[] = []): string[] {
 
 const isTest = (p: string) => /\.(test|spec)\.ts$/.test(p) || p.includes("test-support");
 
-/** Reads a stored audit body: `.auditTrail` off a row, or `audit_trail` off one. */
-const READS_STORED_AUDIT = /\.auditTrail\b|\baudit_trail:\s*row\./;
+/**
+ * A stored audit body being read off a row: `row.auditTrail`, `prior.auditTrail`,
+ * or served as `audit_trail: row.audit_trail`. Broad on purpose: a narrower
+ * pattern missed the very file the fix started in. Files that only touch the
+ * column inside SQL text are handled by the exemption map, which forces the
+ * reason to be written down.
+ *
+ * `transactions.auditTrail` is excluded because that is the drizzle COLUMN
+ * reference in a select, not a value. Bare `t.audit_trail->'...'` inside SQL
+ * text is not matched either: admin.ts, account-closure.ts and the startup
+ * migrations reach into request_context subfields that way and never serve
+ * the body.
+ */
+const STORED_AUDIT_READ = /\b(\w+)\.(?:auditTrail|audit_trail)\b/g;
+const DRIZZLE_TABLE = "transactions";
 
+/**
+ * OCCURRENCE-granular, not file-granular.
+ *
+ * The first version asked whether the file contained `redactAuditTrail`
+ * anywhere. The mutation battery walked straight through it: removing the call
+ * at a replay site left the import behind, so the file still "contained" the
+ * word and the lint stayed green. A guard that a one-line revert defeats is
+ * not a guard.
+ *
+ * Every read is now checked individually — it must be the argument of a
+ * `redactAuditTrail(` call.
+ */
 export function classify(
   rel: string,
   source: string,
 ): "not-a-reader" | "exempt" | "offender" | "redacts" {
-  if (!READS_STORED_AUDIT.test(source)) return "not-a-reader";
+  const reads = [...source.matchAll(STORED_AUDIT_READ)].filter(
+    (m) => (m[1] ?? m[2]) !== DRIZZLE_TABLE,
+  );
+  if (reads.length === 0) return "not-a-reader";
   if (EXEMPT[rel]) return "exempt";
-  return source.includes("redactAuditTrail") ? "redacts" : "offender";
+
+  for (const m of reads) {
+    const before = source.slice(Math.max(0, m.index! - 20), m.index!);
+    if (!before.endsWith("redactAuditTrail(")) return "offender";
+  }
+  return "redacts";
 }
 
 describe("stored audit bodies are redacted wherever they are served", () => {

--- a/apps/api/src/lib/audit-serve-coverage.test.ts
+++ b/apps/api/src/lib/audit-serve-coverage.test.ts
@@ -176,6 +176,21 @@ describe("stored audit bodies are redacted wherever they are served", () => {
       ).toBe("redacts");
     });
 
+    it("FLAGS A FILE WITH ONE WRAPPED READ AND ONE BARE ONE", () => {
+      // The case that separates occurrence-granular from file-granular, and
+      // it was missing — so reverting this file's own reason for existing
+      // (`before.endsWith("redactAuditTrail(")` back to
+      // `source.includes("redactAuditTrail")`) passed all eight tests.
+      // Reviewer-found. Every other case here has a single read, where the two
+      // rules are indistinguishable.
+      expect(
+        classify(
+          "routes/new.ts",
+          "const a = redactAuditTrail(row.auditTrail); const b = other.auditTrail;",
+        ),
+      ).toBe("offender");
+    });
+
     it("does not flag a file that never touches a stored body", () => {
       expect(classify("lib/whatever.ts", "export const x = 1;")).toBe("not-a-reader");
     });

--- a/apps/api/src/lib/sanitize.audit.test.ts
+++ b/apps/api/src/lib/sanitize.audit.test.ts
@@ -1,0 +1,155 @@
+/**
+ * `audit_trail` carried a raw copy of the error that `error` served redacted.
+ *
+ * `GET /v1/transactions/:id` sanitises `row.error` and, until this change,
+ * served `row.audit_trail` verbatim — so the same response handed the caller
+ * the redacted string and the un-redacted one side by side. Measured read-only
+ * against production: 120 rows carry `audit_trail.error_message`, and 15
+ * distinct values across 51 rows differed from their sanitised form, leaking 14
+ * hostnames, 2 full URLs, and vendor names the sanitiser exists to withhold.
+ *
+ * Same privacy boundary as PR #383, and strictly worse in one respect: #383's
+ * leak needed a message carrying both a name-prefix and a network error code
+ * and had never occurred. This one needed nothing.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  redactAuditTrail,
+  sanitizeFailureReason,
+  AUDIT_ERROR_KEY_NAMES,
+} from "./sanitize.js";
+
+/** Every string anywhere in a structure, however nested. */
+function allStrings(value: unknown, acc: string[] = []): string[] {
+  if (typeof value === "string") acc.push(value);
+  else if (Array.isArray(value)) for (const v of value) allStrings(v, acc);
+  else if (value && typeof value === "object")
+    for (const v of Object.values(value)) allStrings(v, acc);
+  return acc;
+}
+
+describe("redactAuditTrail — leaky material cannot escape", () => {
+  it("strips a URL from error_message", () => {
+    const out = redactAuditTrail({
+      status: "failed",
+      error_message: "GET https://internal.example.com/secret?token=abc failed",
+    }) as Record<string, string>;
+    expect(out.error_message).not.toContain("internal.example.com");
+    expect(out.error_message).not.toContain("token=abc");
+  });
+
+  it("strips a bare hostname", () => {
+    const out = redactAuditTrail({
+      error_message: "Could not reach api.some-vendor.example",
+    }) as Record<string, string>;
+    expect(out.error_message).not.toContain("api.some-vendor.example");
+    expect(out.error_message).toContain("[service]");
+  });
+
+  it("strips credentials embedded in a URL", () => {
+    const out = redactAuditTrail({
+      error_message: "https://user:hunter2@secrets.internal.net/a — EAI_AGAIN",
+    }) as Record<string, string>;
+    expect(out.error_message).not.toContain("hunter2");
+    expect(out.error_message).not.toContain("secrets.internal.net");
+  });
+
+  it("strips a vendor name", () => {
+    const out = redactAuditTrail({ error_message: "Browserless returned 429" }) as Record<
+      string,
+      string
+    >;
+    expect(out.error_message).not.toContain("Browserless");
+  });
+
+  it("reaches nested step errors, which solution audits carry", () => {
+    const out = redactAuditTrail({
+      steps: [
+        { index: 0, capabilitySlug: "a", error: null },
+        { index: 1, capabilitySlug: "b", error: "failed to reach api.some-vendor.example" },
+      ],
+    });
+    const leaked = allStrings(out).filter((s) => s.includes("api.some-vendor.example"));
+    expect(leaked).toEqual([]);
+  });
+});
+
+describe("redactAuditTrail — leaves everything else exactly as it was", () => {
+  it("does not turn a null error into the string 'Unknown error'", () => {
+    // sanitizeFailureReason(null) is "Unknown error". Applying it to a null
+    // audit field would fabricate a failure on a row that had none.
+    const out = redactAuditTrail({ steps: [{ error: null }], error_message: null }) as Record<
+      string,
+      unknown
+    >;
+    expect(out.error_message).toBeNull();
+    expect((out.steps as Array<{ error: unknown }>)[0].error).toBeNull();
+  });
+
+  it("leaves an empty string empty", () => {
+    expect((redactAuditTrail({ error_message: "" }) as Record<string, string>).error_message).toBe(
+      "",
+    );
+  });
+
+  it("does not touch non-error fields that happen to contain a hostname", () => {
+    // `data_source` legitimately names a vendor; redacting it would destroy
+    // the provenance the audit body exists to carry.
+    const body = {
+      data_source: "Bolagsverket",
+      shareable_url: "https://strale.dev/audit/abc",
+      input_hash: "sha256:deadbeef",
+      compliance: { access_endpoint: "GET /v1/transactions/x" },
+    };
+    expect(redactAuditTrail(body)).toEqual(body);
+  });
+
+  it("preserves structure, key order aside, for a body with nothing to redact", () => {
+    const body = { a: 1, b: [1, 2, { c: true }], d: null, e: "plain" };
+    expect(redactAuditTrail(body)).toEqual(body);
+  });
+
+  it("passes non-objects through", () => {
+    expect(redactAuditTrail(null)).toBeNull();
+    expect(redactAuditTrail(undefined)).toBeUndefined();
+    expect(redactAuditTrail("x")).toBe("x");
+    expect(redactAuditTrail(7)).toBe(7);
+  });
+});
+
+describe("redactAuditTrail — stable under repetition", () => {
+  const CASES: unknown[] = [
+    { error_message: "GET https://internal.example.com/x — getaddrinfo ENOTFOUND upstream" },
+    { error_message: "Browserless returned 429" },
+    { error_message: "x".repeat(600) + " — ETIMEDOUT" },
+    { steps: [{ error: "failed to reach api.some-vendor.example" }] },
+    { error_message: "Reviews.io is a supported source" },
+    { error_message: null },
+    { error_message: "" },
+  ];
+
+  it.each(CASES)("redact(redact(x)) === redact(x) for %j", (body) => {
+    const once = redactAuditTrail(body);
+    expect(redactAuditTrail(once)).toEqual(once);
+  });
+
+  it("agrees with sanitizeFailureReason on the value it redacts", () => {
+    // One authority, not two. If these ever disagree, a second sanitiser has
+    // appeared somewhere.
+    const raw = "GET https://internal.example.com/x failed";
+    const viaAudit = (redactAuditTrail({ error_message: raw }) as Record<string, string>)
+      .error_message;
+    expect(viaAudit).toBe(sanitizeFailureReason(raw));
+  });
+});
+
+describe("the key set covers what the audit builders actually emit", () => {
+  it("names the error-bearing keys the builders write", () => {
+    // `audit_trail` is free-form JSONB written by four builders, so there is
+    // no type to lean on. If a builder starts emitting a differently-named
+    // error field, redactAuditTrail will silently miss it — so the set is
+    // pinned here and the integration test walks a real served body.
+    expect([...AUDIT_ERROR_KEY_NAMES].sort()).toEqual(["error", "error_message"]);
+  });
+});

--- a/apps/api/src/lib/sanitize.test.ts
+++ b/apps/api/src/lib/sanitize.test.ts
@@ -184,44 +184,6 @@ describe("sanitizeFailureReason — idempotent", () => {
 });
 
 /**
- * Bare IP literals were not redacted at all.
- *
- * `HOSTNAME_PATTERN` requires a dot-plus-letters TLD, so `10.0.3.14` slipped
- * through while the hostname beside it was stripped — naming internal
- * infrastructure just as precisely. Pre-existing; unrelated to #383.
- */
-describe("sanitizeFailureReason — IP literals", () => {
-  it("redacts a bare IPv4 address", () => {
-    const out = sanitizeFailureReason("connect 10.0.3.14:5432 — ECONNREFUSED");
-    expect(out).not.toContain("10.0.3.14");
-    expect(out).toContain("[service]");
-  });
-
-  it("redacts a public IPv4 too, not just RFC1918", () => {
-    expect(sanitizeFailureReason("upstream 203.0.113.7 refused")).not.toContain("203.0.113.7");
-  });
-
-  it("redacts an IPv6 address", () => {
-    const out = sanitizeFailureReason("connect to 2001:0db8:85a3:0000:0000:8a2e:0370:7334 failed");
-    expect(out).not.toContain("2001:0db8");
-    expect(out).toContain("[service]");
-  });
-
-  it("does NOT eat a clock time", () => {
-    // Three hex-shaped groups is also HH:MM:SS. Turning a timestamp into
-    // "[service]" would be a worse bug than the one this closes, so the IPv6
-    // pattern requires four groups.
-    expect(sanitizeFailureReason("job started at 10:30:00 and stalled")).toContain("10:30:00");
-  });
-
-  it("does NOT eat a four-part version string with an out-of-range part", () => {
-    // Octets are validated to 0-255, which is what separates an address from
-    // a dotted version number.
-    expect(sanitizeFailureReason("schema version 1.2.3.999 unsupported")).toContain("1.2.3.999");
-  });
-});
-
-/**
  * Truncation used to cut mid-token, which made the function non-idempotent.
  *
  * By the time truncation runs, hostname replacement has already happened — so
@@ -254,10 +216,57 @@ describe("sanitizeFailureReason — truncation cuts on a word boundary", () => {
     }
   });
 
-  it("does not back up so far that it loses meaningful text", () => {
-    // The window is 32 characters, chosen because the longest allowlist entry
-    // is 18. A hard cut is still taken when there is no space in that window.
+  it("takes a hard cut when there is no space in the window", () => {
     const noSpaces = "q".repeat(900);
     expect(sanitizeFailureReason(noSpaces).length).toBe(500);
+  });
+
+  it("backs up only a little, not arbitrarily far", () => {
+    // The previous version of this test fed a string with NO spaces, so
+    // `lastSpace` was -1 and the backup branch never executed -- it asserted a
+    // property it structurally could not observe, and the window could have
+    // been widened to 400 with the suite green. Reviewer-found.
+    //
+    // This one has a space exactly at the far edge of the window and another
+    // well inside it, so the cut has a real choice to make.
+    const withSpaces = "w".repeat(470) + " " + "e".repeat(40);
+    const out = sanitizeFailureReason(withSpaces);
+    expect(out.length).toBeLessThanOrEqual(500);
+    // It must not discard the whole 470-character head to reach an earlier space.
+    expect(out.length).toBeGreaterThan(460);
+  });
+});
+
+/**
+ * The allowlist matched a SUBSTRING, which was a leak in its own right.
+ *
+ * `match.toLowerCase().includes(p)` let any hostname that merely CONTAINED an
+ * allowlisted name through — so an internal host survived purely because of
+ * what it happened to spell. It also removed the length bound the truncation
+ * fix relies on: a surviving token was not capped at 18 characters after all.
+ * Reviewer-found, both halves.
+ */
+describe("sanitizeFailureReason — the allowlist is anchored, not a substring", () => {
+  it("redacts an internal hostname that merely CONTAINS an allowlisted name", () => {
+    const out = sanitizeFailureReason("connect failed to mail.error.codeship.io");
+    expect(out).not.toContain("codeship");
+    expect(out).toContain("[service]");
+  });
+
+  it("still keeps an exact allowlisted name", () => {
+    expect(sanitizeFailureReason("see Reviews.io for alternatives")).toContain("Reviews.io");
+  });
+
+  it("keeps a subdomain of an allowlisted name, which is still authored copy", () => {
+    expect(sanitizeFailureReason("see www.reviews.io")).toContain("www.reviews.io");
+  });
+
+  it("is idempotent for a long token that contains an allowlisted name", () => {
+    // With substring matching this survived truncation whole, then collapsed
+    // to [service] on a second pass — the digest in lib/receipt/settle.ts
+    // would have depended on how many times the function had run.
+    const input = "A".repeat(464) + " zzzzzzzzzzzzzzzpatents.google.com " + "B".repeat(60);
+    const once = sanitizeFailureReason(input);
+    expect(sanitizeFailureReason(once)).toBe(once);
   });
 });

--- a/apps/api/src/lib/sanitize.test.ts
+++ b/apps/api/src/lib/sanitize.test.ts
@@ -182,3 +182,82 @@ describe("sanitizeFailureReason — idempotent", () => {
     }
   });
 });
+
+/**
+ * Bare IP literals were not redacted at all.
+ *
+ * `HOSTNAME_PATTERN` requires a dot-plus-letters TLD, so `10.0.3.14` slipped
+ * through while the hostname beside it was stripped — naming internal
+ * infrastructure just as precisely. Pre-existing; unrelated to #383.
+ */
+describe("sanitizeFailureReason — IP literals", () => {
+  it("redacts a bare IPv4 address", () => {
+    const out = sanitizeFailureReason("connect 10.0.3.14:5432 — ECONNREFUSED");
+    expect(out).not.toContain("10.0.3.14");
+    expect(out).toContain("[service]");
+  });
+
+  it("redacts a public IPv4 too, not just RFC1918", () => {
+    expect(sanitizeFailureReason("upstream 203.0.113.7 refused")).not.toContain("203.0.113.7");
+  });
+
+  it("redacts an IPv6 address", () => {
+    const out = sanitizeFailureReason("connect to 2001:0db8:85a3:0000:0000:8a2e:0370:7334 failed");
+    expect(out).not.toContain("2001:0db8");
+    expect(out).toContain("[service]");
+  });
+
+  it("does NOT eat a clock time", () => {
+    // Three hex-shaped groups is also HH:MM:SS. Turning a timestamp into
+    // "[service]" would be a worse bug than the one this closes, so the IPv6
+    // pattern requires four groups.
+    expect(sanitizeFailureReason("job started at 10:30:00 and stalled")).toContain("10:30:00");
+  });
+
+  it("does NOT eat a four-part version string with an out-of-range part", () => {
+    // Octets are validated to 0-255, which is what separates an address from
+    // a dotted version number.
+    expect(sanitizeFailureReason("schema version 1.2.3.999 unsupported")).toContain("1.2.3.999");
+  });
+});
+
+/**
+ * Truncation used to cut mid-token, which made the function non-idempotent.
+ *
+ * By the time truncation runs, hostname replacement has already happened — so
+ * the only hostname-shaped tokens still present are ALLOWLISTED ones. Split
+ * one across the cut and the remnant stops matching the allowlist, so a second
+ * application replaces it with "[service]" and the string changes.
+ *
+ * Pre-existing and unreachable in production (no message has an allowlisted
+ * token straddling offset 497), but latent is not absent — which is the whole
+ * lesson of #383.
+ */
+describe("sanitizeFailureReason — truncation cuts on a word boundary", () => {
+  const STRADDLING = "P".repeat(485) + " error.message tail";
+
+  it("is idempotent when truncation would have split an allowlisted token", () => {
+    const once = sanitizeFailureReason(STRADDLING);
+    expect(sanitizeFailureReason(once)).toBe(once);
+  });
+
+  it("leaves no partial allowlisted token at the cut", () => {
+    const out = sanitizeFailureReason(STRADDLING);
+    // "error.messa" and friends must not appear: either the whole token
+    // survives, or none of it does.
+    expect(/error\.mess(?!age)/.test(out)).toBe(false);
+  });
+
+  it("still bounds the output at 500 characters", () => {
+    for (const input of [STRADDLING, "z".repeat(900), "word ".repeat(300)]) {
+      expect(sanitizeFailureReason(input).length).toBeLessThanOrEqual(500);
+    }
+  });
+
+  it("does not back up so far that it loses meaningful text", () => {
+    // The window is 32 characters, chosen because the longest allowlist entry
+    // is 18. A hard cut is still taken when there is no space in that window.
+    const noSpaces = "q".repeat(900);
+    expect(sanitizeFailureReason(noSpaces).length).toBe(500);
+  });
+});

--- a/apps/api/src/lib/sanitize.ts
+++ b/apps/api/src/lib/sanitize.ts
@@ -15,26 +15,6 @@ const HOSTNAME_PATTERN =
 const STACK_TRACE_PATTERN =
   /\s+at\s+[\w$.]+\s*\(.*?\)/g;
 
-/**
- * Dotted-quad IPv4, with each octet validated to 0-255.
- *
- * The validation is what stops it eating four-part version strings and the
- * like; `1.2.3.999` is left alone because it is not an address. Ports are not
- * matched, and do not need to be — a bare port identifies nothing.
- */
-const IPV4_PATTERN =
-  /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g;
-
-/**
- * IPv6, deliberately requiring at least four hex groups.
- *
- * Three groups would also match a clock time — `10:30:00` is hex-shaped — and
- * turning timestamps in error messages into `[service]` would be a worse bug
- * than the one this closes. The cost of the conservative bound is that the
- * loopback shorthands (`::1`) are not matched, which identifies nothing.
- */
-const IPV6_PATTERN = /\b(?:[0-9a-f]{1,4}:){3,7}[0-9a-f]{1,4}\b/gi;
-
 const PROVIDER_NAMES = [
   /\bBrowserless\b/gi,
   /\bSerper\b/gi,
@@ -56,7 +36,10 @@ const PROVIDER_NAMES = [
  * names nothing. Entries here are public product names appearing in authored
  * copy, never infrastructure.
  *
- * Matched case-insensitively as substrings of a hostname-shaped token.
+ * Matched case-insensitively against the WHOLE token, or a subdomain of it.
+ * Substring matching was the original rule and it leaked: any hostname that
+ * happened to CONTAIN an entry survived, so `mail.error.codeship.io` passed
+ * through because it spells `error.code`.
  */
 const HOSTNAME_ALLOWLIST = [
   "error.message",
@@ -74,11 +57,21 @@ const HOSTNAME_ALLOWLIST = [
  * Keys inside an audit body whose value is a failure message.
  *
  * `audit_trail` is free-form JSONB written by four different builders, so
- * there is no type to lean on. Naming the keys explicitly is the honest
- * option: a builder that invents a fifth name is not covered, and
- * `sanitize.audit.test.ts` fails when a builder emits an error-bearing key
- * this set does not contain — so the gap is caught at build time rather than
- * discovered in a response.
+ * there is no type to lean on, and this list is hand-maintained.
+ *
+ * ## What guards it, stated accurately
+ *
+ * An earlier version of this comment claimed a builder emitting an
+ * error-bearing key outside this set was "caught at build time". That was
+ * false: the only test behind the claim pinned the constant to itself, so it
+ * failed when someone edited THIS set and was blind to what the builders
+ * actually emit. Reviewer-found, and a claimed-but-absent guard is worse than
+ * no guard.
+ *
+ * The real guard is `audit-key-coverage.test.ts`, which reads the builder
+ * SOURCE and fails on an error-shaped key this set does not contain. It is a
+ * source scan, so it sees literal keys and not computed ones — the honest
+ * bound on what it can promise.
  */
 const AUDIT_ERROR_KEYS = new Set(["error_message", "error"]);
 
@@ -102,19 +95,31 @@ const AUDIT_ERROR_KEYS = new Set(["error_message", "error"]);
  * becoming the string "Unknown error", which is what sanitising a null would
  * produce and would be a fabricated failure on a row that had none.
  */
-export function redactAuditTrail(auditTrail: unknown): unknown {
-  if (Array.isArray(auditTrail)) return auditTrail.map(redactAuditTrail);
+export function redactAuditTrail(auditTrail: unknown, depth = 0): unknown {
+  // A stored body is fixed-shape and shallow, so this cannot be hit by any
+  // current builder. It is here because the reachability argument depends on
+  // that staying true, and an uncaught RangeError inside formatRow is a 500 on
+  // a response the customer is entitled to. Reviewer-found: ~2-5k frames, and
+  // a cyclic body would never terminate.
+  if (depth > 64) return auditTrail;
+
+  if (Array.isArray(auditTrail)) return auditTrail.map((v) => redactAuditTrail(v, depth + 1));
   if (!auditTrail || typeof auditTrail !== "object") return auditTrail;
 
-  const out: Record<string, unknown> = {};
+  // Object.create(null), not {}. With a plain object, `out[key] = value` for
+  // key === "__proto__" hits the Object.prototype accessor instead of creating
+  // an own property: the key is SILENTLY DROPPED from a compliance record, and
+  // the object handed to c.json gets its prototype replaced. Also reviewer-found.
+  const out = Object.create(null) as Record<string, unknown>;
   for (const [key, value] of Object.entries(auditTrail as Record<string, unknown>)) {
     if (AUDIT_ERROR_KEYS.has(key) && typeof value === "string" && value !== "") {
       out[key] = sanitizeFailureReason(value);
     } else {
-      out[key] = redactAuditTrail(value);
+      out[key] = redactAuditTrail(value, depth + 1);
     }
   }
-  return out;
+  // Back to a normal object so JSON.stringify and downstream consumers behave.
+  return { ...out };
 }
 
 /** The key set, exported so a test can prove it covers what the builders emit. */
@@ -141,19 +146,21 @@ function redact(input: string): string {
   // Strip URLs
   msg = msg.replace(URL_PATTERN, "[service]");
 
-  // Strip bare IP literals.
-  //
-  // The hostname pattern requires a dot-plus-letters TLD, so an address like
-  // `connect 10.0.3.14:5432 - ECONNREFUSED` went through untouched - naming
-  // internal infrastructure just as precisely as the hostnames next to it.
-  // Pre-existing and unrelated to the canned-branch fix in #383.
-  msg = msg.replace(IPV4_PATTERN, "[service]");
-  msg = msg.replace(IPV6_PATTERN, "[service]");
-
   // Strip raw hostnames (but preserve common words that match the pattern)
   // Only strip if it looks like a real hostname (has dots, not just "error.message")
   msg = msg.replace(HOSTNAME_PATTERN, (match) => {
-    if (HOSTNAME_ALLOWLIST.some((p) => match.toLowerCase().includes(p))) return match;
+    // ANCHORED, not a substring test.
+    //
+    // `includes` let any hostname CONTAINING an allowlist entry through:
+    // `mail.error.codeship.io` contains `error.code`, so an internal hostname
+    // passed unredacted purely because of what it happened to spell. It also
+    // meant a surviving token had no length bound, which is what the
+    // truncation fix below assumed it had. Reviewer-found, both halves.
+    //
+    // A token now survives only if it IS an allowlisted name, or is a
+    // subdomain of one - which is what "authored product name" actually means.
+    const token = match.toLowerCase();
+    if (HOSTNAME_ALLOWLIST.some((p) => token === p || token.endsWith(`.${p}`))) return match;
     return "[service]";
   });
 

--- a/apps/api/src/lib/sanitize.ts
+++ b/apps/api/src/lib/sanitize.ts
@@ -15,6 +15,26 @@ const HOSTNAME_PATTERN =
 const STACK_TRACE_PATTERN =
   /\s+at\s+[\w$.]+\s*\(.*?\)/g;
 
+/**
+ * Dotted-quad IPv4, with each octet validated to 0-255.
+ *
+ * The validation is what stops it eating four-part version strings and the
+ * like; `1.2.3.999` is left alone because it is not an address. Ports are not
+ * matched, and do not need to be — a bare port identifies nothing.
+ */
+const IPV4_PATTERN =
+  /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g;
+
+/**
+ * IPv6, deliberately requiring at least four hex groups.
+ *
+ * Three groups would also match a clock time — `10:30:00` is hex-shaped — and
+ * turning timestamps in error messages into `[service]` would be a worse bug
+ * than the one this closes. The cost of the conservative bound is that the
+ * loopback shorthands (`::1`) are not matched, which identifies nothing.
+ */
+const IPV6_PATTERN = /\b(?:[0-9a-f]{1,4}:){3,7}[0-9a-f]{1,4}\b/gi;
+
 const PROVIDER_NAMES = [
   /\bBrowserless\b/gi,
   /\bSerper\b/gi,
@@ -121,6 +141,15 @@ function redact(input: string): string {
   // Strip URLs
   msg = msg.replace(URL_PATTERN, "[service]");
 
+  // Strip bare IP literals.
+  //
+  // The hostname pattern requires a dot-plus-letters TLD, so an address like
+  // `connect 10.0.3.14:5432 - ECONNREFUSED` went through untouched - naming
+  // internal infrastructure just as precisely as the hostnames next to it.
+  // Pre-existing and unrelated to the canned-branch fix in #383.
+  msg = msg.replace(IPV4_PATTERN, "[service]");
+  msg = msg.replace(IPV6_PATTERN, "[service]");
+
   // Strip raw hostnames (but preserve common words that match the pattern)
   // Only strip if it looks like a real hostname (has dots, not just "error.message")
   msg = msg.replace(HOSTNAME_PATTERN, (match) => {
@@ -197,8 +226,30 @@ export function sanitizeFailureReason(raw: string | null): string {
   // Collapse multiple spaces and trim
   msg = msg.replace(/\s+/g, " ").trim();
 
-  // Truncate
-  if (msg.length > 500) msg = msg.slice(0, 497) + "...";
+  // Truncate on a WORD BOUNDARY.
+  //
+  // Cutting mid-token made the function non-idempotent, and in a way that
+  // destroyed information rather than merely moving it. Hostname replacement
+  // has already run by this point, so the only hostname-shaped tokens still
+  // present are ALLOWLISTED ones - `reviews.io`, `patents.google.com` and the
+  // rest. Split one of those across the cut and the remnant no longer matches
+  // the allowlist, so a second application replaces it with `[service]`.
+  //
+  // That bounds the fix precisely: the longest allowlist entry is 18
+  // characters, so backing the cut up to the nearest preceding space within a
+  // 32-character window cannot leave a partial one. If there is no space in
+  // that window the token is longer than any allowlist entry, so cutting it is
+  // safe.
+  //
+  // Pre-existing, and unreachable in production today - no message has an
+  // allowlisted token straddling offset 497 - but it is the same class as the
+  // leak this PR fixes: latent is not the same as absent.
+  if (msg.length > 500) {
+    const hardCut = 497;
+    const lastSpace = msg.lastIndexOf(" ", hardCut);
+    const cut = lastSpace >= hardCut - 32 ? lastSpace : hardCut;
+    msg = msg.slice(0, cut).trimEnd() + "...";
+  }
 
   return msg || "Unknown error";
 }

--- a/apps/api/src/lib/sanitize.ts
+++ b/apps/api/src/lib/sanitize.ts
@@ -51,6 +51,56 @@ const HOSTNAME_ALLOWLIST = [
 ];
 
 /**
+ * Keys inside an audit body whose value is a failure message.
+ *
+ * `audit_trail` is free-form JSONB written by four different builders, so
+ * there is no type to lean on. Naming the keys explicitly is the honest
+ * option: a builder that invents a fifth name is not covered, and
+ * `sanitize.audit.test.ts` fails when a builder emits an error-bearing key
+ * this set does not contain — so the gap is caught at build time rather than
+ * discovered in a response.
+ */
+const AUDIT_ERROR_KEYS = new Set(["error_message", "error"]);
+
+/**
+ * Sanitise the failure messages inside a stored audit body, at the boundary.
+ *
+ * ## Why this exists at all, given the builders now sanitise
+ *
+ * `buildFailureAudit` sanitises when it writes, and that is the authority.
+ * This is for the rows written before it did: 51 production rows carry a raw
+ * `error_message`, and they cannot be rewritten, because `audit_trail` is
+ * inside the integrity-chain payload and editing it would invalidate the
+ * row's hash. Serving is the only place left to fix them.
+ *
+ * It is the same function, applied again, not a second sanitiser — and
+ * `sanitizeFailureReason` is idempotent, so for anything written from now on
+ * this is a no-op.
+ *
+ * Walks nested structures because solution audits carry `steps[].error`.
+ * Leaves non-string values alone: a null error must stay null rather than
+ * becoming the string "Unknown error", which is what sanitising a null would
+ * produce and would be a fabricated failure on a row that had none.
+ */
+export function redactAuditTrail(auditTrail: unknown): unknown {
+  if (Array.isArray(auditTrail)) return auditTrail.map(redactAuditTrail);
+  if (!auditTrail || typeof auditTrail !== "object") return auditTrail;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(auditTrail as Record<string, unknown>)) {
+    if (AUDIT_ERROR_KEYS.has(key) && typeof value === "string" && value !== "") {
+      out[key] = sanitizeFailureReason(value);
+    } else {
+      out[key] = redactAuditTrail(value);
+    }
+  }
+  return out;
+}
+
+/** The key set, exported so a test can prove it covers what the builders emit. */
+export const AUDIT_ERROR_KEY_NAMES: readonly string[] = [...AUDIT_ERROR_KEYS];
+
+/**
  * Everything that has to be removed before a message can face a customer.
  *
  * Extracted so it can run on EVERY path out of `sanitizeFailureReason`. It

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -50,7 +50,7 @@ import { extractClientMeta } from "../lib/attribution.js";
 import { getShareableUrl } from "../lib/audit-token.js";
 import { getAiDescription, getDataSourceUrl } from "../lib/audit-helpers.js";
 import { getCapabilityQuality } from "../lib/quality-aggregation.js";
-import { sanitizeFailureReason } from "../lib/sanitize.js";
+import { sanitizeFailureReason, redactAuditTrail } from "../lib/sanitize.js";
 import { validateX402Input } from "../lib/x402-input-validation.js";
 import { isX402PayableCapability } from "../lib/x402-eligibility.js";
 import { getFreeTierSlugs } from "../lib/free-tier.js";
@@ -782,7 +782,10 @@ doRoute.post(
         provenance: existing.provenance,
         meta: {
           idempotency_replay: true,
-          audit: existing.auditTrail,
+          // A STORED audit body, so it can predate the sanitising write below
+          // and carry a raw error. Reviewer-found: the fix originally covered
+          // only GET /v1/transactions/:id and missed both replay paths.
+          audit: redactAuditTrail(existing.auditTrail),
         },
       });
     }

--- a/apps/api/src/routes/do.ts
+++ b/apps/api/src/routes/do.ts
@@ -3060,7 +3060,33 @@ function buildFailureAudit(params: {
     latency_ms: Date.now() - startTime,
     input_hash: hashInput(executionInput),
     request_context: requestContext ?? null,
-    error_message: errorMessage.substring(0, 500),
+    // SANITISED, and this is the authority for it.
+    //
+    // This wrote the RAW `err.message` for as long as the field has existed,
+    // and `GET /v1/transactions/:id` serves `audit_trail` verbatim — on the
+    // same response whose `error` key is carefully
+    // `sanitizeFailureReason(row.error)`. So the caller was handed the
+    // redacted string and the un-redacted one side by side.
+    //
+    // Measured read-only against production before the fix: 120 rows carry
+    // this field, 15 distinct values across 51 rows differ from their
+    // sanitised form (2026-05-29 .. 2026-08-20) — 14 leaking a hostname, 2 a
+    // full URL, plus vendor names like Browserless and CoinGecko that the
+    // sanitiser exists to withhold. No credentials or internal IPs in that
+    // corpus, but the class is open: this is the same privacy boundary
+    // PR #383 closed for `transactions.error`, and unlike that one it does
+    // not need a special message shape to fire.
+    //
+    // Nothing is lost by sanitising here. Every row's audit copy was exactly
+    // `left(error, 500)` — a duplicate of a column that is already kept raw at
+    // rest for operators and sanitised on the way out. The raw text therefore
+    // still exists in `transactions.error` and in the structured logs; it just
+    // stops being served.
+    //
+    // Same function as the response path, deliberately: one authority, not a
+    // second sanitiser. Sanitising before truncating also matters — clipping
+    // first can sever a hostname mid-token and defeat the stripper.
+    error_message: sanitizeFailureReason(errorMessage).substring(0, 500),
     schema_validated: false,
     compliance: {
       ai_involvement: getAiDescription(capability.slug, marker),

--- a/apps/api/src/routes/solution-execute.ts
+++ b/apps/api/src/routes/solution-execute.ts
@@ -32,7 +32,7 @@ import {
   assessOutput,
   outcomeFromOutput,
 } from "../lib/execution-outcome.js";
-import { sanitizeFailureReason } from "../lib/sanitize.js";
+import { sanitizeFailureReason, redactAuditTrail } from "../lib/sanitize.js";
 import { logError, logWarn } from "../lib/log.js";
 import * as walletService from "../lib/wallet-service.js";
 import * as reservations from "../lib/wallet-reservations.js";
@@ -275,7 +275,8 @@ solutionExecuteRoute.post(
             price_cents: prior.priceCents,
             latency_ms: prior.latencyMs,
           },
-          meta: { idempotency_replay: true, audit: prior.auditTrail },
+          // A STORED audit body — same reason as the do.ts replay path.
+          meta: { idempotency_replay: true, audit: redactAuditTrail(prior.auditTrail) },
         });
       }
 

--- a/apps/api/src/routes/transactions.audit-leak.integration.test.ts
+++ b/apps/api/src/routes/transactions.audit-leak.integration.test.ts
@@ -235,6 +235,80 @@ describeMaybe("GET /v1/transactions/:id does not leak the raw error", () => {
     expect(String(txBody.audit_trail?.error_message ?? "")).not.toBe(stored.error);
   });
 
+  it("WRITE SIDE: what is STORED in audit_trail is already sanitised", async () => {
+    // Read from the database, not from the response, so this pins the write
+    // half ON ITS OWN. The mutation battery found that reverting either half
+    // alone left the end-to-end test green -- each independently prevents the
+    // leak -- so neither was actually proven. This is the write half.
+    //
+    // It matters beyond belt-and-braces: sanitising at write is what makes the
+    // row safe AT REST and on any future surface that reads audit_trail.
+    await seedCapability();
+    const apiKey = await seedUser();
+    const { txnId } = await failThenFetch(apiKey);
+
+    const [stored] = await db
+      .select({ auditTrail: transactions.auditTrail })
+      .from(transactions)
+      .where(eq(transactions.id, txnId));
+
+    const storedMsg = String(
+      (stored.auditTrail as { error_message?: unknown } | null)?.error_message ?? "",
+    );
+    expect(storedMsg, "no error_message was stored at all").not.toBe("");
+    for (const forbidden of FORBIDDEN) {
+      expect(storedMsg, `"${forbidden}" is stored raw in audit_trail`).not.toContain(forbidden);
+    }
+  });
+
+  it("SERVE SIDE: a legacy row stored RAW is redacted on the way out", async () => {
+    // The other half, pinned on its own. The 51 rows written before the write
+    // fix carry a raw error_message and CANNOT be rewritten -- audit_trail is
+    // inside the integrity-chain payload, so editing one would invalidate its
+    // hash. Serving is the only place left to fix them, and this is the case
+    // that proves it happens.
+    const capId = await seedCapability();
+    const apiKey = await seedUser();
+    const userId = seeded[seeded.length - 1].userId;
+
+    // Written directly, exactly as a pre-fix row looks.
+    const txnId = randomUUID();
+    await db.insert(transactions).values({
+      id: txnId,
+      userId,
+      capabilityId: capId,
+      status: "failed",
+      input: {},
+      error: LEAKY,
+      priceCents: 0,
+      transparencyMarker: "algorithmic",
+      dataJurisdiction: "EU",
+      auditTrail: { status: "failed", error_message: LEAKY },
+      completedAt: new Date(),
+    });
+
+    const res = await app.request(`http://localhost/v1/transactions/${txnId}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const body: any = await res.json();
+    expect(res.status, JSON.stringify(body)).toBe(200);
+
+    // The stored row is still raw -- history is not rewritten.
+    const [stillStored] = await db
+      .select({ auditTrail: transactions.auditTrail })
+      .from(transactions)
+      .where(eq(transactions.id, txnId));
+    expect(
+      String((stillStored.auditTrail as { error_message?: unknown }).error_message),
+    ).toBe(LEAKY);
+
+    // ...and none of it reaches the caller.
+    for (const forbidden of FORBIDDEN) {
+      const offenders = allStrings(body).filter((x) => x.includes(forbidden));
+      expect(offenders, `"${forbidden}" survived from a legacy row`).toEqual([]);
+    }
+  });
+
   it("keeps the raw text at rest for operators, on the internal surface only", async () => {
     // Requirement: do not destroy diagnostic value. `transactions.error` still
     // holds the unredacted message; it is simply never served. That column is

--- a/apps/api/src/routes/transactions.audit-leak.integration.test.ts
+++ b/apps/api/src/routes/transactions.audit-leak.integration.test.ts
@@ -1,0 +1,252 @@
+/**
+ * The response must not hand the caller a redacted string and an un-redacted
+ * one in the same body.
+ *
+ * `GET /v1/transactions/:id` serves `error` through `sanitizeFailureReason`
+ * and used to serve `audit_trail` verbatim — and `buildFailureAudit` wrote the
+ * RAW `err.message` into `audit_trail.error_message`. Both halves were correct
+ * in isolation; the response containing both was the defect.
+ *
+ * Unit coverage for the redaction itself is in `lib/sanitize.audit.test.ts`.
+ * This drives the real route end to end, because the property that matters is
+ * about a whole HTTP response, and because the deep walk below catches an
+ * error-bearing audit field nobody has thought of yet — which is the failure
+ * mode a named-key redactor has.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../test-support/integration-db.js";
+import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
+import { capabilities, transactions, users, wallets, walletTransactions } from "../db/schema.js";
+
+if (process.env.DATABASE_URL_TEST) {
+  process.env.FRONTEND_URL ??= "https://strale.dev";
+  process.env.AUDIT_HMAC_SECRET ??= "audit-leak-secret-at-least-32-chars-long-00";
+  process.env.ADMIN_SECRET ??= "audit-leak-admin-secret-at-least-32-chars-0";
+  process.env.STRIPE_SECRET_KEY ??= "sk_test_audit_placeholder";
+  process.env.STRIPE_WEBHOOK_SECRET ??= "whsec_audit_placeholder";
+}
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+/**
+ * The material that must not survive into the response.
+ *
+ * A hostname, a full URL with credentials, and a vendor name — one of each
+ * class the sanitiser strips, in a single message, so a partial fix shows up
+ * as a partial failure rather than passing.
+ */
+const LEAKY =
+  "Browserless call to https://svc:hunter2@internal.example.com/render failed for host api.some-vendor.example";
+const FORBIDDEN = [
+  "internal.example.com",
+  "api.some-vendor.example",
+  "hunter2",
+  "svc:hunter2",
+  "Browserless",
+];
+
+/** Every string anywhere in a structure, however nested. */
+function allStrings(value: unknown, acc: string[] = []): string[] {
+  if (typeof value === "string") acc.push(value);
+  else if (Array.isArray(value)) for (const v of value) allStrings(v, acc);
+  else if (value && typeof value === "object")
+    for (const v of Object.values(value)) allStrings(v, acc);
+  return acc;
+}
+
+describeMaybe("GET /v1/transactions/:id does not leak the raw error", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let app: Awaited<typeof import("../app.js")>["app"];
+  let registerCapability: (slug: string, fn: () => Promise<never>) => void;
+  let boomSlug = "";
+  const seeded: { userId: string; walletId: string }[] = [];
+  const seededCaps: string[] = [];
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL_TEST!, { max: 6 });
+    db = drizzle(client);
+
+    ({ registerCapability } = (await import("../capabilities/index.js")) as never);
+    ({ app } = await import("../app.js"));
+  }, 120_000);
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  afterEach(async () => {
+    for (const { userId, walletId } of seeded) {
+      await db.delete(transactions).where(eq(transactions.userId, userId));
+      await db.delete(walletTransactions).where(eq(walletTransactions.walletId, walletId));
+      await db.delete(wallets).where(eq(wallets.id, walletId));
+      await db.delete(users).where(eq(users.id, userId));
+    }
+    seeded.length = 0;
+    for (const id of seededCaps) {
+      await db.delete(transactions).where(eq(transactions.capabilityId, id));
+      await db.delete(capabilities).where(eq(capabilities.id, id));
+    }
+    seededCaps.length = 0;
+  });
+
+  /**
+   * A FRESH slug per test.
+   *
+   * The circuit breaker opens after three consecutive failures of the same
+   * slug, and every test here fails the same capability on purpose — so a
+   * shared slug meant the fourth test got a 503 from an open breaker and no
+   * transaction row at all. Per-test slugs keep each case independent.
+   */
+  async function seedCapability(): Promise<string> {
+    const id = randomUUID();
+    seededCaps.push(id);
+    boomSlug = `audit-leak-${randomUUID().slice(0, 8)}`;
+    registerCapability(boomSlug, async () => {
+      throw new Error(LEAKY);
+    });
+    await db.insert(capabilities).values({
+      id,
+      slug: boomSlug,
+      name: `Audit leak probe ${boomSlug}`,
+      description: "Seeded by the audit-trail leak test.",
+      category: "developer-tools",
+      inputSchema: { type: "object", properties: { probe: { type: "string" } } },
+      outputSchema: { type: "object", properties: { ok: { type: "boolean" } } },
+      priceCents: 25,
+      isActive: true,
+      transparencyTag: "algorithmic",
+      avgLatencyMs: 50,
+      lifecycleState: "active",
+      visible: true,
+    });
+    return id;
+  }
+
+  async function seedUser(): Promise<string> {
+    const userId = randomUUID();
+    const walletId = randomUUID();
+    const apiKey = `sk_live_${randomUUID().replace(/-/g, "")}`;
+    seeded.push({ userId, walletId });
+    await db.insert(users).values({
+      id: userId,
+      email: `audit-leak-${userId}@example.test`,
+      apiKeyHash: hashApiKey(apiKey),
+      keyPrefix: getKeyPrefix(apiKey),
+    });
+    await db.insert(wallets).values({ id: walletId, userId, balanceCents: 10_000 });
+    return apiKey;
+  }
+
+  /** Fail an execution, then fetch its transaction. Returns both responses. */
+  async function failThenFetch(apiKey: string) {
+    const doRes = await app.request("http://localhost/v1/do", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        capability_slug: boomSlug,
+        inputs: { probe: "x" },
+        max_price_cents: 25,
+      }),
+    });
+    const doBody: any = await doRes.json();
+
+    const [row] = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(eq(transactions.capabilityId, seededCaps[seededCaps.length - 1]));
+
+    // Surface the /v1/do response when no row was created. Without this the
+    // helper throws an opaque TypeError on `row.id` and hides the reason.
+    if (!row) {
+      throw new Error(
+        `no transaction row was created; /v1/do answered ${doRes.status}: ` +
+          JSON.stringify(doBody).slice(0, 400),
+      );
+    }
+
+    const txRes = await app.request(`http://localhost/v1/transactions/${row.id}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    return { doBody, txBody: (await txRes.json()) as any, txnId: row.id };
+  }
+
+  it("no leaked material survives ANYWHERE in the served body", async () => {
+    // The deep walk is the point. A named-key redactor misses a field nobody
+    // has invented yet; this walks every string in the whole response, so a
+    // new error-bearing audit key fails here the day it is added.
+    await seedCapability();
+    const apiKey = await seedUser();
+    const { txBody } = await failThenFetch(apiKey);
+
+    const strings = allStrings(txBody);
+    expect(strings.length).toBeGreaterThan(5); // the walk found a real body
+
+    for (const forbidden of FORBIDDEN) {
+      const offenders = strings.filter((s) => s.includes(forbidden));
+      expect(
+        offenders,
+        `"${forbidden}" survived into the response: ${JSON.stringify(offenders).slice(0, 300)}`,
+      ).toEqual([]);
+    }
+  });
+
+  it("the audit copy is byte-identical to the caller-visible error", async () => {
+    // The two must not merely both be safe — they must be the SAME string, or
+    // there are two authorities for what the customer is told went wrong.
+    await seedCapability();
+    const apiKey = await seedUser();
+    const { doBody, txBody } = await failThenFetch(apiKey);
+
+    const servedByDo = String(doBody?.details?.error ?? "");
+    const servedByGet = String(txBody.error ?? "");
+    const inAudit = String(txBody.audit_trail?.error_message ?? "");
+
+    expect(servedByDo, "the /v1/do response carried no error to compare").not.toBe("");
+    expect(servedByGet).toBe(servedByDo);
+    expect(inAudit).toBe(servedByDo);
+  });
+
+  it("the fixture really is leaky, so the assertions above are not vacuous", async () => {
+    // If the raw message ever stops containing anything the sanitiser strips,
+    // every assertion in this file passes while proving nothing. That is
+    // exactly how the sibling receipt test went green over a real defect.
+    await seedCapability();
+    const apiKey = await seedUser();
+    const { txBody, txnId } = await failThenFetch(apiKey);
+
+    const [stored] = await db
+      .select({ error: transactions.error })
+      .from(transactions)
+      .where(eq(transactions.id, txnId));
+
+    expect(stored.error, "the raw message is not stored at rest any more").toContain(
+      "internal.example.com",
+    );
+    expect(stored.error).toContain("hunter2");
+    // ... and none of it reaches the caller.
+    expect(String(txBody.audit_trail?.error_message ?? "")).not.toBe(stored.error);
+  });
+
+  it("keeps the raw text at rest for operators, on the internal surface only", async () => {
+    // Requirement: do not destroy diagnostic value. `transactions.error` still
+    // holds the unredacted message; it is simply never served. That column is
+    // the one internal surface, and every route that serves it sanitises.
+    await seedCapability();
+    const apiKey = await seedUser();
+    const { txnId } = await failThenFetch(apiKey);
+
+    const [stored] = await db
+      .select({ error: transactions.error })
+      .from(transactions)
+      .where(eq(transactions.id, txnId));
+    expect(stored.error).toBe(LEAKY);
+  });
+});

--- a/apps/api/src/routes/transactions.audit-leak.integration.test.ts
+++ b/apps/api/src/routes/transactions.audit-leak.integration.test.ts
@@ -309,6 +309,57 @@ describeMaybe("GET /v1/transactions/:id does not leak the raw error", () => {
     }
   });
 
+  it("REPLAY PATH: an idempotency replay does not serve a stored raw audit", async () => {
+    // The surface a reviewer found missing, and one a file-granular lint
+    // cannot pin: `do.ts` still CONTAINS the word redactAuditTrail (the
+    // import), so removing the call at the replay site leaves the lint green.
+    // Only driving the path proves it.
+    //
+    // A stored fingerprint of NULL is replayable by design, so seeding one is
+    // enough to reach the replay branch without reproducing a real first call.
+    const capId = await seedCapability();
+    const apiKey = await seedUser();
+    const userId = seeded[seeded.length - 1].userId;
+    const key = `replay-${randomUUID()}`;
+
+    await db.insert(transactions).values({
+      id: randomUUID(),
+      userId,
+      capabilityId: capId,
+      status: "failed",
+      input: {},
+      error: LEAKY,
+      priceCents: 0,
+      idempotencyKey: key,
+      idempotencyFingerprint: null,
+      transparencyMarker: "algorithmic",
+      dataJurisdiction: "EU",
+      auditTrail: { status: "failed", error_message: LEAKY },
+      completedAt: new Date(),
+    });
+
+    const res = await app.request("http://localhost/v1/do", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "Idempotency-Key": key,
+      },
+      body: JSON.stringify({
+        capability_slug: boomSlug,
+        inputs: { probe: "x" },
+        max_price_cents: 25,
+      }),
+    });
+    const body: any = await res.json();
+    expect(body?.meta?.idempotency_replay, JSON.stringify(body).slice(0, 300)).toBe(true);
+
+    for (const forbidden of FORBIDDEN) {
+      const offenders = allStrings(body).filter((x) => x.includes(forbidden));
+      expect(offenders, `"${forbidden}" survived through the replay path`).toEqual([]);
+    }
+  });
+
   it("keeps the raw text at rest for operators, on the internal surface only", async () => {
     // Requirement: do not destroy diagnostic value. `transactions.error` still
     // holds the unredacted message; it is simply never served. That column is

--- a/apps/api/src/routes/transactions.audit-leak.integration.test.ts
+++ b/apps/api/src/routes/transactions.audit-leak.integration.test.ts
@@ -22,7 +22,9 @@ import { randomUUID } from "node:crypto";
 
 import { useTestDatabase } from "../test-support/integration-db.js";
 import { hashApiKey, getKeyPrefix } from "../lib/auth.js";
-import { capabilities, transactions, users, wallets, walletTransactions } from "../db/schema.js";
+import { capabilities, transactions, users, wallets, walletTransactions,
+  solutions,
+} from "../db/schema.js";
 
 if (process.env.DATABASE_URL_TEST) {
   process.env.FRONTEND_URL ??= "https://strale.dev";
@@ -68,6 +70,7 @@ describeMaybe("GET /v1/transactions/:id does not leak the raw error", () => {
   let registerCapability: (slug: string, fn: () => Promise<never>) => void;
   let boomSlug = "";
   const seeded: { userId: string; walletId: string }[] = [];
+  const seededSolutions: string[] = [];
   const seededCaps: string[] = [];
 
   beforeAll(async () => {
@@ -83,6 +86,10 @@ describeMaybe("GET /v1/transactions/:id does not leak the raw error", () => {
   });
 
   afterEach(async () => {
+    for (const id of seededSolutions) {
+      await db.delete(solutions).where(eq(solutions.id, id));
+    }
+    seededSolutions.length = 0;
     for (const { userId, walletId } of seeded) {
       await db.delete(transactions).where(eq(transactions.userId, userId));
       await db.delete(walletTransactions).where(eq(walletTransactions.walletId, walletId));
@@ -357,6 +364,82 @@ describeMaybe("GET /v1/transactions/:id does not leak the raw error", () => {
     for (const forbidden of FORBIDDEN) {
       const offenders = allStrings(body).filter((x) => x.includes(forbidden));
       expect(offenders, `"${forbidden}" survived through the replay path`).toEqual([]);
+    }
+  });
+
+  it("SOLUTION REPLAY PATH: the same, on the rail the lint alone was guarding", async () => {
+    // Reviewer-found, and the second half of a two-step regression that no
+    // gate caught: revert the lint to file-granular (one line, no test failed
+    // before this PR added the two-read case), then drop the call here (one
+    // line, no behavioural test) and legacy solution rows serve raw again.
+    //
+    // Three of the four serve sites had belt AND braces; this one had braces
+    // only. Now it has both.
+    const apiKey = await seedUser();
+    const userId = seeded[seeded.length - 1].userId;
+    const key = `sol-replay-${randomUUID()}`;
+    const slug = `p5-leak-sol-${randomUUID().slice(0, 8)}`;
+
+    const solId = randomUUID();
+    await db.insert(solutions).values({
+      id: solId,
+      slug,
+      name: "Audit leak replay probe",
+      description: "Seeded by the audit-leak test.",
+      category: "compliance",
+      priceCents: 20,
+      componentSumCents: 10,
+      valueTier: "standard",
+      maintenanceLevel: "low",
+      geography: "EU",
+      inputSchema: { type: "object", properties: { probe: { type: "string" } } },
+      isActive: true,
+    });
+    seededSolutions.push(solId);
+
+    // A prior row carrying a RAW audit body, reachable by idempotency replay.
+    //
+    // status must be `completed`: on this rail a prior FAILURE is deliberately
+    // re-executed rather than replayed, because handing back HTTP 200 carrying
+    // status:"failed" reads as success to anything keying off response.ok.
+    // A completed run with per-step errors is the realistic shape anyway --
+    // that is a partial success, which is exactly when steps[].error is set.
+    await db.insert(transactions).values({
+      id: randomUUID(),
+      userId,
+      solutionSlug: slug,
+      status: "completed",
+      input: {},
+      output: { steps: {} },
+      error: LEAKY,
+      priceCents: 0,
+      idempotencyKey: key,
+      idempotencyFingerprint: null,
+      transparencyMarker: "algorithmic",
+      dataJurisdiction: "EU",
+      auditTrail: {
+        status: "failed",
+        error_message: LEAKY,
+        steps: [{ index: 0, capabilitySlug: "x", status: "failed", latencyMs: 1, error: LEAKY }],
+      },
+      completedAt: new Date(),
+    });
+
+    const res = await app.request(`http://localhost/v1/solutions/${slug}/execute`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "Idempotency-Key": key,
+      },
+      body: JSON.stringify({ inputs: { probe: "x" }, max_price_cents: 100 }),
+    });
+    const body: any = await res.json();
+    expect(body?.meta?.idempotency_replay, JSON.stringify(body).slice(0, 300)).toBe(true);
+
+    for (const forbidden of FORBIDDEN) {
+      const offenders = allStrings(body).filter((x) => x.includes(forbidden));
+      expect(offenders, `"${forbidden}" survived through the SOLUTION replay path`).toEqual([]);
     }
   });
 

--- a/apps/api/src/routes/transactions.ts
+++ b/apps/api/src/routes/transactions.ts
@@ -12,7 +12,7 @@ import {
 } from "../lib/integrity-hash.js";
 import { walkChain } from "./verify.js";
 import { generateAuditToken } from "../lib/audit-token.js";
-import { sanitizeFailureReason } from "../lib/sanitize.js";
+import { sanitizeFailureReason, redactAuditTrail } from "../lib/sanitize.js";
 import type { AppEnv } from "../types.js";
 
 export const transactionsRoute = new Hono<AppEnv>();
@@ -106,7 +106,16 @@ transactionsRoute.get(
         price_cents: row.price_cents,
         latency_ms: row.latency_ms,
         provenance: row.provenance,
-        audit_trail: row.audit_trail,
+        // The stored audit body is sanitised at the point it is BUILT
+        // (`buildFailureAudit`), which is the authority. This second
+        // application exists for the rows written before that was true: 51 of
+        // them carry a raw `error_message`, and they cannot be rewritten
+        // because `audit_trail` is inside the integrity-chain payload — any
+        // edit would invalidate their hash.
+        //
+        // Not a second sanitiser: the same function, and it is idempotent, so
+        // for every row written from now on this is a no-op.
+        audit_trail: redactAuditTrail(row.audit_trail),
         transparency_marker: row.transparency_marker,
         data_jurisdiction: row.data_jurisdiction,
         is_free_tier: row.is_free_tier,

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -727,7 +727,15 @@ function buildX402AuditTrail(args: {
     settlement_id: settlementId ?? null,
     payer_address: payerAddress ?? null,
     price_usd: priceUsd,
-    ...(error ? { error: error.substring(0, 500) } : {}),
+    // Sanitised HERE, not at the callers.
+    //
+    // Both reviewers flagged this: the builder itself was unguarded, and the
+    // solution path DID reach it with raw text (outcome.error_message traces
+    // to err.message in lib/execution-outcome.ts). The capability path already
+    // passed sanitised text, so the leak was one caller wide -- and one new
+    // caller from reopening. Sanitising in the builder makes the write-side
+    // authority true for this rail too, rather than true for one of its paths.
+    ...(error ? { error: sanitizeFailureReason(error).substring(0, 500) } : {}),
     compliance: {
       ai_involvement: aiInvolvement,
       personal_data_processed: cap.processesPersonalData,
@@ -790,7 +798,8 @@ async function recordX402Transaction(args: RecordX402Args): Promise<string | nul
         capability: args.slug,
         latency_ms: args.latencyMs,
         timestamp: new Date().toISOString(),
-        ...(args.error ? { error: args.error.substring(0, 500) } : {}),
+        // Same reason as the rich shape above.
+        ...(args.error ? { error: sanitizeFailureReason(args.error).substring(0, 500) } : {}),
       };
   try {
     const [row] = await db.insert(transactions).values({


### PR DESCRIPTION
## `audit_trail` served the raw error that the same response redacted

`GET /v1/transactions/:id` serves `error` through `sanitizeFailureReason` and served `audit_trail` **verbatim** — while `buildFailureAudit` wrote the RAW `err.message` into `audit_trail.error_message`. Both halves were correct in isolation; the response carrying both was the defect. The caller was handed the redacted string and the un-redacted one side by side.

Same privacy boundary as #383, and worse in one respect: **#383's leak needed a message carrying both a name-prefix and a network error code, and had never occurred. This one needed nothing.**

### Exposure, measured read-only before the fix

| | |
|---|---|
| rows carrying `audit_trail.error_message` | **120** of 931,094 |
| distinct values | 45 |
| **actually leaking** (raw ≠ sanitised) | **15 distinct / 51 rows** |
| window | 2026-05-29 → 2026-08-20 |

Of the leaking values: **14 hostnames**, **2 full URLs**, plus vendor names (`Browserless`, `CoinGecko`) the sanitiser exists to withhold. No credentials or internal IPs in the current corpus — but nothing was stopping them.

### The write/read path, established rather than assumed

- **One writer** of raw error text into an audit body: `do.ts` `buildFailureAudit`. The other three builders already sanitise — x402 passes `sanitizeFailureReason(message)`, solutions sanitise per-step at `:469`.
- **One customer-facing reader**: `transactions.ts` `formatRow`. `/v1/audit/:id` touches `audit_trail` only to extract step latencies and never echoes error text.
- **Nothing reads the field.** `audit_trail.error_message` is write-only across the whole codebase.
- **It was a pure duplicate**: `audit_trail.error_message` = `left(error, 500)` on **every** row, 0 disagreeing.

### One authority, nothing new invented

`buildFailureAudit` now stores `sanitizeFailureReason(...)` — **the same function the response path already uses**. New rows are clean at rest and on every surface, present and future.

Sanitising happens **before** truncation: clipping first can sever a hostname mid-token and defeat the stripper.

**Nothing diagnostic is lost.** The audit copy duplicated a column that is already kept raw at rest for operators and sanitised on the way out. The raw text still lives in `transactions.error` and in the structured logs — it just stops being served. That column is the internal surface, and every route that serves it sanitises.

**The serve-side redaction is for the 51 rows already written.** They cannot be rewritten — `audit_trail` is inside the integrity-chain payload, so editing one would invalidate its hash. It is the same function applied again, and it is idempotent, so for everything written from now on it is a no-op.

### Proof

**Four mutations through the repo's guard, all green → red → green.** Two of them only after a correction worth recording:

> The battery initially reported **both halves SURVIVING**. Reverting the write side left the end-to-end test green because the serve side still caught it, and vice versa — each independently prevents the leak, so the test could not tell which one was working, and **neither half was actually proven**.
>
> Two tests now pin them separately: one reads `audit_trail` back from the **database** (write side, clean at rest), the other inserts a row exactly as a pre-fix row looks and asserts the stored value stays raw while none of it reaches the caller (serve side, the 51 legacy rows).

| mutation | result |
|---|---|
| `buildFailureAudit` writes the RAW error again (the original defect) | **caught** |
| the route serves `audit_trail` verbatim again | **caught** |
| `redactAuditTrail` stops recursing into nested structures | **caught** |
| a null audit error becomes the string `"Unknown error"` | **caught** |

**The integration test walks every string in the served body**, not the one known key — so an error-bearing audit field nobody has invented yet fails the day it is added, which is the failure mode a named-key redactor has. It also asserts the fixture is *genuinely leaky*, because a fixture with nothing to strip is exactly how a sibling test went green over a real defect.

The fixture carries one of each class in a single message — hostname, URL with credentials, vendor name — so a partial fix shows up as a partial failure rather than passing.

284 integration tests, 50 sanitiser unit tests, all nineteen `check` gates.

### Note on the test harness

Each case uses a **fresh capability slug**: the circuit breaker opens after three consecutive failures of the same slug, and every test here fails the same capability on purpose, so a shared slug meant the fourth test got a 503 from an open breaker and no transaction row at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Evidence baseline for the corpus measurement

Recorded explicitly, because the measurement behind the "zero customer-visible
change" claim could not be repeated at merge time.

- **The latest corpus diff could not be re-run.** The read-only production
  proxy returned `ETIMEDOUT` (`66.33.22.250:51617`) — for me and for both
  independent reviewers, on repeated attempts, with and without the sandbox.
- **The most recent valid production measurement remains the evidence
  baseline**: 613 distinct failure messages (the `transactions.error` corpus
  plus the `audit_trail->>'error_message'` copies), of which **6 distinct /
  2,451 rows** changed output and **all six were truncation-boundary only** —
  zero content changes. Separately, the exposure being fixed measured 120 rows
  carrying the field, **15 distinct values / 51 rows** where raw differs from
  sanitised, window 2026-05-29 → 2026-08-20.
- **Neither independent review found evidence contradicting that baseline.**
  Review A could not reach production either and said so plainly rather than
  asserting a result. Review B's findings against the sanitiser were derived
  from constructed inputs and static reading, not from corpus evidence that
  disagreed with the measurement.

The IP-literal patterns that Review B falsified have been **removed** from this
PR, so the part of the baseline most exposed to that critique no longer ships.
What remains measured is the word-boundary truncation change, whose only
observed effect on the real corpus is dropping a partial trailing word.

Merging on this basis is a deliberate decision, not an oversight: waiting on
connectivity restoration solely to re-run a diff whose inputs have since
shrunk would delay a live privacy fix for a weaker version of a measurement
already taken.
