### PR TITLE
docs: execution receipt Phase 5 ACCEPTED, rollout closed

### DIFF
--- a/docs/design/execution-receipt/PHASE-4-RECONCILIATION.md
+++ b/docs/design/execution-receipt/PHASE-4-RECONCILIATION.md
@@ -1,7 +1,19 @@
 # Execution receipt, Phase 4 — post-deploy reconciliation
 
-**Status:** `MERGED_DEPLOYED_NOT_YET_ACTIVE`. **Not** accepted, and not active: no
-rail produces receipt state, so every artifact below is present and inert.
+**Status: ACCEPTED** — superseded 2026-08-24 by Phase 5 activation.
+
+Phase 4's artifacts are no longer inert: Phase 5 wired the rails, the epoch is
+`2026-08-24 20:32:58.705669+00`, and the snapshot authority, receipt lifecycle
+and chain-v2 machinery built here are all carrying production traffic. See
+`README.md` for the programme record and `PHASE-5-RAIL-INTEGRATION.md` §9 for
+the acceptance evidence.
+
+The original status line is kept below rather than edited, because it was
+accurate when written and the reasoning behind it is the point.
+
+> **Status (as recorded 2026-08-23):** `MERGED_DEPLOYED_NOT_YET_ACTIVE`. **Not**
+> accepted, and not active: no rail produces receipt state, so every artifact
+> below is present and inert.
 
 **Merged:** PR #380, squash `bd539ecf14e1643a24a655c3c86641b908192302`.
 **Deployed:** `GET /health` → `{"status":"ok","commit":"bd539ecf14e1"}` — the

--- a/docs/design/execution-receipt/PHASE-5-RAIL-INTEGRATION.md
+++ b/docs/design/execution-receipt/PHASE-5-RAIL-INTEGRATION.md
@@ -1,5 +1,19 @@
 # Execution receipt, Phase 5 — rail integration and activation
 
+**Status: ACCEPTED** — 2026-08-24 21:20 UTC.
+
+Activation merged as `967c9be4ad774bbd8f14c7585accc6667f523bab`. Held `UNDER
+OBSERVATION` from deploy until the two conditions in §9 were met by production
+evidence rather than by argument; both are now satisfied. §9 records what
+closed them.
+
+Everything below §9 is the record as written at the time, including the review
+rounds that failed and the residual risks that remain true. None of it has been
+revised in light of acceptance — the failures are the most useful part of the
+audit trail, and a residual does not stop being real because the phase shipped.
+
+---
+
 Phase 4 built every artifact and deliberately wired none of it, and its own
 reconciliation said the epoch was **not** structurally real: a transaction
 inserted after that deploy was byte-identical to one from April. This phase
@@ -364,3 +378,74 @@ state is ~10,000 transactions/day against a sweeper capacity of 100 rows per
     `{steps, errors}` while the response omits `errors` when empty, so a holder
     of the response cannot unambiguously reconstruct the hashed object. The
     capability path on that rail is unaffected.
+
+---
+
+## 9. Acceptance
+
+**ACCEPTED 2026-08-24 21:20 UTC.** Recorded after the two observation
+conditions were closed by production evidence.
+
+The phase was deliberately **not** accepted at deploy. Post-deploy
+reconciliation passed on every check that could be run, but two things could
+not be established from a five-minute window, and calling the phase accepted
+without them would have been the same overclaim this document criticises
+elsewhere.
+
+### Condition 1 — organic x402 with a valid receipt and v2 chain verification
+
+**Met: 5 of 5.** Every x402 row created after the epoch:
+
+| property | result |
+|---|---|
+| `receipt_status` | `complete` |
+| receipt metadata | `strale.execution.v1` / `RFC8785` / `sha256`, none missing |
+| `receipt_manifest_digest` | present and resolving to a stored snapshot |
+| `integrity_payload_version` | `2` |
+| `/v1/verify/:id` | `hash_valid: true` |
+
+**No x402 traffic was manufactured.** These are organic executions, observed
+rather than produced — which is why the condition was written as "wait" rather
+than "test".
+
+### Condition 2 — epoch stability across a normal deploy
+
+**Met by the #385 deploy**, which was an unrelated privacy fix
+(`657c911ba1436fcd0db9962b387a8b35b12f0d80`) and therefore a genuinely normal
+deploy rather than one staged to prove a point.
+
+- The epoch instant remained **exactly `2026-08-24 20:32:58.705669+00`**
+  through it. Block 0109 chooses the epoch once, guarded on the constraint's
+  existence, and this is the production evidence for what was previously only
+  proven locally.
+- Transactions created after that deploy record the **new** serving commit
+  `657c911ba143…`, while earlier post-epoch rows retain `967c9be4ad77…`. The
+  deploy commit is captured per transaction at INSERT (block 0110), so the two
+  populations coexist correctly rather than the later deploy rewriting history.
+
+### An operational observation, not a defect
+
+During verification, `/v1/verify/:id` twice returned a response with no
+`hash_valid` key, which reads at a glance like a verification failure. Both
+times the cause was **HTTP 429 rate limiting triggered by the verification
+probing itself** — a `{"error_code":"rate_limited"}` body, not a verdict. Both
+rows returned `hash_valid: true` when rechecked after cooldown.
+
+Worth writing down because it is a trap for anyone reconciling a future phase:
+a verification sweep that walks rows quickly will rate-limit itself, and the
+resulting absence of a verdict is easy to read as a negative one. Check the
+`error_code` before concluding anything from a missing `hash_valid`.
+
+### What acceptance does not close
+
+The residual risks in §8 remain true and are not retired by this acceptance.
+Two are worth restating because they will recur:
+
+- **The cutover-window artifact.** Two rows created after the new instance set
+  the epoch but while the previous deployment was still serving received the
+  new database defaults with no rail and no settle call; the sweeper resolved
+  them to `failed` / `unmapped_rail`, which is the designed outcome for a site
+  that records no rail. This will happen on every deploy of this shape, and it
+  is correct behaviour rather than something to fix.
+- **`a2a` and `mcp` remain unreachable rails** by deliberate design (see §5).
+

--- a/docs/design/execution-receipt/README.md
+++ b/docs/design/execution-receipt/README.md
@@ -1,0 +1,70 @@
+# Execution receipt — programme status
+
+**All phases ACCEPTED. Rollout closed 2026-08-24.**
+
+No further rollout work is required unless a new defect is found.
+
+| phase | scope | status | record |
+|---|---|---|---|
+| **1–3** | Current-truth audit, `strale.execution.v1` specification, RFC 8785 canonicalisation with committed conformance vectors | **ACCEPTED** | `PHASES-1-3-ACCEPTANCE.md`, `PHASE-1-CURRENT-TRUTH.md`, `PHASE-2-SPEC.md` |
+| **4** | Receipt authority, immutable manifest snapshots, chain v2 | **ACCEPTED** | `PHASE-4-RECONCILIATION.md` |
+| **5** | Rail integration and activation | **ACCEPTED** 2026-08-24 21:20 UTC | `PHASE-5-RAIL-INTEGRATION.md` §9, `PHASE-5-DEPLOY-IDENTITY-EVIDENCE.md` |
+
+## What exists now, in production
+
+A Strale-owned, independently recomputable commitment binding a specific
+request to the specific result Strale returned. Every transaction created after
+the epoch carries receipt state; every completed receipt records the
+implementation that produced it; and the tamper-evident chain commits to the
+receipt digest.
+
+- **Epoch:** `2026-08-24 20:32:58.705669+00`, chosen once and held in the
+  definition of `transactions_post_epoch_has_receipt`. There is no second copy
+  to drift from it, and it survived a subsequent normal deploy unchanged.
+- **No backfill, ever.** Pre-epoch rows report `legacy_unavailable`. Their
+  manifest digest and deploy commit are not recoverable at any price, and a
+  receipt assembled from surviving content plus reconstructed identity would
+  assert something nobody measured.
+- **Activation is structural, not conventional.** `receipt_status` defaults to
+  `pending`, so a rail nobody wired produces a visible pending row the sweeper
+  reports — not a silent NULL indistinguishable from a pre-epoch row.
+
+## What the programme is not
+
+Receipts are produced and chained. **Nothing serves them yet** — no endpoint
+exposes a receipt, and `describeReceiptState`'s `redacted` arm is correct
+against a surface that does not exist. Exposing them is separate work, and
+this record should not be read as claiming a customer-facing verification
+product.
+
+## The most useful parts of the record
+
+Each phase document keeps its failures rather than summarising past them. If
+you read only three things:
+
+1. **Phase 5 §2** — a migration that defaulted one column and not its
+   companion, which would have made *every* INSERT into `transactions` violate
+   a `NOT VALID` CHECK. The migration applied cleanly; the platform would
+   simply have stopped being able to write. 93 integration tests caught it
+   while the entire unit suite stayed green.
+2. **Phase 4's round-three finding, and its recurrence in Phase 5** — one
+   un-updatable row halting the tamper-evident chain for every transaction,
+   permanently. Two independent causes, one shape. The fix belongs at the
+   blast-radius site, not at either cause.
+3. **Phase 5 §6a** — a fail-before fixture too weak to catch the defect it
+   named, and a fix that read as correct, rolled back correctly, and still
+   failed at commit. Both were found by review, not by the suite.
+
+## Related work shipped alongside
+
+Two privacy fixes were found during receipt review and deliberately kept out of
+the receipt PRs, because they were pre-existing and independent:
+
+- **#383** — `sanitizeFailureReason`'s canned branches returned a name prefix
+  captured before any redaction ran, leaking hostnames and making the function
+  non-idempotent in two ways. Idempotence matters here precisely because
+  `settle.ts` sanitises when building a receipt.
+- **#384** — `audit_trail.error_message` was written raw and served verbatim
+  beside a carefully sanitised `error`, on the same response.
+- **#385** — the A2A rail served `transactions.error` raw; that file did not
+  import the sanitiser at all.


### PR DESCRIPTION
Records Phase 5 as **ACCEPTED** and closes the execution-receipt rollout. Documentation only — no code changes.

### Why it was not accepted at deploy

Phase 5 was held `UNDER OBSERVATION` even though post-deploy reconciliation passed on every check that could be run, because two things could not be established from a five-minute window. Both are now closed by production evidence.

**Condition 1 — organic x402 with a valid receipt and v2 chain verification: 5 of 5.** Every post-epoch x402 row carries `receipt_status=complete`, full `strale.execution.v1` / `RFC8785` / `sha256` metadata, a manifest digest resolving to a stored snapshot, `integrity_payload_version=2`, and `hash_valid=true` through the deployed verifier. **No x402 traffic was manufactured** — these were observed, which is why the condition was written as *wait* rather than *test*.

**Condition 2 — epoch stability across a normal deploy.** Proven by the #385 deploy, which was an unrelated privacy fix and therefore a genuinely normal deploy rather than one staged to prove the point. The epoch held at exactly `2026-08-24 20:32:58.705669+00`, and rows created after it record the new serving commit `657c911ba143…` while earlier post-epoch rows retain `967c9be4ad77…`.

### One operational observation, recorded as such

`/v1/verify/:id` twice returned a body with **no `hash_valid` key**, which reads at a glance like a verification failure. Both times it was **HTTP 429 from the verification probing itself**. Both rows returned `true` after cooldown. Written down because a future reconciliation sweep will rate-limit itself the same way — check `error_code` before concluding anything from a missing verdict.

### The audit trail is preserved

Nothing earlier is rewritten. The failed review rounds stay. The residual risks stay — **a residual does not stop being real because the phase shipped**. Phase 4's superseded status line is quoted rather than edited, because it was accurate when written and the reasoning behind it is the point.

### Programme record

New `README.md` states all phases ACCEPTED, what exists in production, and what this deliberately **is not**: receipts are produced and chained, but nothing serves them yet, so it should not be read as a customer-facing verification product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)