### PR TITLE
docs(remediation): rebaseline the governance record against current main

### DIFF
--- a/docs/remediation/CURRENT-STATE.md
+++ b/docs/remediation/CURRENT-STATE.md
@@ -1,6 +1,65 @@
 # Remediation Program — Current State
 
-_Last updated: 2026-08-23 (WP10 session)_
+_Last updated: 2026-08-25 (governance rebaseline)_
+
+## Governance rebaseline, 2026-08-25
+
+`PACKAGE-GRAPH.yaml` had drifted far enough to mislead: WP3–WP9 and WP11 still
+read `PLANNED` long after acceptance, WP17 was absent entirely, WP12 was not
+marked blocked, and WP7's exit list still asked for a unique index the package
+file itself records as impossible. The graph is machine-readable, so a graph
+that disagrees with its own package files is worse than none.
+
+**Authority is now stated explicitly: the per-package YAML files are the
+source of truth for status, and the graph is a view reconciled against them.**
+
+### One finding worth more than the tidy-up
+
+**WP8's acceptance was written and lost.** Its status read `REMEDIATED` — not a
+value in this programme's own legend, used exactly once, unexplained. It was
+not deliberate. Commit `f2e76f4` ("docs(WP8): accepted, with production
+reconciliation", 2026-08-22) set it to `ACCEPTED` and recorded a real
+reconciliation: constraint present and validated in production, census zero,
+both incident capabilities correctly withdrawn, and the constraint proved to
+**bite** — a half-quarantine write inside a rolled-back transaction was
+refused, because existence is not enforcement.
+
+**That commit never reached `main`.** It exists only on
+`remediation/wp9-artifacts`, unmerged. So for three days the programme record
+said a package was in an undefined state when it had in fact been accepted with
+evidence.
+
+The mechanism is worth naming, because it will recur: squash merges make a
+merged branch look permanently "ahead", so a branch that still shows unmerged
+commits reads as normal. Most of that branch's content *did* land via PR #360;
+this one docs commit did not, and nothing distinguished it.
+
+**Two documents on that branch are also still unmerged** and were deliberately
+not swept into this PR, because they have not been reviewed here:
+`docs/remediation/DECISION-BRIEFS.md` and
+`docs/remediation/PUBLIC-COPY-CORRECTION.md`. They need a decision of their
+own — merge, supersede, or discard.
+
+### Also reconciled
+
+- **WP7** — the impossible `prev_hash uniqueness` exit criterion is formally
+  superseded in the graph, with the reason preserved rather than deleted. The
+  package file was already correct; only the graph asked for it.
+- **VERIFY-P3** — no longer an undifferentiated `PARTIAL`. Three of its four
+  deferred portions are closed (settlement by WP5, process-kill by WP10's
+  measured 1.0h restart interval, plus the original read-only work); only
+  cadence remains, and that is WP10's dated gate rather than unstarted work.
+- **WP9's `transaction_id` linkage** — classified as a **residual, not an
+  acceptance blocker**, determined by reading the package's six exit
+  conditions, none of which mention it.
+- **Adjacent workstreams recorded** in the graph — the execution-receipt
+  programme, the production-authorization incident, daily-run reform, trusted
+  publishing / MCP trust / post-publish smoke test, and the three privacy PRs —
+  because several of them narrowed packages above and a graph that omits them
+  overstates the remaining work.
+
+---
+
 
 - **Current package:** WP10 — **MERGED, DEPLOYED, UNDER OBSERVATION**.
   Squash `ce5e63f` (PR #376), verified live on `ce5e63f09186`. Immediate

--- a/docs/remediation/PACKAGE-GRAPH.yaml
+++ b/docs/remediation/PACKAGE-GRAPH.yaml
@@ -4,7 +4,19 @@
 
 meta:
   audited_baseline: "482ef93"
-  current_main: "e825a05"
+  current_main: "82c59e0"          # rebaselined 2026-08-25
+  rebaselined:
+    date: "2026-08-25"
+    why: >
+      Statuses here had drifted badly enough to be misleading: WP3-WP9 and WP11
+      still read PLANNED long after they were accepted, WP17 was missing
+      entirely, and WP7's exit list still asked for something the package itself
+      had already recorded as impossible. A graph that disagrees with its own
+      package files is worse than no graph, because it is the machine-readable
+      one.
+    authority: >
+      Per-package YAML files are the authority for status. This file is a view
+      over them and is reconciled against them, never the other way round.
   m0_status: ACCEPTED
   checkin_a_triggered: false
   fable_acceptance_required:
@@ -56,7 +68,7 @@ packages:
 
   WP3:
     title: Durable wallet reservations + reconciler
-    status: PLANNED
+    status: ACCEPTED
     depends_on: [WP2]
     risks: [CR-01, N1]
     inherited_exit_conditions:
@@ -66,7 +78,7 @@ packages:
 
   WP4:
     title: Capability Runner + canonical ExecutionOutcome/OutputAssessment
-    status: PLANNED
+    status: ACCEPTED
     depends_on: [WP2]
     risks: [CR-02]
     review: {codex: required, fable: required}
@@ -74,7 +86,7 @@ packages:
 
   WP5:
     title: x402 durable payment state + recovery
-    status: PLANNED
+    status: ACCEPTED
     depends_on: [WP3, WP4]
     risks: [CR-01]
     review: {codex: required, fable: required}
@@ -82,15 +94,30 @@ packages:
 
   WP7:
     title: Audit finality (reframed threat model — see C2)
-    status: PLANNED
+    status: ACCEPTED
     depends_on: [WP4]
     risks: [CR-04]
     review: {codex: required, fable: required}
-    exit: [terminal-only admission incl. free-tier, consistent head selection, prev_hash uniqueness, fail-closed genesis, branch-topology check]
+    exit: [terminal-only admission incl. free-tier, consistent head selection,
+           single-parent CHECKED not enforced, fail-closed genesis, branch-topology check]
+    superseded_exit_criterion:
+      was: "prev_hash uniqueness"
+      superseded: "2026-08-25"
+      why: >
+        A unique index over prev_hash CANNOT be added: it would abort boot on
+        the existing forks. One parent has 150,719 children and the chain has
+        not been a chain since 2026-05-04. History is deliberately not
+        rewritten, because recomputing 863,946 hashes would erase the evidence
+        that the break happened — the opposite of what an audit chain is for.
+        Block 0097 adds a NON-unique index and detectChainForks() checks
+        single-parent instead, scoped to rows after the fix so the historical
+        break does not drown the signal that a NEW fork appeared.
+        The package file (packages/WP7.yaml) already recorded this correctly;
+        only this graph still asked for the impossible thing.
 
   WP6:
     title: Idempotency & replay (fingerprint + capability binding)
-    status: PLANNED
+    status: ACCEPTED
     depends_on: [WP4]
     risks: [CR-03, N4]
     review: {codex: required, fable: required}
@@ -98,7 +125,18 @@ packages:
 
   WP8:
     title: Policy convergence (one eligibility authority)
-    status: PLANNED
+    status: ACCEPTED
+    status_note: >
+      The package file read REMEDIATED, which is not a value in this programme's
+      own status legend and was used exactly once. It was NOT deliberate: commit
+      f2e76f4 ("docs(WP8): accepted, with production reconciliation",
+      2026-08-22) changed it to ACCEPTED and recorded the reconciliation —
+      constraint present and validated in production, census zero, both incident
+      capabilities correctly withdrawn, and the constraint proved to BITE by a
+      half-quarantine write inside a rolled-back transaction being refused.
+      That commit never reached main. It exists only on the unmerged branch
+      remediation/wp9-artifacts, so the acceptance was written and then lost.
+      Normalised here on that evidence rather than on tidiness.
     depends_on: [WP4]
     risks: [CR-05, N5, N6]
     review: {codex: required, fable: required}
@@ -106,7 +144,17 @@ packages:
 
   WP9:
     title: Capability Invocation Facts
-    status: PLANNED
+    status: MERGED_DEPLOYED_UNDER_OBSERVATION
+    observation_exit: >
+      The first solution_step fact whose slug has no direct transaction traffic
+      becoming quarantinable. Condition, not a date.
+    transaction_id_linkage: >
+      RESIDUAL, NOT AN ACCEPTANCE BLOCKER. Checked against the package's own six
+      exit conditions, none of which mention it: the column is null for 100% of
+      writes and its index is dead, and the package file already records this as
+      deliberately out of scope ("a one-line-per-site change"). It is a cheap
+      enhancement to fold into the next touch of those sites, and it does not
+      hold acceptance.
     depends_on: [WP4, WP8]
     risks: [CR-06]
     review: {codex: required, fable: optional}
@@ -114,7 +162,7 @@ packages:
 
   WP11:
     title: Account / trial / Stripe lifecycle
-    status: PLANNED
+    status: ACCEPTED
     depends_on: [WP2]
     risks: [CR-09, CR-10]
     review: {codex: required, fable: required}
@@ -122,7 +170,11 @@ packages:
 
   WP12:
     title: Network/resource safety substrate
-    status: PLANNED
+    status: BLOCKED
+    blocked_by: VERIFY-IP
+    blocked_note: >
+      Reading the wrong X-Forwarded-For entry breaks every IP-keyed rate limit
+      at once. Confirm the Railway hop count first; do not infer it.
     depends_on: [WP0]
     risks: [CR-11, CR-12, CR-19]
     review: {codex: required, fable: required}
@@ -131,6 +183,7 @@ packages:
   WP10:
     title: Durable Job Coordinator
     status: MERGED_DEPLOYED_UNDER_OBSERVATION
+    acceptance_gate: "2026-08-30 — seven-day cadence measurement. Do not manufacture a deploy to satisfy it."
     depends_on: [WP1]
     risks: [CR-08]
     review: {codex: required, fable: optional}
@@ -138,7 +191,16 @@ packages:
 
   WP14:
     title: Legal & Data Policy Authority
-    status: PLANNED
+    status: NOT_STARTED
+    blocked_by: VERIFY-LEGAL
+    blocked_note: "Founder-only under DEC-20260815-A. Not a Claude-closable gate."
+    partially_superseded_by: [privacy-prs-383-384-385]
+    superseded_note: >
+      sanitizeFailureReason is now a single, tested, mutation-proven authority
+      for customer-visible error text on every rail — a control this package
+      would otherwise have had to build. The legal-text rewrites, the Dilisense
+      role and DPA, real assent, and WP0's deferred publication-approval
+      artifact all remain.
     depends_on: [WP0]
     risks: [CR-14, CR-15, CR-16, CR-17, CR-18]
     review: {codex: required, fable: required}
@@ -149,7 +211,11 @@ packages:
 
   WP16:
     title: Discovery & Retrieval Authority
-    status: PLANNED
+    status: NOT_STARTED
+    sequencing_note: >
+      Held deliberately as of 2026-08-25: the remaining cheap, unblocked
+      defensive work finishes before the programme moves from remediation into
+      forward-looking product.
     depends_on: [WP8]
     subpackages:
       WP16.0: {title: Discovery containment, start: immediate_parallel}
@@ -163,14 +229,47 @@ packages:
 
   WP13:
     title: Supply chain
-    status: PLANNED
+    status: NOT_STARTED
+    partially_superseded_by: [trusted-publishing, mcp-trust-fix, post-publish-smoke-test]
+    superseded_note: >
+      The publish-integrity half is closed: npm trusted publishing (PR #363,
+      #367) removed the long-lived token, PR #369 fixed MCP trust data that had
+      been silently empty for every public install, and PR #370 made a
+      production contract smoke test mandatory after every publish. What
+      remains is the dependency half, and VERIFY-DEP's reachability triage is
+      the gate on it.
     depends_on: [VERIFY-DEP]
     risks: [CR-13, N8]
     review: {codex: required, fable: optional}
 
+  WP17:
+    title: Immutable capability-state change ledger
+    status: SPECIFIED_NOT_STARTED
+    depends_on: [WP8]
+    risks: [CR-05]
+    note: >
+      Absent from this graph until the 2026-08-25 rebaseline; it exists as
+      packages/WP17.yaml and was spawned by WP8.
+    narrowed_by_execution_receipts: >
+      The DETECTION half is delivered and was not asked for. Manifest snapshots
+      make the declaration in force at execution time immutable and
+      recomputable, so two executions carrying different manifest digests now
+      PROVE the declaration changed between them. What remains is ATTRIBUTION:
+      the digest establishes THAT a capability's state changed, never WHO
+      changed it or on what authority — which is the question the 2026-08-21
+      incident could not answer at all.
+
   WP15:
     title: CI/runtime hygiene
-    status: PLANNED
+    status: PARTIALLY_SUPERSEDED
+    superseded_by: production-authorization-incident-2026-08-22
+    superseded_note: >
+      guard-production-write-access.mjs, guard-worktree-isolation.mjs and the
+      test-runner alerting isolation were all delivered by that workstream
+      rather than by this package. What remains is WP1's inherited residual:
+      the integration lane should create and drop its own uniquely-named
+      database, so disposability holds by construction rather than by
+      row-count heuristics.
     depends_on: [WP1]
     risks: [CR-20, N7]
     inherited_exit_conditions:
@@ -183,7 +282,42 @@ verification_gates:
   VERIFY-IP:    {status: OPEN, blocks: [WP12], note: "leftmost XFF confirmed spoofable; confirm Railway hop count"}
   VERIFY-DEP:   {status: PARTIAL, blocks: [WP13], note: "1crit/14high/7mod/2low counted; reachability triage unrun"}
   VERIFY-LEGAL: {status: OPEN, blocks: [WP14], note: "Dilisense role, DPA, assent evidence"}
-  VERIFY-P3:    {status: PARTIAL, note: "prod read-only done for index/orphans/delisting/free-x402/publication; process-kill+cadence+settlement deferred to WP1-5"}
+  VERIFY-P3:
+    status: PARTIAL
+    complete:
+      - "index / orphans / delisting / free-x402 / publication — production read-only, done at audit time"
+      - "settlement — closed by WP5 (durable x402 payment state and its reconciler), ACCEPTED"
+      - "process-kill — closed by WP10, which MEASURED the production restart interval at a 1.0h median rather than assuming one"
+    outstanding:
+      - "cadence — the measurement exists but its acceptance is WP10's seven-day gate, due 2026-08-30"
+    note: >
+      Previously an undifferentiated PARTIAL, which read as though none of it
+      had moved. Three of the four deferred portions are in fact closed, and
+      the fourth is a dated gate rather than unstarted work.
+
+# Workstreams outside the master plan that changed its assumptions. Recorded
+# here because several of them narrowed or partly closed packages above, and a
+# graph that omits them overstates the remaining work.
+adjacent_workstreams:
+  execution-receipt-programme:
+    status: ACCEPTED
+    closed: "2026-08-25"
+    record: docs/design/execution-receipt/README.md
+    effect: "Narrows WP17 to attribution only. Additive to WP7 rather than superseding it."
+  production-authorization-incident:
+    status: ACCEPTED
+    date: "2026-08-22"
+    effect: "Delivers most of WP15."
+  daily-run-reform:
+    status: ACCEPTED
+    date: "2026-08-22"
+  trusted-publishing + mcp-trust-fix + post-publish-smoke-test:
+    status: SHIPPED
+    effect: "Closes WP13's publish-integrity half."
+  privacy-prs-383-384-385:
+    status: SHIPPED
+    date: "2026-08-24"
+    effect: "Establishes one sanitisation authority; partly serves WP14."
 
 execution_order:
   [M0, WP0, WP1, WP2, WP3, WP4, WP5, WP7, WP6, WP8, WP9, WP11, WP12, WP10, WP14, WP16, WP13, WP15]

--- a/docs/remediation/REMEDIATION-LEDGER.md
+++ b/docs/remediation/REMEDIATION-LEDGER.md
@@ -4,7 +4,13 @@ Durable source of truth for the autonomous remediation program
 (governing doc: `STRALE-AUTONOMOUS-REMEDIATION-ORCHESTRATOR.md`, v1.0, 2026-08-20).
 Audited baseline: `482ef93341df1fe676bd6f9de4688be85609394b`.
 
-Status values: PLANNED · IN_PROGRESS · REVIEW · ACCEPTED · BLOCKED
+Status values: PLANNED · IN_PROGRESS · REVIEW · ACCEPTED · BLOCKED ·
+MERGED_DEPLOYED_UNDER_OBSERVATION · PARTIALLY_SUPERSEDED · NOT_STARTED ·
+SPECIFIED_NOT_STARTED
+
+_The last four were in use before they were in this legend. Added 2026-08-25;
+`REMEDIATED` was also in use, once, and was an unintended value — see
+`packages/WP8.yaml`._
 
 Companion files:
 - `CURRENT-STATE.md` — what a fresh session needs to resume

--- a/docs/remediation/packages/WP8.yaml
+++ b/docs/remediation/packages/WP8.yaml
@@ -1,6 +1,22 @@
 package: WP8
 title: Policy convergence — one eligibility authority
-status: REMEDIATED
+status: ACCEPTED
+
+# Was REMEDIATED, which is not a value in this programme's status legend
+# (PLANNED / IN_PROGRESS / REVIEW / ACCEPTED / BLOCKED) and was used exactly
+# once, here, with no explanation anywhere in the file.
+#
+# It was not deliberate. Commit f2e76f4 -- "docs(WP8): accepted, with
+# production reconciliation", 2026-08-22 -- changed this line to ACCEPTED and
+# recorded the reconciliation: the constraint present and validated in
+# production, census zero, both incident capabilities correctly withdrawn, and
+# the constraint proved to BITE by a half-quarantine write inside a rolled-back
+# transaction being refused. Existence is not enforcement, and that commit
+# checked the difference.
+#
+# That commit never reached main. It exists only on remediation/wp9-artifacts,
+# an unmerged branch, so the acceptance was written and then lost. Normalised
+# 2026-08-25 on that evidence rather than for tidiness.
 depends_on: [WP4]
 risks: [CR-05, N5, N6]
 

--- a/docs/remediation/packages/WP9.yaml
+++ b/docs/remediation/packages/WP9.yaml
@@ -77,6 +77,15 @@ design:
     else. It carries no customer content, so it is not subject to the 90-day
     content redaction and can be retained on its own schedule.
 
+# transaction_id linkage: RESIDUAL, NOT AN ACCEPTANCE BLOCKER.
+#
+# Determined 2026-08-25 by reading the six exit conditions below rather than by
+# judgement: none of them mentions it. The column is null for 100% of writes
+# and its index is dead, and this file already records that as deliberately out
+# of scope -- "a one-line-per-site change". It is cheap enough to fold into the
+# next touch of those sites and it does not hold acceptance. The observation
+# gate is the bundle-only quarantine signal, which is a different thing.
+
 exit_conditions:
   - one immutable invocation fact per capability execution, including solution sub-calls
   - the quality floor consumes facts rather than joining billing rows


### PR DESCRIPTION
Documentation and metadata only. **No production code changes** — the diff
touches five files, all under `docs/remediation/`.

## Why

`PACKAGE-GRAPH.yaml` had drifted far enough to mislead. WP3–WP9 and WP11 still
read `PLANNED` long after they were accepted, **WP17 was absent from the graph
entirely**, WP12 was not marked blocked, and WP7's exit list still asked for a
unique index the package file itself records as impossible to add. It is the
machine-readable artifact of the programme, so a graph that disagrees with its
own package files is worse than no graph.

Authority is now stated explicitly: **the per-package YAML files are the source
of truth for status, and the graph is a view reconciled against them.**

## One finding worth more than the tidy-up

The instruction was to investigate whether WP8's `REMEDIATED` status was
deliberate, and not to silently normalise it if the evidence did not support
that. It was **not** deliberate, and the evidence is worse than a typo.

`REMEDIATED` is not a value in this programme's own status legend and was used
exactly once, unexplained. Commit `f2e76f4` — *"docs(WP8): accepted, with
production reconciliation"*, 2026-08-22 — set it to `ACCEPTED` and recorded a
real reconciliation: constraint present and validated in production, census
zero, both incident capabilities correctly withdrawn, and the constraint proved
to **bite**, by a half-quarantine write inside a rolled-back transaction being
refused. Existence is not enforcement, and that commit checked the difference.

**That commit never reached `main`.**

```
git merge-base --is-ancestor f2e76f4 origin/main   # → not an ancestor
git branch -a --contains f2e76f4                   # → remediation/wp9-artifacts only
```

So the acceptance was written and then lost. For three days the programme
record said a package was in an undefined state when it had in fact been
accepted with production evidence. Normalised here on that evidence, not for
tidiness.

The mechanism is worth naming because it will recur: squash merges make a
merged branch look permanently "ahead", so a branch still showing unmerged
commits reads as normal. Most of that branch's content *did* land via #360;
this one docs commit did not, and nothing distinguished it.

### Two documents are still stranded, and are deliberately NOT in this PR

`docs/remediation/DECISION-BRIEFS.md` and
`docs/remediation/PUBLIC-COPY-CORRECTION.md` are also on
`remediation/wp9-artifacts` and not on `main`. They have not been reviewed
here, so sweeping them in under a rebaseline PR would be exactly the kind of
quiet scope-widening this PR is trying to make visible. **They need a decision
of their own: merge, supersede, or discard.**

## Also reconciled

| item | before | after |
|---|---|---|
| WP3–WP7, WP11 | `PLANNED` | `ACCEPTED` |
| WP8 | `REMEDIATED` | `ACCEPTED` + the stranded-commit evidence |
| WP9 | `PLANNED` | `MERGED_DEPLOYED_UNDER_OBSERVATION` |
| WP12 | `PLANNED` | `BLOCKED` on VERIFY-IP |
| WP13 | `PLANNED` | `NOT_STARTED`, publish-integrity half recorded as closed |
| WP14 | `PLANNED` | `NOT_STARTED`, `BLOCKED` on founder-only VERIFY-LEGAL |
| WP15 | `PLANNED` | `PARTIALLY_SUPERSEDED` by the production-authorization work |
| WP16 | `PLANNED` | `NOT_STARTED` + the deliberate sequencing hold |
| WP17 | *absent* | `SPECIFIED_NOT_STARTED`, narrowed to attribution |

- **WP7's impossible exit criterion** is formally superseded, with the reason
  preserved rather than deleted: one parent has 150,719 children, and
  recomputing 863,946 hashes to make a unique index applyable would erase the
  evidence that the break happened — the opposite of what an audit chain is
  for. The package file was already correct; only the graph asked for it.
- **VERIFY-P3** is no longer an undifferentiated `PARTIAL`, which read as
  though none of it had moved. Three of its four deferred portions are closed
  (settlement by WP5; process-kill by WP10, which *measured* the production
  restart interval rather than assuming one; plus the original read-only work).
  Only cadence remains, and that is WP10's dated gate, not unstarted work.
- **WP9's `transaction_id` linkage** is classified as a **residual, not an
  acceptance blocker** — determined by reading the package's six exit
  conditions, none of which mention it. The column is null for 100% of writes
  and its index is dead; the package file already scoped it out as "a
  one-line-per-site change".
- **The ledger's status legend** now lists the four statuses that were in use
  before they were in the legend.
- **Adjacent workstreams recorded** — the execution-receipt programme, the
  production-authorization incident, daily-run reform, trusted publishing /
  MCP trust / post-publish smoke test, and the three privacy PRs. Several of
  them narrowed packages above, and a graph that omits them overstates the
  remaining work.

## Preserved deliberately

- WP10's **2026-08-30** acceptance gate, with the note not to manufacture a
  deploy to satisfy it.
- WP12 **blocked** until VERIFY-IP is actually resolved — the hop count is not
  inferred here.
- WP14 blocked on founder-only VERIFY-LEGAL under DEC-20260815-A.
- Every historical FAIL/PASS and every residual that remains true.

## Verification

- `PACKAGE-GRAPH.yaml` parses under `yaml.safe_load`; 19 packages, each status
  now agreeing with its package file.
- Diff confined to `docs/remediation/` — checked, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
