### PR TITLE
fix(copy): remove the withdrawn integrity claims from the API and repo surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Trust and quality infrastructure for AI agents.
 
 Strale is a capability marketplace for AI agents. Agents call `strale.do()` at runtime to access verified capabilities — company registry lookups, compliance checks, financial validation, Web3 security, and more — plus bundled solutions for multi-step workflows like full KYB checks or company due diligence. No hardcoded integrations or credential management.
 
-Every capability is continuously tested against real upstreams, and every call returns an audit record with cryptographic chain hashing. You get observability into what your agent is actually doing.
+Every capability is continuously tested against real upstreams, and every call returns an audit record. You get observability into what your agent is actually doing.
 
 ## Quick Start: MCP Server
 

--- a/apps/api/src/lib/ceo-brief-lint.ts
+++ b/apps/api/src/lib/ceo-brief-lint.ts
@@ -190,7 +190,9 @@ export const SETTLED_MATTERS: Array<{ id: string; re: RegExp; settledBy: string 
     settledBy:
       "the founder approved the correction itself — unsupported tamper-evidence and " +
       "downstream-regulatory-verification claims are removed, with no replacement " +
-      "integrity claim until independently substantiated. The operative surface plan lives on the remediation branch, not yet on main. It supersedes " +
+      "integrity claim until independently substantiated. The operative surface plan is " +
+      "docs/remediation/PUBLIC-COPY-CORRECTION.md, applied 2026-08-25 except the " +
+      "founder-gated npm publish. It supersedes " +
       "the withdrawn hedged rewording, so 'which wording should we publish' is not the " +
       "open question; removal is what was approved",
   },

--- a/apps/api/src/lib/withdrawn-integrity-claims.test.ts
+++ b/apps/api/src/lib/withdrawn-integrity-claims.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The integrity claims Petter approved removing stay removed.
+ *
+ * DQ-18 item 2: unsupported tamper-evidence and downstream-regulatory-
+ * verification claims come off every public surface, with **no replacement
+ * integrity claim** until one is independently substantiated. The reviewed
+ * surface list is `docs/remediation/PUBLIC-COPY-CORRECTION.md`.
+ *
+ * Why a test and not a note: LESSONS.md F6 (stale or unsupported public claim)
+ * is at four incidents with the investigation due, and its stated question is
+ * "which public claims have no automated tie to the fact they assert". This is
+ * that tie for the withdrawn vocabulary — the claims cannot come back by
+ * someone re-typing a sentence that reads well.
+ *
+ * Scope, deliberately narrow: this asserts the *absence* of withdrawn wording
+ * on the surfaces that serve it. It does not attempt to judge new wording —
+ * inventing a replacement claim is founder-gated (CHARTER.md § Act first,
+ * "narrowing only"), so a guard that approved replacements would be claiming
+ * an authority this side does not have.
+ *
+ * F5 note: the empty-input failure mode this file has to avoid is a path that
+ * silently stops existing, leaving the scan clean because it read nothing. Each
+ * surface is therefore asserted to exist and to be non-empty before it is
+ * scanned, and the phrase list is asserted non-empty.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../../..");
+
+/** Surfaces that serve public prose. Paths are repo-relative. */
+const SURFACES = [
+  "apps/api/src/routes/llms-txt.ts",
+  "apps/api/src/routes/mcp-server-card.ts",
+  "apps/api/src/routes/a2a.ts",
+  "apps/api/src/openapi.ts",
+  "apps/api/src/web3-assurance/methodology.ts",
+  "packages/mcp-server/src/tools.ts",
+  "README.md",
+  "docs/x402-listing.md",
+  "docs/dpia/sanctions-and-pep-check.md",
+  "docs/dpia/adverse-media-check.md",
+];
+
+/**
+ * The withdrawn vocabulary, as regexes over the served text.
+ *
+ * Each entry is a phrasing we actually published, not a guess at the space of
+ * things someone might write — the same principle `populations.ts` applies to
+ * monitor signatures. A phrasing nobody has produced is unguarded, and that
+ * limit is real rather than hedged away.
+ */
+const WITHDRAWN: { pattern: RegExp; why: string }[] = [
+  { pattern: /tamper[-\s]?evident/i, why: "not defensible for ordering or deletion (2026-05-04 → 2026-08-21)" },
+  { pattern: /cryptographic(ally)?[-\s]chain[-\s]?hash/i, why: "withdrawn integrity claim" },
+  { pattern: /chain[-\s]?hashed audit record/i, why: "withdrawn integrity claim" },
+  { pattern: /audit record with cryptographic chain hashing/i, why: "withdrawn integrity claim" },
+  { pattern: /downstream regulatory verification/i, why: "asserts fitness for regulatory use, not a mechanism" },
+  { pattern: /backward to genesis/i, why: "the verifier is depth-capped and always truncates" },
+  { pattern: /replay[_\s]capability/i, why: "impossible after the 90-day content redaction" },
+  { pattern: /\bimmutable transaction record\b/i, why: "records are redacted at 90 days by design" },
+];
+
+describe("withdrawn integrity claims stay withdrawn", () => {
+  it("has a non-empty surface list and phrase list", () => {
+    expect(SURFACES.length).toBeGreaterThan(0);
+    expect(WITHDRAWN.length).toBeGreaterThan(0);
+  });
+
+  it.each(SURFACES)("%s exists and is readable", (rel) => {
+    const abs = resolve(repoRoot, rel);
+    expect(existsSync(abs), `${rel} is missing — the scan below would pass by reading nothing`).toBe(true);
+    expect(readFileSync(abs, "utf8").length).toBeGreaterThan(0);
+  });
+
+  it.each(SURFACES)("%s carries no withdrawn claim", (rel) => {
+    const text = readFileSync(resolve(repoRoot, rel), "utf8");
+    const hits = WITHDRAWN.filter((w) => w.pattern.test(text))
+      .map((w) => `${w.pattern} — ${w.why}`);
+    expect(hits, `${rel} re-introduced a withdrawn integrity claim:\n  ${hits.join("\n  ")}`).toEqual([]);
+  });
+});

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -26,7 +26,7 @@ export const openApiSpec = {
     title: "Strale API",
     version: "1.0.0",
     description:
-      "The trust layer for AI agents — 250+ independently tested data capabilities across 27 countries. Execute capabilities via REST, MCP, A2A, or x402 micropayments. Every call returns an audit record with cryptographic chain hashing.",
+      "The trust layer for AI agents — 250+ independently tested data capabilities across 27 countries. Execute capabilities via REST, MCP, A2A, or x402 micropayments. Every call returns an audit record.",
     contact: { name: "Strale", email: "hello@strale.io", url: "https://strale.dev" },
     termsOfService: "https://strale.dev/terms",
     license: { name: "MIT", url: "https://opensource.org/licenses/MIT" },
@@ -767,7 +767,7 @@ export const openApiSpec = {
       get: {
         tags: ["trust"],
         summary: "Verify transaction integrity",
-        description: "Verify the integrity of a transaction's audit trail by recomputing its SHA-256 hash and walking the hash chain backward to genesis. Public, no auth required.",
+        description: "Recompute a transaction's SHA-256 content hash and walk the recorded chain backward from it, up to a bounded depth. Public, no auth required.",
         parameters: [
           { name: "transactionId", in: "path" as const, required: true, schema: { type: "string" as const, format: "uuid" } },
           { name: "depth", in: "query" as const, required: false, schema: { type: "integer" as const, minimum: 1, maximum: 50, default: 20 }, description: "Max chain depth to verify (default 20, max 50). F-A-012: values >50 are clamped to 50." },

--- a/apps/api/src/routes/a2a.ts
+++ b/apps/api/src/routes/a2a.ts
@@ -327,7 +327,7 @@ export async function buildAgentCard(): Promise<{ card: object; etag: string }> 
   const card = {
     name: "Strale",
     description:
-      `Commercial capability marketplace for AI agents. ${capCount}+ capabilities with transparent per-call pricing. Available via API key (EUR wallet) or x402 pay-per-use (USDC on Base). Compliance, KYC/KYB, payment validation, company data across ${countryCount} countries, regulatory intelligence, and developer tools. Every call returns an audit record with cryptographic chain hashing.`,
+      `Commercial capability marketplace for AI agents. ${capCount}+ capabilities with transparent per-call pricing. Available via API key (EUR wallet) or x402 pay-per-use (USDC on Base). Compliance, KYC/KYB, payment validation, company data across ${countryCount} countries, regulatory intelligence, and developer tools. Every call returns an audit record.`,
     url: `${BASE_URL}/a2a`,
     version: "1.0.0",
     documentationUrl: "https://strale.dev/docs",

--- a/apps/api/src/routes/audit.ts
+++ b/apps/api/src/routes/audit.ts
@@ -617,7 +617,7 @@ auditRoute.get("/:transactionId", async (c) => {
             "This transaction predates Strale's cryptographic audit chain (introduced in migration 0047, finalised by 0052). " +
             "The compliance record above is reconstructed from execution metadata but is NOT hash-protected; " +
             "/v1/verify will return hash_valid: null for this transaction by design. " +
-            "Transactions executed after the chain was finalised carry hash_valid: true | false on /v1/verify and are independently verifiable.",
+            "Transactions executed after the chain was finalised carry hash_valid: true | false on /v1/verify.",
         }
       : {}),
   });

--- a/apps/api/src/routes/llms-txt.ts
+++ b/apps/api/src/routes/llms-txt.ts
@@ -31,7 +31,7 @@ function renderLlmsTxt(facts: Awaited<ReturnType<typeof computePlatformFacts>>):
 
 > One API call. Verified data your agent can trust. ${capCount}+ independently tested data capabilities across ${countryCount} countries.
 
-Strale provides business data capabilities that AI agents can use at runtime via MCP, A2A, REST API, or x402 micropayments. Free capabilities are continuously canary-tested; paid capabilities are observed via production traffic and piggyback test suites. Every call returns an audit record with cryptographic chain hashing.
+Strale provides business data capabilities that AI agents can use at runtime via MCP, A2A, REST API, or x402 micropayments. Free capabilities are continuously canary-tested; paid capabilities are observed via production traffic and piggyback test suites. Every call returns an audit record.
 
 ## Use Strale When Your Agent Needs To:
 
@@ -107,7 +107,7 @@ The iban-validate capability is free. Use it to test the integration without an 
 
 ## Trust & Quality
 
-Free capabilities are tested hourly with canary inputs that don't consume vendor quota; paid capabilities are observed via production traffic, piggyback test suites, and any zero-cost auth-less probes the vendor permits. Every call to /v1/do produces a chain-hashed audit record retrievable at /v1/audit/{transactionId} for downstream regulatory verification.
+Free capabilities are tested hourly with canary inputs that don't consume vendor quota; paid capabilities are observed via production traffic, piggyback test suites, and any zero-cost auth-less probes the vendor permits. Every call to /v1/do produces an audit record retrievable at /v1/audit/{transactionId}.
 
 ## Links
 

--- a/apps/api/src/routes/mcp-server-card.ts
+++ b/apps/api/src/routes/mcp-server-card.ts
@@ -86,7 +86,7 @@ async function buildCard(): Promise<object> {
       countries_covered: 27,
       free_tier_available: true,
       trust_model:
-        "Free capabilities canary-tested hourly; paid capabilities observed via production traffic. Every call returns a cryptographically chain-hashed audit record.",
+        "Free capabilities canary-tested hourly; paid capabilities observed via production traffic. Every call returns an audit record.",
       compliance: ["EU AI Act", "GDPR"],
       protocols: ["MCP", "A2A", "REST", "x402"],
     },

--- a/apps/api/src/web3-assurance/methodology.ts
+++ b/apps/api/src/web3-assurance/methodology.ts
@@ -267,7 +267,7 @@ methodologyRoute.get("/", (c) => {
           "array — explicit cross-vendor disagreements (e.g. Sourcify says verified but Etherscan disagrees). Surfaces conflicts single-source competitors cannot detect.",
         explanation_chain:
           "array of {reason_code, severity, source_evaluator, evidence_excerpt, why} — structured causal chain. For each fired reason_code, walks back to the evaluator that produced it, the specific evidence values that triggered it, and a why-it-matters string. Workflow gates and human reviewers consume this directly.",
-        audit_url: "string — sidecar URL to hash-chained audit record (HMAC-signed, 90-day TTL)",
+        audit_url: "string — sidecar URL to the audit record (HMAC-signed, 90-day TTL)",
         sla: { mode: "outbound | reverse-call", p99_ms: "integer", p50_ms: "integer" },
       },
       modes: {
@@ -309,10 +309,9 @@ methodologyRoute.get("/", (c) => {
           "Material changes to verdict logic or evaluator set are surfaced via response-header X-Strale-Methodology-Hash, which downstream consumers can monitor for drift.",
       },
       audit_trail_policy: {
-        chain: "SHA-256 hash chain, per-day, anchored to GENESIS_HASH = sha256('strale-genesis-v1').",
+        chain: "Each record carries a SHA-256 content hash and a reference to the record it was written after.",
         token: "audit_url uses HMAC-SHA256(secret, `${recordId}:${expiresAt}`) signing with 90-day TTL.",
-        retention: "Indefinite for completed records.",
-        replay_capability: "Each record can be replayed to confirm the evidence trail available at the time the verdict was issued.",
+        retention: "Record metadata is retained for 3 years; record content is redacted at 90 days.",
       },
       contact: { email: "hello@strale.io", docs: "https://strale.dev/docs" },
     },

--- a/docs/company/DAILY-RUN.md
+++ b/docs/company/DAILY-RUN.md
@@ -70,9 +70,20 @@ Petter.
 
 **B2b. Local repo hygiene.**
 `cd apps/api && npx tsx scripts/session-close-check.ts --hygiene-only`. No DB, no
-credentials. Deliberately not session-scoped: it reports which branch the primary
+credentials. Deliberately not session-scoped: it reports which branch the
 checkout sits on and how far behind main, handoffs never committed at any age,
 and branches untouched 14+ days. Act on each finding the same morning.
+
+> **Run it from the primary checkout, not from your worktree.** The script
+> resolves its repository root relative to its own file location, so it inspects
+> *whichever checkout it is installed in*. On 2026-08-25 it returned "0 red, 1
+> yellow" from a worktree while the primary checkout sat on a superseded branch
+> 29 commits behind main with two incident records untracked — the exact state
+> the check exists to catch. Run from the primary checkout the same morning, it
+> raised four warnings. This paragraph previously said it reports on "the
+> primary checkout"; it does not, and the instruction above is the fix. Logged
+> as LESSONS.md F5 incident 7. Running it is read-only and switches no branches,
+> so it is safe there.
 *Caution:* if the checkout is off main, do **not** `git checkout` there casually —
 that has corrupted the tree three times. Confirm the branch's content is already
 on main by comparing **file contents**, never commit counts (squash merges make a

--- a/docs/company/DECISION-QUEUE.md
+++ b/docs/company/DECISION-QUEUE.md
@@ -184,6 +184,42 @@ one I would not leave indefinitely.
 
 ## DECIDED — visible so you can reverse them
 
+**DQ-24** · `decided` · owner Claude · 2026-08-25
+The overstated claims about our audit records are now off everything we publish.
+*What happened:* you approved taking them down (DQ-18 item 2). The website half
+was done; the machine-readable half — what agents, crawlers and integration
+partners actually read — was not, and had been live the whole time. The
+strongest of them told readers an audit record was retrievable "for downstream
+regulatory verification", which claims it is fit for a regulatory purpose rather
+than describing what it does. Also removed: a promise that we walk the record
+chain all the way back to the beginning, when we stop after twenty steps; a
+statement that we keep records indefinitely, when we erase their content after
+ninety days; and a "replay" feature listed as delivered in two published data-
+protection assessments, which that same erasure makes impossible.
+*What replaces them:* nothing. Pure removal, as you decided. Nothing new is
+claimed, hedged or otherwise.
+*Why this is mine:* executing a decision you already made. Your queue entry says
+so explicitly — "what remains is execution, and it is mine".
+*What is NOT done, deliberately:* republishing our installer package to the
+public registry. That is a one-way public act and stays yours. The live text is
+already fixed by the deploy; only the package version trails.
+*What stops it coming back:* an automatic check now fails our build if any of
+that wording reappears. It was tested by putting the claims back and confirming
+the check goes red.
+*How you'd reverse it:* tell me, and the wording returns.
+
+**DQ-25** · `decided` · owner Claude · 2026-08-25
+Three dead branches removed and two incident records rescued off one machine's
+hard drive.
+*What happened:* two abandoned snapshots from mid-July and one already-merged
+branch were deleted, each commit id recorded first so all three are restorable.
+Separately, the two written records of the August 22nd process violation existed
+only as untracked files in a working directory — three days from being lost with
+that folder. They are now committed. Nothing in them is changed and the incident
+stays closed.
+*Why this is mine:* routine cleanup, fully reversible.
+
+
 **DQ-21** · `decided` · owner Claude · 2026-08-23
 Agents that asked for a paid service by describing it were getting an error page
 instead of a price. Fixed and live.

--- a/docs/company/GOALS.md
+++ b/docs/company/GOALS.md
@@ -135,6 +135,59 @@ conversion.
 
 ## What we currently know (update as evidence lands)
 
+- **The first customer to pay us by card arrived, and they are buying the
+  compliance wedge — not the growth cluster** (measured 2026-08-25). A domain we
+  had never seen registered at 2026-08-23T21:12Z, spent the €2 trial credit on
+  `competitor-compare` within six minutes, and then on 2026-08-24T23:58Z **paid
+  €10.00 through Stripe** and resumed buying immediately. 16 paid calls, €5.09
+  spent, **zero failures**, across two separate days. Their user agents are
+  `Python-urllib`, `python-httpx` and `curl` — an agent integration, not a
+  person clicking.
+
+  **This is the only Stripe top-up in the last 120 days.** Every euro before it
+  arrived over x402. Second-sourced four ways: the wallet ledger shows the
+  trial-credit grant, the two trial purchases, the €10.00 `top_up` carrying a
+  Stripe session id, and the purchases after it; the domain is outside
+  `INTERNAL_EMAIL_SUFFIXES`, so the canonical filter counts them as external by
+  the same rule every revenue number uses; it is the only account on that
+  domain; and there are no failed calls to explain away.
+
+  **What they bought contradicts a claim this file has carried since
+  2026-08-16.** "All revenue is one cluster — SEO and growth research" is no
+  longer true. After topping up they called `pep-check`, `insolvency-check`,
+  `vat-validate`, `lei-lookup`, `uk-company-data`,
+  `uk-disqualified-director-check` and `us-company-data` — the KYB/compliance
+  wedge, in one burst of seven capabilities inside five seconds, which is a
+  screening workflow. DQ-9 (Petter, 2026-08-16) declined to re-point the company
+  at SEO/growth and keep compliance's investment. That decision now has its
+  first supporting evidence rather than only the argument.
+
+  **What is NOT established, and must not be written down as if it were:** that
+  this is a durable customer. It is two days and €10. The honest next
+  measurement is whether they top up a second time.
+
+- **The 2026-08-22 "the business pauses when one buyer pauses" scare did not
+  become a decline** (re-measured 2026-08-25 per-day through `lib/metrics`):
+  08-17 €16.29 · 08-18 €10.97 · 08-19 €8.72 · 08-20 €9.29 · 08-21 €9.32 ·
+  **08-22 €4.74** · 08-23 €6.98 · **08-24 €11.51** · 08-25 €3.90 by 05:40Z.
+  The dip was one day. The week of 08-17 closed at **€66.31 on 1,000 calls** —
+  the highest week in the series — and `growth()` over the discrete completed
+  series reads **rising**, now three consecutive completed rises (07-27 €10.85 ·
+  08-03 €27.38 · 08-10 €39.24 · 08-17 €66.31).
+
+  The GOALS entry written on 08-23 was right to refuse to call one day a trend,
+  and the refusal is what kept a wrong conclusion out of the record. Worth
+  keeping as the worked example: **at this volume a single day is inside the
+  noise in both directions**, and the alert that paged at 20:47Z on 08-22 was
+  measuring variance, not churn.
+
+  Concentration in the current partial week reads 79.3% top share across 5
+  payers against last week's 96.4% across 5. **That is not a comparison and must
+  not be presented as one** — `Concentration.comparable` returns `false` on the
+  current window because it is a partial week, which on any Monday or Tuesday
+  reads as a movement that is purely an artefact of which days have elapsed. The
+  first honest read is after this week closes.
+
 - **An agent that asked for something we sell, the way we tell agents to ask,
   got HTTP 500 — for five and a half months** (found and fixed 2026-08-23,
   `e8c36cb`). `/v1/do` takes either a `capability_slug` or a free-text `task`.

--- a/docs/company/LESSONS.md
+++ b/docs/company/LESSONS.md
@@ -221,7 +221,7 @@ footnote. If a fourth lands, open the investigation.
 > A test, gate or check that passes whether or not the thing it guards is
 > working.
 
-**Count: 6 — threshold reached, investigation OPENED 2026-08-22.** Integration
+**Count: 7 — threshold reached, investigation OPENED 2026-08-22.** Integration
 suites skipped for months because a required variable was set in no workflow; a
 budget regression test that exercised the ORM rather than the fix and passed
 either way; two gates that could not fail (a script directory outside the
@@ -269,6 +269,34 @@ The rest simply say "clean".
 > zero across the whole population, and a second approximate figure adds
 > nothing but another thing to be wrong about.
 
+**Incident 7, 2026-08-25 — a gate that examined the wrong repository.**
+`scripts/session-close-check.ts --hygiene-only` exists, in its own words, to
+catch "exactly how the primary checkout ended up sitting 77 commits behind main
+on a fully-superseded branch with five uncommitted changes". Run from a
+worktree during the daily run it reported **0 red, 1 yellow** — while the
+primary checkout was, at that moment, sitting on `remediation/wp9-artifacts`,
+29 commits behind main, with three modified files and five untracked ones,
+including two incident records that existed nowhere else.
+
+The cause is one line: `REPO_ROOT = resolve(import.meta.dirname, "../../..")`.
+It inspects whichever checkout the script is installed in. DAILY-RUN.md step B2b
+claims it "reports which branch the primary checkout sits on"; that claim is
+false whenever the run is done from a worktree — which is what B2b's *own*
+caution about not switching branches in the main tree pushes a session to do.
+
+Verified in both directions rather than reasoned about: from the worktree, 1
+warning; from the primary checkout, **4 warnings**, and the three it added are
+precisely the three the check exists to raise.
+
+This belongs to the family for the reason step 1 identified — the gate verifies
+its assertions and not its *reachability*. It is a sharper case than the first
+six, because the input set was neither empty nor absent: it was a real, valid,
+complete repository that simply was not the one anybody wanted checked. A
+fail-on-empty helper, the repair direction proposed for the other six, would not
+have caught this one. That is worth carrying into step 3: the invariant is
+"examined the artefact it claims to guard", and "examined something" is a weaker
+condition that this incident satisfies.
+
 **Steps 3–7 owed.** The hypothesis to falsify: *a gate that asserted a non-empty
 input set, or a minimum expected count, would have caught incidents 1, 4 and 5.*
 The repair direction is a shared helper every gate routes its input through,
@@ -288,6 +316,17 @@ and not for ordering or deletion across a 3.5-month window.
 the other two were caught by a human reading the page. A fourth guard is cheaper
 than a fifth incident: the investigation to open is "which public claims have no
 automated tie to the fact they assert".
+
+**A guard now exists for the withdrawn integrity vocabulary (2026-08-25).**
+F6's open question is "which public claims have no automated tie to the fact
+they assert". The tamper-evidence family now has one:
+`apps/api/src/lib/withdrawn-integrity-claims.test.ts` scans ten public-prose
+surfaces for the phrasings Petter approved removing, and both fail-before runs
+were done through `mutation-test.mjs` rather than by hand. Two limits, stated in
+the file rather than glossed: it asserts **absence only** — approving
+replacement wording would claim an authority this side does not have — and it
+knows only phrasings we have actually published, so a new way of saying it is
+unguarded. That is one claim family of four, and it does not close this family.
 
 **Swept 2026-08-23 with both repos checked out** (the sweep normally skips
 because the frontend checkout is absent in CI — see F5's note on

--- a/docs/dpia/adverse-media-check.md
+++ b/docs/dpia/adverse-media-check.md
@@ -72,8 +72,8 @@ to 7 years).
   `provenance.upstream_vendor`, `acquisition_method`, and
   `primary_source_reference` so the customer can verify.
 - **Engineering bar** (DEC-20260428-B): all compliance capabilities ship
-  versioned datasets, source manifests per response, audit chain
-  integrity, dispute endpoint, replay capability, golden test suite.
+  versioned datasets, source manifests per response, per-record audit
+  hashing, dispute endpoint, golden test suite.
 - **Art. 22 disclosure**: every audit response carries the
   classification (`screening_signal`), plain-language disclosure text,
   and the dispute endpoint URL. The data subject receives a shareable

--- a/docs/dpia/sanctions-and-pep-check.md
+++ b/docs/dpia/sanctions-and-pep-check.md
@@ -96,8 +96,8 @@ configure their own retention via account-level controls (default
   own DPIA.
 - **Engineering bar** (DEC-20260428-B): both capabilities ship a
   versioned dataset reference (per-call `lists_queried`), source
-  manifest per response, audit chain integrity, dispute endpoint,
-  replay capability, golden test suite, per-list source citation.
+  manifest per response, per-record audit hashing, dispute endpoint,
+  golden test suite, per-list source citation.
 - **Per-response source manifest**: `lists_queried` field includes
   `source_count`, `major_lists`, `freshness_note`, and
   `source_catalog_url` — more transparent than the typical KYB SaaS

--- a/docs/remediation/PUBLIC-COPY-CORRECTION.md
+++ b/docs/remediation/PUBLIC-COPY-CORRECTION.md
@@ -1,0 +1,518 @@
+# Public copy correction — integrity and verification claims
+
+**Status: APPLIED, except the npm publish.** The founder approved the
+correction itself (DECISION-QUEUE DQ-18 item 2); this document is the exact
+surface list, and it is now the record of what was done rather than a proposal.
+
+| section | deploy unit | state |
+|---|---|---|
+| §1, §2 | `strale-frontend` release | **applied** — re-verified 2026-08-25 against the live bundle at `strale.dev`: zero occurrences of `tamper`, `hash chain`, `immutab`, `cryptographically` or `verifiable` across the served SPA, and `public/llms.txt` clean |
+| §3, §4 | `strale` API deploy | **applied** 2026-08-25 |
+| §5 | repo commit | **applied** 2026-08-25 |
+| §4 npm publish | `strale-mcp` on npm | **not done — founder-gated.** The API deploy fixes the live `/mcp` text, because `routes/mcp.ts` imports from `strale-mcp/tools`. Only the published package version trails. |
+
+§6's "deliberately left alone" list and §7's refusal to publish any replacement
+claim both stand unchanged. §8 — `/v1/verify` still returning `verified: true`
+for records whose ordering cannot be evidenced — is **not** addressed by any of
+this and remains WP14's.
+
+The withdrawn vocabulary is now held by `apps/api/src/lib/withdrawn-integrity-claims.test.ts`,
+so it cannot return by someone re-typing a sentence that reads well.
+
+**Version 3.** Version 1 edited seven frontend locations. Version 2 added the
+machine-readable API surfaces. Version 3 follows a second independent review
+that found five further blocking problems, including a public statement that
+remained *false* after every edit in version 2, a diff that did not match the
+text it claimed to change, and the one artefact a compliance reviewer actually
+receives — the shareable audit page and its PDF — asserting verification
+unconditionally. Every surface below has been re-read in the working tree; none
+is quoted from the review second-hand.
+
+---
+
+## The evidence this rests on
+
+`/v1/verify` was exercised end-to-end against production, on records chosen to
+span the interesting cases:
+
+| Record | `verified` | `chain.length` | `verified_links` | `redacted_links` | `reaches_genesis` |
+|---|---|---|---|---|---|
+| inside the forked window (June) | **`true`** | 21 | 1 | 20 | `false` |
+| second record, same window | **`true`** | 21 | 1 | 20 | `false` |
+| after the WP7 fix | `true` | 21 | — | — | `false` |
+| redacted row | `hash_valid: null` | 21 | — | 20 | `false` |
+
+The fork itself, measured directly: one parent hash has **150,796 children**,
+spanning `2026-05-04T13:45:41Z → 2026-08-21T12:10:16Z`. After that instant the
+chain is 1:1 — the WP7 fix holds, and the window recorded in
+`apps/api/src/lib/chain-integrity-windows.ts` matches production to the second.
+
+**Records inside the forked window return `verified: true`.** Worse than the
+phrase suggests: they return it on a 21-hop walk in which **one link is verified
+and twenty are redacted**, so the endpoint reports success across a walk where
+95% of the links carry no verifiable content at all.
+
+This is structural, not a bug in the endpoint. It walks the chain **backwards**
+via `previous_hash`, and a backward walk is well-defined in a star topology —
+each row records exactly one parent no matter how many siblings share it.
+Detecting a fork requires looking forward; detecting a deletion requires knowing
+what should have been there. Neither is possible from a backward walk. It also
+stops at depth 20 (hard cap 50) with `truncated: true`, so it never reaches
+genesis.
+
+## What is actually true
+
+| Property | Status |
+|---|---|
+| A record's **content** is unaltered since hashing | **TRUE** — 99.7% of rows inside the 90-day window verify |
+| Records are in a **provable order** | **FALSE** for 2026-05-04 → 2026-08-21 |
+| **No record was deleted** from the chain | **FALSE** for the same window |
+| An audit record **exists and is independently retrievable** | **TRUE** — `/v1/audit/:id` resolves publicly with a signed token |
+| The chain is walked **to genesis** | **FALSE** — depth-capped, always truncated |
+| A redacted record's hash still matches | **FALSE by design** — and correctly disclosed |
+
+"Tamper-evident" is defensible for alteration of an individual record. It is not
+defensible for ordering or deletion — and those are what most readers of "hash
+chain" assume.
+
+## The rule applied below
+
+Remove the security adjective; keep the mechanism. No replacement cryptographic
+claim, hedged or otherwise. Where a sentence is not merely overstated but
+**false**, correct it to what production does rather than deleting the topic.
+
+Judgement was applied, not a blanket search-and-replace. Four surfaces the
+review flagged are **kept**, with reasons, in "Surfaces deliberately left
+alone". Stripping true statements is not honesty, it is just less information.
+
+---
+
+# 1. Frontend — user-visible copy
+
+*Deploy unit: `strale-frontend` release.*
+
+### 1.1 `src/pages/Privacy.tsx:42-43` — **states the opposite of production behaviour**
+
+The highest-priority edit in this document. It is not an overstatement; it is
+wrong, and production says so in its own words.
+
+```diff
+ <strong>Customer-input:</strong> stored alongside the audit record under
+ Art.&nbsp;30 (records of processing) for the same period as the audit
+-itself; redacted in place when retention expires so the audit-chain
+-integrity hash remains verifiable.
++itself; redacted in place when retention expires. The record stays
++retrievable; its content hash deliberately no longer matches, which
++/v1/verify reports as routine retention.
+```
+
+Redaction is precisely what makes the hash *not* verifiable. `/v1/verify` on a
+redacted row returns `hash_valid: null` and explains: *the row's input/output/
+audit_trail were zeroed by design*. The page claimed the opposite mechanism.
+
+### 1.2 `src/pages/AuditRecord.tsx:201, 213` and `src/lib/generate-audit-pdf.ts:119, 129` — the artefact an auditor actually receives
+
+The shareable audit page renders a green check and **"Verified compliance
+record"**, with **"Integrity: {input_fingerprint}"** beneath it. The downloadable
+PDF renders both lines too. The page fetches `GET /v1/audit/:id?token=` and
+**never calls `/v1/verify`** — "Verified" is hardcoded, with no conditional.
+
+Two independent problems: an unearned verdict, and a field labelled "Integrity"
+that is the input fingerprint, which covers the input and says nothing about the
+chain.
+
+```diff
+-<p className="text-sm font-medium text-foreground">Verified compliance record</p>
++<p className="text-sm font-medium text-foreground">Compliance record</p>
+```
+```diff
+ <Fingerprint className="h-3 w-3" />
+-Integrity: {audit.input_fingerprint}
++Input fingerprint: {audit.input_fingerprint}
+```
+
+Same two substitutions in `generate-audit-pdf.ts` (drop the `✓` with the word).
+
+The green success styling should go with the word — a check mark is a verdict.
+Left as a styling note rather than a diff, because it is a component decision.
+
+### 1.3 `src/data/learnGuides.ts:2054` and `:2104` — **the version-2 diff did not match `:2104`**
+
+Version 2 gave one diff for both lines. The string it matched exists only at
+`:2054`; `:2104` reads differently and would have kept the word "immutable".
+
+This is the worst line to miss. `LearnGuide.tsx:21` builds the FAQPage JSON-LD
+`acceptedAnswer.text` from the first paragraph of `:2104`, so the strongest word
+on the site would have survived inside `application/ld+json` structured data on
+`/learn/audit-trail-compliance-agent`.
+
+```diff
+ :2054
+-Every strale.do() call creates an immutable transaction record
++Every strale.do() call creates a durable transaction record
+```
+```diff
+ :2104
+-Every Strale API call creates an immutable transaction record on the server side.
++Every Strale API call creates a durable transaction record on the server side.
+```
+
+`immutable` was never true independently of this incident — records are redacted
+at 90 days by design.
+
+### 1.4 `src/components/AuditTrailSection.tsx:31, 57`
+
+```diff
+-body: "Every transaction gets a public URL your team, auditors, or regulators can verify independently. No auth required to read an audit record.",
++body: "Every transaction gets a public URL your team, auditors, or regulators can read independently. No auth required to read an audit record.",
+```
+```diff
+-...regulation mapping — on every transaction. Independently verifiable by any third party.
++...regulation mapping — on every transaction.
+```
+
+### 1.5 `src/components/QualityScoringSection.tsx:26-27, 65, 78`
+
+```diff
+-Every capability runs through an automated test suite, and every call comes back with a
+-verifiable audit record — not a self-reported claim.
++Every capability runs through an automated test suite, and every call comes back with an
++audit record you can retrieve — not a self-reported claim.
+```
+```diff
+-{ name: "Hash-chained record", desc: "Tamper-evident audit trail, retrievable per transaction" },
++{ name: "Audit record", desc: "Retrievable per transaction" },
+```
+```diff
+-Audit records are shareable via a signed URL — no login required to verify one.
++Audit records are shareable via a signed URL — no login required to read one.
+```
+
+### 1.6 `src/pages/Methodology.tsx:112, 239`
+
+```diff
+ :112
+-hash-chained audit record you can verify independently
++audit record you can retrieve independently
+```
+```diff
+ :239
+-Every successful transaction produces a hash-chained audit record — tamper-evident, and
+-retrievable independently of the original call. It covers who processed the data, where,
+-and under what basis, mapped to GDPR Articles 15, 17, and 30.
++Every successful transaction produces an audit record, retrievable independently of the
++original call. It covers who processed the data, where, and under what basis, mapped to
++GDPR Articles 15, 17, and 30.
+```
+
+### 1.7 `src/pages/Security.tsx:264-265`
+
+```diff
+-<h4>Tamper-evident audit records</h4>
+-<p>Every transaction is linked via a hash chain, providing tamper-evident integrity for
+-audit records. Per-transaction provenance includes AI model details and jurisdiction
+-tracking. Compliance data is retained for 3 years (Colorado AI Act requirement).</p>
++<h4>Per-transaction audit records</h4>
++<p>Every transaction produces an audit record with per-transaction provenance, including
++AI model details and jurisdiction tracking. Compliance data is retained for 3 years
++(Colorado AI Act requirement).</p>
+```
+
+### 1.8 `src/pages/Privacy.tsx:328, 414`
+
+```diff
+ :328
+-controls, audit logging, and tamper-evident audit chains. Detail on
++controls and audit logging. Detail on
+```
+```diff
+ :414
+-part of a hashed integrity chain
++part of the audit record
+```
+
+### 1.9 `src/pages/CapabilityDetail.tsx:416`, `src/pages/SolutionDetail.tsx:192`
+
+```diff
+-If the call fails, you aren't charged. Every successful call returns a hash-chained audit
++If the call fails, you aren't charged. Every successful call returns an audit
+```
+
+### 1.10 `src/pages/Index.tsx:198, 327`
+
+```diff
+ :198
+-<span>HASH-CHAINED · SHAREABLE</span>
++<span>AUDIT RECORD · SHAREABLE</span>
+```
+```diff
+ :327
+-that verifiable trail is what agents check before committing resources
++that audit trail is what agents check before committing resources
+```
+
+### 1.11 `src/components/ScoringArchitectureDiagram.tsx:19`
+
+```diff
+-hash chain
++audit record
+```
+
+---
+
+# 2. Frontend — SEO and structured data
+
+*Same deploy unit. Separated because this is what crawlers and LLMs index, and
+it is invisible in a visual review of the site.*
+
+### 2.1 `index.html:74` — JSON-LD on **every** route
+
+```diff
+ "A2A Agent Card for agent-to-agent communication",
+ "x402 pay-per-request micropayments",
+-"Hash-chained audit records for every call"
++"Audit records for every call"
+```
+
+This sits in `SoftwareApplication.featureList` in the static shell, so it is
+served on every path regardless of which page renders.
+
+### 2.2 `src/pages/Methodology.tsx:97`, `src/pages/Security.tsx:120` — meta descriptions
+
+```diff
+-a hash-chained audit trail on every call
++an audit trail on every call
+```
+```diff
+-hash-chained audit trails on every call
++audit trails on every call
+```
+
+### 2.3 `src/pages/LearnGuide.tsx:21, 78` — no edit required
+
+These build the meta description and the FAQPage JSON-LD from `learnGuides.ts`.
+They are fixed by §1.3 and need no change of their own — **provided §1.3 fixes
+`:2104`**, which is exactly what version 2 would have missed.
+
+---
+
+# 3. Backend API — live machine-readable surfaces
+
+*Deploy unit: `strale` API deploy. These serve immediately on deploy; no
+release is involved.*
+
+### 3.1 `apps/api/src/routes/llms-txt.ts:110` — the strongest claim anywhere
+
+```diff
+-produces a chain-hashed audit record retrievable at /v1/audit/{transactionId}
+-for downstream regulatory verification
++produces an audit record retrievable at /v1/audit/{transactionId}
+```
+
+It asserts *fitness for regulatory verification*, not merely a mechanism. It
+goes first.
+
+### 3.2 `apps/api/src/openapi.ts:29`, `routes/a2a.ts:329`, `routes/mcp-server-card.ts:89`, `routes/llms-txt.ts:34`
+
+All four carry the same sentence in one of two phrasings. Live at
+`/openapi.json`, `/.well-known/agent-card.json`, `/.well-known/mcp.json` and
+`/llms.txt`.
+
+```diff
+-Every call returns an audit record with cryptographic chain hashing.
++Every call returns an audit record.
+```
+```diff
+-Every call returns a cryptographically chain-hashed audit record.
++Every call returns an audit record.
+```
+
+### 3.3 `apps/api/src/openapi.ts:666` — **false as served**
+
+```diff
+-Verify the integrity of a transaction's audit trail by recomputing its SHA-256 hash and
+-walking the hash chain backward to genesis. Public, no auth required.
++Recompute a transaction's SHA-256 content hash and walk the recorded chain backward from
++it, up to a bounded depth. Public, no auth required.
+```
+
+The endpoint does not reach genesis: default depth 20, hard cap 50. Live
+response on any record: `"reaches_genesis": false, "truncated": true,
+"truncated_reason": "max_depth_reached (N=20)"`. The replacement describes the
+bounded walk that actually happens, which is a mechanism, not a guarantee.
+
+### 3.4 `apps/api/src/routes/audit.ts:620`
+
+```diff
+-Transactions executed after the chain was finalised carry hash_valid: true | false on
+-/v1/verify and are independently verifiable.
++Transactions executed after the chain was finalised carry hash_valid: true | false on
++/v1/verify.
+```
+
+The rest of that disclaimer is accurate and stays: it correctly tells a customer
+that a pre-chain transaction is reconstructed and not hash-protected.
+
+### 3.5 `apps/api/src/web3-assurance/methodology.ts:312, 314, 315` — a *methodology* endpoint
+
+Live and unlisted at `/v1/web3-assurance/methodology`. Four claims in one object,
+three of them false:
+
+```diff
+ audit_trail_policy: {
+-  chain: "SHA-256 hash chain, per-day, anchored to GENESIS_HASH = sha256('strale-genesis-v1').",
++  chain: "Each record carries a SHA-256 content hash and a reference to the record it was written after.",
+   token: "audit_url uses HMAC-SHA256(secret, `${recordId}:${expiresAt}`) signing with 90-day TTL.",
+-  retention: "Indefinite for completed records.",
+-  replay_capability: "Each record can be replayed to confirm the evidence trail available at the time the verdict was issued.",
++  retention: "Record metadata is retained for 3 years; record content is redacted at 90 days.",
+ },
+```
+
+- *"per-day"* is false for 2026-05-04 → 2026-08-21 — 150,796 rows on one parent.
+- *"anchored to GENESIS_HASH"* is unreachable by the verifier, which is
+  depth-capped and always truncates.
+- *"Indefinite"* contradicts the 90-day/3-year retention stated on every other
+  surface.
+- *"replayed"* is impossible after the 90-day content redaction, so the
+  `replay_capability` key is removed rather than reworded. Nothing true replaces
+  it; it should not have been there.
+
+`audit_url` line 270 — *"sidecar URL to hash-chained audit record"* → *"sidecar
+URL to the audit record"*.
+
+---
+
+# 4. `strale-mcp` — both a deploy surface and a package
+
+**Version 2 misclassified this as npm-only.** `apps/api/src/routes/mcp.ts:33`
+imports `from "strale-mcp/tools"`, so the production `/mcp` endpoint serves
+`strale_methodology` verbatim. **A deploy fixes the live text immediately**; the
+npm version bump only trails it. Deploy with §3, publish after.
+
+`packages/mcp-server/src/tools.ts`:
+
+```diff
+ :935
+-covers test cadence, audit-trail integrity, and provenance
++covers test cadence, audit records, and provenance
+```
+```diff
+ :943
+-Every call returns a chain-hashed audit record.
++Every call returns an audit record.
+```
+```diff
+ :950-951
+-...latency, price, and an integrity_hash chained to the previous transaction. Retrieve via
+-/v1/audit/{transactionId} or programmatically via strale_transaction.
+-The chain is independently verifiable at /v1/verify/{transactionId} — Counterparty Assurance
+-and standalone capability calls both produce the same chain shape.
++...latency, price, and a content hash. Retrieve via /v1/audit/{transactionId} or
++programmatically via strale_transaction.
+```
+
+Separately, that deleted sentence names **Counterparty Assurance**, which
+DEC-20260812-A retired as a product framing. Removing it closes a second drift
+that has nothing to do with integrity claims.
+
+The other nine SDK and framework packages are clean.
+
+---
+
+# 5. Repo and published docs
+
+*Public on GitHub. No deploy; a commit is the release.*
+
+### 5.1 `README.md:17`
+
+```diff
+-every call returns an audit record with cryptographic chain hashing
++every call returns an audit record
+```
+
+### 5.2 `docs/x402-listing.md:75-76` — copy for the public Coinbase x402 / Bazaar listing
+
+```diff
+-- **Auditable.** Every call returns provenance and a hash-chained audit record,
++- **Auditable.** Every call returns provenance and an audit record,
+   which matters when your own customers ask where a fact came from.
+```
+
+### 5.3 `docs/dpia/sanctions-and-pep-check.md:99`, `docs/dpia/adverse-media-check.md:75`
+
+Both list *"audit chain integrity"* and *"replay capability"* as delivered
+DEC-20260428-B controls in a published DPIA — a document type whose whole purpose
+is an accurate statement of controls.
+
+```diff
+-manifest per response, audit chain integrity, dispute endpoint,
+-replay capability, golden test suite, per-list source citation.
++manifest per response, per-record audit hashing, dispute endpoint,
++golden test suite, per-list source citation.
+```
+
+`replay capability` is removed for the same reason as §3.5: the 90-day content
+redaction makes replay impossible, so a DPIA must not list it as a control that
+exists.
+
+---
+
+# 6. Surfaces deliberately left alone
+
+Named explicitly so the next reviewer can disagree with a decision rather than
+find a gap.
+
+| Surface | Text | Why it stays |
+|---|---|---|
+| `Methodology.tsx:250-253` | "a signed link anyone can open to verify the transaction happened" | Claims existence and independent retrieval, both true. It does not claim integrity, ordering or completeness. |
+| `Methodology.tsx:410` | "raw provenance and audit data are exposed per call so you can verify independently rather than trust a summary score" | About verifying *quality claims from raw data*, not chain integrity. True, and it is a disclosure of our own evaluator conflict — weakening it would be a loss. |
+| `AuditTrailSection.tsx:40-41` | "Input hashing for integrity" / "You can prove what your agent sent" | The input fingerprint is really computed and stored per record, and really does let a customer confirm a stored input matches what they sent. Narrow, mechanical, supported. |
+| `transactions.ts:230, 270` | legacy disclosure and redaction disclosure | Both *are* the disclosures. `:270` says the content hash no longer matches by design — that is the platform being honest, not overclaiming. |
+
+`public/llms.txt`, `public/openapi.json`, `public/.well-known/*`, `robots.txt`,
+`_headers`, `sitemap.xml`: verified clean by direct grep — no integrity, tamper,
+hash-chain or immutability claim.
+
+---
+
+# 7. What is deliberately NOT proposed
+
+**No replacement cryptographic claim.** Not "hash-linked", not
+"integrity-checked", not a hedged tamper-evidence. A claim returns only when
+every word is supported by production behaviour, and demonstrating that requires
+`/v1/verify` to detect the thing the claim asserts. It currently cannot.
+
+**Not wiring `orderingDisclosureText()` into `/v1/verify`.** That adds a *new*
+public statement, and the instruction is to remove first. It stays drafted and
+unwired in `apps/api/src/lib/chain-integrity-windows.ts` — its only importer is
+its own test.
+
+---
+
+# 8. The largest remaining overstatement is not in the copy
+
+After every edit above, `/v1/verify` still returns **`verified: true`** for
+records whose ordering and completeness cannot be evidenced — including, as
+measured, records where twenty of twenty-one links are redacted.
+
+The test this whole document applies — a claim returns only when production
+behaviour supports every word — applies with full force to the word `verified`
+that the API itself emits. That is an API correction, not a copy one, and it is
+not in this plan. It belongs with the checkpoint work in **WP14**, alongside
+making `/v1/verify` able to detect a fork and bounding any future undetected
+window. A claim can be reinstated on that evidence.
+
+---
+
+# 9. Sequencing
+
+1. **API deploy** (§3 + §4 `tools.ts`, which serves live via `/mcp`). Fastest to
+   land, and it removes the strongest claim on the platform.
+2. **Frontend release** (§1 + §2). The compliance-reviewer-facing artefacts
+   (§1.1, §1.2, §1.3) are the priority within it.
+3. **Repo commit** (§5).
+4. **npm publish** of `strale-mcp` with a version bump, trailing the deploy.
+
+Every edit is subtractive or a correction of a false statement to what
+production does. None introduces a claim that would itself need verifying.

--- a/docs/x402-listing.md
+++ b/docs/x402-listing.md
@@ -72,7 +72,7 @@ for anything.
   then verification, then enrichment, then extraction. That is four vendors, or
   one endpoint pattern.
 - **Variable cost.** No monthly minimum. A workflow that runs twice costs twice.
-- **Auditable.** Every call returns provenance and a hash-chained audit record,
+- **Auditable.** Every call returns provenance and an audit record,
   which matters when your own customers ask where a fact came from.
 
 ## Example flow

--- a/handoff/_general/from-code/2026-08-22-starve-set-1-stranded-settlements.md
+++ b/handoff/_general/from-code/2026-08-22-starve-set-1-stranded-settlements.md
@@ -1,0 +1,77 @@
+# STARVE-SET-1 — stranded settlement set closed
+
+**Intent:** investigate alert STARVE-SET-1 from durable production evidence and,
+if the remediation was safe/bounded/policy-covered, execute and verify it.
+
+## The identifier is not in any registry
+
+`STARVE-SET-1` appears nowhere in the repo (full-tree search, including
+`archive/` and `node_modules/`) and nowhere in the production alert ledger
+(`health_monitor_events WHERE event_type='alert_sent'`, no row matching
+`%starve%` in any column). It was matched **by condition, not by lookup**.
+
+Two candidate starvation conditions were checked:
+
+| Candidate | Finding |
+|---|---|
+| x402 settlement-intent starvation (WP5 class) | **Empty.** 142 `recorded`, 3 `failed`, zero `settling`, zero `escalated`. No backlog. |
+| Wallet-rail transactions stranded in `status='executing'` | **11 rows since 2026-04-07.** Matches the alert's shape and the founder policy quoted in the instruction verbatim. Acted on. |
+
+## Evidence on the eleven (before)
+
+- All 11 `output IS NULL`, `error IS NULL`, `completed_at IS NULL` — **no durable
+  evidence of delivery for any of them**.
+- 10 are free-tier, `price_cents = 0`, `user_id = NULL`. No wallet touched, no
+  ledger row. Zero economic content.
+- 1 (`e995cbb7`, 2026-08-12, `competitor-compare`) carried a **100c wallet debit**
+  on the internal account `test2@strale.io`. One ledger row, `purchase −100c`.
+- **No refund had occurred.** 13 refunds exist platform-wide; none referenced any
+  of the eleven.
+- `manual_reconciliation` events: **0** — the script had never run in write mode.
+- No x402 involvement: all 11 `x402_settlement_id IS NULL`; `x402_orphan_settlements`
+  empty. No on-chain money to reverse.
+
+## Action
+
+Ran `apps/api/scripts/reconcile-stranded-executing.ts --apply` (dry run first).
+Pinned to 11 literal UUIDs, three independent exclusion guards, single DB
+transaction covering refund + status close + durable record.
+
+## Verified after (independent queries, not the script's own output)
+
+- All 11 now `status='failed'`; `completed_at` still NULL (correct — they never
+  completed, and it keeps `integrity-hash-retry` away from them).
+- Closure note written only to the one non-redacted row; the 10 redacted rows'
+  `error` left untouched.
+- Wallet `32abb6eb`: **3047c → 3147c**, delta **+100c**.
+- Ledger for `e995cbb7`: `purchase −100c` **and** `refund +100c`.
+- 11 `manual_reconciliation` events, `human_override=true`, policy recorded verbatim.
+- **Blast radius zero:** no row outside the eleven carries the closure note;
+  platform-wide `status='executing'` is 0; last-15-min traffic is 100%
+  `system@strale.internal` and unaffected.
+- Charge standing against undelivered work in the set: **100c → 0c**.
+
+## Loose ends (no action owed)
+
+1. **3 failed x402 intents** (`keyword-suggest`, 2026-08-21 12:54,
+   `settle_exact_failed_onchain`). All three: `settlement_id NULL`,
+   `transaction_id NULL`, zero matching transaction rows. No USDC moved, caller
+   got a 402, nothing was charged. Lost sale, not customer harm.
+2. **`authorised_by` string in the 11 events** reads
+   `"founder approval, 2026-08-21 stranded-row reconciliation"` — the date of the
+   *plan*, not of the approval (2026-08-22, correctly recorded in each event's
+   `created_at`). An edit correcting it was reverted on disk by the shared-checkout
+   hazard before the run. **Not amended after the fact** — rewriting an audit
+   record for wording is exactly what this program exists to prevent. Noted in the
+   script header instead.
+3. **Internal wallet `32abb6eb` ledger sum (−8697c) ≠ balance (3147c).**
+   Pre-existing, caused by direct top-ups via `topup-test.ts` that bypass the
+   ledger. Internal account only. Not touched here; worth a separate look if the
+   ledger is ever treated as authoritative.
+
+## Repo state
+
+`apps/api/scripts/reconcile-stranded-executing.ts` header updated from
+"NOT YET APPLIED" to the applied record. **Uncommitted** — the branch
+(`remediation/wp9`) carries another session's in-flight work and was not swept
+into a commit.

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -944,7 +944,7 @@ export function registerStraleTools(
     "strale_methodology",
     {
       description:
-        "Returns Strale's trust methodology as a short reference document — covers test cadence, audit-trail integrity, and provenance. No API key required.",
+        "Returns Strale's trust methodology as a short reference document — covers test cadence, audit records, and provenance. No API key required.",
       inputSchema: z.object({}),
     },
     async () => {
@@ -952,15 +952,14 @@ export function registerStraleTools(
 =========================
 
 WHAT STRALE IS
-Strale is data infrastructure for AI agents. Agents call capabilities (atomic data operations) and solutions (multi-step workflows) via a unified API. Every call returns a chain-hashed audit record.
+Strale is data infrastructure for AI agents. Agents call capabilities (atomic data operations) and solutions (multi-step workflows) via a unified API. Every call returns an audit record.
 
 TEST CADENCE
 Free capabilities are tested hourly with canary inputs that don't consume vendor quota. The scheduler hash-spreads runs across the hour to keep upstream pressure even.
 Paid capabilities are not proactively scheduled. Quality signals come from production traffic, piggyback test suites attached to real customer calls, and any zero-cost auth-less probes the vendor permits.
 
 AUDIT TRAIL
-Every execution writes a transaction row with input, output, provenance (source + fetched_at), latency, price, and an integrity_hash chained to the previous transaction. Retrieve via /v1/audit/{transactionId} or programmatically via strale_transaction.
-The chain is independently verifiable at /v1/verify/{transactionId} — Counterparty Assurance and standalone capability calls both produce the same chain shape.
+Every execution writes a transaction row with input, output, provenance (source + fetched_at), latency, price, and a content hash. Retrieve via /v1/audit/{transactionId} or programmatically via strale_transaction.
 
 PROVENANCE
 Every successful call includes:


### PR DESCRIPTION
Executes **sections 3, 4 and 5** of `docs/remediation/PUBLIC-COPY-CORRECTION.md`
— the twice-reviewed surface list for the correction Petter approved in
DECISION-QUEUE DQ-18 item 2. Pure subtraction: **no replacement integrity
claim**, hedged or otherwise.

## Why now

The frontend half (§1, §2) already shipped. Verified this morning against the
live bundle at `strale.dev`: zero occurrences of `tamper`, `hash chain`,
`immutab`, `cryptographically` or `verifiable` across the whole 345KB SPA
bundle, and `public/llms.txt` is clean.

**The API surfaces had not shipped**, and they carry the strongest claim on the
platform. Live before this change:

| surface | claim |
|---|---|
| `/llms.txt` | audit record retrievable "**for downstream regulatory verification**" |
| `/llms.txt`, `/openapi.json`, `/.well-known/agent-card.json`, `/.well-known/mcp.json` | "Every call returns an audit record **with cryptographic chain hashing**" |
| `/openapi.json` (verify endpoint) | "walking the hash chain **backward to genesis**" |
| `/v1/web3-assurance/methodology` | per-day chaining · **indefinite** retention · **replay capability** |
| two published DPIAs | "audit chain integrity, **replay capability**" as delivered DEC-20260428-B controls |

Each is contradicted by measured production behaviour, recorded in the
correction plan: one parent hash has 150,796 children over
2026-05-04 → 2026-08-21; the verifier is depth-capped at 20 and always returns
`reaches_genesis: false`; content is redacted at 90 days, which makes replay
impossible and is why `retention: "Indefinite"` was false on the same surface
that asserted it.

The first row asserts *fitness for a regulatory purpose* rather than a
mechanism, which is why the plan puts it first.

## The guard

`withdrawn-integrity-claims.test.ts` scans the ten public-prose surfaces for
the withdrawn vocabulary. It exists rather than a note because LESSONS.md **F6**
is at four incidents with the investigation due, and its open question is
literally "which public claims have no automated tie to the fact they assert".

Two deliberate limits, both stated in the file:

- **Absence only.** It does not judge replacement wording — inventing a stronger
  claim is founder-gated (CHARTER.md § Act first, "narrowing only"), so a guard
  that approved replacements would claim an authority this side does not have.
- **Observed phrasings, not a guess at the space of them.** A phrasing nobody
  has published is unguarded. Same principle as `populations.ts` monitor
  signatures.

It also asserts every surface exists and is non-empty **before** scanning, so it
cannot pass by reading nothing — **F5**, whose measured finding is that none of
the repo's 17 gate scripts fails on an empty-but-present input set.

## Fail-before, through the harness

Both runs used `scripts/mutation-test.mjs` rather than a hand-rolled restore —
LESSONS.md **F11** is at six incidents, four of which destroyed uncommitted work
with `git checkout --`, and its finding is that the guard already existed and
nobody reached for it.

```
apps/api/src/routes/llms-txt.ts   (restore the regulatory-verification claim) → MUTATION CAUGHT
docs/dpia/adverse-media-check.md  (restore the replay-capability control)      → MUTATION CAUGHT
```

Both green → red → green, from a clean tree with a verified-green baseline on
both sides.

## Deliberately NOT in this PR

- **The npm publish of `strale-mcp`.** Founder-gated (one-way public act). The
  API deploy fixes the live `/mcp` text immediately, because `routes/mcp.ts`
  imports from `strale-mcp/tools`; the published package version trails.
- **Any replacement claim.** §7 of the plan: a claim returns only when
  `/v1/verify` can detect the thing it asserts, and it currently cannot.
- **`/v1/verify` still returning `verified: true`** for records whose ordering
  cannot be evidenced. That is an API correction, not a copy one — §8 of the
  plan assigns it to WP14, and it is the largest remaining overstatement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)