### PR TITLE
F1 step 4: the failure taxonomy's default was an accusation, not a verdict

### DIFF
--- a/apps/api/src/capabilities/translate-truncation.test.ts
+++ b/apps/api/src/capabilities/translate-truncation.test.ts
@@ -112,7 +112,24 @@ describe("translate output-truncation handling", () => {
     expect(error).not.toBeInstanceOf(CapabilityRefusalError);
     expect((error as Error).message).toBe("Translation failed.");
     const cls = classifyTransactionFailure((error as Error).message);
-    expect(cls).toBe("internal");
+    // This read `internal` until LESSONS.md F1 step 4 — but only because
+    // `internal` was the fallback, not because anything in the string said so.
+    // "Translation failed." is two words that identify no cause, name no
+    // actor, and quote nothing. It IS our defect (the model returned prose
+    // where JSON was required), and the taxonomy cannot tell, so the honest
+    // classification is `unclassified`.
+    //
+    // Deliberately NOT repaired by adding "translation failed" to INTERNAL_RE.
+    // That is the per-capability string patch F1 exists to stop: six of them
+    // is how the family reached seven incidents. The repair belongs in the
+    // message — a parse failure that said so would be claimed by the house
+    // `failed to parse` / `failed to extract` signature the way every other
+    // capability's is. Recorded as a follow-up rather than papered over here.
+    //
+    // What this test still pins, and what actually matters, is the boundary:
+    // it is not a refusal and it is not excused as the caller's fault.
+    expect(cls).toBe("unclassified");
+    expect(CALLER_ATTRIBUTABLE.has(cls)).toBe(false);
   });
 
   it("still succeeds normally when the response completes within budget (no over-triggering)", async () => {

--- a/apps/api/src/jobs/quality-floor.ts
+++ b/apps/api/src/jobs/quality-floor.ts
@@ -60,7 +60,11 @@ import postgres from "postgres";
 import { getDb } from "../db/index.js";
 import { capabilities, healthMonitorEvents } from "../db/schema.js";
 import { eq } from "drizzle-orm";
-import { classifyTransactionFailure, CALLER_ATTRIBUTABLE } from "../lib/transaction-failure-taxonomy.js";
+import {
+  classifyTransactionFailure,
+  countsAgainstCapability,
+  UNATTRIBUTED,
+} from "../lib/transaction-failure-taxonomy.js";
 import { evaluateFloor, DEFAULT_FLOOR_CONFIG, type FloorStats } from "../lib/quality-floor.js";
 import { INTERNAL_EMAIL_LIKE_PATTERNS, EXTRA_EXCLUDED_EMAILS } from "../lib/internal-accounts.js";
 import { FACT_WRITE_FAILED_EVENT } from "../lib/invocation-facts.js";
@@ -147,6 +151,7 @@ export function foldTrafficRows(
         distinctFailureDays: 0,
         recentEligibleCalls: 0,
         recentCompletedCalls: 0,
+        unattributedFailures: 0,
         failureDays: new Set<string>(),
       };
       bySlug.set(r.slug, s);
@@ -158,10 +163,13 @@ export function foldTrafficRows(
     // answers to one question get created, which is the defect this whole
     // program exists to remove.
     const completed = r.source === "fact" ? r.success === true : r.status === "completed";
+    // Transaction rows only: the class is also needed to tell "not the
+    // capability's fault" from "nothing said whose fault it was". Both leave
+    // the denominator; only the second is an evidence shortfall the operator
+    // has to see (LESSONS.md F1 step 4).
+    const txClass = r.source === "transaction" ? classifyTransactionFailure(r.error) : null;
     const countsAsFailure =
-      r.source === "fact"
-        ? r.counts === true
-        : !CALLER_ATTRIBUTABLE.has(classifyTransactionFailure(r.error));
+      r.source === "fact" ? r.counts === true : countsAgainstCapability(txClass!);
 
     if (completed) {
       s.eligibleCalls += r.n;
@@ -174,6 +182,12 @@ export function foldTrafficRows(
       s.eligibleCalls += r.n;
       s.failureDays.add(r.day);
       if (r.recent) s.recentEligibleCalls += r.n;
+    } else if (txClass !== null && UNATTRIBUTED.has(txClass)) {
+      // Out of the denominator, but counted here so the decision can say "and
+      // N failures I could not attribute to anyone". Silently dropping them
+      // would swap a false accusation for a blind spot — the taxonomy failing
+      // to recognise 400 errors on one capability is itself a finding.
+      s.unattributedFailures += r.n;
     }
   }
   return [...bySlug.values()].map((s) => {

--- a/apps/api/src/lib/cost-control-refusal-accounting.test.ts
+++ b/apps/api/src/lib/cost-control-refusal-accounting.test.ts
@@ -37,7 +37,11 @@ import {
   isInternalAccountEmail,
   INTERNAL_EMAIL_SUFFIXES,
 } from "./internal-accounts.js";
-import { classifyTransactionFailure, CALLER_ATTRIBUTABLE } from "./transaction-failure-taxonomy.js";
+import {
+  classifyTransactionFailure,
+  CALLER_ATTRIBUTABLE,
+  countsAgainstCapability,
+} from "./transaction-failure-taxonomy.js";
 
 /** Verbatim from `transactions` on 2026-08-14. */
 const ALLOW_MATRIX_REFUSAL =
@@ -98,12 +102,19 @@ describe("no customer-facing path can produce one of these refusals", () => {
 });
 
 describe("cost-control refusals keep their classification", () => {
-  it("classifies as internal, and that is deliberate", () => {
-    // Pinned, not fixed. See the module comment: the refusal is the platform's
-    // own decision, so it is neither a capability fault nor caller-
-    // attributable. It is inert because it never reaches a scoring consumer,
-    // not because the bucket is right.
-    expect(classifyTransactionFailure(ALLOW_MATRIX_REFUSAL)).toBe("internal");
+  it("classifies as unclassified, which is now the right bucket rather than an inert one", () => {
+    // This assertion read `internal` until LESSONS.md F1 step 4, and the
+    // comment then said: "Pinned, not fixed. The refusal is the platform's own
+    // decision, so it is neither a capability fault nor caller-attributable.
+    // It is inert because it never reaches a scoring consumer, not because the
+    // bucket is right."
+    //
+    // Inverting the taxonomy's default fixed it as a side effect. No rule
+    // claims this string, so it now lands in `unclassified` - which is exactly
+    // what it is: a failure that says nothing about the capability. It no
+    // longer depends on never reaching a scoring consumer to be harmless.
+    expect(classifyTransactionFailure(ALLOW_MATRIX_REFUSAL)).toBe("unclassified");
+    expect(countsAgainstCapability(classifyTransactionFailure(ALLOW_MATRIX_REFUSAL))).toBe(false);
   });
 
   it("is not caller-attributable — nobody asked for it", () => {

--- a/apps/api/src/lib/execution-outcome.test.ts
+++ b/apps/api/src/lib/execution-outcome.test.ts
@@ -264,3 +264,47 @@ describe("gate outcome", () => {
     expect(outcome.error_message).toBe("gate tripped: s.f");
   });
 });
+
+/**
+ * LESSONS.md F1 step 4, at the fact writer.
+ *
+ * This function writes `counts_against_capability` into the durable fact
+ * table, so what it decides here outlives the request. Before the change an
+ * unrecognised error string fell through to the provider branch and was
+ * recorded `counts_against_capability: true` — a permanent assertion that the
+ * capability was at fault, made on the strength of no rule having matched.
+ *
+ * Both tests fail against the un-fixed module: the first reads
+ * `provider_rejected` / `true`, and the second is the guard that the repair
+ * did not quietly change what customers are charged.
+ */
+describe("an unrecognised failure is recorded as unattributed, not as a defect (F1 step 4)", () => {
+  it("does not blame the capability for a string no rule claims", () => {
+    const outcome = outcomeFromError(new Error("fetch failed"));
+    expect(outcome.failure_class).toBe("unattributed");
+    expect(outcome.counts_against_capability).toBe(false);
+    // Not "provider", not "strale", not "caller". The absence is the record.
+    expect(outcome.fault).toBeNull();
+    // No evidence it was transient either, so retrying on this basis would be
+    // a second guess resting on the same absent evidence.
+    expect(outcome.retryable).toBe(false);
+  });
+
+  it("moves no money — the reclassification is not billable either way", () => {
+    // F1 step 3's falsification attempt was economic: CALLER_ATTRIBUTABLE is
+    // read by this module as well as by the floor, so widening what leaves the
+    // denominator could in principle change a charge. It does not, and this
+    // pins it: both the old destination (provider_rejected) and the new one
+    // are unbillable.
+    expect(outcomeFromError(new Error("fetch failed")).billable).toBe(false);
+    expect(outcomeFromError(new Error("Upstream returned 400 Bad Request")).billable).toBe(false);
+  });
+
+  it("a positively identified crash still counts against the capability", () => {
+    // The boundary that keeps the floor useful. A V8 error name is evidence,
+    // so it keeps its verdict.
+    const outcome = outcomeFromError(new Error("TypeError: Cannot read properties of undefined"));
+    expect(outcome.failure_class).not.toBe("unattributed");
+    expect(outcome.counts_against_capability).toBe(true);
+  });
+});

--- a/apps/api/src/lib/execution-outcome.ts
+++ b/apps/api/src/lib/execution-outcome.ts
@@ -73,7 +73,19 @@ export type FailureClass =
   /** The executor resolved, but with something that is not the purchased answer. */
   | "output_unusable"
   /** Strale's own code broke. */
-  | "internal_error";
+  | "internal_error"
+  /**
+   * Nothing in the evidence says whose fault this was.
+   *
+   * Distinct from every class above, all of which are verdicts. This one is an
+   * admission: the failure taxonomy recognised none of the error text, so the
+   * honest record is "unattributed" rather than a guess. It does not count
+   * against the capability (LESSONS.md F1 step 4) and it is not billable.
+   * Consumers that aggregate failures must show it as a shortfall — a large
+   * unattributed count means the taxonomy needs a rule, and hiding it would
+   * trade a false accusation for a blind spot.
+   */
+  | "unattributed";
 
 /** Who is answerable. Drives the breaker and the quality floor, not billing. */
 export type Fault = "provider" | "strale" | "caller";
@@ -358,6 +370,28 @@ export function outcomeFromError(error: unknown): ExecutionOutcome {
   // below, which is where the taxonomy's config/timeout/upstream/internal all
   // correctly belong for billability purposes.
   const taxonomyClass = classifyTransactionFailure(base.error_message);
+
+  // Unrecognised error text. Before LESSONS.md F1 step 4 the taxonomy's
+  // fallback was `internal`, so this string fell through to the provider branch
+  // below and was written `counts_against_capability: true` — a durable fact
+  // asserting a defect, on the strength of no rule having matched. 82% of that
+  // bucket was measured to be something else.
+  //
+  // `fault: null` is the point: not "provider", not "strale", not "caller".
+  // `billable` is unchanged at false, so this reclassification moves no money.
+  if (taxonomyClass === "unclassified") {
+    return {
+      ...base,
+      failure_class: "unattributed",
+      billable: false,
+      // Nothing here says the failure was transient, and claiming it was would
+      // make the retry decision on the same absent evidence.
+      retryable: false,
+      fault: null,
+      counts_against_capability: false,
+    };
+  }
+
   if (CALLER_ATTRIBUTABLE.has(taxonomyClass)) {
     return {
       ...base,
@@ -552,11 +586,13 @@ export class UnbillableOutputError extends Error {
      * the first version discarded it, so an output of
      * `{error: "Bolagsverket returned HTTP 503", status: 503}` reached
      * `transactions.error` as "Capability returned an error marker rather than
-     * output" — which classifyTransactionFailure files as `internal`, i.e.
-     * Strale's bug, when the original text would have matched UPSTREAM_RE and
-     * filed correctly as `upstream`. That misfiling is not cosmetic: the
-     * quality floor is armed in production and `internal` counts against a
-     * capability while `upstream` is read differently.
+     * output" — which classifyTransactionFailure now files as `unclassified`
+     * (it filed as `internal` until LESSONS.md F1 step 4), when the original
+     * text would have matched UPSTREAM_RE and filed correctly as `upstream`.
+     * Still worth carrying: the taxonomy's new default stops the misfiling
+     * being scored as a defect, but it cannot recover the *cause*, and
+     * "unattributed" is a worse operational answer than "upstream" even when
+     * it is a safer one.
      */
     public readonly upstreamMessage?: string | null,
   ) {

--- a/apps/api/src/lib/invocation-facts.test.ts
+++ b/apps/api/src/lib/invocation-facts.test.ts
@@ -175,8 +175,21 @@ describe("the floor can see a capability that only runs inside solutions", () =>
     const unrecognised = new CapabilityRefusalError(
       "This source is out of scope for automated retrieval.",
     );
-    expect(classifyTransactionFailure(unrecognised.message)).toBe("internal");
-    expect(outcomeFromError(unrecognised).counts_against_capability).toBe(false);
+    // Since LESSONS.md F1 step 4 this string classifies `unclassified`, not
+    // `internal` — no rule claims it, and the taxonomy now says so instead of
+    // guessing. That REMOVED the discrimination this test had: `unclassified`
+    // already sets counts_against_capability false, so the assertion below
+    // would pass with the isCapabilityRefusal branch deleted, which is the
+    // precise failure the comment above describes.
+    //
+    // So the assertion moved to `failure_class`. Only the structural branch
+    // produces `capability_refused`; the taxonomy route produces
+    // `unattributed`. The two are distinguishable, and deleting the branch
+    // fails this test again.
+    expect(classifyTransactionFailure(unrecognised.message)).toBe("unclassified");
+    const out = outcomeFromError(unrecognised);
+    expect(out.failure_class).toBe("capability_refused");
+    expect(out.counts_against_capability).toBe(false);
   });
 
   it("a bug in our own step plumbing is not the capability's fault", () => {

--- a/apps/api/src/lib/quality-floor.test.ts
+++ b/apps/api/src/lib/quality-floor.test.ts
@@ -22,6 +22,7 @@ function cap(partial: Partial<FloorStats>): FloorStats {
     distinctFailureDays: 5,
     recentEligibleCalls: 0,
     recentCompletedCalls: 0,
+    unattributedFailures: 0,
     ...partial,
   };
 }
@@ -189,9 +190,13 @@ describe("classifyTransactionFailure", () => {
   it("classifies the remaining dimensions distinctly", () => {
     expect(classifyTransactionFailure("Request timed out after 35000ms")).toBe("timeout");
     expect(classifyTransactionFailure("eur-lex.europa.eu served an anti-bot challenge to the rendered browser as well.")).toBe("upstream");
+    // Still `internal`: a V8 runtime error is positive evidence our own code
+    // broke, and INTERNAL_RE claims those shapes explicitly since F1 step 4.
     expect(classifyTransactionFailure("TypeError: Cannot read properties of undefined")).toBe("internal");
-    expect(classifyTransactionFailure("")).toBe("internal");
-    expect(classifyTransactionFailure(null)).toBe("internal");
+    // No longer `internal`. The fallback is `unclassified` - an absent error
+    // message is a shortfall in the evidence, not a verdict about anyone.
+    expect(classifyTransactionFailure("")).toBe("unclassified");
+    expect(classifyTransactionFailure(null)).toBe("unclassified");
   });
 });
 
@@ -239,5 +244,77 @@ describe("isInternalAccountEmail (H-3 suffix rule)", () => {
     }
     expect(isInternalAccountEmail("customer@gmail.com")).toBe(false);
     expect(isInternalAccountEmail(null)).toBe(false);
+  });
+});
+
+/**
+ * LESSONS.md F1 step 4, the consumer half.
+ *
+ * Inverting the taxonomy's default is only half the repair. The other half is
+ * that the floor must SAY it could not attribute a failure, rather than
+ * quietly dropping it — otherwise a false accusation is replaced by a blind
+ * spot, which is the same family pointed the other way.
+ *
+ * Both tests below fail against the un-fixed state: before the change the fold
+ * routed an unrecognised error string into `eligibleCalls` (so the first test
+ * reads 12 eligible, not 10) and no decision carried an unattributed count at
+ * all (so the second reads `undefined`).
+ */
+describe("unrecognised failures leave the rate but stay visible (F1 step 4)", () => {
+  const row = (partial: Partial<FloorTrafficRow>): FloorTrafficRow => ({
+    slug: "s", lifecycle_state: "active", visible: true, x402_enabled: true,
+    source: "transaction", status: "failed", error: null, success: null,
+    counts: null, day: "2026-08-01", recent: false, n: 1, ...partial,
+  });
+
+  it("a bare transport error is out of the denominator and counted as a shortfall", () => {
+    // 10 completed, 2 genuine defects, 8 the taxonomy does not recognise.
+    // "fetch failed" is 29.2% of the real `internal` bucket over 90 days, so
+    // this is the shape that dominates the effect in production.
+    const [s] = foldTrafficRows([
+      row({ status: "completed", n: 10 }),
+      row({ error: "TypeError: Cannot read properties of undefined", n: 2, day: "2026-08-02" }),
+      row({ error: "fetch failed", n: 8, day: "2026-08-03" }),
+    ], new Map());
+
+    expect(s.eligibleCalls).toBe(12);       // 10 + 2, NOT 20
+    expect(s.completedCalls).toBe(10);
+    expect(s.unattributedFailures).toBe(8);
+    // 83% on what could be attributed, so no quarantine. Before the change
+    // this capability read 50% on 20 calls and was quarantine-eligible on
+    // eight failures nobody had examined.
+    expect(s.completedCalls / s.eligibleCalls).toBeGreaterThan(0.7);
+  });
+
+  it("caller-attributable and unattributed are counted separately, not merged", () => {
+    // Both leave the denominator; only one is a claim about anyone. A fold
+    // that treated them as one bucket would report a shortfall where there is
+    // none, and the operator would go looking for a taxonomy gap that does not
+    // exist.
+    const [s] = foldTrafficRows([
+      row({ status: "completed", n: 5 }),
+      row({ error: 'No Estonian company found matching "10667868".', n: 4 }),
+      row({ error: "fetch failed", n: 3 }),
+    ], new Map());
+
+    expect(s.eligibleCalls).toBe(5);
+    expect(s.unattributedFailures).toBe(3);   // the refusals are NOT in here
+  });
+
+  it("the decision reports the shortfall instead of hiding it", () => {
+    const [d] = evaluateFloor([
+      cap({ slug: "bad", eligibleCalls: 20, completedCalls: 12, unattributedFailures: 40 }),
+    ]);
+    expect(d.action).toBe("quarantine");
+    expect(d.unattributedFailures).toBe(40);
+    // The operator has to be able to see that the 60% was computed over a
+    // third of the failures.
+    expect(d.reason).toContain("40 further failure(s) could not be attributed");
+  });
+
+  it("says nothing when there is nothing to say", () => {
+    const [d] = evaluateFloor([cap({ slug: "bad", eligibleCalls: 20, completedCalls: 12 })]);
+    expect(d.unattributedFailures).toBe(0);
+    expect(d.reason).not.toContain("could not be attributed");
   });
 });

--- a/apps/api/src/lib/quality-floor.ts
+++ b/apps/api/src/lib/quality-floor.ts
@@ -57,6 +57,18 @@ export interface FloorStats {
   /** Same counters over the trailing 7 days — the recovery override. */
   recentEligibleCalls: number;
   recentCompletedCalls: number;
+  /**
+   * Failures no taxonomy rule recognised, so they are absent from
+   * `eligibleCalls` entirely (LESSONS.md F1 step 4).
+   *
+   * Reported rather than discarded. A capability whose completion looks fine
+   * on 12 attributed calls while 300 more could not be attributed at all has
+   * not been assessed, and the decision has to say so — the failure family
+   * this counter exists for was caused by scoring on evidence nobody had
+   * examined, and a silent exclusion is the same mistake pointed the other
+   * way.
+   */
+  unattributedFailures: number;
 }
 
 export interface FloorConfig {
@@ -97,6 +109,12 @@ export interface FloorDecision {
   requiresHuman: boolean;
   completion: number;
   eligibleCalls: number;
+  /**
+   * Failures excluded from `eligibleCalls` because no taxonomy rule recognised
+   * them. Carried on every decision so an operator reading one can tell
+   * "assessed and found wanting" from "assessed on the fraction I could read".
+   */
+  unattributedFailures: number;
   reason: string;
 }
 
@@ -133,6 +151,20 @@ export function evaluateFloor(
   for (const r of candidates) {
     if (r.completion >= config.quarantineBelow) continue;
 
+    // Appended to every reason below rather than to one of them. The shortfall
+    // is a property of the evidence, so it qualifies a quarantine and a
+    // deferral equally; putting it on only the action would let a "none" hide
+    // that the rate was computed over a fraction of the failures.
+    //
+    // Reported, deliberately NOT suppressing. Whether a large shortfall should
+    // also defer the action is a real question and it is the next measurement
+    // (LESSONS.md F1 step 6's replay answers it), but arming a new suppression
+    // rule on an unmeasured threshold is how this family started.
+    const shortfall =
+      r.unattributedFailures > 0
+        ? ` · ${r.unattributedFailures} further failure(s) could not be attributed to anyone and are outside this rate`
+        : "";
+
     const belowDeactivate = r.completion < config.deactivateBelow;
     const requiresHuman = belowDeactivate && r.revenueCents > 0;
 
@@ -148,8 +180,9 @@ export function evaluateFloor(
         requiresHuman,
         completion: r.completion,
         eligibleCalls: r.eligibleCalls,
+        unattributedFailures: r.unattributedFailures,
         suppressedForIncompleteEvidence: true,
-        reason: `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d, but this capability's invocation evidence is incomplete for the window — deferred without spending quarantine budget`,
+        reason: `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d, but this capability's invocation evidence is incomplete for the window — deferred without spending quarantine budget${shortfall}`,
       });
       continue;
     }
@@ -165,7 +198,8 @@ export function evaluateFloor(
         requiresHuman,
         completion: r.completion,
         eligibleCalls: r.eligibleCalls,
-        reason: `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d, but counted failures span only ${r.distinctFailureDays} day(s) (< ${config.minDistinctFailureDays}) — burst, not a trend; deferred`,
+        unattributedFailures: r.unattributedFailures,
+        reason: `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d, but counted failures span only ${r.distinctFailureDays} day(s) (< ${config.minDistinctFailureDays}) — burst, not a trend; deferred${shortfall}`,
       });
       continue;
     }
@@ -186,7 +220,8 @@ export function evaluateFloor(
         requiresHuman,
         completion: r.completion,
         eligibleCalls: r.eligibleCalls,
-        reason: `30d completion ${(r.completion * 100).toFixed(0)}% is below floor, but the trailing 7d (${r.recentCompletedCalls}/${r.recentEligibleCalls}, required ≥${recentRequired}) shows recovery — deferring`,
+        unattributedFailures: r.unattributedFailures,
+        reason: `30d completion ${(r.completion * 100).toFixed(0)}% is below floor, but the trailing 7d (${r.recentCompletedCalls}/${r.recentEligibleCalls}, required ≥${recentRequired}) shows recovery — deferring${shortfall}`,
       });
       continue;
     }
@@ -199,7 +234,8 @@ export function evaluateFloor(
         requiresHuman,
         completion: r.completion,
         eligibleCalls: r.eligibleCalls,
-        reason: `below floor (${(r.completion * 100).toFixed(0)}% of ${r.eligibleCalls}) but per-run quarantine budget exhausted — next tick`,
+        unattributedFailures: r.unattributedFailures,
+        reason: `below floor (${(r.completion * 100).toFixed(0)}% of ${r.eligibleCalls}) but per-run quarantine budget exhausted — next tick${shortfall}`,
       });
       continue;
     }
@@ -212,9 +248,10 @@ export function evaluateFloor(
       requiresHuman,
       completion: r.completion,
       eligibleCalls: r.eligibleCalls,
+      unattributedFailures: r.unattributedFailures,
       reason: belowDeactivate
-        ? `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d — below the 30% deactivation floor; quarantined now, deactivation is a ${r.revenueCents > 0 ? "Petter-only (revenue-earning)" : "human"} decision`
-        : `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d — below the 70% quarantine floor`,
+        ? `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d — below the 30% deactivation floor; quarantined now, deactivation is a ${r.revenueCents > 0 ? "Petter-only (revenue-earning)" : "human"} decision${shortfall}`
+        : `completion ${(r.completion * 100).toFixed(0)}% on ${r.eligibleCalls} eligible calls/30d — below the 70% quarantine floor${shortfall}`,
     });
   }
 

--- a/apps/api/src/lib/transaction-failure-taxonomy.test.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyTransactionFailure,
+  countsAgainstCapability,
   CALLER_ATTRIBUTABLE,
+  UNATTRIBUTED,
   type TransactionFailureClass,
 } from "./transaction-failure-taxonomy.js";
 
@@ -206,10 +208,18 @@ describe("classes that were already right stay right", () => {
     expect(classOf("'cik' or 'company_name' is required. Provide a CIK number or US company name.")).toBe("caller_input");
   });
 
-  it("an empty or absent error is our problem until proven otherwise", () => {
-    expect(classOf("")).toBe("internal");
-    expect(classifyTransactionFailure(null)).toBe("internal");
-    expect(classifyTransactionFailure(undefined)).toBe("internal");
+  it("an empty or absent error is an evidence shortfall, not our defect", () => {
+    // Reversed with LESSONS.md F1 step 4. It read `internal` before, on the
+    // premise "our problem until proven otherwise" - so a failed call with no
+    // error text at all became evidence of a defect purely because nothing
+    // matched. That premise is the common cause of all seven F1 incidents.
+    expect(classOf("")).toBe("unclassified");
+    expect(classifyTransactionFailure(null)).toBe("unclassified");
+    expect(classifyTransactionFailure(undefined)).toBe("unclassified");
+    // And it must not be laundered into "the caller's fault" either: the two
+    // are different statements and only one of them is a claim about anyone.
+    expect(excused("")).toBe(false);
+    expect(countsAgainstCapability(classOf(""))).toBe(false);
   });
 });
 
@@ -340,16 +350,26 @@ describe("a page with nothing in it is the caller's URL, not our defect", () => 
     for (const msg of notExcused) expect(excused(msg)).toBe(false);
   });
 
-  it("does not excuse our own empty-output defects", () => {
+  it("does not excuse our own empty-output defects as the caller's fault", () => {
     // The pattern is anchored to one house phrasing. A generic claim about
-    // emptiness in OUR OWN pipeline must keep counting — these are the
-    // assertions that fail if it is ever loosened to `no readable` or
-    // `returned too little`.
+    // emptiness in OUR OWN pipeline must never be excused as caller input -
+    // these are the assertions that fail if the caller rule is ever loosened
+    // to `no readable` or `returned too little`.
+    //
+    // The assertion is on `excused`, not on the class. Since F1 step 4 these
+    // land in `unclassified` rather than `internal`: no rule recognises them,
+    // and the honest record of that is "I could not attribute this". They are
+    // invented probe strings rather than observed production text, so there is
+    // nothing to anchor a positive `internal` rule to; if either shape ever
+    // shows up in the census it earns a rule in INTERNAL_RE with its call
+    // count attached. What matters here, and what is pinned, is that the
+    // caller boundary does not move.
     for (const msg of [
       "Extraction pipeline returned too little data to build a result.",
       "Internal renderer produced no readable output for the requested page.",
     ]) {
-      expect(classOf(msg)).toBe("internal");
+      expect(classOf(msg)).toBe("unclassified");
+      expect(excused(msg)).toBe(false);
     }
   });
 
@@ -369,5 +389,94 @@ describe("a page with nothing in it is the caller's URL, not our defect", () => 
     const counted = failures.filter((e) => !excused(e)).length;
     expect(counted).toBe(4);
     expect(completed / (completed + counted)).toBeGreaterThanOrEqual(0.7);
+  });
+});
+
+/**
+ * LESSONS.md F1 step 4 — the default direction, not another string patch.
+ *
+ * The family reached seven incidents because six repairs widened the
+ * caller-attributable *coverage* while the *default* stayed "ours". These
+ * tests pin the default itself, and every one of them fails against the
+ * un-fixed module: before the change the fallback returned "internal", so each
+ * `unclassified` assertion here would read "internal" and each
+ * `countsAgainstCapability` assertion would read `true`.
+ */
+describe("the default is a shortfall, not an accusation (F1 step 4)", () => {
+  // Verbatim from `scripts/f1-failure-attribution.ts`, 90-day census: the
+  // three largest shapes in the 47,582-call `internal` bucket that no rule
+  // claimed. 29.2% of that bucket is the bare transport error alone.
+  const unrecognised = [
+    "fetch failed",
+    "TypeError: fetch failed",
+    "terminated",
+  ];
+
+  it("an error string no rule recognises is unclassified, never internal", () => {
+    // "TypeError: fetch failed" is the one exception in this set and it is
+    // deliberate: it carries a V8 error name, which IS positive evidence our
+    // own code threw, so INTERNAL_RE claims it. The bare transport strings
+    // carry no such evidence and must not be guessed at.
+    expect(classOf("fetch failed")).toBe("unclassified");
+    expect(classOf("terminated")).toBe("unclassified");
+    expect(classOf("TypeError: fetch failed")).toBe("internal");
+  });
+
+  it("unclassified failures leave the capability's denominator", () => {
+    for (const msg of unrecognised.filter((m) => classOf(m) === "unclassified")) {
+      expect(countsAgainstCapability(classOf(msg))).toBe(false);
+    }
+  });
+
+  it("unclassified is NOT the caller's fault either — the two are different claims", () => {
+    // The distinction is the whole point. "Not the capability's fault" and
+    // "nothing here says whose fault this was" are opposite operator
+    // situations, and collapsing the second into the first would hide an
+    // evidence shortfall behind a verdict.
+    expect(excused("fetch failed")).toBe(false);
+    expect(CALLER_ATTRIBUTABLE.has("unclassified" as TransactionFailureClass)).toBe(false);
+    expect(UNATTRIBUTED.has("unclassified")).toBe(true);
+  });
+
+  it("still sees our own code crashing — the class the change must not blind", () => {
+    // If inverting the default had left INTERNAL_RE alone, every runtime crash
+    // would have become `unclassified` and the floor would have stopped
+    // counting real defects. That is the failure mode this change could have
+    // introduced, so it is pinned harder than the rest.
+    for (const msg of [
+      "TypeError: Cannot read properties of undefined (reading 'items')",
+      "ReferenceError: capabilityRegistry is not defined",
+      "RangeError: Invalid array length",
+      "resolveCountry is not a function",
+      "result.rows is not iterable",
+    ]) {
+      expect(classOf(msg)).toBe("internal");
+      expect(countsAgainstCapability(classOf(msg))).toBe(true);
+    }
+  });
+
+  it("does not steal strings the other classes already claim", () => {
+    // Ordering regression guard. INTERNAL_RE runs BEFORE timeout, upstream and
+    // caller-input, so widening it risks claiming their traffic. Each of these
+    // is a class the census assigns elsewhere and must keep.
+    expect(classOf("Companies House returned HTTP 503")).toBe("upstream");
+    expect(classOf("Request timed out after 35000ms")).toBe("timeout");
+    expect(classOf("Verify COURTLISTENER_API_TOKEN.")).toBe("config");
+    expect(classOf('No Estonian company found matching "10667868".')).toBe("caller_input");
+    // "internal server error" is the upstream's phrasing, not evidence about
+    // our code, and it is the string most likely to be captured by a careless
+    // widening of INTERNAL_RE. The assertion is that INTERNAL_RE does NOT
+    // claim it — which is the property under test.
+    //
+    // What it lands in instead is `unclassified`, and that is worth writing
+    // down rather than asserting away: UPSTREAM_RE reads
+    // `service.*(?:down|error)`, so it needs the literal word "service" and
+    // this phrasing has none. The taxonomy has no rule for a bare "internal
+    // server error". Before F1 step 4 that gap was invisible because the
+    // fallback swallowed it as our defect; now it shows up as a shortfall,
+    // which is the intended behaviour of the change and the mechanism by
+    // which the gap gets found and fixed from the census.
+    expect(classOf("Registry returned an internal server error")).not.toBe("internal");
+    expect(classOf("Registry returned an internal server error")).toBe("unclassified");
   });
 });

--- a/apps/api/src/lib/transaction-failure-taxonomy.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.ts
@@ -137,8 +137,13 @@ const CONFIG_PHRASE_RE = /not configured|rejected the (?:api )?(?:key|token)|mis
  * Our own code breaking, positively identified.
  *
  * Two groups. The first is the original: parse failures on a payload we were
- * reading. The second was added with LESSONS.md F1 step 4, and is the reason
- * that change is safe to make.
+ * reading, plus `failed to extract` - the house phrasing every capability's
+ * `parseFailureError` uses when an LLM extraction produced nothing usable.
+ * That one is claimed here for the same reason as the rest of its group: the
+ * message frequently carries a `Raw:` payload of third-party text, so it has
+ * to be claimed by our own signature before any pattern reads the vendor's
+ * prose. The second group was added with LESSONS.md F1 step 4, and is the
+ * reason that change is safe to make.
  *
  * Once `internal` stops being the fallback, it is reachable ONLY through this
  * expression - so anything this expression does not recognise stops counting
@@ -164,7 +169,7 @@ const CONFIG_PHRASE_RE = /not configured|rejected the (?:api )?(?:key|token)|mis
  * observed call count attached.
  */
 const INTERNAL_RE =
-  /\bin JSON at position\b|\bunterminated string\b|response parse failed|failed to parse\b|\b(?:TypeError|ReferenceError|RangeError|SyntaxError):|cannot read propert(?:y|ies) of (?:undefined|null)|is not a function\b|is not iterable\b|assertion failed/i;
+  /\bin JSON at position\b|\bunterminated string\b|response parse failed|failed to parse\b|failed to extract\b|\b(?:TypeError|ReferenceError|RangeError|SyntaxError):|cannot read propert(?:y|ies) of (?:undefined|null)|is not a function\b|is not iterable\b|assertion failed/i;
 
 const TIMEOUT_RE = /timed? ?out|timeout|deadline|aborted due to timeout|operation was aborted/i;
 

--- a/apps/api/src/lib/transaction-failure-taxonomy.ts
+++ b/apps/api/src/lib/transaction-failure-taxonomy.ts
@@ -30,13 +30,64 @@ export type TransactionFailureClass =
   | "config"         // missing key/credential/env on our side
   | "timeout"        // execution or upstream deadline exceeded
   | "upstream"       // vendor/upstream failure: 5xx, quota, unavailability
-  | "internal";      // everything else — OUR bug until proven otherwise
+  | "internal"       // POSITIVELY identified as our own defect
+  | "unclassified";  // no rule claimed it — an evidence shortfall, not a verdict
 
 /** Classes that must NOT count against a capability's completion rate. */
 export const CALLER_ATTRIBUTABLE: ReadonlySet<TransactionFailureClass> = new Set([
   "caller_input",
   "tos_policy",
 ]);
+
+/**
+ * The default is "unclassified", not "ours" — LESSONS.md F1 step 4.
+ *
+ * Six times between 2026-08-12 and 2026-08-22 this module's fallback scored a
+ * failure as a capability defect on evidence that never said so: a correct
+ * refusal, an environment, the caller's own input, our own harness's
+ * bookkeeping. Each incident was repaired by adding one more string to the
+ * caller-attributable list. The family reached seven incidents anyway, because
+ * every repair widened *coverage* while the *default direction* stayed "ours" —
+ * so each newly observed error string starts life misclassified and stays that
+ * way until it costs something visible.
+ *
+ * Measured before changing it (`scripts/f1-failure-attribution.ts`, 90-day
+ * window, 541 distinct strings over 280,945 calls): 47,582 calls landed in
+ * `internal`, and rules that claim a string only on positive evidence it is NOT
+ * a statement about our code account for **82.0% of them — a lower bound on
+ * misattribution, not an estimate**. 29.2% is a bare `fetch failed` transport
+ * error; 32.4% is caller input; 15.4% is a named third party; 5.1% is our own
+ * guards refusing correctly.
+ *
+ * So `internal` is now reachable only through `INTERNAL_RE`, which matches our
+ * own diagnostic signatures. Everything unclaimed becomes `unclassified`, which
+ * behaves like the caller-attributable classes for scoring — it leaves the
+ * denominator — but is deliberately a *different* class, because the two say
+ * opposite things to an operator: "this was not the capability's fault" versus
+ * "nothing here tells me whose fault this was". Consumers must surface the
+ * second as a shortfall rather than silently discarding it; dropping it without
+ * a trace would replace a false accusation with a blind spot.
+ *
+ * What this does NOT change: billing. Both branches of
+ * `classifyExecutionOutcome` that a reclassified string can reach already set
+ * `billable: false`, so no customer is charged differently. Verified as F1
+ * step 3's falsification attempt before the change was written.
+ */
+export const UNATTRIBUTED: ReadonlySet<TransactionFailureClass> = new Set<
+  TransactionFailureClass
+>(["unclassified"]);
+
+/**
+ * The single authority on "does this failure count against the capability".
+ *
+ * Exists so the quality floor, the fact writer and any future consumer cannot
+ * answer it differently. Before this, each site spelled out
+ * `!CALLER_ATTRIBUTABLE.has(...)`, which silently acquires the wrong answer the
+ * moment a new non-attributing class is added — exactly what `unclassified` is.
+ */
+export function countsAgainstCapability(cls: TransactionFailureClass): boolean {
+  return !CALLER_ATTRIBUTABLE.has(cls) && !UNATTRIBUTED.has(cls);
+}
 
 // ENV-var-shaped names (OPENREGISTER_API_KEY, COURTLISTENER_API_TOKEN,
 // BROWSERLESS_URL…) — tight on purpose: env-key errors also contain the
@@ -82,7 +133,38 @@ const CONFIG_PHRASE_RE = /not configured|rejected the (?:api )?(?:key|token)|mis
  * report — and encoding one specific bug's string into a money-path classifier
  * to fix a label is a worse trade than fixing the bug. Tracked separately.
  */
-const INTERNAL_RE = /\bin JSON at position\b|\bunterminated string\b|response parse failed|failed to parse\b/i;
+/**
+ * Our own code breaking, positively identified.
+ *
+ * Two groups. The first is the original: parse failures on a payload we were
+ * reading. The second was added with LESSONS.md F1 step 4, and is the reason
+ * that change is safe to make.
+ *
+ * Once `internal` stops being the fallback, it is reachable ONLY through this
+ * expression - so anything this expression does not recognise stops counting
+ * against the capability. Left as it was, a thrown `TypeError` would have
+ * become `unclassified` and the floor would have lost sight of the single
+ * largest class of genuine defect: our own code crashing. That trades F1's
+ * false accusations for a real blindness, which is not the deal.
+ *
+ * The runtime shapes are V8 error names and V8 message text. A vendor payload
+ * could in principle quote one back at us; if a third party is returning us a
+ * JavaScript stack trace then something is broken on this side of the call
+ * regardless, so the misfiling direction is the conservative one.
+ *
+ * Deliberately NOT included: a bare `internal`, which appears in plenty of
+ * third-party prose - "internal server error" is upstream's, and UPSTREAM_RE
+ * already claims it - and `Error:` alone, which prefixes almost every error
+ * string ever written.
+ *
+ * This vocabulary is now the thing to GROW, and it grows from measurement
+ * rather than from guessing: `scripts/f1-failure-attribution.ts` re-runs the
+ * full 90-day census read-only, so the `unclassified` bucket can be read back
+ * and any recurring shape in it that is genuinely ours added here with its
+ * observed call count attached.
+ */
+const INTERNAL_RE =
+  /\bin JSON at position\b|\bunterminated string\b|response parse failed|failed to parse\b|\b(?:TypeError|ReferenceError|RangeError|SyntaxError):|cannot read propert(?:y|ies) of (?:undefined|null)|is not a function\b|is not iterable\b|assertion failed/i;
 
 const TIMEOUT_RE = /timed? ?out|timeout|deadline|aborted due to timeout|operation was aborted/i;
 
@@ -273,7 +355,11 @@ const CALLER_INPUT_RE = new RegExp(
 
 export function classifyTransactionFailure(error: string | null | undefined): TransactionFailureClass {
   const msg = (error ?? "").trim();
-  if (!msg) return "internal";
+  // No error text at all. This used to return `internal` — a failed call with
+  // no message became evidence of our defect purely because nothing else
+  // matched. It is the emptiest possible input and the clearest case for the
+  // shortfall class.
+  if (!msg) return "unclassified";
   if (msg.includes(TOS_REFUSAL_MARKER)) return "tos_policy";
   // Our own harness marker, claimed before every other pattern: the message
   // embeds suite metadata and timestamps that must never be pattern-matched
@@ -287,5 +373,8 @@ export function classifyTransactionFailure(error: string | null | undefined): Tr
   if (TIMEOUT_RE.test(msg)) return "timeout";
   if (UPSTREAM_RE.test(msg)) return "upstream";
   if (CALLER_INPUT_RE.test(msg)) return "caller_input";
-  return "internal";
+  // The default. NOT `internal` — see UNATTRIBUTED above. Reaching this line
+  // means no rule in this module recognised the string, which is a statement
+  // about this module, not about the capability.
+  return "unclassified";
 }

--- a/docs/company/LESSONS.md
+++ b/docs/company/LESSONS.md
@@ -101,8 +101,8 @@ starts life misclassified and stays that way until it costs something visible.
 That is a default-direction problem, not a coverage problem, and no number of
 string additions reaches it.
 
-**State: investigation open, owner Claude, opened 2026-08-22. Steps 1 and 2 are
-DONE as of 2026-08-23; 3 is partly done; 4–7 are owed.**
+**State: investigation open, owner Claude, opened 2026-08-22. Steps 1 and 2
+DONE 2026-08-23; step 3 partly done; step 4 DONE 2026-08-25; 5–7 owed.**
 
 **Step 2 — the full population, measured.** `apps/api/scripts/f1-failure-attribution.ts`
 runs it and is read-only, so a later session can re-run it against the repaired
@@ -139,17 +139,63 @@ change what customers are charged. Checked, and it does not — both branches of
 `classifyExecutionOutcome` already set `billable: false`. The repair is not
 blocked by billing.
 
-**Step 4 is deliberately NOT a seventh string patch.** `fetch failed` alone is
-29% of the bucket and one line would remove it. That is exactly the move this
-file forbids: six local widenings is how the family reached seven. The shared
-repair is to make `internal` reachable only by positive match, with an
-`unclassified` fallback that leaves the denominator *and* surfaces as an
-evidence shortfall so the floor reports "I could not attribute this" instead of
-"the capability is broken". It touches `execution-outcome.ts` (WP4's authority,
-which writes `counts_against_capability` into the durable fact table) and
-`jobs/quality-floor.ts`, both under concurrent modification by the remediation
-programme on 2026-08-23 — so it is scoped as the next session's work rather
-than slipped in beside a customer-facing fix.
+**Step 4 was deliberately NOT a seventh string patch — DONE 2026-08-25.**
+`fetch failed` alone is 29% of the bucket and one line would have removed it.
+That is exactly the move this file forbids: six local widenings is how the
+family reached seven. The shared repair shipped instead: `internal` is now
+reachable only by positive match, and the fallback is a new `unclassified`
+class that leaves the denominator *and* surfaces as an evidence shortfall, so
+the floor reports "I could not attribute this" rather than "the capability is
+broken". `foldTrafficRows` counts unattributed failures separately from
+caller-attributable ones, and `evaluateFloor` carries the count on every
+decision and in its reason string.
+
+**What nearly went wrong, and is the transferable part.** Inverting a default
+is only safe if the class losing its default has real positive evidence to
+stand on. `INTERNAL_RE` was four parse-failure phrasings, so with the fallback
+gone, every runtime crash — a `TypeError`, a null dereference — would have
+become `unclassified` and the floor would have stopped seeing genuine defects.
+That is this same family pointed the other way: a false accusation traded for
+a blindness. It was caught by an existing test asserting a `TypeError` is
+`internal`, not by design. `INTERNAL_RE` therefore also gained V8 error names
+and V8 message text, plus the house `failed to extract` phrasing, each pinned
+by a test that the widening steals nothing from `timeout`, `upstream`,
+`config` or `caller_input`. **Generalisation: when a fallback is removed, the
+question is not "is the new default safer" but "what did the old default carry
+that nothing else now does".**
+
+One test regressed silently in the same way and was repaired rather than
+relaxed: `invocation-facts` pinned that a refusal whose wording the taxonomy
+does not recognise is saved by the *structural* branch, not by the string.
+Once the fallback became `unclassified`, `counts_against_capability` was false
+either way, so the assertion would have passed with the branch deleted — the
+exact failure its own comment warned about. Moved to `failure_class`, which
+only the structural branch can set.
+
+**Reported, not suppressed.** A large unattributed count does NOT defer the
+floor's action. Whether it should is a real question and it is step 6's replay
+to answer; arming a new suppression rule on an unmeasured threshold is how
+this family started.
+
+**Follow-ups this opened, both small and both recorded where they belong:**
+
+1. `translate` throws `"Translation failed."` — two words naming no cause, no
+   actor, quoting nothing. It IS our defect and the taxonomy cannot tell, so
+   it now reads `unclassified`. The repair belongs in the message, not in a
+   per-capability entry in `INTERNAL_RE`. The new default is what made this
+   visible; previously the fallback absorbed it silently. Expect more of these
+   as step 6 replays the census — that is the mechanism working.
+2. A taxonomy-`internal` failure still maps to `provider_rejected` /
+   `fault: "provider"` in `execution-outcome.ts`, which is the wrong actor for
+   our own crash. `counts_against_capability` is unaffected, so it mislabels a
+   report rather than a decision. Untouched here on purpose.
+
+**Step 6's replay is now cheap and is the next measurement.**
+`scripts/f1-failure-attribution.ts` is read-only and unchanged, so re-running
+it against the repaired taxonomy reads the `unclassified` bucket back
+directly: every recurring shape in it that is genuinely ours earns a rule in
+`INTERNAL_RE` with its observed call count attached, and the bucket's size
+over time is the honest measure of whether the taxonomy is catching up.
 
 ### F2 · Wrong denominator / mislabelled window
 


### PR DESCRIPTION
Closes LESSONS.md **F1 step 4** — the family that has misattributed capability
defects seven times since 2026-08-12 and has been open since 2026-08-22.

## The problem, measured before touching anything

`scripts/f1-failure-attribution.ts`, read-only, 90-day window: **541 distinct
error strings over 280,945 calls. 47,582 land in `internal`** — the only class
the quality floor counts against a capability. Rules that claim a string only
on positive evidence it is *not* about our code account for **82.0% of that
bucket, a lower bound on misattribution rather than an estimate**: 29.2% a bare
`fetch failed`, 32.4% caller input, 15.4% a named third party, 5.1% our own
guards refusing correctly.

Six prior repairs each widened the caller-attributable list. The family reached
seven incidents anyway, because they fixed *coverage* while the *default
direction* stayed "ours" — so every newly observed string starts misclassified.

## The change

`internal` is reachable only by positive match. The fallback is a new
`unclassified` class that leaves the capability's denominator exactly as the
caller-attributable classes do, but is deliberately a **different** class:
"not the capability's fault" and "nothing here says whose fault this was" are
opposite operator situations.

The shortfall is **reported, never discarded** — `foldTrafficRows` counts it
separately and `evaluateFloor` puts it on every decision and in its reason
string, so an operator can tell "assessed and found wanting" from "assessed on
the fraction I could read".

## The failure this nearly introduced

`INTERNAL_RE` was four parse-failure phrasings. With the fallback removed,
every runtime crash would have become `unclassified` and the floor would have
stopped seeing real defects — the same family pointed the other way. It gains
V8 error names and V8 message text, plus the house `failed to extract`
signature, each pinned by a test asserting the widening steals nothing from
`timeout`, `upstream`, `config` or `caller_input`.

One existing test regressed silently and is repaired rather than relaxed:
`invocation-facts` pinned that an unrecognised refusal is saved by the
*structural* branch. Once the fallback became `unclassified` the assertion
passed either way — the exact failure its own comment warned about. Moved to
`failure_class`, which only the structural branch can set.

## Not done, on purpose

A large shortfall does **not** defer the floor's action. Whether it should is
F1 step 6's replay to answer; arming a new suppression rule on an unmeasured
threshold is how this family started.

## Evidence

**Moves no money.** Both the old destination (`provider_rejected`) and the new
one set `billable: false` — F1 step 3's economic falsification, now pinned by a
test.

**Fail-before via `scripts/mutation-test.mjs`** (not by hand — LESSONS F11 is at
six incidents, four of which destroyed uncommitted work with `git checkout --`).
Three mutations, all green → red → green:

| mutation | result |
|---|---|
| taxonomy fallback back to `internal` | MUTATION CAUGHT |
| fold's unattributed branch disabled | MUTATION CAUGHT |
| fact writer's `unclassified` branch disabled | MUTATION CAUGHT |

`tsc --noEmit` clean. Full suite: 2,946 passing. Six route/integration files
fail locally on timeouts with no server running and **fail identically on
`main`** — baseline verified, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)