### PR TITLE
test(js-yaml): apply the review findings that missed the #389 merge

### DIFF
--- a/apps/api/src/capabilities/workflow-security-audit.merge-bomb.test.ts
+++ b/apps/api/src/capabilities/workflow-security-audit.merge-bomb.test.ts
@@ -5,12 +5,13 @@
  * ## The finding
  *
  * VERIFY-DEP / WP13 triage, 2026-08-25. `js-yaml@4.1.1` is affected by
- * GHSA-class quadratic-complexity DoS in merge-key handling. This capability
- * is the reachable path: `workflow-security-audit.ts:22` calls
+ * quadratic-complexity DoS in merge-key handling. This capability is the
+ * reachable path: `workflow-security-audit.ts:22` calls
  * `jsYaml.load(workflow)` where `workflow` is
  * `input.workflow ?? input.yaml ?? input.content ?? input.task` — the caller's
- * request body, unparsed. The capability is live in production
- * (`is_active = true`), and an API key is free to obtain.
+ * request body, unparsed, with the route allowing bodies up to 1 MB. The
+ * capability is live in production (`is_active = true`), and an API key is
+ * free to obtain.
  *
  * Measured on 4.1.1, single-threaded, with the generator below:
  *
@@ -23,27 +24,43 @@
  * `/v1/do`'s synchronous ceiling is 15 seconds, so one request very nearly
  * saturates it — and the ceiling bounds a single call, not concurrent ones.
  *
- * ## What 4.3.1 changed, and why this test asserts a refusal rather than a time
+ * **The tests below deliberately use a 200-level chain, not those sizes.** 200
+ * exceeds the budget (~20,000 merge operations against a 10,000 default) while
+ * costing about 15 ms on the vulnerable version. Reviewer-found: with 3,000-
+ * and 6,000-level chains, a *regression* would have made this suite itself
+ * burn ~22 seconds of synchronous CPU, and Vitest's 10-second per-test timeout
+ * cannot interrupt a synchronous parser — so the regression would have stalled
+ * or exhausted a worker instead of producing a clean failure. A test that
+ * becomes the DoS when the DoS returns is the wrong shape.
  *
- * 4.3.1 did not make the merge faster. It added a document-wide budget,
- * `maxTotalMergeKeys` (default 10,000), and throws once the total number of
- * merge-key copy operations crosses it. So the fix is observable as a
- * deterministic error, and this test does not have to be a timing test — which
- * on shared CI runners is how flaky tests get written.
+ * ## What actually changed upstream, and why this is not a timing test
+ *
+ * Neither release made the merge faster.
+ *
+ *   - **4.2.0** added `maxDepth` (default 100) and fixed the repeated-alias
+ *     case named in the advisory.
+ *   - **4.3.0** added `maxTotalMergeKeys` (default 10,000), a document-wide
+ *     budget on merge-key copy operations, and throws when it is crossed.
+ *   - **4.3.1** added the `!!omap` complexity fix.
+ *
+ * So the fix is observable as a deterministic error, and these tests do not
+ * have to measure time — which on shared CI runners is how flaky tests get
+ * written. (An earlier draft asserted a five-second wall-clock bound. It was
+ * dropped: one sample does not establish scaling, and the named-budget
+ * assertion already gives a deterministic bound.)
  *
  * ## Fail-before
  *
- * Against `js-yaml@4.1.1` the bomb parses successfully and the executor
- * returns findings, so `rejects` fails; against 4.3.1 it throws. Verified in
- * both directions before this test was committed: 4 fail / 5 pass on 4.1.1,
- * 9 pass on 4.3.1.
+ * Verified in both directions before committing. On 4.1.1 the bomb parses
+ * successfully and the executor returns findings, so `rejects` fails.
  *
- * **To reproduce, downgrade `apps/api/node_modules`, not the repo root.** npm
- * keeps a nested `apps/api/node_modules/js-yaml`, and that is the copy the
- * executor resolves. The first attempt at this proof downgraded only the
- * hoisted root copy: the bomb tests passed, the vulnerable version was never
- * loaded, and the proof established nothing. Run
- * `cd apps/api && npm i js-yaml@4.1.1 --no-save`.
+ * To reproduce, check which copy Node actually resolves first —
+ * `createRequire(import.meta.url).resolve("js-yaml")`. A first attempt
+ * downgraded the hoisted root copy while `apps/api/node_modules` held the
+ * fixed version; the bomb tests passed, the vulnerable parser was never
+ * loaded, and the proof established nothing. The layout is not stable across
+ * checkouts, which is why the version assertion below resolves rather than
+ * building a path.
  */
 
 import { describe, expect, it } from "vitest";
@@ -60,13 +77,13 @@ import { getExecutor } from "./index.js";
 /**
  * A merge-key chain. Level `i` merges level `i-1` and adds one key, so level
  * `i` carries `i` keys and merging it copies `i` of them. Total copy
- * operations across the document are O(n²/2) — the quadratic the advisory
- * describes, from linear input.
+ * operations across the document are O(n²/2) — quadratic, from linear input.
  *
- * Not a YAML *syntax* error: see the positive control below, which parses a
- * short chain from this same generator successfully. Without that control this
- * test would pass just as happily on malformed output, which is the failure
- * mode where a test runs, finds nothing, and means nothing.
+ * Not a YAML *syntax* error: the positive control below parses a short chain
+ * from this same generator and checks the merge actually happened. Without
+ * that control these tests would pass just as happily on malformed output,
+ * which is the failure mode where a test runs, finds nothing, and means
+ * nothing.
  */
 function mergeChain(levels: number): string {
   const lines = ["a0: &a0", "  k0: 0"];
@@ -76,82 +93,125 @@ function mergeChain(levels: number): string {
   return lines.join("\n");
 }
 
+/** ~20,000 merge operations against a 10,000 default: over budget, cheap to run. */
+const OVER_BUDGET = 200;
+/** ~1,250 operations: comfortably under, and still deep enough to be a real merge. */
+const UNDER_BUDGET = 50;
+
 const run = () => getExecutor("workflow-security-audit")!;
 
 describe("workflow-security-audit refuses merge-key bombs", () => {
   it("rejects a chain that exceeds the merge-key budget", async () => {
-    // ~117 KB. Costs 4.1.1 about four seconds; 4.3.1 refuses immediately.
-    await expect(run()({ workflow: mergeChain(3000) })).rejects.toThrow(
+    await expect(run()({ workflow: mergeChain(OVER_BUDGET) })).rejects.toThrow(
       /Invalid YAML/,
     );
   });
 
   it("names the budget in the refusal, so the cause is diagnosable", async () => {
-    await expect(run()({ workflow: mergeChain(3000) })).rejects.toThrow(
+    // The load-bearing assertion. `/Invalid YAML/` alone would match any parse
+    // error, including one from a malformed generator.
+    await expect(run()({ workflow: mergeChain(OVER_BUDGET) })).rejects.toThrow(
       /maxTotalMergeKeys/,
     );
   });
 
-  it("POSITIVE CONTROL: the same generator below the budget parses fine", async () => {
-    // 100 levels is ~5,000 copy operations, under the 10,000 default. If this
-    // threw, the test above would be proving the generator emits broken YAML
-    // rather than proving the budget fires.
-    const result = (await run()({ workflow: mergeChain(100) })) as {
+  it("POSITIVE CONTROL: the same generator under budget parses AND merges", async () => {
+    // `expect(output).toBeTruthy()` was the original assertion here and it was
+    // worth nothing: the executor always returns an output object after any
+    // successful parse, so it proved the generator emits loadable YAML and
+    // stopped there. Reviewer-found.
+    //
+    // Parsing the generator's output directly is the honest check: every level
+    // must have inherited every key below it. If merges silently stopped being
+    // applied, the refusal tests above would still pass while meaning nothing.
+    const parsed = jsYaml.load(mergeChain(UNDER_BUDGET)) as Record<
+      string,
+      Record<string, number>
+    >;
+    const top = parsed[`a${UNDER_BUDGET}`]!;
+    expect(Object.keys(top)).toHaveLength(UNDER_BUDGET + 1);
+    expect(top.k0).toBe(0); // inherited all the way from level 0
+    expect(top[`k${UNDER_BUDGET}`]).toBe(UNDER_BUDGET); // its own key
+
+    // And the executor accepts it rather than refusing everything.
+    const result = (await run()({ workflow: mergeChain(UNDER_BUDGET) })) as {
       output: Record<string, unknown>;
     };
     expect(result.output).toBeTruthy();
   });
-
-  it("refuses the bomb far inside the /v1/do sync ceiling", async () => {
-    // The gap being asserted is three orders of magnitude (14s vs 20ms), so a
-    // 5-second bound is loose enough for a loaded CI runner and still fails
-    // outright on the vulnerable version. This is deliberately not a tight
-    // budget — the property is "does not scale with input", not "under Xms".
-    const started = Date.now();
-    await expect(run()({ workflow: mergeChain(6000) })).rejects.toThrow();
-    expect(Date.now() - started).toBeLessThan(5000);
-  });
 });
 
 describe("the fix does not break legitimate workflows", () => {
-  // The false-positive direction. A parser that refuses everything would pass
-  // every test above.
-  const realistic = [
+  /**
+   * The false-positive direction. A parser that refused everything would pass
+   * every test above.
+   *
+   * `runs-on: self-hosted` and `permissions: write-all` are declared ONLY on
+   * the anchor, never on the jobs. That matters: an earlier version of this
+   * fixture declared both on the job itself and asserted on the resulting
+   * findings, so the assertions passed whether or not `<<` was applied — they
+   * proved the audit works, not that merge semantics survived the upgrade.
+   * Reviewer-found. Declared only on the anchor, each finding appears if and
+   * only if the merge happened.
+   */
+  const anchored = [
     "name: ci",
     "on: [push]",
     "defaults: &defaults",
-    "  runs-on: ubuntu-latest",
-    "  timeout-minutes: 10",
+    "  runs-on: self-hosted",
+    "  permissions: write-all",
     "jobs:",
     "  build:",
     "    <<: *defaults",
-    "    permissions: write-all",
     "    steps:",
     "      - uses: actions/checkout@v4",
     "      - run: npm ci",
-    "  test:",
-    "    <<: *defaults",
-    "    steps:",
-    "      - uses: actions/checkout@v4",
-    "      - run: npm test",
   ].join("\n");
 
-  it("audits a workflow that uses anchors and merge keys", async () => {
-    const result = (await run()({ workflow: realistic })) as {
-      output: { findings?: unknown[] };
-    };
-    expect(Array.isArray(result.output.findings)).toBe(true);
-    // The merge must actually have been applied — `build` inherits `runs-on`
-    // from the anchor, and an unpinned-action finding proves the audit read
-    // the merged job rather than an empty one.
-    expect(JSON.stringify(result.output)).toMatch(/actions\/checkout@v4/);
-  });
-
-  it("still reports the over-broad permission in the merged job", async () => {
-    const result = (await run()({ workflow: realistic })) as {
+  it("sees the runner that was inherited through the merge key", async () => {
+    const result = (await run()({ workflow: anchored })) as {
       output: { findings?: Array<Record<string, unknown>> };
     };
-    expect(JSON.stringify(result.output.findings)).toMatch(/write-all|permission/i);
+    // checkRunner() returns early when `runs-on` is undefined, so this finding
+    // exists only if `<<: *defaults` was applied to jobs.build.
+    const runner = (result.output.findings ?? []).filter(
+      (f) => f.category === "runner_security" && f.location === "jobs.build",
+    );
+    expect(runner, "runs-on was not inherited through the merge key").toHaveLength(1);
+  });
+
+  it("sees the permissions that were inherited through the merge key", async () => {
+    const result = (await run()({ workflow: anchored })) as {
+      output: { findings?: Array<Record<string, unknown>> };
+    };
+    const perms = (result.output.findings ?? []).filter(
+      (f) => f.category === "permissions_scope" && f.location === "jobs.build",
+    );
+    expect(perms.length, "permissions were not inherited through the merge key")
+      .toBeGreaterThan(0);
+  });
+});
+
+describe("the new limits, and what they cost", () => {
+  /**
+   * 4.2.0 added `maxDepth` (default 100). Recording it deliberately: it is a
+   * behaviour change on caller input that this PR accepts rather than one it
+   * discovered afterwards. A GitHub Actions workflow nested more than 100
+   * levels deep is not a thing anyone writes, but the boundary is now real and
+   * belongs in the record rather than in a surprise.
+   */
+  it("refuses YAML nested past maxDepth", async () => {
+    const deep = "a:\n" + Array.from({ length: 150 }, (_, i) => "  ".repeat(i + 1) + "b:").join("\n") + "\n" + "  ".repeat(151) + "c: 1";
+    await expect(run()({ workflow: deep })).rejects.toThrow(/Invalid YAML/);
+  });
+
+  it("accepts nesting at a depth real workflows actually reach", async () => {
+    // A GitHub Actions workflow bottoms out around 6-8 levels
+    // (jobs > name > steps > item > with > key). 20 is generous headroom.
+    const nested =
+      "a:\n" + Array.from({ length: 20 }, (_, i) => "  ".repeat(i + 1) + "b:").join("\n") + "\n" + "  ".repeat(21) + "c: 1";
+    const result = (await run()({ workflow: nested })) as { output: unknown };
+    expect(result.output).toBeTruthy();
   });
 });
 
@@ -162,13 +222,14 @@ describe("the other production import site: manifest loading at boot", () => {
    * break, and it breaks the whole platform if it does: no manifests parsed
    * means no capabilities registered.
    *
-   * 4.3.1 added `maxTotalMergeKeys` AND a `maxDepth` limit, either of which
-   * could in principle reject a manifest that 4.1.1 accepted. This parses the
-   * real files rather than a fixture, because a fixture cannot answer that.
+   * This checks **parser compatibility over the real manifest corpus** — 4.2.0
+   * and 4.3.0 both added limits, and either could in principle reject a file
+   * 4.1.1 accepted. A fixture cannot answer that question; the real files can.
    *
-   * `readManifestSlugs` is module-private, so this reproduces its parse
-   * exactly instead of importing it — calling `autoRegisterCapabilities()`
-   * would fire 300+ dynamic imports.
+   * It is deliberately not a claim to have tested the boot path itself. The
+   * registration path is exercised by `ssrf-bucket-a.test.ts`, which calls
+   * `autoRegisterCapabilities()` directly, and was additionally run by hand
+   * against 4.3.1 for this change: 321 executors, 4 providers, 0 errors.
    */
   const manifestsDir = resolve(import.meta.dirname, "..", "..", "..", "..", "manifests");
 
@@ -192,25 +253,40 @@ describe("the other production import site: manifest loading at boot", () => {
         failures.push(`${file}: ${(e as Error).message.split("\n")[0]}`);
       }
     }
-    expect(failures, `manifests js-yaml 4.3.1 will not load:\n${failures.join("\n")}`).toEqual(
+    expect(failures, `manifests js-yaml will not load:\n${failures.join("\n")}`).toEqual(
       [],
     );
   });
 });
 
-describe("js-yaml is declared where production can actually find it", () => {
+describe("js-yaml is declared where production code can rely on it", () => {
   /**
-   * Observation 1 of the VERIFY-DEP triage. `js-yaml` was a devDependency of
-   * `apps/api` while being imported by two production paths — the boot-time
-   * manifest read and this capability. It worked only because the Dockerfile
-   * runs a bare `npm ci`, which installs devDependencies too.
+   * `js-yaml` was a devDependency of `apps/api` while two production paths
+   * imported it: the boot-time manifest read and this capability.
    *
-   * That made an ordinary, correct optimisation into an outage: adding
-   * `--omit=dev` to slim the image would have crashed the API at startup with
-   * no capabilities registered. A triage concluding "most findings are
-   * dev-only" is exactly the context in which someone reaches for that flag.
+   * **The original justification for this move was wrong, and the correction
+   * is worth more than the claim was.** The triage asserted that a production
+   * install with `--omit=dev` would crash at boot with no capabilities
+   * registered. It would not. There is a second, entirely production-side
+   * chain to the same package:
    *
-   * The declaration is now honest. This keeps it that way.
+   *     apps/api → c2pa-node → @changesets/cli → @changesets/parse → js-yaml ^4.1.1
+   *
+   * No `dev: true` marker anywhere on it, so `npm ci --omit=dev` installs
+   * js-yaml regardless. Reviewer-found, and verified against the pre-PR
+   * lockfile before this comment was written.
+   *
+   * The real defect is quieter. With the direct declaration dev-only, the
+   * version that lands at `node_modules/js-yaml` in a production install is
+   * decided by `@changesets/parse`'s `^4.1.1` — a range belonging to a
+   * changelog tool that `c2pa-node` should not be shipping as a runtime
+   * dependency in the first place. Production parser behaviour was a
+   * side-effect of someone else's build tooling, and dropping or bumping
+   * `c2pa-node` could have changed or removed it with no signal here.
+   *
+   * That is why the declaration matters, and it is also why the upgrade
+   * without the move would have been insufficient: the range would still have
+   * permitted 4.1.1.
    */
   it("is a dependency, not a devDependency", () => {
     const pkg = JSON.parse(
@@ -221,22 +297,15 @@ describe("js-yaml is declared where production can actually find it", () => {
     expect(pkg.devDependencies["js-yaml"]).toBeUndefined();
   });
 
-  it("is pinned at or above the version that added the merge-key budget", () => {
-    // RESOLVED, not the hoisted root copy.
-    //
-    // This test originally read `<repo>/node_modules/js-yaml/package.json`
-    // directly, and it was wrong in a way that mattered: npm keeps a nested
-    // `apps/api/node_modules/js-yaml`, and that is the copy the executor
-    // actually loads. During the fail-before proof the root was downgraded to
-    // 4.1.1 while the nested copy stayed at 4.3.1 — the bomb tests passed, the
-    // vulnerable version was never exercised, and the whole proof was
-    // vacuous. Resolving through Node's own algorithm is the only way to
-    // assert on the copy that runs.
-    const version = createRequire(import.meta.url)("js-yaml/package.json").version as string;
+  it("resolves to a version at or above the one that added the merge-key budget", () => {
+    // RESOLVED, not a hand-built path to the hoisted root copy. Which copy
+    // wins is not stable across checkouts, and asserting on the wrong one is
+    // what made the first fail-before proof vacuous.
+    const version = createRequire(import.meta.url)("js-yaml/package.json")
+      .version as string;
 
     const [maj, min, patch] = version.split(".").map(Number);
-    const atLeast431 =
-      maj! > 4 || (maj === 4 && (min! > 3 || (min === 3 && patch! >= 1)));
-    expect(atLeast431, `js-yaml ${version} predates the fix`).toBe(true);
+    const atLeast430 = maj! > 4 || (maj === 4 && (min! > 3 || (min === 3 && patch! >= 0)));
+    expect(atLeast430, `js-yaml ${version} predates maxTotalMergeKeys`).toBe(true);
   });
 });


### PR DESCRIPTION
#389 merged at `2da24a2`, one commit before the review response landed on the
branch. **The dependency fix is correct and is on main** — `js-yaml ^4.3.1` in
`dependencies`, and the security property holds. What did not arrive is the fix
to the *test* that guards it, plus a correction to the reasoning #389 gave.

One test file. No production code changes.

## 1. The `--omit=dev` claim now on main is false

#389 argued `js-yaml` had to move to `dependencies` because a production install
with `--omit=dev` would otherwise crash at boot with no capabilities registered.
**It would not.** There is a second chain to the same package, entirely
production-side:

```
apps/api -> c2pa-node -> @changesets/cli -> @changesets/parse -> js-yaml ^4.1.1
```

No `dev: true` marker anywhere on it, verified against the pre-#389 lockfile.

**The move is still right, for a quieter and stronger reason.** With the direct
declaration dev-only, the version reaching production was decided by
`@changesets/parse`'s `^4.1.1` — a range belonging to a changelog tool that
`c2pa-node` should not ship at runtime at all. That range **still permits
4.1.1**, so the version bump alone would not have bound; the declaration is what
makes it stick. The comment now says that, instead of the thing that was not true.

## 2. The suite became the DoS when the DoS returned

This is the change worth having.

The merged version parses 3,000-level chains twice and a 6,000-level chain once.
On a regression that is **~22 seconds of synchronous CPU** — and vitest's 10 s
per-test timeout cannot interrupt a synchronous parser, so a real regression
would stall or exhaust a worker rather than fail cleanly.

Now 200 levels: still ~20,000 merge operations against a 10,000 budget, but
**173 ms** on the vulnerable version instead of 22 seconds.

## 3. The compatibility assertions did not prove what their comments claimed

The fixture declared `runs-on` and `permissions` **on the job itself**, so the
findings appeared whether or not `<<` was applied — proving the audit works, not
that merge semantics survived the upgrade.

Both are now declared **only on the anchor**, where `checkRunner()` returning
early on an undefined `runs-on` makes each finding conditional on the merge
actually having happened. The positive control asserted `toBeTruthy()` on an
always-present object; it now checks that every level inherited every key below it.

## 4. Release attribution was wrong

`maxDepth` and the repeated-alias fix landed in **4.2.0**; `maxTotalMergeKeys` in
**4.3.0**; **4.3.1** added the `!!omap` fix. Verified by diffing the three
published tarballs. 4.3.1 remains the right target — the description of *why* was
not.

## 5. `maxDepth` was an unrecorded behaviour change

Default 100, on caller input. Now tested at both ends: refused past the limit,
accepted at the depth real workflows reach (6-8 levels; the test uses 20).

## Verification

- **4 fail / 6 pass on js-yaml 4.1.1 · 10 pass on 4.3.1**, re-proven on this branch.
- To reproduce, check which copy Node resolves first —
  `createRequire(import.meta.url).resolve("js-yaml")`. My first attempt downgraded
  the hoisted root copy while `apps/api/node_modules` held the fixed version: the
  bomb tests passed and the proof established nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
