### PR TITLE
fix(x402): bound the request body, and the work a small request can buy

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -314,6 +314,32 @@ app.use("/v1/*", bodyLimit({ maxSize: 1024 * 1024 }));   // 1 MB for API routes
 app.use("/a2a", bodyLimit({ maxSize: 256 * 1024 }));      // 256 KB for A2A
 app.use("/mcp", bodyLimit({ maxSize: 512 * 1024 }));      // 512 KB for MCP
 
+// The x402 rail had NO body cap at all. Every other entry point above has had
+// one for months; this one was simply never added, so `/x402/:slug` buffered
+// whatever a caller sent straight into `c.req.json()`.
+//
+// ## Why 8 MiB and not the 1 MiB used for /v1
+//
+// Copying the /v1 number would have broken a capability contract. Measured
+// evidence, 2026-08-25:
+//
+//   - Largest x402 request body ever observed: 2,658 bytes, across 1,537
+//     requests since 2026-08-15. p50 41 B, p95 111 B, p99 289 B.
+//   - Largest input the platform INTENTIONALLY supports: image-to-text
+//     declares MAX_IMAGE_BYTES = 4 MiB decoded. Base64 is 4/3 expansion, so
+//     that is ~5.33 MiB on the wire before the JSON wrapper.
+//   - Seven x402 capabilities accept base64 (image-resize, image-to-text,
+//     receipt-categorize, pdf-extract, invoice-extract, contract-extract,
+//     resume-parse). Four of those are document extractors where multi-MiB
+//     PDFs are the normal case.
+//
+// 8 MiB clears the 5.33 MiB contract with room for the JSON wrapper and
+// sibling fields, and is ~3,000x the largest request ever seen — so it cannot
+// affect real traffic. Its job is not to be tight. It is to turn "unbounded"
+// into "bounded"; the tight limits belong in the capabilities, where the units
+// are decoded bytes and output pixels rather than wire bytes.
+app.use("/x402/*", bodyLimit({ maxSize: 8 * 1024 * 1024 }));  // 8 MiB for the x402 rail
+
 // A2A: Link header pointing to Agent Card on all API responses
 app.use("*", async (c, next) => {
   await next();

--- a/apps/api/src/capabilities/image-resize.limits.test.ts
+++ b/apps/api/src/capabilities/image-resize.limits.test.ts
@@ -1,0 +1,309 @@
+/**
+ * `image-resize` must refuse oversized and over-ambitious requests BEFORE any
+ * bytes reach sharp/libvips.
+ *
+ * ## Why a rail body cap is not enough
+ *
+ * The `/x402/*` body cap added alongside this bounds the wire. It says nothing
+ * about how much work a *small* request can buy, and measuring that turned up
+ * a much cheaper attack than an oversized body. From a **235-byte** source
+ * image, varying only the requested output dimensions (sharp 0.35.3 /
+ * libvips 8.18.3):
+ *
+ *     2,000 x 2,000      60 KB       88 ms
+ *     10,000 x 10,000    1.3 MB      2.1 s
+ *     30,000 x 30,000    11.9 MB     5.8 s
+ *     100,000 x 100,000  131 MB      95.8 s
+ *
+ * A few hundred bytes buys 96 seconds of CPU and a 131 MB allocation. No body
+ * limit can see that, because the request is tiny — the amplification is in
+ * the parameters, so the limit has to be there too.
+ *
+ * ## Why sharp is spied on rather than trusted
+ *
+ * "Refuses oversized input" and "oversized input never reaches the decoder"
+ * are different claims, and only the second one is the security property. A
+ * test that asserts the error message proves the first. These assert the
+ * decoder was never constructed, which is the one that matters when the
+ * decoder is native code with memory-safety advisories against it.
+ *
+ * The spy delegates to the real sharp, so the success cases below still
+ * exercise the actual pipeline.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const sharpCalls = vi.fn();
+const safeFetchMock = vi.fn();
+
+// safeFetch is mocked so the URL branch can be driven without a network. Its
+// own SSRF behaviour is covered by ssrf-bucket-a.test.ts; what is under test
+// here is what image-resize does with the RESPONSE.
+vi.mock("../lib/safe-fetch.js", () => ({
+  safeFetch: (...args: unknown[]) => safeFetchMock(...args),
+}));
+
+vi.mock("sharp", async (importOriginal) => {
+  const actual = (await importOriginal()) as { default: unknown };
+  const real = actual.default as (...args: unknown[]) => unknown;
+  const spy = (...args: unknown[]) => {
+    sharpCalls(...args);
+    return real(...args);
+  };
+  return { default: Object.assign(spy, real) };
+});
+
+import sharp from "sharp";
+import "./image-resize.js";
+import { getExecutor } from "./index.js";
+import {
+  MAX_DECODED_IMAGE_BYTES,
+  MAX_OUTPUT_DIMENSION,
+  MAX_OUTPUT_PIXELS,
+  decodedLengthOfBase64,
+  assertOutputGeometryWithinLimit,
+  readBodyWithLimit,
+  ImageLimitError,
+} from "./lib/image-limits.js";
+import { classifyTransactionFailure, countsAgainstCapability } from "../lib/transaction-failure-taxonomy.js";
+
+const run = () => getExecutor("image-resize")!;
+
+/** A Response that streams `totalBytes`, optionally declaring a content-length. */
+function streamingResponse(totalBytes: number, declare?: number): Response {
+  const chunk = new Uint8Array(64 * 1024);
+  let sent = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(ctrl) {
+      if (sent >= totalBytes) {
+        ctrl.close();
+        return;
+      }
+      ctrl.enqueue(chunk);
+      sent += chunk.byteLength;
+    },
+  });
+  const headers = new Headers();
+  if (declare !== undefined) headers.set("content-length", String(declare));
+  return new Response(body, { status: 200, headers });
+}
+
+async function tinyPng(): Promise<Buffer> {
+  return sharp({
+    create: { width: 64, height: 64, channels: 3, background: { r: 1, g: 2, b: 3 } },
+  })
+    .png()
+    .toBuffer();
+}
+
+beforeEach(() => {
+  sharpCalls.mockClear();
+  safeFetchMock.mockReset();
+});
+
+describe("oversized base64 cannot reach sharp/libvips", () => {
+  it("refuses a base64 payload over the decoded-size limit", async () => {
+    // 'a' is a valid base64 char, so this is a well-formed payload that
+    // decodes to ~6 MiB. It is not rejected for being malformed.
+    const b64 = "a".repeat(Math.ceil(((MAX_DECODED_IMAGE_BYTES + 2 * 1024 * 1024) * 4) / 3));
+    await expect(run()({ base64: b64, target_width: 100 })).rejects.toThrow(
+      /'base64' must be .* or less once decoded/,
+    );
+  });
+
+  it("and sharp was never constructed", async () => {
+    const b64 = "a".repeat(Math.ceil(((MAX_DECODED_IMAGE_BYTES + 2 * 1024 * 1024) * 4) / 3));
+    await expect(run()({ base64: b64, target_width: 100 })).rejects.toThrow();
+    expect(sharpCalls, "oversized bytes reached the native decoder").not.toHaveBeenCalled();
+  });
+
+  it("the size is computed WITHOUT decoding the payload", () => {
+    // Decoding to measure would allocate the very thing being refused. The
+    // helper works from the string length, so this holds for any size.
+    const decoded = 9 * 1024 * 1024;
+    const b64 = "a".repeat(Math.ceil((decoded * 4) / 3));
+    expect(decodedLengthOfBase64(b64)).toBeGreaterThan(MAX_DECODED_IMAGE_BYTES);
+  });
+
+  it("POSITIVE CONTROL: the same path accepts a payload under the limit", async () => {
+    // Without this, every assertion above would pass on a capability that
+    // refused everything.
+    const b64 = (await tinyPng()).toString("base64");
+    const r = (await run()({ base64: b64, target_width: 32, target_height: 32 })) as {
+      output: { width: number; height: number };
+    };
+    expect(r.output.width).toBe(32);
+    expect(sharpCalls).toHaveBeenCalled();
+  });
+});
+
+describe("output geometry is bounded before anything is decoded", () => {
+  it("refuses a single dimension past the per-side cap", async () => {
+    const b64 = (await tinyPng()).toString("base64");
+    await expect(
+      run()({ base64: b64, target_width: MAX_OUTPUT_DIMENSION + 1, target_height: 10 }),
+    ).rejects.toThrow(/'target_width' must be \d+px or less/);
+  });
+
+  it("refuses an area past the megapixel cap even when both sides are legal", async () => {
+    // 10,000 x 10,000 is exactly at the per-side cap and 100 MP — four times
+    // the area cap. Without the area check each side would pass individually.
+    const b64 = (await tinyPng()).toString("base64");
+    await expect(
+      run()({
+        base64: b64,
+        target_width: MAX_OUTPUT_DIMENSION,
+        target_height: MAX_OUTPUT_DIMENSION,
+      }),
+    ).rejects.toThrow(/megapixels or less/);
+  });
+
+  it("the 100,000-square case is refused, and sharp is never constructed", async () => {
+    const b64 = (await tinyPng()).toString("base64");
+    // The fixture is built BY sharp, so the spy has one call on it already.
+    // Clearing here rather than in beforeEach is the difference between
+    // measuring the executor and measuring the test's own setup — the first
+    // version of this assertion failed for exactly that reason.
+    sharpCalls.mockClear();
+
+    await expect(
+      run()({ base64: b64, target_width: 100_000, target_height: 100_000 }),
+    ).rejects.toThrow();
+    expect(sharpCalls, "the amplifying request reached the decoder").not.toHaveBeenCalled();
+  });
+
+  it("refuses negative, fractional and non-finite dimensions", () => {
+    for (const bad of [-1, 0, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => assertOutputGeometryWithinLimit(bad, 10), `accepted ${bad}`).toThrow(
+        ImageLimitError,
+      );
+    }
+  });
+
+  it("POSITIVE CONTROL: a realistic large resize is still allowed", async () => {
+    // 4000 x 3000 is 12 MP — a normal camera frame, comfortably under the cap.
+    expect(() => assertOutputGeometryWithinLimit(4000, 3000)).not.toThrow();
+    expect(4000 * 3000).toBeLessThan(MAX_OUTPUT_PIXELS);
+  });
+});
+
+describe("the image_url path is bounded too", () => {
+  // Otherwise it is simply the cheaper way in: it carries no body at all, so
+  // the rail cap never sees it and the base64 limit above is decorative.
+  it("refuses on a declared content-length over the limit, without reading", async () => {
+    const res = streamingResponse(1024, MAX_DECODED_IMAGE_BYTES + 1);
+    await expect(readBodyWithLimit(res)).rejects.toThrow(/'image_url' must return/);
+  });
+
+  it("aborts a stream that exceeds the limit even with no content-length", async () => {
+    const res = streamingResponse(MAX_DECODED_IMAGE_BYTES + 2 * 1024 * 1024);
+    await expect(readBodyWithLimit(res)).rejects.toThrow(/'image_url' must return/);
+  });
+
+  it("does not buffer materially more than the limit before aborting", async () => {
+    // The property that makes this a limit rather than a report. Counts what
+    // the reader actually pulled.
+    let pulled = 0;
+    const chunk = new Uint8Array(64 * 1024);
+    const body = new ReadableStream<Uint8Array>({
+      pull(ctrl) {
+        pulled += chunk.byteLength;
+        ctrl.enqueue(chunk);
+      },
+    });
+    await expect(readBodyWithLimit(new Response(body))).rejects.toThrow();
+    expect(pulled).toBeLessThanOrEqual(MAX_DECODED_IMAGE_BYTES + 128 * 1024);
+  });
+
+  it("POSITIVE CONTROL: an under-limit body is returned intact", async () => {
+    const png = await tinyPng();
+    const out = await readBodyWithLimit(new Response(new Uint8Array(png)));
+    expect(out.byteLength).toBe(png.byteLength);
+  });
+
+  /**
+   * The tests above prove the HELPER bounds a response. They do not prove
+   * `image-resize` uses it, and that gap was real: reverting the executor's
+   * `readBodyWithLimit(response)` back to `Buffer.from(await
+   * response.arrayBuffer())` left all 33 tests passing. Found by the mutation
+   * run, not by review — a guard that is never wired in is indistinguishable
+   * from no guard.
+   *
+   * These drive the executor's own `image_url` branch.
+   */
+  it("the EXECUTOR refuses an oversized image_url response", async () => {
+    const res = streamingResponse(MAX_DECODED_IMAGE_BYTES + 2 * 1024 * 1024);
+    safeFetchMock.mockResolvedValueOnce(res);
+
+    await expect(
+      run()({ image_url: "https://example.test/big.png", target_width: 100 }),
+    ).rejects.toThrow(/'image_url' must return/);
+  });
+
+  it("and sharp is never constructed for an oversized image_url", async () => {
+    safeFetchMock.mockResolvedValueOnce(
+      streamingResponse(MAX_DECODED_IMAGE_BYTES + 2 * 1024 * 1024),
+    );
+    sharpCalls.mockClear();
+
+    await expect(
+      run()({ image_url: "https://example.test/big.png", target_width: 100 }),
+    ).rejects.toThrow();
+    expect(sharpCalls, "oversized fetched bytes reached the decoder").not.toHaveBeenCalled();
+  });
+
+  it("POSITIVE CONTROL: the executor still resizes an under-limit image_url", async () => {
+    const png = await tinyPng();
+    safeFetchMock.mockResolvedValueOnce(
+      new Response(new Uint8Array(png), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    const r = (await run()({
+      image_url: "https://example.test/ok.png",
+      target_width: 32,
+      target_height: 32,
+    })) as { output: { width: number; height: number } };
+    expect(r.output.width).toBe(32);
+  });
+});
+
+describe("a refusal is the caller's fault, not the capability's", () => {
+  /**
+   * The quality floor is armed (quarantine below 70% on >=10 real calls). A
+   * correct refusal counted as a capability failure would push `image-resize`
+   * toward delisting for doing its job — the exact failure the taxonomy's own
+   * comments describe. Verified rather than assumed.
+   */
+  it("every refusal message classifies as caller_input and does not count", () => {
+    const messages: string[] = [];
+    const capture = (f: () => void) => {
+      try {
+        f();
+      } catch (e) {
+        messages.push((e as Error).message);
+      }
+    };
+    capture(() => assertOutputGeometryWithinLimit(-1, 10));
+    capture(() => assertOutputGeometryWithinLimit(MAX_OUTPUT_DIMENSION + 1, 10));
+    capture(() => assertOutputGeometryWithinLimit(MAX_OUTPUT_DIMENSION, MAX_OUTPUT_DIMENSION));
+    expect(messages.length).toBe(3);
+
+    for (const m of messages) {
+      const cls = classifyTransactionFailure(m);
+      expect(cls, `"${m}" classified as ${cls}`).toBe("caller_input");
+      expect(countsAgainstCapability(cls)).toBe(false);
+    }
+  });
+
+  it("refusals throw rather than returning an output, so nothing settles", () => {
+    // The executor contract: a thrown error means no output object, and the
+    // /v1 and x402 paths both settle only after a successful execution
+    // (x402-gateway-v2 verifies, executes, then settles; do.ts is
+    // verify -> execute -> settle per DEC-14). A refusal cannot produce a
+    // charge because it cannot produce a success.
+    expect(() => assertOutputGeometryWithinLimit(100_000, 100_000)).toThrow(ImageLimitError);
+  });
+});

--- a/apps/api/src/capabilities/image-resize.ts
+++ b/apps/api/src/capabilities/image-resize.ts
@@ -1,6 +1,12 @@
 import { registerCapability, type CapabilityInput } from "./index.js";
 import sharp from "sharp";
 import { safeFetch } from "../lib/safe-fetch.js";
+import {
+  assertDecodedSizeWithinLimit,
+  assertOutputGeometryWithinLimit,
+  decodedLengthOfBase64,
+  readBodyWithLimit,
+} from "./lib/image-limits.js";
 
 registerCapability("image-resize", async (input: CapabilityInput) => {
   const imageUrl = (input.image_url as string) ?? (input.url as string) ?? undefined;
@@ -20,12 +26,23 @@ registerCapability("image-resize", async (input: CapabilityInput) => {
     throw new Error("'target_width' or 'target_height' is required.");
   }
 
+  // Geometry first, before a single byte is fetched or decoded. This is the
+  // cheap-request/expensive-work case: a 235-byte source with
+  // target_width=100000 produced a 131 MB output over 96 seconds of CPU. The
+  // rail body cap cannot see that — the request is tiny — so the check has to
+  // sit next to the parameter that does the amplifying. See lib/image-limits.ts.
+  assertOutputGeometryWithinLimit(targetWidth, targetHeight);
+
   // Get image buffer
   let imageBuffer: Buffer;
   if (base64Input) {
     const data = base64Input.startsWith("data:")
       ? base64Input.replace(/^data:image\/\w+;base64,/, "")
       : base64Input;
+    // Sized from the string, then decoded — not decoded and then measured. A
+    // check that runs after Buffer.from() has already allocated the thing it
+    // was meant to prevent.
+    assertDecodedSizeWithinLimit(decodedLengthOfBase64(data));
     imageBuffer = Buffer.from(data, "base64");
   } else {
     // F-0-006: safeFetch validates + refuses DNS-rebinding / private-IP redirects.
@@ -34,7 +51,11 @@ registerCapability("image-resize", async (input: CapabilityInput) => {
       headers: { "User-Agent": "Strale/1.0 (image processor; admin@strale.io)" },
     });
     if (!response.ok) throw new Error(`Failed to fetch image: HTTP ${response.status}`);
-    imageBuffer = Buffer.from(await response.arrayBuffer());
+    // Streamed with a cap rather than arrayBuffer(). Without this the URL path
+    // is the cheaper way in: it is not covered by the rail body limit at all,
+    // so it would set the real ceiling and the base64 cap above would be
+    // decorative.
+    imageBuffer = await readBodyWithLimit(response);
   }
 
   // Process with Sharp

--- a/apps/api/src/capabilities/lib/image-limits.ts
+++ b/apps/api/src/capabilities/lib/image-limits.ts
@@ -47,6 +47,8 @@ export const MAX_OUTPUT_DIMENSION = 10_000;
  */
 export const MAX_OUTPUT_PIXELS = 25_000_000;
 
+import { logError } from "../../lib/log.js";
+
 /** Thrown for a refusal that is the caller's fault, so it maps to a 4xx rather than a 500. */
 export class ImageLimitError extends Error {
   constructor(message: string) {
@@ -176,7 +178,15 @@ export async function readBodyWithLimit(
       if (total > maxBytes) {
         // Stop pulling. The bytes already read are bounded by maxBytes plus
         // one chunk, which is the point.
-        await reader.cancel().catch(() => {});
+        //
+        // cancel() can reject if the peer already tore the connection down.
+        // That is expected here and must not mask the refusal below — but it
+        // is logged rather than swallowed, per F-0-009: a bare
+        // `.catch(() => {})` is exactly how a real transport fault becomes
+        // invisible.
+        await reader
+          .cancel()
+          .catch((err) => logError("image-limit-reader-cancel", err, { maxBytes }));
         throw new ImageLimitError(
           `'${field}' must return ${mib(maxBytes)} or less.`,
         );

--- a/apps/api/src/capabilities/lib/image-limits.ts
+++ b/apps/api/src/capabilities/lib/image-limits.ts
@@ -1,0 +1,190 @@
+/**
+ * Resource limits for capabilities that hand caller-supplied bytes to a native
+ * image decoder.
+ *
+ * ## Why these exist
+ *
+ * VERIFY-DEP / WP13 follow-up, 2026-08-25. The `/x402/*` rail had no body cap,
+ * which is fixed at the rail in `app.ts`. But a rail cap only bounds the wire:
+ * it says nothing about how much work a *small* request can buy, and measuring
+ * that turned up a far cheaper attack than an oversized body.
+ *
+ * Measured against sharp 0.35.3 / libvips 8.18.3, from a **235-byte** source
+ * image, varying only the requested output dimensions:
+ *
+ *     target          result                       cost
+ *     2,000x2,000     60 KB                        88 ms
+ *     10,000x10,000   1.3 MB                       2.1 s
+ *     30,000x30,000   11.9 MB                      5.8 s
+ *     100,000x100,000 131 MB                       95.8 s
+ *
+ * A few hundred bytes on the wire buys 96 seconds of CPU and a 131 MB
+ * allocation. No body limit can catch that, because the request is tiny. The
+ * amplification is in the *parameters*, so the limit has to be there too.
+ *
+ * sharp's own `limitInputPixels` default (268,402,689) guards decode INPUT.
+ * There is no corresponding default for output geometry.
+ */
+
+/**
+ * Largest decoded image the platform accepts.
+ *
+ * 4 MiB, matching `image-to-text`'s existing `MAX_IMAGE_BYTES` rather than
+ * inventing a second number. Note that image-to-text applies it only on its
+ * URL path — its base64 path is unchecked — so this is the platform's stated
+ * figure, not a uniformly enforced one. Enforcing the same value here keeps
+ * the number singular while that asymmetry is closed separately.
+ */
+export const MAX_DECODED_IMAGE_BYTES = 4 * 1024 * 1024;
+
+/** No single output edge beyond this. 10,000 px is well past any real display or print need. */
+export const MAX_OUTPUT_DIMENSION = 10_000;
+
+/**
+ * Total output pixels. 25 MP comfortably exceeds a 6000x4000 full-frame frame
+ * (24 MP), so it does not constrain a real resize; it stops the 100,000-square
+ * case above, which is four hundred times larger.
+ */
+export const MAX_OUTPUT_PIXELS = 25_000_000;
+
+/** Thrown for a refusal that is the caller's fault, so it maps to a 4xx rather than a 500. */
+export class ImageLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ImageLimitError";
+  }
+}
+
+const mib = (n: number) => `${(n / 1024 / 1024).toFixed(1)}MB`;
+
+/**
+ * Decoded size of a base64 payload, WITHOUT allocating it.
+ *
+ * Deliberately computed from the string length: `Buffer.from(s, "base64")`
+ * would allocate the very thing being checked, so a check performed after
+ * decoding is not a limit, it is a post-mortem.
+ */
+export function decodedLengthOfBase64(b64: string): number {
+  const data = b64.startsWith("data:") ? b64.slice(b64.indexOf(",") + 1) : b64;
+  const clean = data.replace(/\s/g, "");
+  if (clean.length === 0) return 0;
+  const padding = clean.endsWith("==") ? 2 : clean.endsWith("=") ? 1 : 0;
+  return Math.floor((clean.length * 3) / 4) - padding;
+}
+
+/**
+ * Messages here open with a quoted field name and use "must be".
+ *
+ * That is this codebase's house style for caller-facing validation, and
+ * `transaction-failure-taxonomy.ts` keys on it: those phrasings classify as
+ * `caller_input`, while free-form prose lands in `unclassified`. Neither
+ * counts against the capability under the armed quality floor — `unclassified`
+ * is in UNATTRIBUTED — so this is precision rather than a rescue. It also
+ * happens to be the better message, because it names the field at fault.
+ *
+ * Checked, not assumed: the phrasings below were run through
+ * `classifyTransactionFailure` before being written this way.
+ */
+export function assertDecodedSizeWithinLimit(
+  bytes: number,
+  field = "base64",
+): void {
+  if (bytes > MAX_DECODED_IMAGE_BYTES) {
+    throw new ImageLimitError(
+      `'${field}' must be ${mib(MAX_DECODED_IMAGE_BYTES)} or less once decoded (received ${mib(bytes)}).`,
+    );
+  }
+}
+
+/**
+ * Refuse output geometry that would cost far more than the request paid for.
+ *
+ * Also rejects non-finite, negative and non-integer values: `resize(NaN)` and
+ * `resize(-1)` are not meaningful, and letting them reach the decoder makes
+ * the failure a 500 that reads like a platform fault.
+ */
+export function assertOutputGeometryWithinLimit(
+  width: number | undefined,
+  height: number | undefined,
+): void {
+  for (const [name, value] of [
+    ["target_width", width],
+    ["target_height", height],
+  ] as const) {
+    if (value === undefined) continue;
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < 1) {
+      throw new ImageLimitError(`'${name}' must be a positive whole number of pixels.`);
+    }
+    if (value > MAX_OUTPUT_DIMENSION) {
+      throw new ImageLimitError(
+        `'${name}' must be ${MAX_OUTPUT_DIMENSION}px or less (received ${value}px).`,
+      );
+    }
+  }
+
+  // Both sides present: bound the area too. Each side can be under its own cap
+  // while the product is not — 10,000 x 10,000 is 100 MP, four times the cap.
+  if (width !== undefined && height !== undefined) {
+    const pixels = width * height;
+    if (pixels > MAX_OUTPUT_PIXELS) {
+      throw new ImageLimitError(
+        `'target_width' x 'target_height' must be ${MAX_OUTPUT_PIXELS / 1_000_000} megapixels or less ` +
+          `(received ${width}x${height}, ${(pixels / 1_000_000).toFixed(1)} megapixels).`,
+      );
+    }
+  }
+}
+
+/**
+ * Read a fetched response body, aborting once the cap is crossed.
+ *
+ * `await response.arrayBuffer()` cannot enforce a limit: by the time it
+ * resolves the bytes are already resident, so checking the length afterwards
+ * bounds nothing. A caller passing `image_url` pointing at a 1 GB file would
+ * otherwise walk straight past every base64 limit above — the size cap and the
+ * URL path have to agree, or the cheaper path decides the real limit.
+ *
+ * Falls back to buffering only when the response exposes no readable stream.
+ */
+export async function readBodyWithLimit(
+  response: Response,
+  maxBytes: number = MAX_DECODED_IMAGE_BYTES,
+  field = "image_url",
+): Promise<Buffer> {
+  // Trust a declared length enough to refuse early, never enough to accept.
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new ImageLimitError(
+      `'${field}' must return ${mib(maxBytes)} or less (it declared ${mib(declared)}).`,
+    );
+  }
+
+  if (!response.body) {
+    const buf = Buffer.from(await response.arrayBuffer());
+    assertDecodedSizeWithinLimit(buf.byteLength, field);
+    return buf;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        // Stop pulling. The bytes already read are bounded by maxBytes plus
+        // one chunk, which is the point.
+        await reader.cancel().catch(() => {});
+        throw new ImageLimitError(
+          `'${field}' must return ${mib(maxBytes)} or less.`,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+  return Buffer.concat(chunks, total);
+}

--- a/apps/api/src/routes/x402-body-limit.test.ts
+++ b/apps/api/src/routes/x402-body-limit.test.ts
@@ -1,0 +1,280 @@
+/**
+ * The `/x402/*` rail must bound the request body, and must refuse cleanly.
+ *
+ * ## The gap
+ *
+ * VERIFY-DEP / WP13 follow-up, 2026-08-25. `app.ts` has applied a `bodyLimit`
+ * to `/v1/*` (1 MiB), `/a2a` (256 KiB), `/mcp` (512 KiB) and `/webhooks/*`
+ * (512 KiB) for months. `/x402/*` had none — it was simply never added — so
+ * `x402-gateway-v2.ts`'s `extractInputs()` buffered whatever a caller sent
+ * straight into `c.req.json()`.
+ *
+ * ## Why 8 MiB rather than copying /v1's 1 MiB
+ *
+ * Measured before choosing, because copying 1 MiB would have broken a
+ * capability contract:
+ *
+ *   - Largest x402 request body ever observed in production: **2,658 bytes**,
+ *     across 1,537 requests since 2026-08-15 (p50 41 B, p95 111 B, p99 289 B).
+ *   - Largest input the platform intentionally supports: `image-to-text`
+ *     declares `MAX_IMAGE_BYTES = 4 MiB` decoded — ~5.33 MiB of base64 on the
+ *     wire before the JSON wrapper.
+ *   - Seven x402 capabilities accept base64, four of them document extractors
+ *     where multi-MiB PDFs are the normal case.
+ *
+ * 1 MiB is below what we already promise. 8 MiB is above it with room for the
+ * wrapper, and still ~3,000x the largest request ever seen.
+ *
+ * ## The half a body cap alone would have missed
+ *
+ * Hono's `bodyLimit` has two branches and only one is a pre-flight rejection:
+ *
+ *   - **Content-Length present** → compared against the cap and rejected
+ *     before the body is touched.
+ *   - **No Content-Length (chunked)** → the body is wrapped in a counting
+ *     stream that ERRORS once the cap is crossed, and that error becomes a 413
+ *     only if it reaches `c.error`.
+ *
+ * `extractInputs()` wrapped `c.req.json()` in `try { … } catch { }` and fell
+ * through to query params. Measured against a real HTTP socket before the fix,
+ * an oversized chunked POST returned **`200 OK` with the body silently treated
+ * as empty** — past payment verification, into input validation, with no
+ * inputs. Memory was bounded; the answer was a lie.
+ *
+ * ## Why the boundary tests do not send eight megabytes
+ *
+ * Because the fix immediately above this one in the programme was a test that
+ * became the workload it guarded against. Sending real 8 MiB bodies through
+ * `app.request` timed out the suite at 10 s per case.
+ *
+ * Two branches, tested where each actually lives:
+ *
+ *   - The **pre-flight** branch reads `Content-Length` and never touches the
+ *     body, so a declared length with a short body exercises exactly the code
+ *     a real oversized request would hit — at no cost. Node's HTTP parser
+ *     rejects a mismatched Content-Length with 400 before Hono sees it
+ *     (verified over a real socket), so this shape is reachable only in-process.
+ *   - The **streaming** branch is exercised on a purpose-built Hono app with a
+ *     small cap, mirroring the middleware plus the gateway's swallowing
+ *     handler. Reaching it through the real app needs a populated capability
+ *     cache and therefore a database.
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { HTTPException } from "hono/http-exception";
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({
+    execute: () => Promise.resolve([]),
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+        innerJoin: () => ({ where: () => ({ orderBy: () => Promise.resolve([]) }) }),
+      }),
+    }),
+  }),
+}));
+
+vi.mock("./mcp.js", () => {
+  const { Hono: H } = require("hono");
+  return { mcpRoute: new H() };
+});
+
+beforeAll(() => {
+  process.env.ADMIN_SECRET = "unit-test-admin-secret-plenty-of-entropy-0123456789";
+  process.env.AUDIT_HMAC_SECRET = "unit-test-audit-secret-plenty-of-entropy-0123456789";
+});
+
+async function loadApp() {
+  const { app } = await import("./../app.js");
+  return app;
+}
+
+/** The declared rail cap, restated so a change in app.ts must change this too. */
+const X402_LIMIT = 8 * 1024 * 1024;
+
+/**
+ * A short body carrying a DECLARED Content-Length. Exercises bodyLimit's
+ * pre-flight branch, which compares the header and returns without reading.
+ */
+function declaring(bytes: number) {
+  return {
+    method: "POST",
+    body: JSON.stringify({ base64: "aaaa" }),
+    headers: {
+      "content-type": "application/json",
+      "content-length": String(bytes),
+    },
+  };
+}
+
+describe("/x402/* enforces a request body cap", () => {
+  it("refuses a body declared just OVER the limit", async () => {
+    const app = await loadApp();
+    const res = await app.request("/x402/image-resize", declaring(X402_LIMIT + 1));
+    expect(res.status).toBe(413);
+  });
+
+  it("does NOT refuse a body declared just under the limit", async () => {
+    // Not asserting 200: with no payment header and an empty catalog in this
+    // DB-less harness the gateway answers 402 or 404. The point is that the
+    // cap let it through to routing.
+    const app = await loadApp();
+    const res = await app.request("/x402/image-resize", declaring(X402_LIMIT - 1));
+    expect(res.status).not.toBe(413);
+  });
+
+  it("is the x402 cap being applied, not some smaller inherited one", async () => {
+    // 2 MiB is over /v1's 1 MiB and over /mcp's 512 KiB. If the x402 rail had
+    // been given one of those numbers — or if this route were somehow covered
+    // by the /v1 middleware — this would 413.
+    const app = await loadApp();
+    const res = await app.request("/x402/image-resize", declaring(2 * 1024 * 1024));
+    expect(res.status).not.toBe(413);
+  });
+
+  it("refuses with the platform's error shape, not raw middleware text", async () => {
+    const app = await loadApp();
+    const res = await app.request("/x402/image-resize", declaring(X402_LIMIT + 1));
+    const body = (await res.json()) as { error_code?: string; message?: string };
+    expect(body.error_code).toBe("invalid_request");
+    expect(body.message).toMatch(/too large/i);
+  });
+
+  it("refuses before the gateway does any x402 work", async () => {
+    // A 413 body carries the fixed refusal and nothing else. Had the request
+    // reached the gateway it would carry discovery fields — an `accepts` block
+    // for a 402, or the catalog hint for an unknown slug.
+    const app = await loadApp();
+    const res = await app.request("/x402/image-resize", declaring(X402_LIMIT + 1));
+    expect(JSON.stringify(await res.json())).not.toMatch(
+      /accepts|x402Version|catalog|payment/i,
+    );
+  });
+});
+
+describe("the streaming branch refuses instead of reporting success", () => {
+  const SMALL = 4 * 1024;
+
+  /** The gateway's shape: bodyLimit, then a handler that swallows json() errors. */
+  function appWith(handler: "swallow" | "rethrow") {
+    const a = new Hono();
+    a.onError((err, c) =>
+      err instanceof HTTPException
+        ? c.json({ status: err.status }, err.status)
+        : c.json({ e: String((err as Error)?.message).slice(0, 60) }, 500),
+    );
+    a.use("/x/*", bodyLimit({ maxSize: SMALL }));
+    a.post("/x/:slug", async (c) => {
+      let inputs: unknown;
+      try {
+        inputs = await c.req.json();
+      } catch (err) {
+        if (handler === "rethrow" && (err as { name?: string })?.name === "BodyLimitError") {
+          throw err;
+        }
+        inputs = c.req.query();
+      }
+      return c.json({ ok: true, keys: Object.keys((inputs ?? {}) as object) });
+    });
+    return a;
+  }
+
+  function oversizedStream() {
+    const chunk = new TextEncoder().encode("a".repeat(1024));
+    let sent = 0;
+    return new ReadableStream<Uint8Array>({
+      pull(ctrl) {
+        if (sent >= SMALL * 2) {
+          ctrl.close();
+          return;
+        }
+        ctrl.enqueue(chunk);
+        sent += chunk.byteLength;
+      },
+    });
+  }
+
+  async function post(a: Hono) {
+    return a.request("http://local/x/image-resize", {
+      method: "POST",
+      body: oversizedStream(),
+      headers: { "content-type": "application/json" },
+      // @ts-expect-error -- Node requires duplex for a streaming request body
+      duplex: "half",
+    });
+  }
+
+  it("FAIL-BEFORE: swallowing the abort reports 200 on an oversized body", async () => {
+    // The pre-fix gateway, reproduced. This is the defect, pinned so the fix
+    // below is measured against something rather than asserted.
+    const res = await post(appWith("swallow"));
+    expect(res.status).toBe(200);
+    expect((await res.json()).keys).toEqual([]); // body silently emptied
+  });
+
+  it("rethrowing the abort produces a 413", async () => {
+    const res = await post(appWith("rethrow"));
+    expect(res.status).toBe(413);
+  });
+});
+
+describe("the gateway itself no longer swallows the abort", () => {
+  /**
+   * The property the fix actually changed, asserted on the real function
+   * rather than on a reproduction of it.
+   */
+  function ctx(err: Error) {
+    return {
+      req: {
+        method: "POST",
+        header: () => "application/json",
+        json: () => Promise.reject(err),
+        query: () => ({ smuggled: "via-query" }),
+      },
+    };
+  }
+
+  it("rethrows a BodyLimitError instead of falling through to query params", async () => {
+    const { extractInputs } = await import("./x402-gateway-v2.js");
+    const err = Object.assign(new Error("Payload Too Large"), { name: "BodyLimitError" });
+    await expect(extractInputs(ctx(err), null)).rejects.toThrow(/Payload Too Large/);
+  });
+
+  it("still falls through to query params for an ordinary parse failure", async () => {
+    // The other direction. A malformed body is not an oversized body, and the
+    // fallback that exists for GET-style callers has to keep working.
+    const { extractInputs } = await import("./x402-gateway-v2.js");
+    const err = new SyntaxError("Unexpected token < in JSON at position 0");
+    await expect(extractInputs(ctx(err), null)).resolves.toEqual({ smuggled: "via-query" });
+  });
+});
+
+describe("the other rails are untouched", () => {
+  const cases: Array<{ path: string; limit: number; name: string }> = [
+    { path: "/v1/do", limit: 1024 * 1024, name: "/v1" },
+    { path: "/a2a", limit: 256 * 1024, name: "/a2a" },
+    { path: "/mcp", limit: 512 * 1024, name: "/mcp" },
+  ];
+
+  for (const c of cases) {
+    it(`${c.name} still refuses just over its own ${c.limit / 1024} KiB cap`, async () => {
+      const app = await loadApp();
+      expect((await app.request(c.path, declaring(c.limit + 1))).status).toBe(413);
+    });
+
+    it(`${c.name} still accepts just under its own cap`, async () => {
+      const app = await loadApp();
+      expect((await app.request(c.path, declaring(c.limit - 1))).status).not.toBe(413);
+    });
+
+    it(`${c.name} did NOT inherit the larger x402 cap`, async () => {
+      // The failure mode if the new middleware were registered too broadly: a
+      // body legal on x402 but illegal here would start being accepted.
+      const app = await loadApp();
+      expect((await app.request(c.path, declaring(4 * 1024 * 1024))).status).toBe(413);
+    });
+  }
+});

--- a/apps/api/src/routes/x402-body-limit.test.ts
+++ b/apps/api/src/routes/x402-body-limit.test.ts
@@ -65,15 +65,32 @@ import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { HTTPException } from "hono/http-exception";
 
+/**
+ * The DB mock returns an EMPTY ARRAY from every terminal call, including a
+ * bare `.where(...)`.
+ *
+ * The obvious mock — `where: () => ({ limit: … })` — makes `.where()` resolve
+ * to an object rather than an array, so the x402 gateway's `ensureCache()`
+ * threw `capRows is not iterable` on every request and retried. The tests
+ * still passed, but each passing request cost about a second and three of them
+ * intermittently blew vitest's 10 s default. A mock that makes the code under
+ * test fail internally is not a neutral stand-in.
+ */
+const emptyResult = () => {
+  const thenable: any = Promise.resolve([]);
+  thenable.where = () => emptyResult();
+  thenable.limit = () => emptyResult();
+  thenable.orderBy = () => emptyResult();
+  thenable.innerJoin = () => emptyResult();
+  thenable.leftJoin = () => emptyResult();
+  thenable.from = () => emptyResult();
+  return thenable;
+};
+
 vi.mock("../db/index.js", () => ({
   getDb: () => ({
     execute: () => Promise.resolve([]),
-    select: () => ({
-      from: () => ({
-        where: () => ({ limit: () => Promise.resolve([]) }),
-        innerJoin: () => ({ where: () => ({ orderBy: () => Promise.resolve([]) }) }),
-      }),
-    }),
+    select: () => emptyResult(),
   }),
 }));
 
@@ -87,9 +104,23 @@ beforeAll(() => {
   process.env.AUDIT_HMAC_SECRET = "unit-test-audit-secret-plenty-of-entropy-0123456789";
 });
 
-async function loadApp() {
+/**
+ * Loaded ONCE. Each test previously called this, and while the module cache
+ * makes the second import cheap, every request still drives app.ts's x402
+ * cache refresh against the mocked (empty) DB. Under load that pushed three
+ * of these past vitest's 10 s default and produced timeouts that looked like
+ * failures of the limit rather than of the harness.
+ */
+let cachedApp: Awaited<ReturnType<typeof importApp>> | undefined;
+
+async function importApp() {
   const { app } = await import("./../app.js");
   return app;
+}
+
+async function loadApp() {
+  cachedApp ??= await importApp();
+  return cachedApp;
 }
 
 /** The declared rail cap, restated so a change in app.ts must change this too. */
@@ -110,7 +141,7 @@ function declaring(bytes: number) {
   };
 }
 
-describe("/x402/* enforces a request body cap", () => {
+describe("/x402/* enforces a request body cap", { timeout: 30_000 }, () => {
   it("refuses a body declared just OVER the limit", async () => {
     const app = await loadApp();
     const res = await app.request("/x402/image-resize", declaring(X402_LIMIT + 1));
@@ -252,7 +283,7 @@ describe("the gateway itself no longer swallows the abort", () => {
   });
 });
 
-describe("the other rails are untouched", () => {
+describe("the other rails are untouched", { timeout: 30_000 }, () => {
   const cases: Array<{ path: string; limit: number; name: string }> = [
     { path: "/v1/do", limit: 1024 * 1024, name: "/v1" },
     { path: "/a2a", limit: 256 * 1024, name: "/a2a" },

--- a/apps/api/src/routes/x402-gateway-v2.ts
+++ b/apps/api/src/routes/x402-gateway-v2.ts
@@ -263,7 +263,13 @@ function isSimpleSchema(schema: Record<string, unknown> | null): boolean {
   );
 }
 
-async function extractInputs(
+/**
+ * Exported for `x402-body-limit.test.ts`, which asserts the body-cap abort is
+ * rethrown rather than swallowed. Reaching this through a full request needs a
+ * populated capability cache and therefore a database; the swallow is a
+ * property of this function alone, so it is tested on this function alone.
+ */
+export async function extractInputs(
   c: any,
   schema: Record<string, unknown> | null,
 ): Promise<Record<string, unknown>> {
@@ -271,7 +277,28 @@ async function extractInputs(
   if (c.req.method === "POST" || c.req.header("content-type")?.includes("json")) {
     try {
       return await c.req.json();
-    } catch {
+    } catch (err) {
+      // A body-cap abort is NOT a parse failure and must not fall through.
+      //
+      // Hono's bodyLimit has two paths. With a Content-Length header it
+      // rejects up front and this catch never runs. Without one — a chunked
+      // request, which is what a client streaming a large upload sends — it
+      // instead wraps the body in a counting stream and ERRORS THAT STREAM
+      // once the cap is crossed, then converts the error to 413 only if it
+      // reaches `c.error`.
+      //
+      // This catch used to eat it. Measured against a real HTTP socket before
+      // the fix: an oversized chunked POST returned `200 OK` with the body
+      // silently treated as empty, so the request continued past payment
+      // verification into input validation with no inputs. Memory was bounded
+      // — the stream did abort — but the caller was told the request
+      // succeeded, and a capability with no required fields would have
+      // executed on empty input.
+      //
+      // Rethrowing lets Hono finish the job: bodyLimit sees the error and
+      // emits its 413, which app.ts's onError maps to the platform's
+      // { error_code: "invalid_request" } shape.
+      if ((err as { name?: string })?.name === "BodyLimitError") throw err;
       // Fall through to query params
     }
   }


### PR DESCRIPTION
Narrow resource-safety containment. **Not** a reopening of WP12/VERIFY-IP — no
IP-keyed logic is touched.

`/x402/*` had **no body cap at all**. Every other entry point has had one for
months — `/v1` 1 MiB, `/a2a` 256 KiB, `/mcp` 512 KiB, `/webhooks` 512 KiB — and
this one was simply never added, so `x402-gateway-v2.ts`'s `extractInputs()`
buffered whatever a caller sent straight into `c.req.json()`.

## Where the bodies are parsed, and when

One read: `extractInputs()` at `x402-gateway-v2.ts:273`, called at `:1156`
(solutions) and `:1519` (capabilities). It runs **after** payment verification —
the gateway's own comment says *"after verify, before settle"* — so buffering
requires a valid x402 authorization first. There are **zero** x402 capabilities
priced at 0, so the `isFree` branch that skips verification is not reachable
today. That bounds the attacker but does not bound the buffer.

## Why 8 MiB, not the 1 MiB used for `/v1`

Copying `/v1` would have broken a capability contract. Measured before choosing:

| | |
|---|---|
| Largest x402 body ever observed | **2,658 bytes** (1,537 requests since 2026-08-15; p50 41 B, p95 111 B, p99 289 B) |
| Largest input we *intentionally* support | `image-to-text` declares `MAX_IMAGE_BYTES = 4 MiB` decoded → **~5.33 MiB** of base64 on the wire |
| x402 capabilities accepting base64 | 7 — `image-resize`, `image-to-text`, `receipt-categorize`, `pdf-extract`, `invoice-extract`, `contract-extract`, `resume-parse` |

1 MiB is **below what we already promise**. 8 MiB clears 5.33 MiB with room for
the JSON wrapper, and is ~3,000× the largest request ever seen — it cannot
affect real traffic. Its job is not to be tight; it is to turn *unbounded* into
*bounded*. The tight limits belong in the capabilities, in decoded bytes and
output pixels rather than wire bytes.

## The half a body cap alone would have missed

Hono's `bodyLimit` has two branches, and only one is a pre-flight rejection:

- **Content-Length present** → header compared, refused without reading.
- **No Content-Length (chunked)** → body wrapped in a counting stream that
  *errors* at the cap, becoming a 413 only if it reaches `c.error`.

`extractInputs()` wrapped `c.req.json()` in `try { … } catch { }` and fell
through to query params. **Measured against a real HTTP socket before the fix:
an oversized chunked POST returned `200 OK` with the body silently treated as
empty** — past payment verification, into input validation, with no inputs.
Memory was bounded; the answer was a lie. Adding the middleware without fixing
that catch would have shipped a limit that reports success.

## A much cheaper attack than an oversized body

A rail cap bounds the wire. It says nothing about what a *small* request can
buy. Measured on sharp 0.35.3 / libvips 8.18.3 from a **235-byte** source image,
varying only the requested output dimensions:

| requested | output | cost |
|---|---|---|
| 2,000 × 2,000 | 60 KB | 88 ms |
| 10,000 × 10,000 | 1.3 MB | 2.1 s |
| 30,000 × 30,000 | 11.9 MB | 5.8 s |
| **100,000 × 100,000** | **131 MB** | **95.8 s** |

A few hundred bytes buys 96 seconds of CPU and a 131 MB allocation. No body
limit can see it — the amplification is in the *parameters*. sharp's
`limitInputPixels` default guards decode **input**; there is no default for
output geometry.

So `image-resize` now bounds, before anything reaches the decoder:

- decoded input **4 MiB** — `image-to-text`'s existing number, not a second one;
- each output side **10,000 px**;
- total output **25 MP** (a 6000×4000 camera frame is 24 MP).

The `image_url` path is **streamed** with the same cap instead of
`await response.arrayBuffer()`. A limit checked after `arrayBuffer()` resolves
bounds nothing, and an unbounded URL fetch would have been the cheaper way in:
it carries no request body, so the rail cap never sees it.

## Refusals do not count against the capability

Messages open with a quoted field name and use "must be" — the house style, and
what `transaction-failure-taxonomy.ts` keys on. Run through
`classifyTransactionFailure`: all classify as `caller_input`,
`countsAgainstCapability = false`. With the quality floor armed, a correct
refusal must not push `image-resize` toward delisting.

No charge is possible either: a refusal **throws**, so there is no output, and
both rails settle only after a successful execution.

## Bypasses, checked against a real socket rather than a fetch harness

| attempt | real runtime |
|---|---|
| honest `Content-Length` over the cap | **413** |
| honest `Content-Length` under the cap | passes the cap |
| **lying `Content-Length: 10`** | Node's HTTP parser refuses; the app never sees an oversized body |
| **`Transfer-Encoding: chunked`, oversized** | route returns before reading, so nothing is buffered; once a handler reads, the rethrow yields 413 |
| no framing headers at all | malformed, refused by Node |

The lying-`Content-Length` case *does* appear to bypass `bodyLimit` through
`app.request()`. That is a property of the fetch harness, not the runtime —
worth knowing when reading the tests.

## Mutation-proven — eight mutations, each caught

| mutation | tests failing |
|---|---|
| rail `bodyLimit` removed | 3 |
| rail cap widened to 1 GiB | 3 |
| `extractInputs` swallowing again | 1 |
| geometry check removed | 3 |
| base64 size check removed | 2 |
| URL path back to `arrayBuffer()` | 2 |
| area cap → `MAX_SAFE_INTEGER` | 2 |
| decoded cap → 1 GiB | 3 |

**The URL-path mutation was not caught by the first version of these tests.**
They exercised the helper directly and never proved the executor calls it — a
guard that is never wired in is indistinguishable from no guard. Found by the
mutation run, not by review, and the test now drives the executor's own branch.

## Why the boundary tests do not send eight megabytes

Because the previous fix in this programme was a test that became the workload
it guarded against. Real 8 MiB bodies through `app.request` timed the suite out
at 10 s per case. The pre-flight branch reads `Content-Length` and never touches
the body, so a declared length with a short body exercises exactly the code a
real oversized request hits, at no cost; the streaming branch is exercised on a
small purpose-built app mirroring the middleware plus the gateway's swallowing
handler, with the pre-fix 200 pinned as an explicit fail-before.

## Verification

- 36 targeted tests green, stable across three consecutive runs.
- `/v1`, `/a2a` and `/mcp` each assert three ways: still refuse just over their
  own cap, still accept just under, and did **not** inherit the larger x402 cap.
- Full suite: 212 files / 3,011 tests pass. Nine files fail locally — the known
  Postgres-dependent set plus two timing-threshold tests
  (`domain-contact-extract` ReDoS scaling, `mutation-test` shell-out); **both
  pass in isolation**, 32/32, and the machine was under load.
- `npm run typecheck` clean.

## Reported, not fixed here

`image-to-text`'s 4 MiB limit applies only to its **URL** path — its base64
input is unchecked. Same class, different capability; flagged rather than folded
in.

The `image-resize` `format` validation is a separate PR, as instructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
