### PR TITLE
feat(competitor-compare): 24h result cache so a repeat question is not repeat work

### DIFF
--- a/apps/api/src/capabilities/competitor-compare.ts
+++ b/apps/api/src/capabilities/competitor-compare.ts
@@ -2,11 +2,73 @@ import { registerCapability, type CapabilityInput } from "./index.js";
 import { fetchRenderedHtml, htmlToText } from "./lib/browserless-extract.js";
 import Anthropic from "@anthropic-ai/sdk";
 import { extractJsonWithLlm } from "./lib/llm-extract.js";
+import { ResultCache } from "./lib/result-cache.js";
+
+/**
+ * 24h result cache, keyed on the normalized domain pair.
+ *
+ * A comparison costs two Browserless renders, an LLM call, and 12-15 seconds.
+ * The customer who prompted this ran one identical pair four times; the last
+ * three were repeats of work already done. Competitor websites do not
+ * meaningfully change within a day, so a day is the window where a repeat is
+ * genuinely the same answer rather than a stale one.
+ *
+ * A hit still bills normally: the caller receives the answer they asked for,
+ * and `vat-validate` — the pattern this follows — bills its cache hits too.
+ * What the caller gains is an instant response instead of a 14-second one, and
+ * `cache_hit` / `cache_age_hours` so the reuse is disclosed rather than hidden.
+ */
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface CachedComparison {
+  output: Record<string, unknown>;
+  /** When the underlying sites were actually fetched. Carried into provenance. */
+  fetchedAt: string;
+}
+
+const cache = new ResultCache<CachedComparison>({
+  ttlMs: CACHE_TTL_MS,
+  maxEntries: 500,
+});
+
+setInterval(() => cache.sweep(), 60 * 60 * 1000).unref();
+
+/**
+ * Order-SENSITIVE key. (a,b) and (b,a) are deliberately different entries,
+ * because the output labels one site `company_a` and the other `company_b` —
+ * serving a flipped pair from cache would silently swap which company each
+ * finding is about, which is a wrong answer rather than a stale one.
+ */
+export function comparisonCacheKey(domain1: string, domain2: string): string {
+  const normalize = (d: string) =>
+    d.trim().toLowerCase()
+      .replace(/^https?:\/\//, "")
+      .replace(/^www\./, "")
+      .replace(/\/+$/, "");
+  return `${normalize(domain1)}|${normalize(domain2)}`;
+}
 
 registerCapability("competitor-compare", async (input: CapabilityInput) => {
   const domain1 = ((input.domain1 as string) ?? (input.company1 as string) ?? "").trim();
   const domain2 = ((input.domain2 as string) ?? (input.company2 as string) ?? "").trim();
   if (!domain1 || !domain2) throw new Error("'domain1' and 'domain2' are required.");
+
+  const cacheKey = comparisonCacheKey(domain1, domain2);
+  const hit = cache.get(cacheKey);
+  if (hit) {
+    return {
+      output: {
+        ...hit.value.output,
+        cache_hit: true,
+        cached_at: new Date(hit.cachedAt).toISOString(),
+        cache_age_hours: Math.round((hit.ageMs / 3_600_000) * 10) / 10,
+      },
+      // The ORIGINAL fetch time, never the time of this hit. Provenance is a
+      // freshness statement, and "fetched_at: now" for a value computed
+      // yesterday would be false.
+      provenance: { source: "claude-haiku", fetched_at: hit.value.fetchedAt },
+    };
+  }
 
   const url1 = domain1.startsWith("http") ? domain1 : `https://${domain1}`;
   const url2 = domain2.startsWith("http") ? domain2 : `https://${domain2}`;
@@ -63,8 +125,13 @@ Return JSON:
   });
   output.disclaimer = "AI-generated competitive analysis. Verify specific claims independently.";
 
+  const fetchedAt = new Date().toISOString();
+  // Store the answer WITHOUT the cache_* fields, so a hit derives them from
+  // its own age rather than replaying a previous hit's numbers.
+  cache.set(cacheKey, { output: { ...output }, fetchedAt });
+
   return {
-    output,
-    provenance: { source: "claude-haiku", fetched_at: new Date().toISOString() },
+    output: { ...output, cache_hit: false },
+    provenance: { source: "claude-haiku", fetched_at: fetchedAt },
   };
 });

--- a/apps/api/src/capabilities/lib/result-cache.test.ts
+++ b/apps/api/src/capabilities/lib/result-cache.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the shared result cache and competitor-compare's key derivation.
+ *
+ * The clock is injected throughout — no `setTimeout`, no real waiting, so TTL
+ * and eviction are exercised deterministically rather than approximately.
+ */
+import { describe, it, expect } from "vitest";
+import { ResultCache } from "./result-cache.js";
+import { comparisonCacheKey } from "../competitor-compare.js";
+
+/** A controllable clock, so expiry is asserted rather than slept for. */
+function clock(start = 1_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+}
+
+describe("ResultCache", () => {
+  it("returns a miss for an unknown key", () => {
+    const c = new ResultCache<string>({ ttlMs: 1000, maxEntries: 10 });
+    expect(c.get("nope")).toBeNull();
+  });
+
+  it("serves a stored value inside the TTL, with the age it was actually held", () => {
+    const k = clock();
+    const c = new ResultCache<string>({ ttlMs: 1000, maxEntries: 10, now: k.now });
+
+    c.set("a", "value");
+    k.advance(400);
+
+    const hit = c.get("a");
+    expect(hit).not.toBeNull();
+    expect(hit!.value).toBe("value");
+    expect(hit!.ageMs).toBe(400);
+  });
+
+  it("reports cachedAt as the ORIGINAL write time, not the hit time", () => {
+    // This is the field competitor-compare puts into provenance.fetched_at.
+    // If it drifted to "now", every cache hit would claim it fetched the
+    // sites at the moment of the hit — a false freshness statement.
+    const k = clock(500_000);
+    const c = new ResultCache<string>({ ttlMs: 10_000, maxEntries: 10, now: k.now });
+
+    c.set("a", "v");
+    k.advance(7_000);
+
+    expect(c.get("a")!.cachedAt).toBe(500_000);
+  });
+
+  it("misses once the TTL has elapsed, and drops the entry on read", () => {
+    const k = clock();
+    const c = new ResultCache<string>({ ttlMs: 1000, maxEntries: 10, now: k.now });
+
+    c.set("a", "value");
+    k.advance(1001);
+
+    expect(c.get("a")).toBeNull();
+    // Deleted on read, not merely hidden — an expired value must be
+    // unreachable even with no sweep running.
+    expect(c.size).toBe(0);
+  });
+
+  it("serves right up to the TTL boundary and not past it", () => {
+    const k = clock();
+    const c = new ResultCache<string>({ ttlMs: 1000, maxEntries: 10, now: k.now });
+
+    c.set("a", "v");
+    k.advance(1000);
+    expect(c.get("a")).not.toBeNull(); // exactly at TTL: still good
+
+    c.set("b", "v");
+    k.advance(1001);
+    expect(c.get("b")).toBeNull();
+  });
+
+  it("evicts the oldest entry when full, keeping the cap", () => {
+    const k = clock();
+    const c = new ResultCache<string>({ ttlMs: 100_000, maxEntries: 2, now: k.now });
+
+    c.set("a", "1"); k.advance(1);
+    c.set("b", "2"); k.advance(1);
+    c.set("c", "3");
+
+    expect(c.size).toBe(2);
+    expect(c.get("a")).toBeNull();
+    expect(c.get("b")!.value).toBe("2");
+    expect(c.get("c")!.value).toBe("3");
+  });
+
+  it("re-writing a key refreshes its position, so a hot key is not evicted first", () => {
+    const k = clock();
+    const c = new ResultCache<string>({ ttlMs: 100_000, maxEntries: 2, now: k.now });
+
+    c.set("a", "1"); k.advance(1);
+    c.set("b", "2"); k.advance(1);
+    c.set("a", "1-again"); k.advance(1); // 'a' is now the newest
+    c.set("c", "3");
+
+    // 'b' was the oldest write at eviction time, so it goes — not 'a'.
+    expect(c.get("b")).toBeNull();
+    expect(c.get("a")!.value).toBe("1-again");
+    expect(c.get("c")!.value).toBe("3");
+  });
+
+  it("sweep removes only expired entries and reports how many", () => {
+    const k = clock();
+    const c = new ResultCache<string>({ ttlMs: 1000, maxEntries: 10, now: k.now });
+
+    c.set("old", "1");
+    k.advance(1500);
+    c.set("new", "2");
+
+    expect(c.sweep()).toBe(1);
+    expect(c.size).toBe(1);
+    expect(c.get("new")).not.toBeNull();
+  });
+});
+
+describe("comparisonCacheKey", () => {
+  it("treats protocol, www, case and trailing slash as the same site", () => {
+    const canonical = comparisonCacheKey("github.com", "gitlab.com");
+    for (const [a, b] of [
+      ["https://github.com", "https://gitlab.com"],
+      ["http://www.GitHub.com/", "WWW.GitLab.com"],
+      ["  GITHUB.COM  ", "gitlab.com///"],
+    ]) {
+      expect(comparisonCacheKey(a, b)).toBe(canonical);
+    }
+  });
+
+  it("keys the reversed pair separately — a flipped hit would mislabel findings", () => {
+    // The output labels one site company_a and the other company_b. Serving
+    // (b,a) from the (a,b) entry would attribute every finding to the wrong
+    // company: a wrong answer, not a stale one.
+    expect(comparisonCacheKey("gitlab.com", "github.com"))
+      .not.toBe(comparisonCacheKey("github.com", "gitlab.com"));
+  });
+
+  it("does not collide two different pairs", () => {
+    expect(comparisonCacheKey("a.com", "b.com"))
+      .not.toBe(comparisonCacheKey("a.com", "c.com"));
+  });
+});

--- a/apps/api/src/capabilities/lib/result-cache.ts
+++ b/apps/api/src/capabilities/lib/result-cache.ts
@@ -1,0 +1,121 @@
+/**
+ * A small in-process TTL cache for expensive capability results.
+ *
+ * Why this exists (2026-08-25). The platform's first card-paying customer ran
+ * the identical `competitor-compare` input four times and was charged €1.00
+ * each time — €4.00 of the €5.09 they had spent in total. Each run cost us two
+ * Browserless renders plus an LLM call and took 12–15 seconds. Nothing about
+ * the second, third or fourth run was different work; they were repeats of a
+ * question we had already answered.
+ *
+ * `vat-validate.ts` already had exactly this shape — a `Map`, a TTL, an
+ * unref'd sweep, and a `cache_hit` field on the output — written inline for one
+ * capability. This generalises that pattern rather than inventing a second one,
+ * so the next expensive capability does not hand-roll a third.
+ *
+ * ## What this deliberately is not
+ *
+ * **It is not shared across instances.** The `Map` lives in one Node process,
+ * so a Railway redeploy or a second instance starts cold. That is an accepted
+ * limit, not an oversight: a shared cache means Redis, and the benefit here
+ * (one buyer's repeated question inside a session) is overwhelmingly
+ * same-instance. Revisit if a cross-instance hit rate ever justifies the
+ * dependency.
+ *
+ * **It is not a freshness claim.** A cache hit returns the value AND the
+ * timestamp it was originally computed at, so callers can report the real
+ * `fetched_at` in provenance rather than the time of the cache hit. Reporting
+ * "fetched now" for a value fetched yesterday is precisely the kind of
+ * unsupported claim this codebase has had to retract from public copy before,
+ * and the API is shaped so the honest version is the easy one — `get` cannot
+ * return a value without also returning when it was computed.
+ */
+
+/** What a hit carries: the value, when it was computed, and how old it is. */
+export interface CacheHit<T> {
+  value: T;
+  /** Epoch ms at which this value was originally computed — NOT the hit time. */
+  cachedAt: number;
+  ageMs: number;
+}
+
+export interface ResultCacheOptions {
+  /** How long an entry stays servable, in ms. */
+  ttlMs: number;
+  /**
+   * Hard cap on retained entries. When full, the oldest entry is evicted.
+   * Bounded on purpose: entries here are whole capability outputs (~6KB for
+   * competitor-compare), and an uncapped Map keyed on caller-supplied input is
+   * a memory leak with a public endpoint in front of it.
+   */
+  maxEntries: number;
+  /** Injectable clock. Tests drive TTL and eviction without sleeping. */
+  now?: () => number;
+}
+
+export class ResultCache<T> {
+  readonly #entries = new Map<string, { value: T; cachedAt: number }>();
+  readonly #ttlMs: number;
+  readonly #maxEntries: number;
+  readonly #now: () => number;
+
+  constructor(options: ResultCacheOptions) {
+    this.#ttlMs = options.ttlMs;
+    this.#maxEntries = options.maxEntries;
+    this.#now = options.now ?? Date.now;
+  }
+
+  /**
+   * A live entry, or null. Expired entries are deleted on read rather than
+   * only on sweep, so an expired value can never be served even if the sweep
+   * interval is not running (it does not run at all under tests, and a
+   * `setInterval` that a test forgets to clear keeps a process alive).
+   */
+  get(key: string): CacheHit<T> | null {
+    const entry = this.#entries.get(key);
+    if (!entry) return null;
+
+    const ageMs = this.#now() - entry.cachedAt;
+    if (ageMs > this.#ttlMs) {
+      this.#entries.delete(key);
+      return null;
+    }
+    return { value: entry.value, cachedAt: entry.cachedAt, ageMs };
+  }
+
+  set(key: string, value: T): void {
+    // Re-inserting an existing key must not leave the original insertion order
+    // in place, or a hot key could be evicted while cold ones survive.
+    this.#entries.delete(key);
+    this.#entries.set(key, { value, cachedAt: this.#now() });
+
+    while (this.#entries.size > this.#maxEntries) {
+      // Map preserves insertion order, so the first key is the oldest write.
+      const oldest = this.#entries.keys().next();
+      if (oldest.done) break;
+      this.#entries.delete(oldest.value);
+    }
+  }
+
+  /** Drop every expired entry. Safe to call from an interval, or never. */
+  sweep(): number {
+    const now = this.#now();
+    let removed = 0;
+    for (const [key, entry] of this.#entries) {
+      if (now - entry.cachedAt > this.#ttlMs) {
+        this.#entries.delete(key);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  get size(): number {
+    return this.#entries.size;
+  }
+
+  /** Test seam. Never called in production paths. */
+  clear(): void {
+    this.#entries.clear();
+  }
+}


### PR DESCRIPTION
Follow-up to #397 (temperature 0), and the second half of the customer-visible repair. Requested explicitly by Petter.

## Why

The first card-paying customer ran the **identical** pair four times at €1.00 each — **€4.00 of the €5.09** they had spent in total. Each run cost two Browserless renders, an LLM call, and 12–15 seconds. Runs 2–4 were repeats of a question already answered.

With #397 those repeats now return the *same* answer. This makes them stop being *work*.

## What

`ResultCache` — a small in-process TTL cache, generalised from the one `vat-validate.ts` already had inline (Map + TTL + unref'd sweep + a `cache_hit` output field), so the next expensive capability doesn't hand-roll a third copy.

Two design points that are load-bearing, not incidental:

- **`get()` cannot return a value without also returning when it was *originally* computed**, and that goes into `provenance.fetched_at`. A hit reporting "fetched now" for yesterday's value is a false freshness claim — the API is shaped so the honest version is the easy one.
- **The key is order-sensitive.** The output labels one site `company_a` and the other `company_b`; serving `(b,a)` from the `(a,b)` entry would attribute every finding to the wrong company — a *wrong* answer, not a stale one.

## Decisions worth disagreeing with explicitly

| decision | reasoning |
|---|---|
| **A hit still bills** | The caller gets the answer they asked for; `vat-validate` bills its hits too; free repeats on a public endpoint invite abuse. They gain an instant response instead of 14s, plus `cache_hit` / `cache_age_hours` so reuse is *disclosed*, not hidden. |
| **TTL 24h** | Competitor sites don't meaningfully change within a day — the window where a repeat is genuinely the same answer rather than a stale one. |
| **500-entry cap, oldest-first** | Entries are whole ~6KB outputs keyed on caller-supplied input; an uncapped Map behind a public endpoint is a memory leak. |
| **Not shared across instances** | Stated in the docstring rather than implied. A redeploy starts cold. Shared means Redis, and the benefit here is overwhelmingly same-instance. |

Adding `cache_hit` / `cached_at` / `cache_age_hours` is additive and safe: harness gates 2 and 3 assert declared fields are **present**, not that extras are absent.

## Fail-before, through the harness

11 tests, clock injected throughout — TTL and eviction are asserted, never slept for. All four mutations via `scripts/mutation-test.mjs`:

```
never expire (drop the TTL check)                → MUTATION CAUGHT
report hit time instead of original write time   → MUTATION CAUGHT
make the key order-insensitive                   → MUTATION CAUGHT
drop the eviction cap                            → MUTATION CAUGHT
```

Typecheck clean (after building `strale-mcp`, whose absence produces unrelated phantom errors in a fresh worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)