### PR TITLE
Fix vendor restoration timestamp cast

### DIFF
--- a/apps/api/src/lib/vendor-control-tower-state.test.ts
+++ b/apps/api/src/lib/vendor-control-tower-state.test.ts
@@ -60,6 +60,7 @@ describe("vendor suspension serving-state integrity", () => {
     const suspensionInserts = seen.filter((sql) => sql.includes("INSERT INTO vendor_") && sql.includes("_suspensions"));
     expect(suspensionInserts).toHaveLength(2);
     expect(suspensionInserts.every((sql) => sql.includes("deactivation_reason IS NULL") && sql.includes("LIKE 'vendor:%'"))).toBe(true);
+    expect(suspensionInserts.every((sql) => sql.includes("::timestamptz"))).toBe(true);
     expect(suspensionInserts.find((sql) => sql.includes("vendor_solution_suspensions")))
       .toContain("OR s.deactivation_reason LIKE 'vendor:%'");
   });

--- a/apps/api/src/lib/vendor-control-tower.ts
+++ b/apps/api/src/lib/vendor-control-tower.ts
@@ -400,7 +400,7 @@ export async function suspendRequiredCapabilities(
         previous_visible, previous_x402_enabled, suspension_marker, restore_after
       )
       SELECT ${providerName}, c.slug, c.lifecycle_state, c.visible, c.x402_enabled,
-             ${marker}, ${restoreAfter}
+             ${marker}, ${restoreAfter}::timestamptz
         FROM vendor_capability_dependencies d
         JOIN capabilities c ON c.slug = d.capability_slug
        WHERE d.provider_name = ${providerName}
@@ -427,7 +427,7 @@ export async function suspendRequiredCapabilities(
         previous_x402_enabled, suspension_marker, restore_after
       )
       SELECT DISTINCT ${providerName}, s.slug, s.is_active, s.x402_enabled,
-             ${marker}, ${restoreAfter}
+             ${marker}, ${restoreAfter}::timestamptz
         FROM vendor_capability_dependencies d
         JOIN solution_steps ss ON ss.capability_slug = d.capability_slug
         JOIN solutions s ON s.id = ss.solution_id


### PR DESCRIPTION
## Summary
- Explicitly cast vendor suspension restoration deadlines to `timestamptz` in both capability and solution `INSERT ... SELECT` paths.
- Add a regression assertion covering both casts.

## Verification
- Targeted Vendor Control Tower tests: 21 passed.
- API typecheck: passed.
- API production build: passed.
- Production evidence: migration 0111 suspended German data successfully; the first hourly tower tick then failed closed on the uncast text parameter.

## Reviewer findings — clean
Two independent Codex xhigh follow-up reviews report 0 HIGH and 0 MEDIUM. Both confirmed ISO timestamps and `NULL` deadlines are correctly covered in capability and solution paths.

## Test plan
- Confirm integration-DB CI passes.
- After deployment, confirm the Vendor Control Tower job succeeds and OpenRegister remains exhausted with a September 7 restoration deadline.