### PR TITLE
fix(vendors): type audit JSON before suspension

### DIFF
--- a/apps/api/src/lib/vendor-control-tower-state.test.ts
+++ b/apps/api/src/lib/vendor-control-tower-state.test.ts
@@ -63,6 +63,11 @@ describe("vendor suspension serving-state integrity", () => {
     expect(suspensionInserts.every((sql) => sql.includes("::timestamptz"))).toBe(true);
     expect(suspensionInserts.find((sql) => sql.includes("vendor_solution_suspensions")))
       .toContain("OR s.deactivation_reason LIKE 'vendor:%'");
+    const auditInserts = seen.filter((sql) => sql.includes("INSERT INTO health_monitor_events"));
+    expect(auditInserts).toHaveLength(2);
+    expect(auditInserts.every((sql) =>
+      sql.includes("jsonb_build_object") && sql.includes("::text")
+    )).toBe(true);
   });
 
   it("records a second blocker when a solution is already vendor-disabled", async () => {
@@ -194,6 +199,9 @@ describe("vendor suspension serving-state integrity", () => {
     expect(requestedUrl).toContain("sortcode=000000");
     const completion = seen.find((source) =>
       source.includes("Scheduled authenticated recovery canary succeeded") && source.includes("RETURNING status"));
+    const claim = seen.find((source) =>
+      source.includes("jsonb_build_object") && source.includes("RETURNING provider_name"));
+    expect(claim).toContain("::text");
     expect(completion).toContain("metadata#>>'{recovery_probe,token}' =");
     expect(completion).toContain("metadata#>>'{recovery_probe,status}' =");
     expect(completion).not.toContain("included_units -");

--- a/apps/api/src/lib/vendor-control-tower.integration.test.ts
+++ b/apps/api/src/lib/vendor-control-tower.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Vendor suspension audit writes against real Postgres.
+ *
+ * jsonb_build_object is variadic, so bind parameters inside it have no type
+ * context unless we cast them. A mock can render valid-looking SQL while the
+ * server rejects it with "could not determine data type of parameter $3".
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { sql } from "drizzle-orm";
+import postgres from "postgres";
+import { randomUUID } from "node:crypto";
+
+import { useTestDatabase } from "../test-support/integration-db.js";
+import { suspendRequiredCapabilities, restoreVendorSuspensions } from "./vendor-control-tower.js";
+
+const DATABASE_URL_TEST = useTestDatabase();
+const describeMaybe = DATABASE_URL_TEST ? describe : describe.skip;
+
+describeMaybe("vendor control tower against a real database", () => {
+  let client: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  const createdSlugs = new Set<string>();
+  const createdProviders = new Set<string>();
+
+  beforeAll(() => {
+    client = postgres(DATABASE_URL_TEST!, { max: 4 });
+    db = drizzle(client);
+  });
+
+  afterEach(async () => {
+    for (const slug of createdSlugs) {
+      await db.execute(sql`DELETE FROM health_monitor_events WHERE capability_slug = ${slug}`);
+      await db.execute(sql`DELETE FROM vendor_capability_suspensions WHERE capability_slug = ${slug}`);
+      await db.execute(sql`DELETE FROM vendor_capability_dependencies WHERE capability_slug = ${slug}`);
+      await db.execute(sql`DELETE FROM capabilities WHERE slug = ${slug}`);
+    }
+    for (const provider of createdProviders) {
+      await db.execute(sql`DELETE FROM vendor_accounts WHERE provider_name = ${provider}`);
+    }
+    createdSlugs.clear();
+    createdProviders.clear();
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  it("suspends and restores a dependency while recording typed JSON audit details", async () => {
+    const suffix = randomUUID().slice(0, 8);
+    const provider = `test-vendor-${suffix}`;
+    const slug = `test-vendor-cap-${suffix}`;
+    createdProviders.add(provider);
+    createdSlugs.add(slug);
+
+    await db.execute(sql`
+      INSERT INTO vendor_accounts (
+        provider_name, display_name, billing_model, monitor_mode, status,
+        remaining_units, usage_unit
+      ) VALUES (${provider}, ${provider}, 'prepaid', 'api_balance', 'auth_error', 0, 'credit')
+    `);
+    await db.execute(sql`
+      INSERT INTO capabilities (
+        slug, name, description, category, price_cents, input_schema,
+        output_schema, lifecycle_state, visible, x402_enabled
+      ) VALUES (
+        ${slug}, ${slug}, 'vendor tower integration fixture', 'validation', 1,
+        '{}'::jsonb, '{}'::jsonb, 'active', true, true
+      )
+    `);
+    await db.execute(sql`
+      INSERT INTO vendor_capability_dependencies (
+        provider_name, capability_slug, dependency_kind, units_per_execution
+      ) VALUES (${provider}, ${slug}, 'required', 1)
+    `);
+
+    await expect(suspendRequiredCapabilities(provider, "auth_error", null))
+      .resolves.toEqual([slug]);
+
+    await db.execute(sql`
+      UPDATE vendor_accounts
+         SET status = 'healthy', remaining_units = 100
+       WHERE provider_name = ${provider}
+    `);
+    await expect(restoreVendorSuspensions(provider)).resolves.toEqual([slug]);
+
+    const events = await db.execute(sql`
+      SELECT event_type, details
+        FROM health_monitor_events
+       WHERE capability_slug = ${slug}
+       ORDER BY created_at
+    `) as unknown as Array<{ event_type: string; details: Record<string, unknown> }>;
+    expect(events.map((event) => event.event_type)).toEqual([
+      "vendor_suspension",
+      "vendor_restoration",
+    ]);
+    expect(events[0]?.details).toMatchObject({
+      provider,
+      status: "auth_error",
+      restore_after: null,
+    });
+  });
+});

--- a/apps/api/src/lib/vendor-control-tower.ts
+++ b/apps/api/src/lib/vendor-control-tower.ts
@@ -288,8 +288,8 @@ async function claimRecoveryProbe(
              COALESCE(metadata, '{}'::jsonb),
              '{recovery_probe}',
              jsonb_build_object(
-               'token', ${token},
-               'status', ${status},
+               'token', ${token}::text,
+               'status', ${status}::text,
                'expires_at', now() + INTERVAL '5 minutes'
              )
            ),
@@ -483,7 +483,11 @@ export async function suspendRequiredCapabilities(
         VALUES (
           'vendor_suspension', ${slug}, 1,
           ${`Suspended because ${providerName} is ${status}`},
-          jsonb_build_object('provider', ${providerName}, 'status', ${status}, 'restore_after', ${restoreAfter}),
+          jsonb_build_object(
+            'provider', ${providerName}::text,
+            'status', ${status}::text,
+            'restore_after', ${restoreAfter}::text
+          ),
           false
         )
       `);
@@ -495,7 +499,11 @@ export async function suspendRequiredCapabilities(
         VALUES (
           'vendor_solution_suspension', ${slug}, 1,
           ${`Suspended solution because ${providerName} is ${status}`},
-          jsonb_build_object('provider', ${providerName}, 'status', ${status}, 'restore_after', ${restoreAfter}),
+          jsonb_build_object(
+            'provider', ${providerName}::text,
+            'status', ${status}::text,
+            'restore_after', ${restoreAfter}::text
+          ),
           false
         )
       `);
@@ -625,7 +633,7 @@ export async function restoreVendorSuspensions(providerName: string): Promise<st
         VALUES (
           'vendor_restoration', ${s.capability_slug}, 1,
           ${`Restored after ${providerName} reported usable allowance`},
-          jsonb_build_object('provider', ${providerName}, 'restore_policy', 'provider-confirmed'),
+          jsonb_build_object('provider', ${providerName}::text, 'restore_policy', 'provider-confirmed'),
           false
         )
       `);
@@ -719,7 +727,7 @@ export async function restoreVendorSuspensions(providerName: string): Promise<st
         VALUES (
           'vendor_solution_restoration', ${s.solution_slug}, 1,
           ${`Restored solution after ${providerName} reported usable allowance`},
-          jsonb_build_object('provider', ${providerName}, 'restore_policy', 'provider-confirmed'),
+          jsonb_build_object('provider', ${providerName}::text, 'restore_policy', 'provider-confirmed'),
           false
         )
       `);


### PR DESCRIPTION
## Summary
- cast dynamic values passed to PostgreSQL `jsonb_build_object`, fixing the production Vendor Control Tower failure after a suspension is created
- cover suspension and restoration audit events with a real-Postgres regression test
- type the dormant recovery-lease JSON path before it can fail in production for the same reason

## Verification
- `npm --workspace=apps/api test -- --run src/lib/vendor-control-tower.test.ts src/lib/vendor-control-tower-state.test.ts src/lib/vendor-control-tower.integration.test.ts` — 22 passed
- `npm --workspace=apps/api run typecheck` — passed
- `npm --workspace=apps/api run build` — passed
- `git diff --check` — passed

## Reviewer findings — clean (technical + product)
- Codex xhigh technical review: 0 HIGH / 0 MEDIUM
- Codex xhigh operations/product review: 0 HIGH / 0 MEDIUM
- Founder waived the usual Claude cross-provider review because the Claude subscription is rate-limited

## Test plan
- CI unit/type/build lane passes
- CI real-Postgres integration lane executes the new suspend/restore audit-event regression
- after deploy, confirm `vendor-control-tower` records `last_outcome=ok`
- confirm `german-company-data` and the three dependent German solutions remain suspended until OpenRegister reports usable credits after 7 September